### PR TITLE
Check authorization in WatchDocument

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -90,6 +90,7 @@ type WatchResponseType string
 
 // The values below are types of WatchResponseType.
 const (
+	WatchStarted     WatchResponseType = "watch-started"
 	DocumentsChanged WatchResponseType = "documents-changed"
 	PeersChanged     WatchResponseType = "peers-changed"
 )
@@ -411,7 +412,7 @@ func (c *Client) Watch(ctx context.Context, docs ...*document.Document) <-chan W
 			}
 
 			return &WatchResponse{
-				Type:          PeersChanged,
+				Type:          WatchStarted,
 				PeersMapByDoc: c.PeersMapByDoc(),
 			}, nil
 		case *api.WatchDocumentsResponse_Event:
@@ -449,20 +450,6 @@ func (c *Client) Watch(ctx context.Context, docs ...*document.Document) <-chan W
 		return nil, fmt.Errorf("unsupported response type")
 	}
 
-	// waiting for starting watch
-	pbResp, err := stream.Recv()
-	if err != nil {
-		rch <- WatchResponse{Err: err}
-		close(rch)
-		return rch
-	}
-	if _, err := handleResponse(pbResp); err != nil {
-		rch <- WatchResponse{Err: err}
-		close(rch)
-		return rch
-	}
-
-	// starting to watch documents
 	go func() {
 		for {
 			pbResp, err := stream.Recv()

--- a/pkg/types/auth_webhook.go
+++ b/pkg/types/auth_webhook.go
@@ -53,6 +53,7 @@ const (
 	AttachDocument   Method = "AttachDocument"
 	DetachDocument   Method = "DetachDocument"
 	PushPull         Method = "PushPull"
+	WatchDocuments   Method = "WatchDocuments"
 )
 
 // IsAuthMethod returns whether the given method can be used for authorization.
@@ -73,6 +74,7 @@ func AuthMethods() []Method {
 		AttachDocument,
 		DetachDocument,
 		PushPull,
+		WatchDocuments,
 	}
 }
 

--- a/test/integration/cluster_mode_test.go
+++ b/test/integration/cluster_mode_test.go
@@ -98,17 +98,19 @@ func TestClusterMode(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			select {
-			case resp := <-rch:
-				if resp.Err == io.EOF {
+			for {
+				select {
+				case resp := <-rch:
+					if resp.Err == io.EOF {
+						return
+					}
+					assert.NoError(t, resp.Err)
+
+					err := clientA.Sync(ctx, resp.Keys...)
+					assert.NoError(t, err)
+				case <-time.After(time.Second):
 					return
 				}
-				assert.NoError(t, resp.Err)
-
-				err := clientA.Sync(ctx, resp.Keys...)
-				assert.NoError(t, err)
-			case <-time.After(time.Second):
-				return
 			}
 		}()
 

--- a/test/integration/document_test.go
+++ b/test/integration/document_test.go
@@ -160,7 +160,7 @@ func TestDocument(t *testing.T) {
 		assert.Equal(t, d1.Marshal(), d2.Marshal())
 	})
 
-	t.Run("watch PeersChanged event test", func(t *testing.T) {
+	t.Run("WatchStarted and PeersChanged event test", func(t *testing.T) {
 		ctx := context.Background()
 
 		d1 := document.New(helper.Collection, t.Name())
@@ -172,6 +172,7 @@ func TestDocument(t *testing.T) {
 
 		wg := sync.WaitGroup{}
 
+		// 01. WatchStarted is triggered when starting to watch a document
 		wg.Add(1)
 		watch1Ctx, cancel1 := context.WithCancel(ctx)
 		wrch := c1.Watch(watch1Ctx, d1)
@@ -206,7 +207,7 @@ func TestDocument(t *testing.T) {
 			}
 		}()
 
-		// 01. PeersChanged is triggered as a new client watches the document
+		// 02. PeersChanged is triggered when another client watches the document
 		watch2Ctx, cancel2 := context.WithCancel(ctx)
 		wg.Add(1)
 		wrch2 := c2.Watch(watch2Ctx, d2)
@@ -222,7 +223,7 @@ func TestDocument(t *testing.T) {
 		}()
 		wg2.Wait()
 
-		// 02. PeersChanged is triggered because the client closes the watch
+		// 03. PeersChanged is triggered when another client closes the watch
 		wg.Add(1)
 		cancel2()
 

--- a/yorkie/rpc/interceptors/default.go
+++ b/yorkie/rpc/interceptors/default.go
@@ -54,7 +54,7 @@ func (i *DefaultInterceptor) Unary() grpc.UnaryServerInterceptor {
 		start := gotime.Now()
 		resp, err := handler(ctx, req)
 		if err != nil {
-			log.Logger.Errorf("RPC : %q %s: %q => %q", info.FullMethod, gotime.Since(start), req, err)
+			log.Logger.Warnf("RPC : %q %s: %q => %q", info.FullMethod, gotime.Since(start), req, err)
 			return nil, toStatusError(err)
 		}
 
@@ -74,7 +74,7 @@ func (i *DefaultInterceptor) Stream() grpc.StreamServerInterceptor {
 		start := gotime.Now()
 		err := handler(srv, ss)
 		if err != nil {
-			log.Logger.Infof("RPC : stream %q %s => %q", info.FullMethod, gotime.Since(start), err.Error())
+			log.Logger.Warnf("RPC : stream %q %s => %q", info.FullMethod, gotime.Since(start), err.Error())
 			return toStatusError(err)
 		}
 

--- a/yorkie/rpc/yorkie_server.go
+++ b/yorkie/rpc/yorkie_server.go
@@ -314,6 +314,20 @@ func (s *yorkieServer) WatchDocuments(
 	}
 	docKeys := converter.FromDocumentKeys(req.DocumentKeys)
 
+	var attrs []types.AccessAttribute
+	for _, k := range docKeys {
+		attrs = append(attrs, types.AccessAttribute{
+			Key:  k.BSONKey(),
+			Verb: types.Read,
+		})
+	}
+	if err := auth.VerifyAccess(stream.Context(), s.backend, &types.AccessInfo{
+		Method:     types.WatchDocuments,
+		Attributes: attrs,
+	}); err != nil {
+		return err
+	}
+
 	subscription, peersMap, err := s.watchDocs(
 		stream.Context(),
 		*client,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Check authorization in WatchDocument.

If an error occurs before starting the watch, there is no way to deliver
the error when waiting synchronously.

So, watch-started event is added and start the watch asynchronously.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #209

**Special notes for your reviewer**:

We need to merge #207 first.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
