### PR TITLE
Fix DeepCopy of Primitive

### DIFF
--- a/pkg/document/json/primitive.go
+++ b/pkg/document/json/primitive.go
@@ -183,7 +183,8 @@ func (p *Primitive) Marshal() string {
 
 // DeepCopy copies itself deeply.
 func (p *Primitive) DeepCopy() Element {
-	return p
+	primitive := *p
+	return &primitive
 }
 
 // CreatedAt returns the creation time.


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature

/kind bug

**What this PR does / why we need it**:
Fix a bug where the DeepCopy method of the Primitive structure did not actually make a deep copy.

Properties change when deleting an instance of Primitive.
It seems that it cannot be considered as immutable.

**Which issue(s) this PR fixes**:
Fixes #66

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note

```

**Additional documentation**:
```docs

```
