### PR TITLE
Delete removed elements from the clone while running GC

### DIFF
--- a/pkg/document/change/context.go
+++ b/pkg/document/change/context.go
@@ -72,3 +72,8 @@ func (c *Context) Push(op operation.Operation) {
 func (c *Context) RegisterElement(elem json.Element) {
 	c.root.RegisterElement(elem)
 }
+
+// RegisterRemovedElementPair registers the given element pair to hash table.
+func (c *Context) RegisterRemovedElementPair(parent json.Container, deleted json.Element) {
+	c.root.RegisterRemovedElementPair(parent, deleted)
+}

--- a/pkg/document/json/rht_pq_map.go
+++ b/pkg/document/json/rht_pq_map.go
@@ -76,7 +76,7 @@ func NewRHTPriorityQueueMap() *RHTPriorityQueueMap {
 // Get returns the value of the given key.
 func (rht *RHTPriorityQueueMap) Get(key string) Element {
 	queue, ok := rht.nodeQueueMapByKey[key]
-	if !ok {
+	if !ok || queue.Len() == 0 {
 		return nil
 	}
 

--- a/pkg/document/json/root.go
+++ b/pkg/document/json/root.go
@@ -77,7 +77,7 @@ func (r *Root) DeregisterElement(elem Element) {
 	delete(r.removedElementPairMapByCreatedAt, createdAt)
 }
 
-// DeregisterElementPair register the given element pair to hash table.
+// RegisterRemovedElementPair register the given element pair to hash table.
 func (r *Root) RegisterRemovedElementPair(parent Container, elem Element) {
 	r.removedElementPairMapByCreatedAt[elem.CreatedAt().Key()] = ElementPair{
 		parent,

--- a/pkg/document/proxy/array_proxy.go
+++ b/pkg/document/proxy/array_proxy.go
@@ -142,7 +142,7 @@ func (p *ArrayProxy) Delete(idx int) json.Element {
 		deleted.CreatedAt(),
 		ticket,
 	))
-
+	p.context.RegisterRemovedElementPair(p, deleted)
 	return deleted
 }
 

--- a/pkg/document/proxy/object_proxy.go
+++ b/pkg/document/proxy/object_proxy.go
@@ -154,6 +154,7 @@ func (p *ObjectProxy) Delete(k string) json.Element {
 		deleted.CreatedAt(),
 		ticket,
 	))
+	p.context.RegisterRemovedElementPair(p, deleted)
 	return deleted
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature

**What this PR does / why we need it**:

Delete removed elements from the clone while running GC

When [initially designing the GC](https://github.com/yorkie-team/yorkie/issues/3), it was implemented so that only removed
 elements from the original were deleted. However, to solve the problem
 of accumulating removed elements in the clone, they are also deleted.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #100 and Related to https://github.com/yorkie-team/yorkie-js-sdk/pull/101

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
