### PR TITLE
Use status for one-dimensional value

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -200,7 +200,7 @@ func (c *Client) Attach(ctx context.Context, doc *document.Document) error {
 		return err
 	}
 
-	doc.UpdateState(document.Attached)
+	doc.SetStatus(document.Attached)
 	c.attachedDocs[doc.Key().BSONKey()] = doc
 
 	return nil
@@ -240,7 +240,7 @@ func (c *Client) Detach(ctx context.Context, doc *document.Document) error {
 		return err
 	}
 
-	doc.UpdateState(document.Detached)
+	doc.SetStatus(document.Detached)
 	delete(c.attachedDocs, doc.Key().BSONKey())
 
 	return nil

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -51,23 +51,6 @@ func New(collection, document string) *Document {
 	}
 }
 
-// FromSnapshot creates a new instance of Document with the snapshot.
-func FromSnapshot(
-	collection string,
-	document string,
-	serverSeq uint64,
-	snapshot []byte,
-) (*Document, error) {
-	doc, err := NewInternalDocumentFromSnapshot(collection, document, serverSeq, snapshot)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Document{
-		doc: doc,
-	}, nil
-}
-
 // Update executes the given updater to update this document.
 func (d *Document) Update(
 	updater func(root *proxy.ObjectProxy) error,
@@ -178,9 +161,9 @@ func (d *Document) Actor() *time.ActorID {
 	return d.doc.Actor()
 }
 
-// UpdateState updates the state of this document.
-func (d *Document) UpdateState(state stateType) {
-	d.doc.UpdateState(state)
+// SetStatus updates the status of this document.
+func (d *Document) SetStatus(status statusType) {
+	d.doc.SetStatus(status)
 }
 
 // IsAttached returns the whether this document is attached or not.

--- a/pkg/document/document_test.go
+++ b/pkg/document/document_test.go
@@ -37,6 +37,14 @@ func TestDocument(t *testing.T) {
 		doc := document.New("c1", "d1")
 		assert.Equal(t, doc.Checkpoint(), checkpoint.Initial)
 		assert.False(t, doc.HasLocalChanges())
+		assert.False(t, doc.IsAttached())
+	})
+
+	t.Run("status test", func(t *testing.T) {
+		doc := document.New("c1", "d1")
+		assert.False(t, doc.IsAttached())
+		doc.SetStatus(document.Attached)
+		assert.True(t, doc.IsAttached())
 	})
 
 	t.Run("equals test", func(t *testing.T) {

--- a/pkg/document/internal_document.go
+++ b/pkg/document/internal_document.go
@@ -26,12 +26,12 @@ import (
 	"github.com/yorkie-team/yorkie/pkg/log"
 )
 
-type stateType int
+type statusType int
 
 const (
 	// Detached means that the document is not attached to the client.
 	// The actor of the ticket is created without being assigned.
-	Detached stateType = iota
+	Detached statusType = iota
 
 	// Attached means that this document is attached to the client.
 	// The actor of the ticket is created with being assigned by the client.
@@ -41,7 +41,7 @@ const (
 // InternalDocument represents a document in MongoDB and contains logical clocks.
 type InternalDocument struct {
 	key          *key.Key
-	state        stateType
+	status       statusType
 	root         *json.Root
 	checkpoint   *checkpoint.Checkpoint
 	changeID     *change.ID
@@ -54,7 +54,7 @@ func NewInternalDocument(collection, document string) *InternalDocument {
 
 	return &InternalDocument{
 		key:        &key.Key{Collection: collection, Document: document},
-		state:      Detached,
+		status:     Detached,
 		root:       json.NewRoot(root),
 		checkpoint: checkpoint.Initial,
 		changeID:   change.InitialID,
@@ -75,7 +75,7 @@ func NewInternalDocumentFromSnapshot(
 
 	return &InternalDocument{
 		key:        &key.Key{Collection: collection, Document: document},
-		state:      Detached,
+		status:     Detached,
 		root:       json.NewRoot(obj),
 		checkpoint: checkpoint.Initial.NextServerSeq(serverSeq),
 		changeID:   change.InitialID,
@@ -163,14 +163,14 @@ func (d *InternalDocument) Actor() *time.ActorID {
 	return d.changeID.Actor()
 }
 
-// UpdateState updates the state of this document.
-func (d *InternalDocument) UpdateState(state stateType) {
-	d.state = state
+// SetStatus sets the status of this document.
+func (d *InternalDocument) SetStatus(status statusType) {
+	d.status = status
 }
 
 // IsAttached returns the whether this document is attached or not.
 func (d *InternalDocument) IsAttached() bool {
-	return d.state == Attached
+	return d.status == Attached
 }
 
 // RootObject returns the root object.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Use status for one-dimensional value.
When I first implemented Yorkie, I named variables without distinction between `status` and `state`. To improve consistency, we use `status` to represent `one-dimensional` values.

I referenced the following discussion.

- https://stackoverflow.com/questions/1162816/naming-conventions-state-versus-status

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
