### PR TITLE
Fix to use internal document when pulling snapshot from agent

### DIFF
--- a/yorkie/packs/pack_service.go
+++ b/yorkie/packs/pack_service.go
@@ -270,7 +270,7 @@ func pullSnapshot(
 		return nil, nil, err
 	}
 
-	doc, err := document.FromSnapshot(
+	doc, err := document.NewInternalDocumentFromSnapshot(
 		docKey.Collection,
 		docKey.Document,
 		snapshotInfo.ServerSeq,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Document is an object that is exposed directly to users including Proxy.
On the other hand, InternalDocument is an internal object that is only
changed by ChangePack. This commit changes document to internal document
 to prevent unintended GC from running.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://app.circleci.com/pipelines/github/yorkie-team/yorkie/341/workflows/1bfd0415-b526-4ae3-a035-e4c76d339712/jobs/346

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xd118b4]

goroutine 996 [running]:
github.com/yorkie-team/yorkie/pkg/document/time.(*Ticket).Compare(0x0, 0xc00045f360, 0xc0002da758)
	/home/circleci/project/pkg/document/time/ticket.go:121 +0x34
github.com/yorkie-team/yorkie/pkg/document/json.(*RGATreeSplit).cleanupRemovedNodes(0xc00010ac20, 0x0, 0xd5e881)
	/home/circleci/project/pkg/document/json/rga_tree_split.go:571 +0x713
github.com/yorkie-team/yorkie/pkg/document/json.(*Text).cleanupRemovedNodes(0xc000499590, 0x0, 0xc0002da8d8)
	/home/circleci/project/pkg/document/json/text.go:220 +0x56
github.com/yorkie-team/yorkie/pkg/document/json.(*Root).GarbageCollect(0xc00010ac00, 0x0, 0x10)
	/home/circleci/project/pkg/document/json/root.go:113 +0x2fc
github.com/yorkie-team/yorkie/pkg/document.(*Document).GarbageCollect(0xc0002fa830, 0x0, 0xf)
	/home/circleci/project/pkg/document/document.go:199 +0xe2
github.com/yorkie-team/yorkie/pkg/document.(*Document).ApplyChangePack(0xc0002fa830, 0xc0002dade0, 0xc000526000, 0xaa118bf29edce15f)
	/home/circleci/project/pkg/document/document.go:139 +0x540
github.com/yorkie-team/yorkie/yorkie/packs.pullSnapshot(0x16c9180, 0xc000526000, 0xc0003b4190, 0xc0001b8230, 0xc000344180, 0xc0003ea0f0, 0xc000114da0, 0xf, 0xc000044868, 0xc0002fa700, ...)
	/home/circleci/project/yorkie/packs/pack_service.go:293 +0xa01
github.com/yorkie-team/yorkie/yorkie/packs.pullPack(0x16c9180, 0xc000526000, 0xc0003b4190, 0xc0001b8230, 0xc000344180, 0xc0003ea0f0, 0xc000114da0, 0xf, 0x0, 0x0, ...)
	/home/circleci/project/yorkie/packs/pack_service.go:191 +0x4bd
github.com/yorkie-team/yorkie/yorkie/packs.PushPull(0x16c9180, 0xc000526000, 0xc0003b4190, 0xc0001b8230, 0xc000344180, 0xc0003ea0f0, 0x1, 0xc0001b8230, 0xc000344180)
	/home/circleci/project/yorkie/packs/pack_service.go:61 +0x12d
github.com/yorkie-team/yorkie/yorkie/rpc.(*Server).AttachDocument(0xc00039c8e0, 0x16c9180, 0xc000526000, 0xc00052ac40, 0x0, 0x0, 0x0)
	/home/circleci/project/yorkie/rpc/server.go:206 +0x13ef
github.com/yorkie-team/yorkie/api._Yorkie_AttachDocument_Handler.func1(0x16c9180, 0xc000526000, 0x12845a0, 0xc00052ac40, 0x7f5ca82c5008, 0xc0003ef6c0, 0xc0003ef6c0, 0x0)
	/home/circleci/project/api/yorkie.pb.go:3769 +0xa2
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1(0x16c9180, 0xc000526000, 0x12845a0, 0xc00052ac40, 0x1a, 0xc0003ea0a0, 0x0, 0xc000562110)
	/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.0.0/chain.go:31 +0x2d4
github.com/grpc-ecosystem/go-grpc-prometheus.(*ServerMetrics).UnaryServerInterceptor.func1(0x16c9180, 0xc000526000, 0x12845a0, 0xc00052ac40, 0xc0005520a0, 0xc0003ea000, 0xc00052ac58, 0xc0004e6000, 0xc00052ac48, 0x0)
	/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0/server_metrics.go:107 +0x100
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1(0x16c9180, 0xc000526000, 0x12845a0, 0xc00052ac40, 0xc000020000, 0x7f5ca83067d0, 0xc00018f6d8, 0x434ffc)
	/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.0.0/chain.go:34 +0x1da
github.com/yorkie-team/yorkie/yorkie/rpc.unaryInterceptor(0x16c9180, 0xc000526000, 0x12845a0, 0xc00052ac40, 0xc0005520a0, 0xc0003ea000, 0x20, 0xc000410200, 0x18, 0x18)
	/home/circleci/project/yorkie/rpc/interceptors.go:35 +0xac
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1(0x16c9180, 0xc000526000, 0x12845a0, 0xc00052ac40, 0xc0005520a0, 0xc000552100, 0xc000406000, 0xc0005f81e8, 0xc00018f878, 0x435878)
	/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.0.0/chain.go:39 +0x340
github.com/yorkie-team/yorkie/api._Yorkie_AttachDocument_Handler(0x12543e0, 0xc00039c8e0, 0x16c9180, 0xc000526000, 0xc00046e000, 0xc0003aa3c0, 0x16c9180, 0xc000526000, 0xc0000e4540, 0x5b)
	/home/circleci/project/api/yorkie.pb.go:3771 +0x1d9
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0003de000, 0x16d5960, 0xc0004da780, 0xc000410200, 0xc0003aa510, 0x1dd0dd0, 0x0, 0x0, 0x0)
	/go/pkg/mod/google.golang.org/grpc@v1.24.0/server.go:995 +0x995
google.golang.org/grpc.(*Server).handleStream(0xc0003de000, 0x16d5960, 0xc0004da780, 0xc000410200, 0x0)
	/go/pkg/mod/google.golang.org/grpc@v1.24.0/server.go:1275 +0x1344
google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc00003e2c0, 0xc0003de000, 0x16d5960, 0xc0004da780, 0xc000410200)
	/go/pkg/mod/google.golang.org/grpc@v1.24.0/server.go:710 +0xc9
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/go/pkg/mod/google.golang.org/grpc@v1.24.0/server.go:708 +0xb9
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [x] Didn't break anything
