### PR TITLE
Fix invalid states of SplayTree when deleting a node

### DIFF
--- a/pkg/splay/splay.go
+++ b/pkg/splay/splay.go
@@ -75,6 +75,16 @@ func (n *Node) increaseWeight(weight int) {
 	n.weight += weight
 }
 
+func (n *Node) unlink() {
+	n.parent = nil
+	n.right = nil
+	n.left = nil
+}
+
+func (n *Node) hasLinks() bool {
+	return n.parent != nil || n.left != nil || n.right != nil
+}
+
 // Tree is weighted binary search tree which is based on Splay tree.
 // original paper on Splay Trees:
 //  - https://www.cs.cmu.edu/~sleator/papers/self-adjusting.pdf
@@ -154,7 +164,7 @@ func (t *Tree) Splay(node *Node) {
 
 // IndexOf Find the index of the given node.
 func (t *Tree) IndexOf(node *Node) int {
-	if node == nil {
+	if node == nil || !node.hasLinks() {
 		return -1
 	}
 
@@ -253,9 +263,17 @@ func (t *Tree) Delete(node *Node) {
 		maxNode := leftTree.maximum()
 		leftTree.Splay(maxNode)
 		leftTree.root.right = rightTree.root
+		if rightTree.root != nil {
+			rightTree.root.parent = leftTree.root
+		}
 		t.root = leftTree.root
 	} else {
 		t.root = rightTree.root
+	}
+
+	node.unlink()
+	if t.root != nil {
+		t.UpdateSubtree(t.root)
 	}
 }
 

--- a/pkg/splay/splay_test.go
+++ b/pkg/splay/splay_test.go
@@ -75,4 +75,25 @@ func TestSplayTree(t *testing.T) {
 		assert.Equal(t, nodeD, node)
 		assert.Equal(t, 2, offset)
 	})
+
+	t.Run("deletion test", func(t *testing.T) {
+		tree := splay.NewTree(nil)
+
+		nodeH := tree.Insert(newSplayNode("H"))
+		assert.Equal(t, "[1,1]H", tree.AnnotatedString())
+		nodeE := tree.Insert(newSplayNode("E"))
+		assert.Equal(t, "[1,1]H[2,1]E", tree.AnnotatedString())
+		nodeL := tree.Insert(newSplayNode("LL"))
+		assert.Equal(t, "[1,1]H[2,1]E[4,2]LL", tree.AnnotatedString())
+		nodeO := tree.Insert(newSplayNode("O"))
+		assert.Equal(t, "[1,1]H[2,1]E[4,2]LL[5,1]O", tree.AnnotatedString())
+
+		tree.Delete(nodeE)
+		assert.Equal(t, "[4,1]H[3,2]LL[1,1]O", tree.AnnotatedString())
+
+		assert.Equal(t, tree.IndexOf(nodeH), 0)
+		assert.Equal(t, tree.IndexOf(nodeE), -1)
+		assert.Equal(t, tree.IndexOf(nodeL), 1)
+		assert.Equal(t, tree.IndexOf(nodeO), 3)
+	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix invalid states of SplayTree when deleting a node.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

This PR is that reflects [the bug fix](https://github.com/yorkie-team/yorkie-js-sdk/pull/153) resolved in JS SDK.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
