### PR TITLE
Fix check already attached document

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -124,6 +124,14 @@ func TestClientAndDocument(t *testing.T) {
 		err = c1.Detach(ctx, doc)
 		assert.NoError(t, err)
 		assert.False(t, doc.IsAttached())
+
+		err = c1.Attach(ctx, doc)
+		assert.NoError(t, err)
+		assert.True(t, doc.IsAttached())
+
+		err = c1.Detach(ctx, doc)
+		assert.NoError(t, err)
+		assert.False(t, doc.IsAttached())
 	})
 
 	t.Run("causal nested array test", func(t *testing.T) {

--- a/yorkie/types/client_info.go
+++ b/yorkie/types/client_info.go
@@ -68,7 +68,7 @@ func (i *ClientInfo) AttachDocument(docID primitive.ObjectID) error {
 
 	hexDocID := docID.Hex()
 
-	if i.hasDocument(hexDocID) {
+	if i.hasDocument(hexDocID) && i.Documents[hexDocID].Status == DocumentAttached {
 		return ErrDocumentAlreadyAttached
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature

/kind bug

**What this PR does / why we need it**:
In AttachDocument, `ErrDocumentAlreadyAttached` error is returned if
there is a document in the current client field. However, AttachDocument
also needs to check the document attachment status to determine whether to
return an error or not.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes yorkie-team/yorkie-js-sdk#111

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
