### PR TITLE
Extract MemPubSub from PubSub

### DIFF
--- a/yorkie/backend/backend.go
+++ b/yorkie/backend/backend.go
@@ -23,6 +23,7 @@ import (
 	"github.com/yorkie-team/yorkie/yorkie/backend/db"
 	"github.com/yorkie-team/yorkie/yorkie/backend/db/mongo"
 	"github.com/yorkie-team/yorkie/yorkie/backend/pubsub"
+	"github.com/yorkie-team/yorkie/yorkie/backend/pubsub/mempubsub"
 	"github.com/yorkie-team/yorkie/yorkie/backend/sync"
 )
 
@@ -43,7 +44,7 @@ type Backend struct {
 
 	DB       db.DB
 	MutexMap *sync.MutexMap
-	PubSub   *pubsub.PubSub
+	PubSub   pubsub.PubSub
 
 	// closing is closed by backend close.
 	closing chan struct{}
@@ -67,7 +68,7 @@ func New(conf *Config, mongoConf *mongo.Config) (*Backend, error) {
 		Config:   conf,
 		DB:       client,
 		MutexMap: sync.NewMutexMap(),
-		PubSub:   pubsub.New(),
+		PubSub:   mempubsub.New(),
 		closing:  make(chan struct{}),
 	}, nil
 }

--- a/yorkie/backend/pubsub/mempubsub/mempubsub.go
+++ b/yorkie/backend/pubsub/mempubsub/mempubsub.go
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2020 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mempubsub
+
+import (
+	"sync"
+
+	"github.com/yorkie-team/yorkie/pkg/document/time"
+	"github.com/yorkie-team/yorkie/pkg/log"
+	"github.com/yorkie-team/yorkie/pkg/types"
+	"github.com/yorkie-team/yorkie/yorkie/backend/pubsub"
+)
+
+// Subscriptions is a collection of subscriptions that subscribe to a specific
+// topic.
+type Subscriptions struct {
+	internalMap map[string]*pubsub.Subscription
+}
+
+func newSubscriptions() *Subscriptions {
+	return &Subscriptions{
+		internalMap: make(map[string]*pubsub.Subscription),
+	}
+}
+
+// Add adds the given subscription.
+func (s *Subscriptions) Add(sub *pubsub.Subscription) {
+	s.internalMap[sub.ID()] = sub
+}
+
+// Map returns the internal map of this Subscriptions.
+func (s *Subscriptions) Map() map[string]*pubsub.Subscription {
+	return s.internalMap
+}
+
+// Delete deletes the subscription of the given id.
+func (s *Subscriptions) Delete(id string) {
+	if subscription, ok := s.internalMap[id]; ok {
+		subscription.Close()
+	}
+	delete(s.internalMap, id)
+}
+
+// MemPubSub is the memory implementation of MemPubSub, used for single agent or
+// tests.
+type MemPubSub struct {
+	mu               *sync.RWMutex
+	subscriptionsMap map[string]*Subscriptions
+}
+
+// New creates an instance of MemoryPubSub.
+func New() *MemPubSub {
+	return &MemPubSub{
+		mu:               &sync.RWMutex{},
+		subscriptionsMap: make(map[string]*Subscriptions),
+	}
+}
+
+// Subscribe subscribes to the given topics.
+func (m *MemPubSub) Subscribe(
+	subscriber types.Client,
+	topics []string,
+) (*pubsub.Subscription, map[string][]types.Client, error) {
+	if len(topics) == 0 {
+		return nil, nil, pubsub.ErrEmptyTopics
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	log.Logger.Debugf(
+		`Subscribe(%s,%s) Start`,
+		topics[0],
+		subscriber.ID.String(),
+	)
+
+	subscription := pubsub.NewSubscription(subscriber)
+	peersMap := make(map[string][]types.Client)
+
+	for _, topic := range topics {
+		if _, ok := m.subscriptionsMap[topic]; !ok {
+			m.subscriptionsMap[topic] = newSubscriptions()
+		}
+		m.subscriptionsMap[topic].Add(subscription)
+
+		var peers []types.Client
+		for _, sub := range m.subscriptionsMap[topic].Map() {
+			peers = append(peers, sub.Subscriber())
+		}
+		peersMap[topic] = peers
+	}
+
+	log.Logger.Debugf(
+		`Subscribe(%s,%s) End`,
+		topics[0],
+		subscriber.ID.String(),
+	)
+	return subscription, peersMap, nil
+}
+
+// Unsubscribe unsubscribes the given topics.
+func (m *MemPubSub) Unsubscribe(topics []string, sub *pubsub.Subscription) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	log.Logger.Debugf(`Unsubscribe(%s,%s) Start`, topics[0], sub.SubscriberID())
+
+	for _, topic := range topics {
+		if subscriptions, ok := m.subscriptionsMap[topic]; ok {
+			subscriptions.Delete(sub.ID())
+		}
+	}
+	log.Logger.Debugf(`Unsubscribe(%s,%s) End`, topics[0], sub.SubscriberID())
+}
+
+// Publish publishes the given event to the given Topic.
+func (m *MemPubSub) Publish(
+	publisherID *time.ActorID,
+	topic string,
+	event pubsub.DocEvent,
+) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	log.Logger.Debugf(`Publish(%s,%s) Start`, event.DocKey, publisherID.String())
+
+	if subscriptions, ok := m.subscriptionsMap[topic]; ok {
+		for _, sub := range subscriptions.Map() {
+			if sub.Subscriber().ID.Compare(publisherID) != 0 {
+				log.Logger.Debugf(
+					`Publish(%s,%s) to %s`,
+					event.DocKey,
+					publisherID.String(),
+					sub.SubscriberID(),
+				)
+				sub.Events() <- event
+			}
+		}
+	}
+
+	log.Logger.Debugf(`Publish(%s,%s) End`, event.DocKey, publisherID.String())
+}

--- a/yorkie/config.sample.json
+++ b/yorkie/config.sample.json
@@ -1,20 +1,20 @@
 {
-    "RPC": {
-        "Port": 11101,
-        "CertFile": "",
-        "KeyFile": ""
-    },
-    "Metrics": {
-        "Port": 11102
-    },
-    "Mongo": {
-        "ConnectionTimeoutSec": 5,
-        "ConnectionURI": "mongodb://localhost:27017",
-        "YorkieDatabase": "yorkie-meta",
-        "PingTimeoutSec": 5
-    },
-    "Backend": {
-        "SnapshotThreshold": 500,
-        "SnapshotInterval": 100
-    }
+  "RPC": {
+    "Port": 11101,
+    "CertFile": "",
+    "KeyFile": ""
+  },
+  "Metrics": {
+    "Port": 11102
+  },
+  "Mongo": {
+    "ConnectionTimeoutSec": 5,
+    "ConnectionURI": "mongodb://localhost:27017",
+    "YorkieDatabase": "yorkie-meta",
+    "PingTimeoutSec": 5
+  },
+  "Backend": {
+    "SnapshotThreshold": 500,
+    "SnapshotInterval": 100
+  }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Extract MemPubSub from PubSub

Before implementing the distributed PubSub implementation using ETCD, we
need to extract the temporarily implemented MemoryPubSub and leave only
the high-level abstraction logic in PubSub.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Address #11

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
