### PR TITLE
Add authorization webhook retry logic

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -219,6 +219,18 @@ func init() {
 		"List of methods that require authorization checks."+
 			" If no value is specified, all methods will be checked.",
 	)
+	cmd.Flags().Uint64Var(
+		&conf.Backend.AuthorizationWebhookMaxRetries,
+		"authorization-webhook-max-retries",
+		yorkie.DefaultAuthorizationWebhookMaxRetries,
+		"Maximum number of retries for an authorization webhook.",
+	)
+	cmd.Flags().Uint64Var(
+		&conf.Backend.AuthorizationWebhookMaxWaitIntervalMillis,
+		"authorization-webhook-max-wait-interval-millis",
+		yorkie.DefaultAuthorizationWebhookWaitIntervalMillis,
+		"Maximum wait interval for authorization webhook.",
+	)
 
 	rootCmd.AddCommand(cmd)
 }

--- a/test/integration/agent_test.go
+++ b/test/integration/agent_test.go
@@ -73,4 +73,3 @@ func TestAgent(t *testing.T) {
 		wg.Wait()
 	})
 }
-

--- a/test/integration/auth_webhook_test.go
+++ b/test/integration/auth_webhook_test.go
@@ -148,7 +148,7 @@ func TestAuthWebhook(t *testing.T) {
 
 		conf := helper.TestConfig(server.URL)
 		conf.Backend.AuthorizationWebhookMaxRetries = recoveryCnt
-		conf.Backend.AuthorizationWebhookMaxWaitInterval = 1000
+		conf.Backend.AuthorizationWebhookMaxWaitIntervalMillis = 1000
 		agent, err := yorkie.New(conf)
 		assert.NoError(t, err)
 		assert.NoError(t, agent.Start())
@@ -174,7 +174,7 @@ func TestAuthWebhook(t *testing.T) {
 
 		conf := helper.TestConfig(server.URL)
 		conf.Backend.AuthorizationWebhookMaxRetries = 2
-		conf.Backend.AuthorizationWebhookMaxWaitInterval = 1000
+		conf.Backend.AuthorizationWebhookMaxWaitIntervalMillis = 1000
 		agent, err := yorkie.New(conf)
 		assert.NoError(t, err)
 		assert.NoError(t, agent.Start())

--- a/test/integration/document_test.go
+++ b/test/integration/document_test.go
@@ -185,7 +185,7 @@ func TestDocument(t *testing.T) {
 			defer wgEvents.Done()
 			for {
 				select {
-				case <- time.After(time.Second):
+				case <-time.After(time.Second):
 					assert.Fail(t, "timeout")
 					return
 				case wr := <-wrch:

--- a/yorkie/backend/backend.go
+++ b/yorkie/backend/backend.go
@@ -48,6 +48,14 @@ type Config struct {
 
 	// AuthorizationWebhookMethods is the methods that run the authorization webhook.
 	AuthorizationWebhookMethods []string `json:"AuthorizationWebhookMethods"`
+
+	// AuthorizationWebhookMaxRetries is the max count
+	// that retries the authorization webhook.
+	AuthorizationWebhookMaxRetries uint64
+
+	// AuthorizationWebhookMaxWaitInterval is the max interval
+	// that waits before retrying the authorization webhook.
+	AuthorizationWebhookMaxWaitInterval uint64
 }
 
 // RequireAuth returns whether the given method require authorization.

--- a/yorkie/backend/backend.go
+++ b/yorkie/backend/backend.go
@@ -51,11 +51,11 @@ type Config struct {
 
 	// AuthorizationWebhookMaxRetries is the max count
 	// that retries the authorization webhook.
-	AuthorizationWebhookMaxRetries uint64
+	AuthorizationWebhookMaxRetries uint64 `json:"AuthorizationWebhookMaxRetries"`
 
-	// AuthorizationWebhookMaxWaitInterval is the max interval
+	// AuthorizationWebhookMaxWaitIntervalMillis is the max interval
 	// that waits before retrying the authorization webhook.
-	AuthorizationWebhookMaxWaitInterval uint64
+	AuthorizationWebhookMaxWaitIntervalMillis uint64 `json:"AuthorizationWebhookMaxWaitIntervalMillis"`
 }
 
 // RequireAuth returns whether the given method require authorization.

--- a/yorkie/config.go
+++ b/yorkie/config.go
@@ -42,6 +42,9 @@ const (
 
 	DefaultSnapshotThreshold = 500
 	DefaultSnapshotInterval  = 100
+
+	DefaultAuthorizationWebhookMaxRetries         = 10
+	DefaultAuthorizationWebhookWaitIntervalMillis = 3000
 )
 
 // Config is the configuration for creating a Yorkie instance.

--- a/yorkie/rpc/interceptors/default.go
+++ b/yorkie/rpc/interceptors/default.go
@@ -87,7 +87,8 @@ func (i *DefaultInterceptor) Stream() grpc.StreamServerInterceptor {
 // occurs while executing logic in API handler, gRPC status.error should be
 // returned so that the client can know more about the status of the request.
 func toStatusError(err error) error {
-	if errors.Is(err, auth.ErrNotAllowed) {
+	if errors.Is(err, auth.ErrNotAllowed) ||
+		errors.Is(err, auth.ErrUnexpectedStatusCode) {
 		return status.Error(codes.Unauthenticated, err.Error())
 	}
 

--- a/yorkie/rpc/interceptors/default.go
+++ b/yorkie/rpc/interceptors/default.go
@@ -88,7 +88,8 @@ func (i *DefaultInterceptor) Stream() grpc.StreamServerInterceptor {
 // returned so that the client can know more about the status of the request.
 func toStatusError(err error) error {
 	if errors.Is(err, auth.ErrNotAllowed) ||
-		errors.Is(err, auth.ErrUnexpectedStatusCode) {
+		errors.Is(err, auth.ErrUnexpectedStatusCode) ||
+		errors.Is(err, auth.ErrWebhookTimeout) {
 		return status.Error(codes.Unauthenticated, err.Error())
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
When the webhook is executed, it should be able to safely retry the request based on the webhook server response.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #194 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
