### PR TITLE
Remove errors that occur when insPrev does not exist

### DIFF
--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -176,6 +176,14 @@ func (d *Document) RootObject() *json.Object {
 	return d.doc.RootObject()
 }
 
+// Root returns the proxy of the root object.
+func (d *Document) Root() *proxy.ObjectProxy {
+	d.ensureClone()
+
+	ctx := change.NewContext(d.doc.changeID.Next(), "", d.clone)
+	return proxy.NewObjectProxy(ctx, d.clone.Object())
+}
+
 // GarbageCollect purge elements that were removed before the given time.
 func (d *Document) GarbageCollect(ticket *time.Ticket) int {
 	if d.clone != nil {

--- a/pkg/document/json/rga_tree_split.go
+++ b/pkg/document/json/rga_tree_split.go
@@ -339,9 +339,9 @@ func (s *RGATreeSplit) findFloorNodePreferToLeft(id *RGATreeSplitNodeID) *RGATre
 	}
 
 	if id.offset > 0 && node.id.offset == id.offset {
+		// NOTE: InsPrev may not be present due to GC.
 		if node.insPrev == nil {
-			log.Logger.Error(s.AnnotatedString())
-			panic("insPrev should be presence")
+			return node
 		}
 		node = node.insPrev
 	}
@@ -536,10 +536,6 @@ func (s *RGATreeSplit) AnnotatedString() string {
 
 	node := s.initialHead
 	for node != nil {
-		if node.id.offset > 0 && node.insPrev == nil {
-			log.Logger.Warn("insPrev should be presence")
-		}
-
 		if node.removedAt != nil {
 			result = append(result, fmt.Sprintf(
 				"{%s}",

--- a/pkg/splay/splay.go
+++ b/pkg/splay/splay.go
@@ -183,6 +183,10 @@ func (t *Tree) IndexOf(node *Node) int {
 
 // Find returns the Node and offset of the given index.
 func (t *Tree) Find(index int) (*Node, int) {
+	if t.root == nil {
+		return nil, 0
+	}
+
 	node := t.root
 	offset := index
 	for {

--- a/pkg/splay/splay_test.go
+++ b/pkg/splay/splay_test.go
@@ -46,6 +46,10 @@ func TestSplayTree(t *testing.T) {
 	t.Run("insert and splay test", func(t *testing.T) {
 		tree := splay.NewTree(nil)
 
+		node, idx := tree.Find(0)
+		assert.Nil(t, node)
+		assert.Equal(t, 0, idx)
+
 		nodeA := tree.Insert(newSplayNode("A2"))
 		assert.Equal(t, "[2,2]A2", tree.AnnotatedString())
 		nodeB := tree.Insert(newSplayNode("B23"))


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Remove errors that occur when `insPrev` does not exist.

InsPrev can be removed due to GC, so remove the panic code added as an assertion.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes yorkie-team/yorkie-codepair#71

**Special notes for your reviewer**:

Text implementation in Agent is used by Agent, and unlike JS SDK, it does not expose `Change` events. Therefore, the error related to `insPrev` could not be reproduced.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
