### PR TITLE
Add gRPC health server

### DIFF
--- a/test/integration/array_test.go
+++ b/test/integration/array_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestArray(t *testing.T) {
-	clients := getActivatedClients(t, 2)
+	clients := createActivatedClients(t, 2)
 	c1 := clients[0]
 	c2 := clients[1]
 	defer func() {

--- a/test/integration/counter_test.go
+++ b/test/integration/counter_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestCounter(t *testing.T) {
-	clients := getActivatedClients(t, 2)
+	clients := createActivatedClients(t, 2)
 	c1 := clients[0]
 	c2 := clients[1]
 	defer func() {

--- a/test/integration/document_test.go
+++ b/test/integration/document_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 func TestDocument(t *testing.T) {
-	clients := getActivatedClients(t, 2)
+	clients := createActivatedClients(t, 2)
 	c1 := clients[0]
 	c2 := clients[1]
 	defer func() {

--- a/test/integration/gc_test.go
+++ b/test/integration/gc_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestGarbageCollection(t *testing.T) {
-	clients := getActivatedClients(t, 2)
+	clients := createActivatedClients(t, 2)
 	c1 := clients[0]
 	c2 := clients[1]
 	defer func() {

--- a/test/integration/health_test.go
+++ b/test/integration/health_test.go
@@ -1,0 +1,40 @@
+// +build integration
+
+/*
+ * Copyright 2021 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+func TestHealthCheck(t *testing.T) {
+	conn, err := createConn()
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, conn.Close())
+	}()
+
+	cli := healthpb.NewHealthClient(conn)
+	resp, err := cli.Check(context.Background(), &healthpb.HealthCheckRequest{})
+	assert.NoError(t, err)
+	assert.Equal(t, resp.Status, healthpb.HealthCheckResponse_SERVING)
+}

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -21,11 +21,11 @@ package integration
 import (
 	"context"
 	"fmt"
-	"google.golang.org/grpc"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
 
 	"github.com/yorkie-team/yorkie/client"
 	"github.com/yorkie-team/yorkie/pkg/document"

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -21,6 +21,7 @@ package integration
 import (
 	"context"
 	"fmt"
+	"google.golang.org/grpc"
 	"os"
 	"testing"
 
@@ -82,7 +83,16 @@ func syncClientsThenAssertEqual(t *testing.T, pairs []clientAndDocPair) {
 	}
 }
 
-func getActivatedClients(t *testing.T, n int) (clients []*client.Client) {
+func createConn() (*grpc.ClientConn, error) {
+	conn, err := grpc.Dial(testYorkie.RPCAddr(), grpc.WithInsecure())
+	if err != nil {
+		return nil, err
+	}
+
+	return conn, nil
+}
+
+func createActivatedClients(t *testing.T, n int) (clients []*client.Client) {
 	for i := 0; i < n; i++ {
 		c, err := client.Dial(
 			testYorkie.RPCAddr(),

--- a/test/integration/object_test.go
+++ b/test/integration/object_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestObject(t *testing.T) {
-	clients := getActivatedClients(t, 2)
+	clients := createActivatedClients(t, 2)
 	c1 := clients[0]
 	c2 := clients[1]
 	defer func() {

--- a/test/integration/primitive_test.go
+++ b/test/integration/primitive_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestPrimitive(t *testing.T) {
-	clients := getActivatedClients(t, 2)
+	clients := createActivatedClients(t, 2)
 	c1 := clients[0]
 	c2 := clients[1]
 	defer func() {

--- a/test/integration/snapshot_test.go
+++ b/test/integration/snapshot_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func TestSnapshot(t *testing.T) {
-	clients := getActivatedClients(t, 2)
+	clients := createActivatedClients(t, 2)
 	c1 := clients[0]
 	c2 := clients[1]
 	defer func() {

--- a/test/integration/text_test.go
+++ b/test/integration/text_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestText(t *testing.T) {
-	clients := getActivatedClients(t, 2)
+	clients := createActivatedClients(t, 2)
 	c1 := clients[0]
 	c2 := clients[1]
 	defer func() {

--- a/yorkie/rpc/server.go
+++ b/yorkie/rpc/server.go
@@ -29,6 +29,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
 
 	"github.com/yorkie-team/yorkie/api"
@@ -85,9 +87,13 @@ func NewServer(conf *Config, be *backend.Backend) (*Server, error) {
 		opts = append(opts, grpc.Creds(creds))
 	}
 
+	grpcServer := grpc.NewServer(opts...)
+	hsrv := health.NewServer()
+	healthpb.RegisterHealthServer(grpcServer, hsrv)
+
 	rpcServer := &Server{
 		conf:       conf,
-		grpcServer: grpc.NewServer(opts...),
+		grpcServer: grpcServer,
 		backend:    be,
 	}
 	api.RegisterYorkieServer(rpcServer.grpcServer, rpcServer)

--- a/yorkie/rpc/server.go
+++ b/yorkie/rpc/server.go
@@ -88,8 +88,8 @@ func NewServer(conf *Config, be *backend.Backend) (*Server, error) {
 	}
 
 	grpcServer := grpc.NewServer(opts...)
-	hsrv := health.NewServer()
-	healthpb.RegisterHealthServer(grpcServer, hsrv)
+	healthServer := health.NewServer()
+	healthpb.RegisterHealthServer(grpcServer, healthServer)
 
 	rpcServer := &Server{
 		conf:       conf,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
While operating, we should be able to check the health status of gRPC.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #170

**Special notes for your reviewer**:
I checked through [grpc-health-probe](https://github.com/grpc-ecosystem/grpc-health-probe) that this works fine.
Do we need to check the gRPC status in the client logic as well? It seems that we can implement through [grpc_health_v1#HealthClient](https://pkg.go.dev/google.golang.org/grpc/health/grpc_health_v1#HealthClient)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
