### PR TITLE
Fix incorrect sequences when detaching documents

### DIFF
--- a/pkg/document/checkpoint/checkpoint.go
+++ b/pkg/document/checkpoint/checkpoint.go
@@ -18,10 +18,14 @@ package checkpoint
 
 import (
 	"fmt"
+	"math"
 )
 
 // Initial is the initial value of the checkpoint.
 var Initial = New(0, 0)
+
+// Max is the max value of the checkpoint.
+var Max = New(math.MaxUint64, math.MaxUint32)
 
 // Checkpoint is used to determine the client received changes.
 type Checkpoint struct {

--- a/test/integration/document_test.go
+++ b/test/integration/document_test.go
@@ -46,9 +46,9 @@ func TestDocument(t *testing.T) {
 		ctx := context.Background()
 		doc := document.New(helper.Collection, t.Name())
 		err := doc.Update(func(root *proxy.ObjectProxy) error {
-			root.SetString("k1", "k1")
+			root.SetString("k1", "v1")
 			return nil
-		}, "update k1 with k1")
+		}, "update k1 with v1")
 		assert.NoError(t, err)
 
 		err = c1.Attach(ctx, doc)
@@ -59,13 +59,16 @@ func TestDocument(t *testing.T) {
 		assert.NoError(t, err)
 		assert.False(t, doc.IsAttached())
 
-		err = c1.Attach(ctx, doc)
-		assert.NoError(t, err)
-		assert.True(t, doc.IsAttached())
+		doc2 := document.New(helper.Collection, t.Name())
+		err = doc2.Update(func(root *proxy.ObjectProxy) error {
+			root.SetString("k1", "v2")
+			return nil
+		}, "update k1 with v2")
 
-		err = c1.Detach(ctx, doc)
+		err = c1.Attach(ctx, doc2)
 		assert.NoError(t, err)
-		assert.False(t, doc.IsAttached())
+		assert.True(t, doc2.IsAttached())
+		assert.Equal(t, `{"k1":"v2"}`, doc2.Marshal())
 	})
 
 	t.Run("concurrent complex test", func(t *testing.T) {

--- a/yorkie/backend/db/client_info.go
+++ b/yorkie/backend/db/client_info.go
@@ -91,6 +91,8 @@ func (i *ClientInfo) DetachDocument(docID ID) error {
 	}
 
 	i.Documents[docID].Status = documentDetached
+	i.Documents[docID].ClientSeq = 0
+	i.Documents[docID].ServerSeq = 0
 	i.UpdatedAt = time.Now()
 
 	return nil

--- a/yorkie/backend/db/client_info_test.go
+++ b/yorkie/backend/db/client_info_test.go
@@ -1,0 +1,34 @@
+package db_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/pkg/document/checkpoint"
+	"github.com/yorkie-team/yorkie/yorkie/backend/db"
+)
+
+func TestClientInfo(t *testing.T) {
+	t.Run("attach/detach document test", func(t *testing.T) {
+		docID := db.ID("000000000000000000000000")
+		clientInfo := db.ClientInfo{
+			Status: db.ClientActivated,
+		}
+
+		err := clientInfo.AttachDocument(docID)
+		assert.NoError(t, err)
+		isAttached, err := clientInfo.IsAttached(docID)
+		assert.NoError(t, err)
+		assert.True(t, isAttached)
+
+		err = clientInfo.UpdateCheckpoint(docID, checkpoint.Max)
+		assert.NoError(t, err)
+
+		err = clientInfo.DetachDocument(docID)
+		assert.NoError(t, err)
+		isAttached, err = clientInfo.IsAttached(docID)
+		assert.NoError(t, err)
+		assert.False(t, isAttached)
+	})
+}

--- a/yorkie/packs/pack_service.go
+++ b/yorkie/packs/pack_service.go
@@ -70,7 +70,7 @@ func PushPull(
 	}
 
 	// 03. store pushed changes, document info and checkpoint of the client to DB.
-	if reqPack.HasChanges() {
+	if len(pushedChanges) > 0 {
 		if err := be.DB.StoreChangeInfos(ctx, docInfo, initialServerSeq, pushedChanges); err != nil {
 			return nil, err
 		}

--- a/yorkie/packs/pack_service.go
+++ b/yorkie/packs/pack_service.go
@@ -234,27 +234,18 @@ func pullChanges(
 	be *backend.Backend,
 	clientInfo *db.ClientInfo,
 	docInfo *db.DocInfo,
-	pack *change.Pack,
+	requestPack *change.Pack,
 	pushedCP *checkpoint.Checkpoint,
 	initialServerSeq uint64,
 ) (*checkpoint.Checkpoint, []*change.Change, error) {
-	fetchedChanges, err := be.DB.FindChangeInfosBetweenServerSeqs(
+	pulledChanges, err := be.DB.FindChangeInfosBetweenServerSeqs(
 		ctx,
 		docInfo.ID,
-		pack.Checkpoint.ServerSeq+1,
+		requestPack.Checkpoint.ServerSeq+1,
 		initialServerSeq,
 	)
 	if err != nil {
 		return nil, nil, err
-	}
-
-	var pulledChanges []*change.Change
-	for _, fetchedChange := range fetchedChanges {
-		if clientInfo.ID.String() == fetchedChange.ID().Actor().String() {
-			continue
-		}
-
-		pulledChanges = append(pulledChanges, fetchedChange)
 	}
 
 	pulledCP := pushedCP.NextServerSeq(docInfo.ServerSeq)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

When the client attaches to a new document with the same key after detaching the document, the previous sequence remains in DB. Therefore, the changes in the new document were not reflected.

https://github.com/yorkie-team/yorkie/blob/8015fefa13d35ab835486ba92e0da762026ddbd3/yorkie/packs/pack_service.go#L169

So when detaching the document, we initialize the checkpoint.

AS-IS

```
ClientInfo: C1
  ㄴ ClientDocInfo: D1, (2, 1), Detached
```

TO-BE

```
ClientInfo: C1
  ㄴ ClientDocInfo: D1, (0, 0), Detached
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Address https://github.com/yorkie-team/yorkie-codepair/issues/94

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
