### PR TITLE
Draft of supporting thread-safe client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -217,12 +217,9 @@ func (c *Client) Close() error {
 // and receives a unique ID from the agent. The given ID is used to distinguish
 // different clients.
 func (c *Client) Activate(ctx context.Context) error {
-	c.clientMutex.RLock()
-	if c.status == activated {
-		c.clientMutex.RUnlock()
+	if c.IsActive() {
 		return nil
 	}
-	c.clientMutex.RUnlock()
 
 	response, err := c.client.ActivateClient(ctx, &api.ActivateClientRequest{
 		ClientKey: c.key,

--- a/client/client.go
+++ b/client/client.go
@@ -415,6 +415,7 @@ func (c *Client) Watch(
 	}
 
 	rch := make(chan WatchResponse)
+	c.clientMutex.RLock()
 	stream, err := c.client.WatchDocuments(ctx, &api.WatchDocumentsRequest{
 		Client: converter.ToClient(types.Client{
 			ID:           c.id,
@@ -423,8 +424,10 @@ func (c *Client) Watch(
 		DocumentKeys: converter.ToDocumentKeys(keys),
 	})
 	if err != nil {
+		c.clientMutex.RUnlock()
 		return nil, err
 	}
+	c.clientMutex.RUnlock()
 
 	handleResponse := func(pbResp *api.WatchDocumentsResponse) (*WatchResponse, error) {
 		switch resp := pbResp.Body.(type) {

--- a/test/integration/client_concurrency_test.go
+++ b/test/integration/client_concurrency_test.go
@@ -47,11 +47,9 @@ func TestClientConcurrency(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				if i%2 == 0 {
-					err = cli.Activate(ctx)
-					assert.NoError(t, err)
+					assert.NoError(t, cli.Activate(ctx))
 				} else {
-					err = cli.Deactivate(ctx)
-					assert.NoError(t, err)
+					assert.NoError(t, cli.Deactivate(ctx))
 				}
 			}()
 		}

--- a/test/integration/client_concurrency_test.go
+++ b/test/integration/client_concurrency_test.go
@@ -80,8 +80,7 @@ func TestClientConcurrency(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				err = cli.Deactivate(ctx)
-				assert.NoError(t, err)
+				assert.NoError(t, cli.Deactivate(ctx))
 			}()
 		}
 

--- a/test/integration/client_concurrency_test.go
+++ b/test/integration/client_concurrency_test.go
@@ -1,7 +1,7 @@
 // +build integration
 
 /*
- * Copyright 2020 The Yorkie Authors. All rights reserved.
+ * Copyright 2021 The Yorkie Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/client_concurrency_test.go
+++ b/test/integration/client_concurrency_test.go
@@ -1,0 +1,94 @@
+// +build integration
+
+/*
+ * Copyright 2020 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration
+
+import (
+	"context"
+	gosync "sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yorkie-team/yorkie/client"
+)
+
+func TestClientConcurrency(t *testing.T) {
+	MAX_ROUTINES := 5
+
+	t.Run("concurrent activate/deactivate test", func(t *testing.T) {
+		cli, err := client.Dial(defaultAgent.RPCAddr())
+		assert.NoError(t, err)
+		defer func() {
+			err := cli.Close()
+			assert.NoError(t, err)
+		}()
+
+		ctx := context.Background()
+		wg := gosync.WaitGroup{}
+
+		// Activate <-> Deactivate in goroutine
+		for i := 0; i <= MAX_ROUTINES; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if i%2 == 0 {
+					err = cli.Activate(ctx)
+					assert.NoError(t, err)
+				} else {
+					err = cli.Deactivate(ctx)
+					assert.NoError(t, err)
+				}
+			}()
+		}
+
+		wg.Wait()
+
+		//assert.True(t, cli.IsActive())\
+		if !cli.IsActive() {
+			cli.Activate(ctx)
+		}
+
+		// All Activate in goroutine
+		for i := 0; i <= MAX_ROUTINES; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				err = cli.Activate(ctx)
+				assert.NoError(t, err)
+			}()
+		}
+
+		assert.True(t, cli.IsActive())
+
+		wg.Wait()
+
+		// All Deactivate in goroutine
+		for i := 0; i <= MAX_ROUTINES; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				err = cli.Deactivate(ctx)
+				assert.NoError(t, err)
+			}()
+		}
+
+		assert.False(t, cli.IsActive())
+
+		wg.Wait()
+	})
+}

--- a/test/integration/client_concurrency_test.go
+++ b/test/integration/client_concurrency_test.go
@@ -92,7 +92,7 @@ func TestClientConcurrency(t *testing.T) {
 		assert.False(t, cli.IsActive())
 	})
 
-	t.Run("concurrent attach/detach intersect test", func(t *testing.T) {
+	t.Run("concurrent attach/detach test", func(t *testing.T) {
 		cli, err := client.Dial(defaultAgent.RPCAddr())
 		assert.NoError(t, err)
 		defer func() {
@@ -152,7 +152,7 @@ func TestClientConcurrency(t *testing.T) {
 		}
 	})
 
-	t.Run("concurrent attach/detach single continuous test", func(t *testing.T) {
+	t.Run("concurrent watch document across agent with one client in go routines", func(t *testing.T) {
 
 	})
 }

--- a/test/integration/client_concurrency_test.go
+++ b/test/integration/client_concurrency_test.go
@@ -70,9 +70,9 @@ func TestClientConcurrency(t *testing.T) {
 			}()
 		}
 
-		assert.True(t, cli.IsActive())
-
 		wg.Wait()
+
+		assert.True(t, cli.IsActive())
 
 		// All Deactivate in goroutine
 		for i := 0; i <= MAX_ROUTINES; i++ {
@@ -83,8 +83,9 @@ func TestClientConcurrency(t *testing.T) {
 			}()
 		}
 
+		wg.Wait()
+
 		assert.False(t, cli.IsActive())
 
-		wg.Wait()
 	})
 }

--- a/test/integration/client_concurrency_test.go
+++ b/test/integration/client_concurrency_test.go
@@ -44,14 +44,14 @@ func TestClientConcurrency(t *testing.T) {
 		// Activate <-> Deactivate in goroutine
 		for i := 0; i <= MAX_ROUTINES; i++ {
 			wg.Add(1)
-			go func() {
+			go func(idx int) {
 				defer wg.Done()
-				if i%2 == 0 {
+				if idx%2 == 0 {
 					assert.NoError(t, cli.Activate(ctx))
 				} else {
 					assert.NoError(t, cli.Deactivate(ctx))
 				}
-			}()
+			}(i)
 		}
 
 		wg.Wait()

--- a/test/integration/client_concurrency_test.go
+++ b/test/integration/client_concurrency_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	
 	"github.com/yorkie-team/yorkie/client"
 	"github.com/yorkie-team/yorkie/pkg/document"
 	"github.com/yorkie-team/yorkie/pkg/document/proxy"

--- a/test/integration/client_concurrency_test.go
+++ b/test/integration/client_concurrency_test.go
@@ -53,9 +53,9 @@ func TestClientConcurrency(t *testing.T) {
 				defer wg.Done()
 				if idx%2 == 0 {
 					assert.NoError(t, cli.Activate(ctx))
-				} else {
-					assert.NoError(t, cli.Deactivate(ctx))
+					return
 				}
+				assert.NoError(t, cli.Deactivate(ctx))
 			}(i)
 		}
 

--- a/test/integration/client_concurrency_test.go
+++ b/test/integration/client_concurrency_test.go
@@ -66,8 +66,7 @@ func TestClientConcurrency(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				err = cli.Activate(ctx)
-				assert.NoError(t, err)
+				assert.NoError(t, cli.Activate(ctx))
 			}()
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Try to make `client` thread-safe. We can use one client for multiple request with go routines.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #190 

**Special notes for your reviewer**:

This is draft PR because cannot pass my own test of `test/integration/client_concurrency_test.go`.
How can I make test that verifying this is a thread-safe client?
Multiple other tests also fails when `test/integration/client_concurrency_test.go` added.
Also, I doubt if this support real thread-safe way in Yorkie client.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [ ] Didn't break anything
