### PR TITLE
Clean up "rpc test" code for readability

### DIFF
--- a/yorkie/rpc/rpc_server_test.go
+++ b/yorkie/rpc/rpc_server_test.go
@@ -2,6 +2,8 @@ package rpc_test
 
 import (
 	"context"
+	"log"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,200 +17,14 @@ import (
 	"github.com/yorkie-team/yorkie/yorkie/rpc"
 )
 
-func TestRPCServer(t *testing.T) {
-	withRPCServer(t, func(t *testing.T, rpcServer *rpc.Server) {
-		t.Run("activate/deactivate client test", func(t *testing.T) {
-			activateResp, err := rpcServer.ActivateClient(
-				context.Background(),
-				&api.ActivateClientRequest{ClientKey: t.Name()},
-			)
-			assert.Nil(t, err)
+const (
+	nilCliendID = "000000000000000000000000"
+	testRPCPort = testhelper.RPCPort + 1
+)
 
-			_, err = rpcServer.DeactivateClient(
-				context.Background(),
-				&api.DeactivateClientRequest{ClientId: activateResp.ClientId},
-			)
-			assert.Nil(t, err)
+var testRPCServer *rpc.Server
 
-			// invalid argument
-			_, err = rpcServer.ActivateClient(
-				context.Background(),
-				&api.ActivateClientRequest{ClientKey: ""},
-			)
-			assert.Equal(t, codes.InvalidArgument, status.Convert(err).Code())
-
-			_, err = rpcServer.DeactivateClient(
-				context.Background(),
-				&api.DeactivateClientRequest{ClientId: ""},
-			)
-			assert.Equal(t, codes.InvalidArgument, status.Convert(err).Code())
-
-			// client not found
-			_, err = rpcServer.DeactivateClient(
-				context.Background(),
-				&api.DeactivateClientRequest{ClientId: "000000000000000000000000"},
-			)
-			assert.Equal(t, codes.NotFound, status.Convert(err).Code())
-		})
-
-		t.Run("attach/detach document test", func(t *testing.T) {
-			activateResp, err := rpcServer.ActivateClient(
-				context.Background(),
-				&api.ActivateClientRequest{ClientKey: t.Name()},
-			)
-			assert.Nil(t, err)
-
-			packWithNoChanges := &api.ChangePack{
-				DocumentKey: &api.DocumentKey{
-					Collection: t.Name(), Document: t.Name(),
-				},
-				Checkpoint: &api.Checkpoint{ServerSeq: 0, ClientSeq: 0},
-			}
-
-			_, err = rpcServer.AttachDocument(
-				context.Background(),
-				&api.AttachDocumentRequest{
-					ClientId:   activateResp.ClientId,
-					ChangePack: packWithNoChanges,
-				},
-			)
-			assert.Nil(t, err)
-
-			// try to attach already attached document
-			_, err = rpcServer.AttachDocument(
-				context.Background(),
-				&api.AttachDocumentRequest{
-					ClientId:   activateResp.ClientId,
-					ChangePack: packWithNoChanges,
-				},
-			)
-			assert.Equal(t, codes.FailedPrecondition, status.Convert(err).Code())
-
-			_, err = rpcServer.DetachDocument(
-				context.Background(),
-				&api.DetachDocumentRequest{
-					ClientId:   activateResp.ClientId,
-					ChangePack: packWithNoChanges,
-				},
-			)
-			assert.Nil(t, err)
-
-			// try to detach already detached document
-			_, err = rpcServer.DetachDocument(
-				context.Background(),
-				&api.DetachDocumentRequest{
-					ClientId:   activateResp.ClientId,
-					ChangePack: packWithNoChanges,
-				},
-			)
-			assert.Equal(t, codes.FailedPrecondition, status.Convert(err).Code())
-
-			// document not found
-			_, err = rpcServer.DetachDocument(
-				context.Background(),
-				&api.DetachDocumentRequest{
-					ClientId: activateResp.ClientId,
-					ChangePack: &api.ChangePack{
-						DocumentKey: &api.DocumentKey{
-							Collection: "invalid", Document: "invalid",
-						},
-						Checkpoint: &api.Checkpoint{ServerSeq: 0, ClientSeq: 0},
-					},
-				},
-			)
-			assert.Equal(t, codes.NotFound, status.Convert(err).Code())
-
-			_, err = rpcServer.DeactivateClient(
-				context.Background(),
-				&api.DeactivateClientRequest{ClientId: activateResp.ClientId},
-			)
-			assert.Nil(t, err)
-
-			// try to attach the document with a deactivated client
-			_, err = rpcServer.AttachDocument(
-				context.Background(),
-				&api.AttachDocumentRequest{
-					ClientId:   activateResp.ClientId,
-					ChangePack: packWithNoChanges,
-				},
-			)
-			assert.Equal(t, codes.FailedPrecondition, status.Convert(err).Code())
-		})
-
-		t.Run("push/pull changes test", func(t *testing.T) {
-			packWithNoChanges := &api.ChangePack{
-				DocumentKey: &api.DocumentKey{
-					Collection: t.Name(), Document: t.Name(),
-				},
-				Checkpoint: &api.Checkpoint{ServerSeq: 0, ClientSeq: 0},
-			}
-
-			activateResp, err := rpcServer.ActivateClient(
-				context.Background(),
-				&api.ActivateClientRequest{ClientKey: t.Name()},
-			)
-			assert.Nil(t, err)
-
-			_, err = rpcServer.AttachDocument(
-				context.Background(),
-				&api.AttachDocumentRequest{
-					ClientId:   activateResp.ClientId,
-					ChangePack: packWithNoChanges,
-				},
-			)
-			assert.Nil(t, err)
-
-			_, err = rpcServer.PushPull(
-				context.Background(),
-				&api.PushPullRequest{
-					ClientId:   activateResp.ClientId,
-					ChangePack: packWithNoChanges,
-				},
-			)
-			assert.Nil(t, err)
-
-			_, err = rpcServer.DetachDocument(
-				context.Background(),
-				&api.DetachDocumentRequest{
-					ClientId:   activateResp.ClientId,
-					ChangePack: packWithNoChanges,
-				},
-			)
-			assert.Nil(t, err)
-
-			// try to push/pull with detached document
-			_, err = rpcServer.PushPull(
-				context.Background(),
-				&api.PushPullRequest{
-					ClientId:   activateResp.ClientId,
-					ChangePack: packWithNoChanges,
-				},
-			)
-			assert.Equal(t, codes.FailedPrecondition, status.Convert(err).Code())
-
-			_, err = rpcServer.DeactivateClient(
-				context.Background(),
-				&api.DeactivateClientRequest{ClientId: activateResp.ClientId},
-			)
-			assert.Nil(t, err)
-
-			// try to push/pull with deactivated client
-			_, err = rpcServer.PushPull(
-				context.Background(),
-				&api.PushPullRequest{
-					ClientId:   activateResp.ClientId,
-					ChangePack: packWithNoChanges,
-				},
-			)
-			assert.Equal(t, codes.FailedPrecondition, status.Convert(err).Code())
-		})
-	})
-}
-
-func withRPCServer(
-	t *testing.T,
-	f func(t *testing.T, rpcServer *rpc.Server),
-) {
+func TestMain(m *testing.M) {
 	be, err := backend.New(&backend.Config{
 		SnapshotThreshold: testhelper.SnapshotThreshold,
 	}, &mongo.Config{
@@ -218,23 +34,211 @@ func withRPCServer(
 		PingTimeoutSec:       testhelper.MongoPingTimeoutSec,
 	})
 	if err != nil {
-		t.Fatal(err)
+		log.Fatal(err)
 	}
-	defer func() {
-		err := be.Close()
-		assert.Nil(t, err)
-	}()
 
-	rpcServer, err := rpc.NewServer(&rpc.Config{
-		Port: testhelper.RPCPort,
-	}, be)
+	conf := &rpc.Config{
+		Port: testRPCPort,
+	}
+	testRPCServer, err = rpc.NewServer(conf, be)
 	if err != nil {
-		t.Fatal(err)
+		log.Fatal(err)
+	}
+	if err := testRPCServer.Start(); err != nil {
+		log.Fatalf("failed rpc listen: %s\n", err)
 	}
 
-	defer func() {
-		rpcServer.Shutdown(true)
-	}()
+	code := m.Run()
 
-	f(t, rpcServer)
+	be.Close()
+	testRPCServer.Shutdown(true)
+	os.Exit(code)
+}
+
+func TestRPCServerBackend(t *testing.T) {
+	t.Run("activate/deactivate client test", func(t *testing.T) {
+		activateResp, err := testRPCServer.ActivateClient(
+			context.Background(),
+			&api.ActivateClientRequest{ClientKey: t.Name()},
+		)
+		assert.Nil(t, err)
+
+		_, err = testRPCServer.DeactivateClient(
+			context.Background(),
+			&api.DeactivateClientRequest{ClientId: activateResp.ClientId},
+		)
+		assert.Nil(t, err)
+
+		// invalid argument
+		_, err = testRPCServer.ActivateClient(
+			context.Background(),
+			&api.ActivateClientRequest{ClientKey: ""},
+		)
+		assert.Equal(t, codes.InvalidArgument, status.Convert(err).Code())
+
+		_, err = testRPCServer.DeactivateClient(
+			context.Background(),
+			&api.DeactivateClientRequest{ClientId: ""},
+		)
+		assert.Equal(t, codes.InvalidArgument, status.Convert(err).Code())
+
+		// client not found
+		_, err = testRPCServer.DeactivateClient(
+			context.Background(),
+			&api.DeactivateClientRequest{ClientId: nilCliendID},
+		)
+		assert.Equal(t, codes.NotFound, status.Convert(err).Code())
+	})
+
+	t.Run("attach/detach document test", func(t *testing.T) {
+		activateResp, err := testRPCServer.ActivateClient(
+			context.Background(),
+			&api.ActivateClientRequest{ClientKey: t.Name()},
+		)
+		assert.Nil(t, err)
+
+		packWithNoChanges := &api.ChangePack{
+			DocumentKey: &api.DocumentKey{
+				Collection: t.Name(), Document: t.Name(),
+			},
+			Checkpoint: &api.Checkpoint{ServerSeq: 0, ClientSeq: 0},
+		}
+
+		_, err = testRPCServer.AttachDocument(
+			context.Background(),
+			&api.AttachDocumentRequest{
+				ClientId:   activateResp.ClientId,
+				ChangePack: packWithNoChanges,
+			},
+		)
+		assert.Nil(t, err)
+
+		// try to attach already attached document
+		_, err = testRPCServer.AttachDocument(
+			context.Background(),
+			&api.AttachDocumentRequest{
+				ClientId:   activateResp.ClientId,
+				ChangePack: packWithNoChanges,
+			},
+		)
+		assert.Equal(t, codes.FailedPrecondition, status.Convert(err).Code())
+
+		_, err = testRPCServer.DetachDocument(
+			context.Background(),
+			&api.DetachDocumentRequest{
+				ClientId:   activateResp.ClientId,
+				ChangePack: packWithNoChanges,
+			},
+		)
+		assert.Nil(t, err)
+
+		// try to detach already detached document
+		_, err = testRPCServer.DetachDocument(
+			context.Background(),
+			&api.DetachDocumentRequest{
+				ClientId:   activateResp.ClientId,
+				ChangePack: packWithNoChanges,
+			},
+		)
+		assert.Equal(t, codes.FailedPrecondition, status.Convert(err).Code())
+
+		// document not found
+		_, err = testRPCServer.DetachDocument(
+			context.Background(),
+			&api.DetachDocumentRequest{
+				ClientId: activateResp.ClientId,
+				ChangePack: &api.ChangePack{
+					DocumentKey: &api.DocumentKey{
+						Collection: "invalid", Document: "invalid",
+					},
+					Checkpoint: &api.Checkpoint{ServerSeq: 0, ClientSeq: 0},
+				},
+			},
+		)
+		assert.Equal(t, codes.NotFound, status.Convert(err).Code())
+
+		_, err = testRPCServer.DeactivateClient(
+			context.Background(),
+			&api.DeactivateClientRequest{ClientId: activateResp.ClientId},
+		)
+		assert.Nil(t, err)
+
+		// try to attach the document with a deactivated client
+		_, err = testRPCServer.AttachDocument(
+			context.Background(),
+			&api.AttachDocumentRequest{
+				ClientId:   activateResp.ClientId,
+				ChangePack: packWithNoChanges,
+			},
+		)
+		assert.Equal(t, codes.FailedPrecondition, status.Convert(err).Code())
+	})
+
+	t.Run("push/pull changes test", func(t *testing.T) {
+		packWithNoChanges := &api.ChangePack{
+			DocumentKey: &api.DocumentKey{
+				Collection: t.Name(), Document: t.Name(),
+			},
+			Checkpoint: &api.Checkpoint{ServerSeq: 0, ClientSeq: 0},
+		}
+
+		activateResp, err := testRPCServer.ActivateClient(
+			context.Background(),
+			&api.ActivateClientRequest{ClientKey: t.Name()},
+		)
+		assert.Nil(t, err)
+
+		_, err = testRPCServer.AttachDocument(
+			context.Background(),
+			&api.AttachDocumentRequest{
+				ClientId:   activateResp.ClientId,
+				ChangePack: packWithNoChanges,
+			},
+		)
+		assert.Nil(t, err)
+
+		_, err = testRPCServer.PushPull(
+			context.Background(),
+			&api.PushPullRequest{
+				ClientId:   activateResp.ClientId,
+				ChangePack: packWithNoChanges,
+			},
+		)
+		assert.Nil(t, err)
+
+		_, err = testRPCServer.DetachDocument(
+			context.Background(),
+			&api.DetachDocumentRequest{
+				ClientId:   activateResp.ClientId,
+				ChangePack: packWithNoChanges,
+			},
+		)
+		assert.Nil(t, err)
+
+		// try to push/pull with detached document
+		_, err = testRPCServer.PushPull(
+			context.Background(),
+			&api.PushPullRequest{
+				ClientId:   activateResp.ClientId,
+				ChangePack: packWithNoChanges,
+			},
+		)
+		assert.Equal(t, codes.FailedPrecondition, status.Convert(err).Code())
+
+		_, err = testRPCServer.DeactivateClient(
+			context.Background(),
+			&api.DeactivateClientRequest{ClientId: activateResp.ClientId},
+		)
+		assert.Nil(t, err)
+
+		// try to push/pull with deactivated client
+		_, err = testRPCServer.PushPull(
+			context.Background(),
+			&api.PushPullRequest{
+				ClientId:   activateResp.ClientId,
+				ChangePack: packWithNoChanges,
+			},
+		)
+		assert.Equal(t, codes.FailedPrecondition, status.Convert(err).Code())
+	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature

**What this PR does / why we need it**:
Cleaned up unclear parts of RPC test and let RPC server running

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
