### PR TITLE
Remove the synced seq when detaching the document

### DIFF
--- a/testhelper/testhelper.go
+++ b/testhelper/testhelper.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"log"
 	"runtime"
-	"time"
+	defaultTime "time"
 
 	"github.com/yorkie-team/yorkie/pkg/document/change"
 	"github.com/yorkie-team/yorkie/pkg/document/json"
-	logicalTime "github.com/yorkie-team/yorkie/pkg/document/time"
+	"github.com/yorkie-team/yorkie/pkg/document/time"
 	"github.com/yorkie-team/yorkie/yorkie"
 	"github.com/yorkie-team/yorkie/yorkie/backend"
 	"github.com/yorkie-team/yorkie/yorkie/backend/mongo"
@@ -46,7 +46,7 @@ const (
 )
 
 func init() {
-	now := time.Now()
+	now := defaultTime.Now()
 	testStartedAt = now.Unix()
 }
 
@@ -61,7 +61,7 @@ func TextChangeContext() *change.Context {
 	return change.NewContext(
 		change.InitialID,
 		"",
-		json.NewRoot(json.NewObject(json.NewRHTPriorityQueueMap(), logicalTime.InitialTicket)),
+		json.NewRoot(json.NewObject(json.NewRHTPriorityQueueMap(), time.InitialTicket)),
 	)
 }
 

--- a/yorkie/packs/pack_service.go
+++ b/yorkie/packs/pack_service.go
@@ -82,7 +82,7 @@ func PushPull(
 	//      the requested seq(reqPack) is stored instead of the response seq(resPack).
 	respPack.MinSyncedTicket, err = be.Mongo.UpdateAndFindMinSyncedTicket(
 		ctx,
-		clientInfo.ID,
+		clientInfo,
 		docInfo.ID,
 		reqPack.Checkpoint.ServerSeq,
 	)

--- a/yorkie/types/client_info.go
+++ b/yorkie/types/client_info.go
@@ -94,6 +94,16 @@ func (i *ClientInfo) DetachDocument(docID primitive.ObjectID) error {
 	return nil
 }
 
+func (i *ClientInfo) IsAttached(docID primitive.ObjectID) (bool, error) {
+	hexDocID := docID.Hex()
+
+	if !i.hasDocument(hexDocID) {
+		return false, ErrDocumentNeverAttached
+	}
+
+	return i.Documents[hexDocID].Status == DocumentAttached, nil
+}
+
 func (i *ClientInfo) GetCheckpoint(id primitive.ObjectID) *checkpoint.Checkpoint {
 	clientDocInfo := i.Documents[id.Hex()]
 	if clientDocInfo == nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

**What this PR does / why we need it**:

To collect garbage like CRDT tombstones left on the document, all the changes should be applied to other replicas before GC. For this, if the document is no longer used by this client, it should be detached.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
