### PR TITLE
Wrap additional information to sentinel errors

### DIFF
--- a/yorkie/rpc/server_test.go
+++ b/yorkie/rpc/server_test.go
@@ -116,6 +116,26 @@ func TestRPCServerBackend(t *testing.T) {
 		)
 		assert.NoError(t, err)
 
+		// try to attach with invalid client ID
+		_, err = testRPCServer.AttachDocument(
+			context.Background(),
+			&api.AttachDocumentRequest{
+				ClientId:   "invalid",
+				ChangePack: packWithNoChanges,
+			},
+		)
+		assert.Equal(t, codes.InvalidArgument, status.Convert(err).Code())
+
+		// try to attach with invalid client
+		_, err = testRPCServer.AttachDocument(
+			context.Background(),
+			&api.AttachDocumentRequest{
+				ClientId:   nilClientID,
+				ChangePack: packWithNoChanges,
+			},
+		)
+		assert.Equal(t, codes.NotFound, status.Convert(err).Code())
+
 		// try to attach already attached document
 		_, err = testRPCServer.AttachDocument(
 			context.Background(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Previously, if there was no client or document, only sentinel errors were returned. This commit wraps sentinel errors and returns additional information, such as the document's key.

I implemented this code by referring to the below.
https://blog.golang.org/go1.13-errors

And the code that returns `status.error` from `error` was duplicated, so I extracted it as a function, `toStatusError`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
