### PR TITLE
Change PushPull changes size metric type

### DIFF
--- a/yorkie/metrics/metrics.go
+++ b/yorkie/metrics/metrics.go
@@ -21,13 +21,13 @@ type Metrics interface {
 	// ObservePushPullResponseSeconds adds response time metrics for PushPull API.
 	ObservePushPullResponseSeconds(seconds float64)
 
-	// AddPushPullReceivedChanges adds the number of changes metric
+	// SetPushPullReceivedChanges sets the number of changes metric
 	// included in the request pack of the PushPull API.
-	AddPushPullReceivedChanges(count int)
+	SetPushPullReceivedChanges(count int)
 
-	// AddPushPullSentChanges adds the number of changes metric
+	// SetPushPullSentChanges sets the number of changes metric
 	// included in the response pack of the PushPull API.
-	AddPushPullSentChanges(count int)
+	SetPushPullSentChanges(count int)
 
 	// ObservePushPullSnapshotDurationSeconds adds the time
 	// spent metric when taking snapshots.

--- a/yorkie/metrics/prometheus/metrics.go
+++ b/yorkie/metrics/prometheus/metrics.go
@@ -32,8 +32,8 @@ type Metrics struct {
 	agentVersion *prometheus.GaugeVec
 
 	pushPullResponseSeconds prometheus.Histogram
-	pushPullReceivedChanges prometheus.Counter
-	pushPullSentChanges     prometheus.Counter
+	pushPullReceivedChanges prometheus.Gauge
+	pushPullSentChanges     prometheus.Gauge
 
 	pushPullSnapshotDurationSeconds prometheus.Histogram
 	pushPullSnapshotBytes           prometheus.Gauge
@@ -54,13 +54,13 @@ func NewMetrics() *Metrics {
 			Name:      "pushpull_response_seconds",
 			Help:      "Response time of PushPull API.",
 		}),
-		pushPullReceivedChanges: promauto.NewCounter(prometheus.CounterOpts{
+		pushPullReceivedChanges: promauto.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: "rpcserver",
 			Name:      "pushpull_received_changes",
 			Help:      "The number of changes included in a request pack in PushPull API.",
 		}),
-		pushPullSentChanges: promauto.NewCounter(prometheus.CounterOpts{
+		pushPullSentChanges: promauto.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: "rpcserver",
 			Name:      "pushpull_sent_changes",
@@ -92,16 +92,16 @@ func (m *Metrics) ObservePushPullResponseSeconds(seconds float64) {
 	m.pushPullResponseSeconds.Observe(seconds)
 }
 
-// AddPushPullReceivedChanges adds the number of changes metric
+// SetPushPullReceivedChanges sets the number of changes metric
 // included in the request pack of the PushPull API.
-func (m *Metrics) AddPushPullReceivedChanges(count int) {
-	m.pushPullReceivedChanges.Add(float64(count))
+func (m *Metrics) SetPushPullReceivedChanges(count int) {
+	m.pushPullReceivedChanges.Set(float64(count))
 }
 
-// AddPushPullSentChanges adds the number of changes metric
+// SetPushPullSentChanges sets the number of changes metric
 // included in the response pack of the PushPull API.
-func (m *Metrics) AddPushPullSentChanges(count int) {
-	m.pushPullSentChanges.Add(float64(count))
+func (m *Metrics) SetPushPullSentChanges(count int) {
+	m.pushPullSentChanges.Set(float64(count))
 }
 
 // ObservePushPullSnapshotDurationSeconds adds the time

--- a/yorkie/rpc/server.go
+++ b/yorkie/rpc/server.go
@@ -294,7 +294,7 @@ func (s *Server) PushPull(
 	}
 
 	if pack.HasChanges() {
-		s.backend.Metrics.AddPushPullReceivedChanges(len(pack.Changes))
+		s.backend.Metrics.SetPushPullReceivedChanges(len(pack.Changes))
 
 		locker, err := s.backend.LockerMap.NewLocker(
 			ctx,
@@ -339,7 +339,7 @@ func (s *Server) PushPull(
 		return nil, toStatusError(err)
 	}
 
-	s.backend.Metrics.AddPushPullSentChanges(len(pbChangePack.Changes))
+	s.backend.Metrics.SetPushPullSentChanges(len(pbChangePack.Changes))
 	s.backend.Metrics.ObservePushPullResponseSeconds(gotime.Since(start).Seconds())
 
 	return &api.PushPullResponse{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The accumulated value of the counter type is changed to a gauge because the practical utility is poor.
Using the Gauge, we can check the point when the size of the change suddenly increases, like the attached image.

![image](https://user-images.githubusercontent.com/40932237/113154917-76fb3100-9273-11eb-9d5e-80cdb0b81406.png)


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
