### PR TITLE
Fix problem of using multiple DB during test

### DIFF
--- a/testhelper/testhelper.go
+++ b/testhelper/testhelper.go
@@ -23,13 +23,20 @@ import (
 	"github.com/yorkie-team/yorkie/yorkie"
 )
 
+var testStartedAt int64
+
 const (
 	TestPort               = 1101
 	TestMongoConnectionURI = "mongodb://localhost:27017"
 )
 
-// TestDBName returns the name of test database with timestamp.
-func TestDBName() string {
+func init() {
 	now := time.Now()
-	return fmt.Sprintf("test-%s-%d", yorkie.DefaultYorkieDatabase, now.Unix())
+	testStartedAt = now.Unix()
+}
+
+// TestDBName returns the name of test database with timestamp.
+// timestamp is set only once on first call.
+func TestDBName() string {
+	return fmt.Sprintf("test-%s-%d", yorkie.DefaultYorkieDatabase, testStartedAt)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature

**What this PR does / why we need it**:
During testing, more than one DB can be created.
This situation difficult to check correct data after testing.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
