### PR TITLE
abandon: Fix convention as "#22"

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -99,9 +99,7 @@ func TestClient(t *testing.T) {
 
 	t.Run("activate/deactivate test", func(t *testing.T) {
 		cli, err := client.NewClient(testYorkie.RPCAddr())
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.Nil(t, err)
 
 		defer func() {
 			err := cli.Close()

--- a/yorkie/rpc/rpc_server_test.go
+++ b/yorkie/rpc/rpc_server_test.go
@@ -215,18 +215,14 @@ func withRPCServer(
 		ConnectionTimeoutSec: 5,
 		PingTimeoutSec:       5,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.Nil(t, err)
 	defer func() {
 		err := be.Close()
 		assert.Nil(t, err)
 	}()
 
 	rpcServer, err := rpc.NewRPCServer(testhelper.TestPort, be)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.Nil(t, err)
 
 	defer func() {
 		rpcServer.Shutdown(true)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature

**What this PR does / why we need it**:
Fixed missing part in #22.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
