### PR TITLE
Connect adjacent insNext and insPrev when running purge

### DIFF
--- a/pkg/document/json/rga_tree_list.go
+++ b/pkg/document/json/rga_tree_list.go
@@ -313,6 +313,8 @@ func (a *RGATreeList) release(node *RGATreeListNode) {
 	if node.next != nil {
 		node.next.prev = node.prev
 	}
+	node.prev, node.next = nil, nil
+
 	a.nodeMapByIndex.Delete(node.indexNode)
 	delete(a.nodeMapByCreatedAt, node.elem.CreatedAt().Key())
 

--- a/pkg/document/json/rga_tree_split.go
+++ b/pkg/document/json/rga_tree_split.go
@@ -580,22 +580,19 @@ func (s *RGATreeSplit) cleanupRemovedNodes(ticket *time.Ticket) int {
 	return count
 }
 
-// purge removes the node passed as a parameter from RGATreeSplit.
+// purge physically purge the given node from RGATreeSplit.
 func (s *RGATreeSplit) purge(node *RGATreeSplitNode) {
-	if node.prev != nil {
-		node.prev.next = node.next
-		if node.next != nil {
-			node.next.prev = node.prev
-		}
-	} else {
-		s.initialHead, node.next.prev = node.next, nil
+	node.prev.next = node.next
+	if node.next != nil {
+		node.next.prev = node.prev
 	}
-	node.next, node.prev = nil, nil
+	node.prev, node.next = nil, nil
 
 	if node.insPrev != nil {
-		node.insPrev.insNext, node.insPrev = nil, nil
+		node.insPrev.insNext = node.insNext
 	}
 	if node.insNext != nil {
-		node.insNext.insPrev, node.insNext = nil, nil
+		node.insNext.insPrev = node.insPrev
 	}
+	node.insPrev, node.insNext = nil, nil
 }

--- a/pkg/document/json/root_test.go
+++ b/pkg/document/json/root_test.go
@@ -26,33 +26,53 @@ import (
 	"github.com/yorkie-team/yorkie/testhelper"
 )
 
-func registerTextElement(fromPos, toPos *json.RGATreeSplitNodePos, root *json.Root, text json.TextElement) {
+func registerRemovedNodeTextElement(fromPos, toPos *json.RGATreeSplitNodePos, root *json.Root, text json.TextElement) {
 	if fromPos.Compare(toPos) != 0 {
 		root.RegisterRemovedNodeTextElement(text)
 	}
 }
 
 func TestRoot(t *testing.T) {
-	t.Run("garbage collect for text test", func(t *testing.T) {
+	t.Run("garbage collection for array test", func(t *testing.T) {
+		root := testhelper.TestRoot()
+		ctx := testhelper.TextChangeContext(root)
+		array := json.NewArray(json.NewRGATreeList(), ctx.IssueTimeTicket())
+
+		array.Add(json.NewPrimitive(0, ctx.IssueTimeTicket()))
+		array.Add(json.NewPrimitive(1, ctx.IssueTimeTicket()))
+		array.Add(json.NewPrimitive(2, ctx.IssueTimeTicket()))
+		assert.Equal(t, "[0,1,2]", array.Marshal())
+
+		targetElement := array.Get(1)
+		array.DeleteByCreatedAt(targetElement.CreatedAt(), ctx.IssueTimeTicket())
+		root.RegisterRemovedElementPair(array, targetElement)
+		assert.Equal(t, "[0,2]", array.Marshal())
+		assert.Equal(t, 1, root.GarbageLen())
+
+		assert.Equal(t, 1, root.GarbageCollect(time.MaxTicket))
+		assert.Equal(t, 0, root.GarbageLen())
+	})
+
+	t.Run("garbage collection for text test", func(t *testing.T) {
 		root := testhelper.TestRoot()
 		ctx := testhelper.TextChangeContext(root)
 		text := json.NewText(json.NewRGATreeSplit(json.InitialTextNode()), ctx.IssueTimeTicket())
 
 		fromPos, toPos := text.CreateRange(0, 0)
 		text.Edit(fromPos, toPos, nil, "Hello World", ctx.IssueTimeTicket())
-		registerTextElement(fromPos, toPos, root, text)
+		registerRemovedNodeTextElement(fromPos, toPos, root, text)
 		assert.Equal(t, `"Hello World"`, text.Marshal())
 		assert.Equal(t, 0, root.GarbageLen())
 
 		fromPos, toPos = text.CreateRange(6, 11)
 		text.Edit(fromPos, toPos, nil, "Yorkie", ctx.IssueTimeTicket())
-		registerTextElement(fromPos, toPos, root, text)
+		registerRemovedNodeTextElement(fromPos, toPos, root, text)
 		assert.Equal(t, `"Hello Yorkie"`, text.Marshal())
 		assert.Equal(t, 1, root.GarbageLen())
 
 		fromPos, toPos = text.CreateRange(0, 6)
 		text.Edit(fromPos, toPos, nil, "", ctx.IssueTimeTicket())
-		registerTextElement(fromPos, toPos, root, text)
+		registerRemovedNodeTextElement(fromPos, toPos, root, text)
 		assert.Equal(t, `"Yorkie"`, text.Marshal())
 		assert.Equal(t, 2, root.GarbageLen())
 
@@ -67,26 +87,26 @@ func TestRoot(t *testing.T) {
 		assert.Equal(t, 1, nodeLen)
 	})
 
-	t.Run("garbage collect for rich text test", func(t *testing.T) {
+	t.Run("garbage collection for rich text test", func(t *testing.T) {
 		root := testhelper.TestRoot()
 		ctx := testhelper.TextChangeContext(root)
 		richText := json.NewRichText(json.NewRGATreeSplit(json.InitialTextNode()), ctx.IssueTimeTicket())
 
 		fromPos, toPos := richText.CreateRange(0, 0)
 		richText.Edit(fromPos, toPos, nil, "Hello World", nil, ctx.IssueTimeTicket())
-		registerTextElement(fromPos, toPos, root, richText)
+		registerRemovedNodeTextElement(fromPos, toPos, root, richText)
 		assert.Equal(t, `[{"attrs":{},"val":"Hello World"}]`, richText.Marshal())
 		assert.Equal(t, 0, root.GarbageLen())
 
 		fromPos, toPos = richText.CreateRange(6, 11)
 		richText.Edit(fromPos, toPos, nil, "Yorkie", nil, ctx.IssueTimeTicket())
-		registerTextElement(fromPos, toPos, root, richText)
+		registerRemovedNodeTextElement(fromPos, toPos, root, richText)
 		assert.Equal(t, `[{"attrs":{},"val":"Hello "},{"attrs":{},"val":"Yorkie"}]`, richText.Marshal())
 		assert.Equal(t, 1, root.GarbageLen())
 
 		fromPos, toPos = richText.CreateRange(0, 6)
 		richText.Edit(fromPos, toPos, nil, "", nil, ctx.IssueTimeTicket())
-		registerTextElement(fromPos, toPos, root, richText)
+		registerRemovedNodeTextElement(fromPos, toPos, root, richText)
 		assert.Equal(t, `[{"attrs":{},"val":"Yorkie"}]`, richText.Marshal())
 		assert.Equal(t, 2, root.GarbageLen())
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Connect adjacent insNext and insPrev when running purge.

In #104, GC was also introduced for text nodes marked with tombstones. However, in `release()`, the link between adjacent insPrev and insNext is missing, so this commit fixes it.

![block-wise-rga](https://user-images.githubusercontent.com/2059311/103050566-f96eb780-45d7-11eb-9abc-64757cc374ad.jpg)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
