### PR TITLE
Do not execute metrics handler if config is not set

### DIFF
--- a/yorkie/metrics/server.go
+++ b/yorkie/metrics/server.go
@@ -25,6 +25,9 @@ type Server struct {
 
 // NewServer creates an instance of Server.
 func NewServer(conf *Config) (*Server, error) {
+	if conf == nil {
+		return nil, nil
+	}
 	return &Server{
 		conf: conf,
 		metricsServer: &http.Server{

--- a/yorkie/yorkie.go
+++ b/yorkie/yorkie.go
@@ -71,10 +71,12 @@ func (r *Yorkie) Start() error {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	err := r.metricsServer.Start()
-	if err != nil {
-		log.Logger.Error(err)
-		return err
+	if r.metricsServer != nil {
+		err := r.metricsServer.Start()
+		if err != nil {
+			log.Logger.Error(err)
+			return err
+		}
 	}
 	return r.rpcServer.Start()
 }
@@ -87,7 +89,9 @@ func (r *Yorkie) Shutdown(graceful bool) error {
 	}
 
 	r.rpcServer.Shutdown(graceful)
-	r.metricsServer.Shutdown(graceful)
+	if r.metricsServer != nil {
+		r.metricsServer.Shutdown(graceful)
+	}
 
 	if err := r.backend.Close(); err != nil {
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature

**What this PR does / why we need it**:
Avoid errors if the user does not specify a metric field

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #97

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
