### PR TITLE
Update go version to 1.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.16
+        go-version: ^1.17
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/docker-publish-latest.yml
+++ b/.github/workflows/docker-publish-latest.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.16
+          go-version: ^1.17
 
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.16
+          go-version: ^1.17
 
       - name: Check out code
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ https://yorkie.dev/docs/main/
 
 ## Developing Yorkie
 
-For building Yorkie, You'll first need [Go](https://golang.org) installed (version 1.16+ is required). Make sure you have Go properly [installed](https://golang.org/doc/install), including setting up your [GOPATH](https://golang.org/doc/code.html#Command). Then download a pre-built binary from [release page](https://github.com/protocolbuffers/protobuf/releases) and install the protobuf compiler (version 3.4.0+ is required).
+For building Yorkie, You'll first need [Go](https://golang.org) installed (version 1.17+ is required). Make sure you have Go properly [installed](https://golang.org/doc/install), including setting up your [GOPATH](https://golang.org/doc/code.html#Command). Then download a pre-built binary from [release page](https://github.com/protocolbuffers/protobuf/releases) and install the protobuf compiler (version 3.4.0+ is required).
 
 We need to install Golang packages to build Yorkie locally. You can run `make tools` to install the required packages.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/yorkie-team/yorkie
 
-go 1.16
+go 1.17
 
 require (
 	github.com/gogo/protobuf v1.3.1
@@ -18,4 +18,158 @@ require (
 	go.mongodb.org/mongo-driver v1.5.1
 	go.uber.org/zap v1.13.0
 	google.golang.org/grpc v1.29.1
+)
+
+require (
+	4d63.com/gochecknoglobals v0.0.0-20201008074935-acfc0b28355a // indirect
+	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24 // indirect
+	github.com/Masterminds/semver v1.5.0 // indirect
+	github.com/OpenPeeDeeP/depguard v1.0.1 // indirect
+	github.com/alexkohler/prealloc v1.0.0 // indirect
+	github.com/ashanbrown/forbidigo v1.2.0 // indirect
+	github.com/ashanbrown/makezero v0.0.0-20210520155254-b6261585ddde // indirect
+	github.com/aws/aws-sdk-go v1.36.30 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bkielbasa/cyclop v1.2.0 // indirect
+	github.com/bombsimon/wsl/v3 v3.3.0 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/charithe/durationcheck v0.0.8 // indirect
+	github.com/chavacava/garif v0.0.0-20210405164556-e8a0a408d6af // indirect
+	github.com/coreos/go-semver v0.3.0 // indirect
+	github.com/coreos/go-systemd v0.0.0-20190620071333-e64a0ec8b42a // indirect
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
+	github.com/daixiang0/gci v0.2.8 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/denis-tingajkin/go-header v0.4.2 // indirect
+	github.com/esimonov/ifshort v1.0.2 // indirect
+	github.com/ettle/strcase v0.1.1 // indirect
+	github.com/fatih/color v1.12.0 // indirect
+	github.com/fatih/structtag v1.2.0 // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/fzipp/gocyclo v0.3.1 // indirect
+	github.com/go-critic/go-critic v0.5.6 // indirect
+	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/go-toolsmith/astcast v1.0.0 // indirect
+	github.com/go-toolsmith/astcopy v1.0.0 // indirect
+	github.com/go-toolsmith/astequal v1.0.0 // indirect
+	github.com/go-toolsmith/astfmt v1.0.0 // indirect
+	github.com/go-toolsmith/astp v1.0.0 // indirect
+	github.com/go-toolsmith/strparse v1.0.0 // indirect
+	github.com/go-toolsmith/typep v1.0.2 // indirect
+	github.com/go-xmlfmt/xmlfmt v0.0.0-20191208150333-d5b6f63a941b // indirect
+	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/gofrs/flock v0.8.0 // indirect
+	github.com/golang/snappy v0.0.1 // indirect
+	github.com/golangci/check v0.0.0-20180506172741-cfe4005ccda2 // indirect
+	github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a // indirect
+	github.com/golangci/go-misc v0.0.0-20180628070357-927a3d87b613 // indirect
+	github.com/golangci/gofmt v0.0.0-20190930125516-244bba706f1a // indirect
+	github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0 // indirect
+	github.com/golangci/maligned v0.0.0-20180506175553-b1d89398deca // indirect
+	github.com/golangci/misspell v0.3.5 // indirect
+	github.com/golangci/revgrep v0.0.0-20210208091834-cd28932614b5 // indirect
+	github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4 // indirect
+	github.com/google/go-cmp v0.5.4 // indirect
+	github.com/gordonklaus/ineffassign v0.0.0-20210225214923-2e10b2664254 // indirect
+	github.com/gostaticanalysis/analysisutil v0.4.1 // indirect
+	github.com/gostaticanalysis/comment v1.4.1 // indirect
+	github.com/gostaticanalysis/forcetypeassert v0.0.0-20200621232751-01d4955beaa5 // indirect
+	github.com/gostaticanalysis/nilerr v0.1.1 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jgautheron/goconst v1.5.1 // indirect
+	github.com/jingyugao/rowserrcheck v1.1.0 // indirect
+	github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/julz/importas v0.0.0-20210419104244-841f0c0fe66d // indirect
+	github.com/kisielk/errcheck v1.6.0 // indirect
+	github.com/kisielk/gotool v1.0.0 // indirect
+	github.com/klauspost/compress v1.11.0 // indirect
+	github.com/kulti/thelper v0.4.0 // indirect
+	github.com/kunwardeep/paralleltest v1.0.2 // indirect
+	github.com/kyoh86/exportloopref v0.1.8 // indirect
+	github.com/ldez/gomoddirectives v0.2.1 // indirect
+	github.com/ldez/tagliatelle v0.2.0 // indirect
+	github.com/magiconair/properties v1.8.1 // indirect
+	github.com/maratori/testpackage v1.0.1 // indirect
+	github.com/matoous/godox v0.0.0-20210227103229-6504466cf951 // indirect
+	github.com/mattn/go-colorable v0.1.8 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/mattn/go-runewidth v0.0.9 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/mbilski/exhaustivestruct v1.2.0 // indirect
+	github.com/mgechev/dots v0.0.0-20190921121421-c36f7dcfbb81 // indirect
+	github.com/mgechev/revive v1.0.7 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/moricho/tparallel v0.2.1 // indirect
+	github.com/nakabonne/nestif v0.3.0 // indirect
+	github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354 // indirect
+	github.com/nishanths/exhaustive v0.1.0 // indirect
+	github.com/nishanths/predeclared v0.2.1 // indirect
+	github.com/olekukonko/tablewriter v0.0.5 // indirect
+	github.com/pelletier/go-toml v1.7.0 // indirect
+	github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/polyfloyd/go-errorlint v0.0.0-20210510181950-ab96adb96fea // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.18.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/quasilyte/go-ruleguard v0.3.4 // indirect
+	github.com/quasilyte/regex/syntax v0.0.0-20200407221936-30656e2c4a95 // indirect
+	github.com/ryancurrah/gomodguard v1.2.2 // indirect
+	github.com/ryanrolds/sqlclosecheck v0.3.0 // indirect
+	github.com/sanposhiho/wastedassign/v2 v2.0.6 // indirect
+	github.com/securego/gosec/v2 v2.8.0 // indirect
+	github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c // indirect
+	github.com/sirupsen/logrus v1.8.1 // indirect
+	github.com/sonatard/noctx v0.0.1 // indirect
+	github.com/sourcegraph/go-diff v0.6.1 // indirect
+	github.com/spf13/afero v1.1.2 // indirect
+	github.com/spf13/cast v1.3.0 // indirect
+	github.com/spf13/jwalterweatherman v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/viper v1.7.1 // indirect
+	github.com/ssgreg/nlreturn/v2 v2.1.0 // indirect
+	github.com/stretchr/objx v0.1.1 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b // indirect
+	github.com/tetafro/godot v1.4.7 // indirect
+	github.com/timakin/bodyclose v0.0.0-20200424151742-cb6215831a94 // indirect
+	github.com/tomarrell/wrapcheck/v2 v2.1.0 // indirect
+	github.com/tommy-muehle/go-mnd/v2 v2.4.0 // indirect
+	github.com/ultraware/funlen v0.0.3 // indirect
+	github.com/ultraware/whitespace v0.0.4 // indirect
+	github.com/uudashr/gocognit v1.0.1 // indirect
+	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
+	github.com/xdg-go/scram v1.0.2 // indirect
+	github.com/xdg-go/stringprep v1.0.2 // indirect
+	github.com/yeya24/promlinter v0.1.0 // indirect
+	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d // indirect
+	go.uber.org/atomic v1.5.0 // indirect
+	go.uber.org/multierr v1.4.0 // indirect
+	go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee // indirect
+	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad // indirect
+	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
+	golang.org/x/mod v0.4.2 // indirect
+	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
+	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
+	golang.org/x/text v0.3.5 // indirect
+	golang.org/x/tools v0.1.3 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	google.golang.org/genproto v0.0.0-20200707001353-8e8330bf89df // indirect
+	google.golang.org/protobuf v1.25.0 // indirect
+	gopkg.in/ini.v1 v1.51.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	honnef.co/go/tools v0.2.0 // indirect
+	mvdan.cc/gofumpt v0.1.1 // indirect
+	mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed // indirect
+	mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b // indirect
+	mvdan.cc/unparam v0.0.0-20210104141923-aac4ce9116a7 // indirect
 )

--- a/test/integration/agent_test.go
+++ b/test/integration/agent_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 /*

--- a/test/integration/agent_test.go
+++ b/test/integration/agent_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
  * Copyright 2021 The Yorkie Authors. All rights reserved.

--- a/test/integration/array_test.go
+++ b/test/integration/array_test.go
@@ -1,4 +1,4 @@
-// +build integration
+//go:build integration
 
 /*
  * Copyright 2020 The Yorkie Authors. All rights reserved.

--- a/test/integration/auth_webhook_test.go
+++ b/test/integration/auth_webhook_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 /*

--- a/test/integration/auth_webhook_test.go
+++ b/test/integration/auth_webhook_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
  * Copyright 2021 The Yorkie Authors. All rights reserved.

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 /*

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
  * Copyright 2020 The Yorkie Authors. All rights reserved.

--- a/test/integration/cluster_mode_test.go
+++ b/test/integration/cluster_mode_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 /*

--- a/test/integration/cluster_mode_test.go
+++ b/test/integration/cluster_mode_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
  * Copyright 2021 The Yorkie Authors. All rights reserved.

--- a/test/integration/counter_test.go
+++ b/test/integration/counter_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 /*

--- a/test/integration/counter_test.go
+++ b/test/integration/counter_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
  * Copyright 2020 The Yorkie Authors. All rights reserved.

--- a/test/integration/document_test.go
+++ b/test/integration/document_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 /*

--- a/test/integration/document_test.go
+++ b/test/integration/document_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
  * Copyright 2020 The Yorkie Authors. All rights reserved.

--- a/test/integration/etcd_test.go
+++ b/test/integration/etcd_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 /*

--- a/test/integration/etcd_test.go
+++ b/test/integration/etcd_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
  * Copyright 2021 The Yorkie Authors. All rights reserved.

--- a/test/integration/gc_test.go
+++ b/test/integration/gc_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 /*

--- a/test/integration/gc_test.go
+++ b/test/integration/gc_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
  * Copyright 2020 The Yorkie Authors. All rights reserved.

--- a/test/integration/health_test.go
+++ b/test/integration/health_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 /*

--- a/test/integration/health_test.go
+++ b/test/integration/health_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
  * Copyright 2021 The Yorkie Authors. All rights reserved.

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 /*

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
  * Copyright 2020 The Yorkie Authors. All rights reserved.

--- a/test/integration/object_test.go
+++ b/test/integration/object_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 /*

--- a/test/integration/object_test.go
+++ b/test/integration/object_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
  * Copyright 2020 The Yorkie Authors. All rights reserved.

--- a/test/integration/peer_awareness_test.go
+++ b/test/integration/peer_awareness_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 /*

--- a/test/integration/peer_awareness_test.go
+++ b/test/integration/peer_awareness_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
  * Copyright 2021 The Yorkie Authors. All rights reserved.

--- a/test/integration/primitive_test.go
+++ b/test/integration/primitive_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 /*

--- a/test/integration/primitive_test.go
+++ b/test/integration/primitive_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
  * Copyright 2020 The Yorkie Authors. All rights reserved.

--- a/test/integration/snapshot_test.go
+++ b/test/integration/snapshot_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 /*

--- a/test/integration/snapshot_test.go
+++ b/test/integration/snapshot_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
  * Copyright 2020 The Yorkie Authors. All rights reserved.

--- a/test/integration/text_test.go
+++ b/test/integration/text_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 /*

--- a/test/integration/text_test.go
+++ b/test/integration/text_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
  * Copyright 2020 The Yorkie Authors. All rights reserved.

--- a/test/stress/document_stress_test.go
+++ b/test/stress/document_stress_test.go
@@ -1,3 +1,4 @@
+//go:build stress
 // +build stress
 
 /*

--- a/test/stress/document_stress_test.go
+++ b/test/stress/document_stress_test.go
@@ -1,5 +1,4 @@
 //go:build stress
-// +build stress
 
 /*
  * Copyright 2020 The Yorkie Authors. All rights reserved.

--- a/test/stress/etcd_stress_test.go
+++ b/test/stress/etcd_stress_test.go
@@ -1,5 +1,4 @@
 //go:build stress
-// +build stress
 
 /*
  * Copyright 2021 The Yorkie Authors. All rights reserved.

--- a/test/stress/etcd_stress_test.go
+++ b/test/stress/etcd_stress_test.go
@@ -1,3 +1,4 @@
+//go:build stress
 // +build stress
 
 /*

--- a/test/stress/sync_stress_test.go
+++ b/test/stress/sync_stress_test.go
@@ -1,5 +1,4 @@
 //go:build stress
-// +build stress
 
 /*
  * Copyright 2021 The Yorkie Authors. All rights reserved.

--- a/test/stress/sync_stress_test.go
+++ b/test/stress/sync_stress_test.go
@@ -1,3 +1,4 @@
+//go:build stress
 // +build stress
 
 /*

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 /*

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,5 +1,4 @@
 //go:build tools
-// +build tools
 
 /*
  * Copyright 2020 The Yorkie Authors. All rights reserved.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
`Go` [1.17](https://go.dev/blog/go1.17) version has been released. so we updated it.
* Update `go.mod` to go 1.17 version
* Update `actions/setup-go@v2` go version in github workflows.
* Add `go:build` as build constraints

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #233 

**Special notes for your reviewer**:

*Go 1.17 includes some changes*
- Pruned module graphs in `go 1.17` modules

	* If a module specifies go 1.17 or higher in its `go.mod` file, its `go.mod` file now contains an	explicit require directive for every module that provides a transitively-imported package.

- `//go:build` line

	* The go command now understands `//go:build` lines and prefers them over `// +build` lines. The new syntax uses boolean expressions, just like Go, and should be less error-prone.
	* As of this release, the new syntax is fully supported, and all Go files should be updated to have both forms with the same meaning.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
