### PR TITLE
Fix actorId conversion

### DIFF
--- a/pkg/document/time/actor_id.go
+++ b/pkg/document/time/actor_id.go
@@ -65,6 +65,11 @@ func ActorIDFromHex(str string) (*ActorID, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", str, ErrInvalidHexString)
 	}
+
+	if len(decoded) != actorIDSize {
+		return nil, fmt.Errorf("decoded length %d: %w", len(decoded), ErrInvalidHexString)
+	}
+
 	copy(actorID[:], decoded[:actorIDSize])
 	return &actorID, nil
 }

--- a/pkg/document/time/actor_id_test.go
+++ b/pkg/document/time/actor_id_test.go
@@ -1,0 +1,41 @@
+package time_test
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/pkg/document/time"
+)
+
+func TestActorID(t *testing.T) {
+	t.Run("get ActorID from hex test", func(t *testing.T) {
+		actorID := time.ActorID{}
+		_, err := rand.Read(actorID[:])
+		assert.NoError(t, err)
+
+		expectedID := actorID.String()
+		actualID, err := time.ActorIDFromHex(expectedID)
+
+		assert.NoError(t, err)
+		assert.Equal(t, expectedID, actualID.String())
+	})
+
+	t.Run("get ActorID from hex on invalid hexadecimal string test", func(t *testing.T) {
+		testID := "testID"
+		_, err := time.ActorIDFromHex(testID)
+		assert.ErrorIs(t, err, time.ErrInvalidHexString)
+	})
+
+	t.Run("get ActorID from hex on invalid decoded length test", func(t *testing.T) {
+		bytes := make([]byte, 5)
+		_, err := rand.Read(bytes)
+		assert.NoError(t, err)
+
+		invalidID := hex.EncodeToString(bytes[:])
+		_, err = time.ActorIDFromHex(invalidID)
+		assert.ErrorIs(t, err, time.ErrInvalidHexString)
+	})
+}

--- a/yorkie/backend/db/change_info.go
+++ b/yorkie/backend/db/change_info.go
@@ -61,9 +61,12 @@ func EncodeOperations(operations []operation.Operation) ([][]byte, error) {
 
 // ToChange creates Change model from this ChangeInfo.
 func (i *ChangeInfo) ToChange() (*change.Change, error) {
-	actorID := time.ActorID{}
-	copy(actorID[:], i.Actor[:])
-	changeID := change.NewID(i.ClientSeq, i.Lamport, &actorID)
+	actorID, err := time.ActorIDFromHex(i.Actor.String())
+	if err != nil {
+		return nil, err
+	}
+
+	changeID := change.NewID(i.ClientSeq, i.Lamport, actorID)
 
 	var pbOps []*api.Operation
 	for _, bytesOp := range i.Operations {

--- a/yorkie/backend/db/change_info_test.go
+++ b/yorkie/backend/db/change_info_test.go
@@ -1,0 +1,28 @@
+package db_test
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/pkg/document/time"
+	"github.com/yorkie-team/yorkie/yorkie/backend/db"
+)
+
+func TestChangeInfo(t *testing.T) {
+	t.Run("comparing actorID equals after calling ToChange test", func(t *testing.T) {
+		actorID := time.ActorID{}
+		_, err := rand.Read(actorID[:])
+		assert.NoError(t, err)
+
+		expectedID := actorID.String()
+		changeInfo := db.ChangeInfo{
+			Actor: db.ID(expectedID),
+		}
+
+		change, err := changeInfo.ToChange()
+		assert.NoError(t, err)
+		assert.Equal(t, change.ID().Actor().String(), expectedID)
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:


When [ToChange](https://github.com/yorkie-team/yorkie/blob/a99b17a9644dc9f9996626da165a117fe815c91a/yorkie/backend/db/change_info.go#L63) is excuted, `copy(actorID[:], i.Actor[:])` the byte size is not all copied. (After this [commit](https://github.com/yorkie-team/yorkie/commits/main) )

so Create PR by using the `time. ActorIDFromHex`


**Special notes for your reviewer**:

Can you help me add test code to this part?

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed a bug that different "actorId" was passed
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
