### PR TITLE
Add Attachment type to pass the peers' status

### DIFF
--- a/api/converter/from_pb.go
+++ b/api/converter/from_pb.go
@@ -159,6 +159,20 @@ func FromDocEvent(docEvent *api.DocEvent) (*sync.DocEvent, error) {
 	}, nil
 }
 
+// FromClients converts the given Protobuf format to model format.
+func FromClients(pbClients *api.Clients) ([]*types.Client, error) {
+	var clients []*types.Client
+	for _, pbClient := range pbClients.Clients {
+		client, err := FromClient(pbClient)
+		if err != nil {
+			return nil, err
+		}
+		clients = append(clients, client)
+	}
+
+	return clients, nil
+}
+
 // FromOperations converts the given Protobuf format to model format.
 func FromOperations(pbOps []*api.Operation) ([]operation.Operation, error) {
 	var ops []operation.Operation

--- a/yorkie/rpc/yorkie_server.go
+++ b/yorkie/rpc/yorkie_server.go
@@ -320,6 +320,7 @@ func (s *yorkieServer) WatchDocuments(
 		return err
 	}
 
+	// TODO(hackerwins): unwatchDocs when shutting down the agent.
 	if err := stream.Send(&api.WatchDocumentsResponse{
 		Body: &api.WatchDocumentsResponse_Initialization_{
 			Initialization: &api.WatchDocumentsResponse_Initialization{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add `Attachment` type to pass the peers' status and provide `WatchResponse` similar to [that of the JS SDK](https://github.com/yorkie-team/yorkie-js-sdk/blob/main/src/core/client.ts#L63-L64)(`document-changed`, `peers-changed`).


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #137

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```go
wrch := c1.Watch(watch1Ctx, d1)
wr := <-wrch:
if wr.Type == client.PeersChanged {
	// peers changed
	wr.PeersMapByDoc[doc.Key().BSONKey()]
} else if wr.Type == DocumentsChanged {
	// document changed
}
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
