### PR TITLE
Handle synchronously until watch initialization

### DIFF
--- a/test/integration/agent_test.go
+++ b/test/integration/agent_test.go
@@ -47,7 +47,8 @@ func TestAgent(t *testing.T) {
 		assert.NoError(t, cli.Attach(ctx, doc))
 
 		wg := sync.WaitGroup{}
-		wrch := cli.Watch(ctx, doc)
+		wrch, err := cli.Watch(ctx, doc)
+		assert.NoError(t, err)
 
 		go func() {
 			for {

--- a/test/integration/auth_webhook_test.go
+++ b/test/integration/auth_webhook_test.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"sync"
 	"testing"
 
 	"github.com/rs/xid"
@@ -119,17 +118,7 @@ func TestAuthWebhook(t *testing.T) {
 		err = cli.Attach(ctx, doc)
 		assert.Equal(t, codes.Unauthenticated, status.Convert(err).Code())
 
-		wg := sync.WaitGroup{}
-
-		wg.Add(1)
-		rch := cli.Watch(ctx, doc)
-		go func() {
-			defer wg.Done()
-
-			resp := <- rch
-			assert.Equal(t, codes.Unauthenticated, status.Convert(resp.Err).Code())
-		}()
-
-		wg.Wait()
+		_, err = cli.Watch(ctx, doc)
+		assert.Equal(t, codes.Unauthenticated, status.Convert(err).Code())
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Handle synchronously until watch initialization

- Remove WatchStarted type
- Returns the second response if an error occurs before initialization

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
