### PR TITLE
Remove panic in types.EncodeOperation

### DIFF
--- a/yorkie/backend/mongo/client.go
+++ b/yorkie/backend/mongo/client.go
@@ -311,6 +311,11 @@ func (c *Client) CreateChangeInfos(
 		var modelChanges []mongo.WriteModel
 
 		for _, c := range changes {
+			encodedOperations, err := types.EncodeOperations(c.Operations())
+			if err != nil {
+				return err
+			}
+
 			modelChanges = append(modelChanges, mongo.NewUpdateOneModel().SetFilter(bson.M{
 				"doc_id":     docID,
 				"server_seq": c.ServerSeq(),
@@ -319,7 +324,7 @@ func (c *Client) CreateChangeInfos(
 				"client_seq": c.ID().ClientSeq(),
 				"lamport":    c.ID().Lamport(),
 				"message":    c.Message(),
-				"operations": types.EncodeOperation(c.Operations()),
+				"operations": encodedOperations,
 			}}).SetUpsert(true))
 		}
 

--- a/yorkie/types/change_info.go
+++ b/yorkie/types/change_info.go
@@ -17,6 +17,8 @@
 package types
 
 import (
+	"errors"
+
 	"go.mongodb.org/mongo-driver/bson/primitive"
 
 	"github.com/yorkie-team/yorkie/api"
@@ -37,18 +39,19 @@ type ChangeInfo struct {
 	Operations [][]byte           `bson:"operations"`
 }
 
-func EncodeOperation(operations []operation.Operation) [][]byte {
+func EncodeOperations(operations []operation.Operation) ([][]byte, error) {
 	var encodedOps [][]byte
 
 	for _, pbOp := range converter.ToOperations(operations) {
 		encodedOp, err := pbOp.Marshal()
 		if err != nil {
-			panic("fail to encode operation")
+			log.Logger.Error(err)
+			return nil, errors.New("fail to encode operation")
 		}
 		encodedOps = append(encodedOps, encodedOp)
 	}
 
-	return encodedOps
+	return encodedOps, nil
 }
 
 func EncodeActorID(id *time.ActorID) primitive.ObjectID {


### PR DESCRIPTION
Remove panic in types.EncodeOperation. And change return value of types.EncodeOperation to ([][]bytes, error).
Add errors.New() with message used in panic.

<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #50 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
