### PR TITLE
add command-line flags for agent command(#152)

### DIFF
--- a/pkg/cli/agent.go
+++ b/pkg/cli/agent.go
@@ -54,7 +54,7 @@ func newAgentCmd() *cobra.Command {
 					Endpoints: etcdEndpoints,
 				}
 			}
-			//if config file is given, command-line argumentes will be overwritten
+			// If config file is given, command-line arguments will be overwritten.
 			if flagConfPath != "" {
 				parsed, err := yorkie.NewConfigFromFile(flagConfPath)
 				if err != nil {
@@ -130,7 +130,7 @@ func init() {
 		"config",
 		"c",
 		"",
-		"config path",
+		"Config path",
 	)
 	cmd.Flags().IntVar(
 		&conf.RPC.Port,
@@ -154,7 +154,7 @@ func init() {
 		&conf.Metrics.Port,
 		"metrics-port",
 		yorkie.DefaultMetricsPort,
-		"metrics port",
+		"Metrics port",
 	)
 	cmd.Flags().IntVar(
 		&mongoConnectionTimeoutSec,
@@ -171,8 +171,8 @@ func init() {
 	cmd.Flags().StringVar(
 		&conf.Mongo.YorkieDatabase,
 		"mongo-yorkie-database",
-		yorkie.DefaultMongoConnectionURI,
-		"MongoDB's connection URI",
+		yorkie.DefaultMongoYorkieDatabase,
+		"Yorkie's database name in MongoDB",
 	)
 	cmd.Flags().IntVar(
 		&mongoPingTimeoutSec,

--- a/pkg/cli/agent.go
+++ b/pkg/cli/agent.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/yorkie-team/yorkie/pkg/log"
 	"github.com/yorkie-team/yorkie/yorkie"
+	"github.com/yorkie-team/yorkie/yorkie/backend/sync/etcd"
 )
 
 var (
@@ -34,7 +35,11 @@ var (
 )
 
 var (
-	flagConfPath string
+	flagConfPath              string
+	mongoConnectionTimeoutSec int
+	mongoPingTimeoutSec       int
+	etcdEndpoints             []string
+	conf                      = yorkie.NewConfig()
 )
 
 func newAgentCmd() *cobra.Command {
@@ -42,7 +47,14 @@ func newAgentCmd() *cobra.Command {
 		Use:   "agent [options]",
 		Short: "Starts yorkie agent",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			conf := yorkie.NewConfig()
+			conf.Mongo.ConnectionTimeoutSec = time.Duration(mongoConnectionTimeoutSec)
+			conf.Mongo.PingTimeoutSec = time.Duration(mongoPingTimeoutSec)
+			if etcdEndpoints != nil {
+				conf.ETCD = &etcd.Config{
+					Endpoints: etcdEndpoints,
+				}
+			}
+			//if config file is given, command-line argumentes will be overwritten
 			if flagConfPath != "" {
 				parsed, err := yorkie.NewConfigFromFile(flagConfPath)
 				if err != nil {
@@ -120,5 +132,73 @@ func init() {
 		"",
 		"config path",
 	)
+	cmd.Flags().IntVar(
+		&conf.RPC.Port,
+		"rpc-port",
+		yorkie.DefaultRPCPort,
+		"RPC port",
+	)
+	cmd.Flags().StringVar(
+		&conf.RPC.CertFile,
+		"rpc-cert-file",
+		"",
+		"RPC certification file's path",
+	)
+	cmd.Flags().StringVar(
+		&conf.RPC.CertFile,
+		"rpc-key-file",
+		"",
+		"RPC key file's path",
+	)
+	cmd.Flags().IntVar(
+		&conf.Metrics.Port,
+		"metrics-port",
+		yorkie.DefaultMetricsPort,
+		"metrics port",
+	)
+	cmd.Flags().IntVar(
+		&mongoConnectionTimeoutSec,
+		"mongo-connection-timeout-sec",
+		yorkie.DefaultMongoConnectionTimeoutSec,
+		"Mongo DB's connection timeout in seconds",
+	)
+	cmd.Flags().StringVar(
+		&conf.Mongo.ConnectionURI,
+		"mongo-connection-uri",
+		yorkie.DefaultMongoConnectionURI,
+		"MongoDB's connection URI",
+	)
+	cmd.Flags().StringVar(
+		&conf.Mongo.YorkieDatabase,
+		"mongo-yorkie-database",
+		yorkie.DefaultMongoConnectionURI,
+		"MongoDB's connection URI",
+	)
+	cmd.Flags().IntVar(
+		&mongoPingTimeoutSec,
+		"mongo-ping-timeout-sec",
+		yorkie.DefaultMongoPingTimeoutSec,
+		"Mongo DB's ping timeout in seconds",
+	)
+	cmd.Flags().StringSliceVar(
+		&etcdEndpoints,
+		"etcd-endpoints",
+		nil,
+		"Comma separated list of etcd endpoints",
+	)
+	cmd.Flags().Uint64Var(
+		&conf.Backend.SnapshotThreshold,
+		"backend-snapshot-threshold",
+		yorkie.DefaultSnapshotThreshold,
+		"Threshold that determines if changes should be sent with snapshot when the number "+
+			"of changes is greater than this value.",
+	)
+	cmd.Flags().Uint64Var(
+		&conf.Backend.SnapshotInterval,
+		"backend-snapshot-interval",
+		yorkie.DefaultSnapshotInterval,
+		"Interval of changes to create a snapshot",
+	)
+
 	rootCmd.AddCommand(cmd)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR adds long flags that can set all configurations of Agent. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #152 

**Special notes for your reviewer**:

It assigns command-line flags directly to the configuration struct variable. 

timeout-second variables don't be assigned directly from command-line flags. Because to assign duration variable from command-line arguments, users have to specify the time unit. (5s, 1m...) this form doesn't fit with the flag's name(timeout-'second'.)

ETCD endpoints don't be assigned directly too. Because etcd config's pointer is nil for default. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add flags that can set all configurations of Agent
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
