### PR TITLE
Fix problem of using same DB as previous test

### DIFF
--- a/testhelper/testhelper.go
+++ b/testhelper/testhelper.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -27,15 +28,23 @@ import (
 )
 
 const (
-	testPort = 1101
+	testDBNameFmt = "test-%s-%d"
+	testPort      = 1101
 )
+
+var testStartedAt int64
+
+func init() {
+	now := time.Now()
+	testStartedAt = now.Unix()
+}
 
 func randBetween(min, max int) int {
 	return rand.Intn(max-min) + min
 }
 
 func WithYorkie(t *testing.T, f func(*testing.T, *yorkie.Yorkie)) {
-	testDBName := fmt.Sprintf("yorkie-meta-%d", randBetween(0, 9999))
+	testDBName := fmt.Sprintf(testDBNameFmt, yorkie.DefaultYorkieDatabase, testStartedAt)
 	conf := yorkie.NewConfigForTest(testPort, testDBName)
 	y, err := yorkie.New(conf)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature

**What this PR does / why we need it**:
When testing, DB of previous test may be used.
This situation difficult to check correct data after testing.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
