### PR TITLE
Fix panic send on closed channel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-YORKIE_VERSION := 0.0.11
+YORKIE_VERSION := 0.0.12
 
 GIT_COMMIT := $(shell git rev-parse --short HEAD)
 

--- a/yorkie/pubsub/pubsub.go
+++ b/yorkie/pubsub/pubsub.go
@@ -38,6 +38,7 @@ type DocEvent struct {
 type Subscription struct {
 	id         string
 	subscriber *time.ActorID
+	closed     bool
 	events     chan DocEvent
 }
 
@@ -67,6 +68,16 @@ func (s *Subscription) SubscriberID() string {
 	return s.subscriber.String()
 }
 
+// Close closes all resources of this Subscription.
+func (s *Subscription) Close() {
+	if s.closed {
+		return
+	}
+
+	s.closed = true
+	close(s.events)
+}
+
 // Subscriptions is a collection of subscriptions that subscribe to a specific
 // topic.
 type Subscriptions struct {
@@ -92,7 +103,7 @@ func (s *Subscriptions) Map() map[string]*Subscription {
 // Delete deletes the subscription of the given id.
 func (s *Subscriptions) Delete(id string) {
 	if subscription, ok := s.internalMap[id]; ok {
-		close(subscription.events)
+		subscription.Close()
 	}
 	delete(s.internalMap, id)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature

**What this PR does / why we need it**:

When a client watches multiple documents, `panic: send on close channel`
 has occurred because it tries to close the channel multiple times.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
