### PR TITLE
Move `golint` and `govet` from `make lint` to `golangci-lint`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
       - checkout
 
       # specify any bash command here prefixed with `run: `
+      - run: make lint
       - run: go get -v -t -d ./...
       - run: go test -race -coverprofile=coverage.txt -covermode=atomic -v ./...
       - codecov/upload:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,15 @@
+linters:
+  enable:
+    - bodyclose
+    - goconst
+    - gocyclo
+    - gofmt
+    - goimports
+# TODO: When adding a rule to force comments on exported methods, be sure to uncomment below.
+#    - golint
+    - goprintffuncname
+    - gosec
+    - interfacer
+    - lll
+    - misspell
+    - nakedret

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ GO_TOOLS = \
   github.com/gogo/protobuf/protoc-gen-gogo \
   github.com/gogo/protobuf/protoc-gen-gofast \
   golang.org/x/tools/cmd/goimports \
-  github.com/golangci/golangci-lint \
+  github.com/golangci/golangci-lint/cmd/golangci-lint@v1.32.2 \
   golang.org/x/lint/golint
 
 GO_LDFLAGS ?=
@@ -49,8 +49,6 @@ fmt:
 	goimports -w -local "github.com/yorkie-team" $(GO_SRC)
 
 lint: tools
-	 golint ./...
-	 go vet ./...
 	 golangci-lint run ./...
 
 test:

--- a/api/converter/to_pb.go
+++ b/api/converter/to_pb.go
@@ -87,9 +87,7 @@ func ToClientsMap(clientsMap map[string][]string) map[string]*api.Clients {
 
 	for k, clients := range clientsMap {
 		var clientIds []string
-		for _, client := range clients {
-			clientIds = append(clientIds, client)
-		}
+		clientIds = append(clientIds, clients...)
 
 		pbClientsMap[k] = &api.Clients{
 			ClientIds: clientIds,

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -37,7 +37,7 @@ import (
 // edit the document.
 type Document struct {
 	// doc is the original data of the actual document.
-	doc   *InternalDocument
+	doc *InternalDocument
 
 	// clone is a copy of `doc` to be exposed to the user and is used to
 	// protect `doc`.

--- a/pkg/document/document_test.go
+++ b/pkg/document/document_test.go
@@ -347,7 +347,8 @@ func TestDocument(t *testing.T) {
 			text.Edit(5, 11, " Yorkie", nil)
 			assert.Equal(
 				t,
-				`[0:0:00:0 {} ""][1:2:00:0 {"b":"1"} "Hel"][1:2:00:3 {"b":"1","i":"1"} "lo"][4:1:00:0 {} " Yorkie"]{1:2:00:5 {} " world"}[1:1:00:0 {} "
+				`[0:0:00:0 {} ""][1:2:00:0 {"b":"1"} "Hel"][1:2:00:3 {"b":"1","i":"1"} "lo"]`+
+					`[4:1:00:0 {} " Yorkie"]{1:2:00:5 {} " world"}[1:1:00:0 {} "
 "]`,
 				text.AnnotatedString(),
 			)
@@ -469,6 +470,7 @@ func TestDocument(t *testing.T) {
 
 			return nil
 		})
+		assert.NoError(t, err)
 		assert.Equal(t, `{"age":120,"price":9000000000000000003,"width":130.000000}`, doc.Marshal())
 	})
 

--- a/pkg/document/json/rga_tree_split.go
+++ b/pkg/document/json/rga_tree_split.go
@@ -50,7 +50,7 @@ func (t *RGATreeSplitNodeID) Compare(other llrb.Key) int {
 	return 0
 }
 
-func (t *RGATreeSplitNodeID) Equal(other *RGATreeSplitNodeID) bool {
+func (t *RGATreeSplitNodeID) Equal(other llrb.Key) bool {
 	return t.Compare(other) == 0
 }
 

--- a/pkg/document/json/rich_text_test.go
+++ b/pkg/document/json/rich_text_test.go
@@ -41,6 +41,10 @@ func TestRichText(t *testing.T) {
 
 		fromPos, toPos = text.CreateRange(0, 1)
 		text.SetStyle(fromPos, toPos, map[string]string{"b": "1"}, ctx.IssueTimeTicket())
-		assert.Equal(t, `[{"attrs":{"b":"1"},"val":"H"},{"attrs":{},"val":"ello "},{"attrs":{},"val":"Yorkie"}]`, text.Marshal())
+		assert.Equal(
+			t,
+			`[{"attrs":{"b":"1"},"val":"H"},{"attrs":{},"val":"ello "},{"attrs":{},"val":"Yorkie"}]`,
+			text.Marshal(),
+		)
 	})
 }

--- a/pkg/document/key/key.go
+++ b/pkg/document/key/key.go
@@ -23,6 +23,7 @@ import (
 
 const (
 	BSONSplitter = "$"
+	TokenLen     = 2
 )
 
 type Key struct {
@@ -32,7 +33,7 @@ type Key struct {
 
 func FromBSONKey(bsonKey string) (*Key, error) {
 	splits := strings.Split(bsonKey, BSONSplitter)
-	if len(splits) != 2 {
+	if len(splits) != TokenLen {
 		return nil, errors.New("fail to create key from bson key")
 	}
 

--- a/pkg/types/event.go
+++ b/pkg/types/event.go
@@ -4,6 +4,6 @@ type EventType string
 
 const (
 	DocumentsChangeEvent    EventType = "documents-change"
-	DocumentsWatchedEvent             = "documents-watched"
-	DocumentsUnwatchedEvent           = "documents-unwatched"
+	DocumentsWatchedEvent   EventType = "documents-watched"
+	DocumentsUnwatchedEvent EventType = "documents-unwatched"
 )

--- a/yorkie/config.go
+++ b/yorkie/config.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/yorkie-team/yorkie/pkg/log"
 	"github.com/yorkie-team/yorkie/yorkie/backend"
@@ -64,7 +65,7 @@ func NewConfig() *Config {
 // NewConfigFromFile returns a Config struct for the given conf file.
 func NewConfigFromFile(path string) (*Config, error) {
 	conf := &Config{}
-	file, err := os.Open(path)
+	file, err := os.Open(filepath.Clean(path))
 	if err != nil {
 		log.Logger.Error(err)
 		return nil, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature

**What this PR does / why we need it**:

Move linters to `golangci-lint` so that it is not executed repeatedly.
And add `make lint` to CI to check PR.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
