### PR TITLE
Remove panics from the converter

### DIFF
--- a/api/converter/converter.go
+++ b/api/converter/converter.go
@@ -1,0 +1,32 @@
+package converter
+
+import "errors"
+
+var (
+	// ErrPackRequired is returned when an empty pack is passed.
+	ErrPackRequired = errors.New("pack required")
+
+	// ErrCheckpointRequired is returned when a pack with an empty checkpoint is
+	// passed.
+	ErrCheckpointRequired = errors.New("checkpoint required")
+
+	// ErrUnsupportedOperation is returned when the given operation is not
+	// supported yet.
+	ErrUnsupportedOperation = errors.New("unsupported operation")
+
+	// ErrUnsupportedElement is returned when the given element is not
+	// supported yet.
+	ErrUnsupportedElement = errors.New("unsupported element")
+
+	// ErrUnsupportedEventType is returned when the given event type is not
+	// supported yet.
+	ErrUnsupportedEventType = errors.New("unsupported event type")
+
+	// ErrUnsupportedValueType is returned when the given value type is not
+	// supported yet.
+	ErrUnsupportedValueType = errors.New("unsupported value type")
+
+	// ErrUnsupportedCounterType is returned when the given counter type is not
+	// supported yet.
+	ErrUnsupportedCounterType = errors.New("unsupported counter type")
+)

--- a/api/converter/to_bytes.go
+++ b/api/converter/to_bytes.go
@@ -50,6 +50,9 @@ func toJSONElement(elem json.Element) *api.JSONElement {
 		return toCounter(elem)
 	}
 
+	// It occurs when the implementation is omitted in the converter after
+	// adding a new data type during development. So we explicitly fire the
+	// panic.
 	panic("fail to encode JSONElement to protobuf")
 }
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/prometheus/client_golang v0.9.3
 	github.com/spf13/cobra v1.0.0
-	github.com/stretchr/testify v1.6.1
+	github.com/stretchr/testify v1.6.2-0.20201103103935-92707c0b2d50
 	github.com/tidwall/pretty v1.0.0 // indirect
 	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c // indirect
 	github.com/xdg/stringprep v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -384,6 +384,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.6.2-0.20201103103935-92707c0b2d50 h1:aQdElrdadJZjGar4PipPBSpVh3yyDIuDSaM5PbMn6o8=
+github.com/stretchr/testify v1.6.2-0.20201103103935-92707c0b2d50/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tdakkota/asciicheck v0.0.0-20200416190851-d7f85be797a2 h1:Xr9gkxfOP0KQWXKNqmwe8vEeSUiUj4Rlee9CMVX2ZUQ=

--- a/pkg/document/json/rga_tree_list.go
+++ b/pkg/document/json/rga_tree_list.go
@@ -123,6 +123,9 @@ func (a *RGATreeList) Marshal() string {
 
 		if !current.isRemoved() {
 			sb.WriteString(current.elem.Marshal())
+
+			// FIXME: When the last element of the array is deleted, it does not
+			// work properly.
 			if current != a.last {
 				sb.WriteString(",")
 			}

--- a/pkg/document/proxy/text_proxy.go
+++ b/pkg/document/proxy/text_proxy.go
@@ -70,3 +70,30 @@ func (p *TextProxy) Edit(from, to int, content string) *TextProxy {
 	}
 	return p
 }
+
+// Select stores that the given range has been selected.
+func (p *TextProxy) Select(from, to int) *TextProxy {
+	if from > to {
+		panic("from should be less than or equal to to")
+	}
+	fromPos, toPos := p.Text.CreateRange(from, to)
+	log.Logger.Debugf(
+		"SELT: f:%d->%s, t:%d->%s",
+		from, fromPos.AnnotatedString(), to, toPos.AnnotatedString(),
+	)
+
+	ticket := p.context.IssueTimeTicket()
+	p.Text.Select(
+		fromPos,
+		toPos,
+		ticket,
+	)
+
+	p.context.Push(operation.NewSelect(
+		p.CreatedAt(),
+		fromPos,
+		toPos,
+		ticket,
+	))
+	return p
+}

--- a/pkg/document/time/actor_id.go
+++ b/pkg/document/time/actor_id.go
@@ -19,6 +19,8 @@ package time
 import (
 	"bytes"
 	"encoding/hex"
+	"errors"
+	"fmt"
 	"math"
 )
 
@@ -43,6 +45,9 @@ var (
 		math.MaxUint8,
 		math.MaxUint8,
 	}
+
+	// ErrInvalidHexString is returned when the given string is not valid hex.
+	ErrInvalidHexString = errors.New("invalid hex string")
 )
 
 // ActorID is bytes represented by the hexadecimal string.
@@ -50,18 +55,18 @@ var (
 type ActorID [actorIDSize]byte
 
 // ActorIDFromHex returns the bytes represented by the hexadecimal string str.
-func ActorIDFromHex(str string) *ActorID {
+func ActorIDFromHex(str string) (*ActorID, error) {
 	if str == "" {
-		return nil
+		return nil, nil
 	}
 
 	actorID := ActorID{}
 	decoded, err := hex.DecodeString(str)
 	if err != nil {
-		panic("fail to decode hex")
+		return nil, fmt.Errorf("%s: %w", str, ErrInvalidHexString)
 	}
 	copy(actorID[:], decoded[:actorIDSize])
-	return &actorID
+	return &actorID, nil
 }
 
 // String returns the hexadecimal encoding of ActorID.

--- a/yorkie/backend/db/mongo/client.go
+++ b/yorkie/backend/db/mongo/client.go
@@ -599,10 +599,15 @@ func (c *Client) findTicketByServerSeq(
 		return nil, err
 	}
 
+	actorID, err := time.ActorIDFromHex(changeInfo.Actor.Hex())
+	if err != nil {
+		return nil, err
+	}
+
 	return time.NewTicket(
 		changeInfo.Lamport,
 		time.MaxDelimiter,
-		time.ActorIDFromHex(changeInfo.Actor.Hex()),
+		actorID,
 	), nil
 }
 

--- a/yorkie/packs/pack_service.go
+++ b/yorkie/packs/pack_service.go
@@ -96,7 +96,12 @@ func PushPull(
 	// 05. publish document change event then store snapshot asynchronously.
 	if reqPack.HasChanges() {
 		be.AttachGoroutine(func() {
-			publisher := time.ActorIDFromHex(clientInfo.ID.Hex())
+			publisher, err := time.ActorIDFromHex(clientInfo.ID.Hex())
+			if err != nil {
+				log.Logger.Error(err)
+				return
+			}
+
 			be.PubSub.Publish(
 				publisher,
 				reqPack.DocumentKey.BSONKey(),

--- a/yorkie/types/change_info.go
+++ b/yorkie/types/change_info.go
@@ -79,7 +79,12 @@ func (i *ChangeInfo) ToChange() (*change.Change, error) {
 		pbOps = append(pbOps, &pbOp)
 	}
 
-	c := change.New(changeID, i.Message, converter.FromOperations(pbOps))
+	ops, err := converter.FromOperations(pbOps)
+	if err != nil {
+		return nil, err
+	}
+
+	c := change.New(changeID, i.Message, ops)
 	c.SetServerSeq(i.ServerSeq)
 
 	return c, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Remove panics from the converter.

If an error occurs in the converter, the converter must return an error
and allow the caller to decide how to handle it.

In particular, when a request that is not supported by the old server is
given, the server should return an error response instead of being
terminated.

This commit is based on the recommendations below.
https://github.com/uber-go/guide/blob/master/style.md#dont-panic

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #50

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [ ] Didn't break anything
