### PR TITLE
Build binaries for environments when releasing a new version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ bin
 
 # idea
 .idea
+
+# release
+release

--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,7 @@ docker:
 docker-latest:
 	docker build -t yorkieteam/yorkie:latest .
 
-.PHONY: tools proto build fmt lint test docker docker-latest
+release:
+	./scripts/build-binary.sh $(YORKIE_VERSION)
+
+.PHONY: tools proto build fmt lint test docker docker-latest release

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,6 @@ docker-latest:
 	docker build -t yorkieteam/yorkie:latest .
 
 release:
-	./scripts/build-binary.sh $(YORKIE_VERSION) '$(GO_LDFLAGS)'
+	./scripts/build-binary.sh $(YORKIE_VERSION) $(GO_LDFLAGS)
 
 .PHONY: tools proto build fmt lint test docker docker-latest release

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,6 @@ docker-latest:
 	docker build -t yorkieteam/yorkie:latest .
 
 release:
-	./scripts/build-binary.sh $(YORKIE_VERSION)
+	./scripts/build-binary.sh $(YORKIE_VERSION) '$(GO_LDFLAGS)'
 
 .PHONY: tools proto build fmt lint test docker docker-latest release

--- a/scripts/build-binary.sh
+++ b/scripts/build-binary.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -e
+
+YORKIE_VERSION=$1
+
+if [ -z "$1" ]; then
+  echo "Usage: ${0} VERSION" >> /dev/stderr
+  exit 255
+fi
+
+set -u
+
+function main {
+  mkdir -p release
+  cd release
+
+  tarcmd=tar
+
+  for os in darwin windows linux; do
+    local ext=""
+
+    export GOOS=${os}
+    TARGET_ARCHS=("amd64")
+
+    if [ "${GOOS}" == "windows" ]; then
+      ext=".exe"
+    fi
+
+    if [ ${GOOS} == "linux" ]; then
+      TARGET_ARCHS+=("arm64")
+      TARGET_ARCHS+=("ppc64le")
+    fi
+
+    for TARGET_ARCH in "${TARGET_ARCHS[@]}"; do
+      export GOARCH=${TARGET_ARCH}
+
+      TARGET="yorkie-v${YORKIE_VERSION}-${GOOS}-${GOARCH}"
+      mkdir -p "${TARGET}"
+
+      go build -o "${TARGET}/yorkie${ext}" -ldflags "" ../cmd/yorkie
+
+      for FILE_NAME in README ROADMAP CHANGELOG ; do
+        cp "../${FILE_NAME}.md" "${TARGET}/${FILE_NAME}.md"
+      done
+
+      if [ ${GOOS} == "linux" ]; then
+        ${tarcmd} cfz "${TARGET}.tar.gz" "${TARGET}"
+        echo "Wrote release/${TARGET}.tar.gz"
+      else
+        zip -qr "${TARGET}.zip" "${TARGET}"
+        echo "Wrote release/${TARGET}.zip"
+      fi
+    done
+  done
+}
+
+main

--- a/scripts/build-binary.sh
+++ b/scripts/build-binary.sh
@@ -3,9 +3,10 @@
 set -e
 
 YORKIE_VERSION=$1
+GO_LDFLAGS=$2
 
-if [ -z "$1" ]; then
-  echo "Usage: ${0} VERSION" >> /dev/stderr
+if [ "$#" -ne 2 ]; then
+  echo "Usage: ${0} VERSION GO_LDFLAGS" >> /dev/stderr
   exit 255
 fi
 
@@ -14,8 +15,6 @@ set -u
 function main {
   mkdir -p release
   cd release
-
-  tarcmd=tar
 
   for os in darwin windows linux; do
     local ext=""
@@ -38,14 +37,14 @@ function main {
       TARGET="yorkie-v${YORKIE_VERSION}-${GOOS}-${GOARCH}"
       mkdir -p "${TARGET}"
 
-      go build -o "${TARGET}/yorkie${ext}" -ldflags "" ../cmd/yorkie
+      go build -o "${TARGET}/yorkie${ext}" -ldflags "${GO_LDFLAGS}" ../cmd/yorkie
 
       for FILE_NAME in README ROADMAP CHANGELOG ; do
         cp "../${FILE_NAME}.md" "${TARGET}/${FILE_NAME}.md"
       done
 
       if [ ${GOOS} == "linux" ]; then
-        ${tarcmd} cfz "${TARGET}.tar.gz" "${TARGET}"
+        tar cfz "${TARGET}.tar.gz" "${TARGET}"
         echo "Wrote release/${TARGET}.tar.gz"
       else
         zip -qr "${TARGET}.zip" "${TARGET}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Users can download and use Yorkie without building for their environment.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #175 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
