### PR TITLE
Check the level before writing debug messages.

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -25,6 +25,10 @@ import (
 
 // Logger is the default logger used by Yorkie.
 var Logger *zap.SugaredLogger
+
+// Core is a minimal, fast logger interface.
+var Core zapcore.Core
+
 var rawLogger *zap.Logger
 
 func encoderConfig() zapcore.EncoderConfig {
@@ -56,9 +60,10 @@ func init() {
 		zapcore.NewCore(
 			zapcore.NewConsoleEncoder(humanEncoderConfig()),
 			zapcore.AddSync(os.Stdout),
-			zap.InfoLevel,
+			zapcore.InfoLevel,
 		),
 	), zap.AddStacktrace(zap.ErrorLevel))
 
 	Logger = rawLogger.Sugar()
+	Core = rawLogger.Core()
 }

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -19,6 +19,8 @@ package document
 import (
 	"fmt"
 
+	"go.uber.org/zap"
+
 	"github.com/yorkie-team/yorkie/internal/log"
 	"github.com/yorkie-team/yorkie/pkg/document/change"
 	"github.com/yorkie-team/yorkie/pkg/document/checkpoint"
@@ -121,7 +123,9 @@ func (d *Document) ApplyChangePack(pack *change.Pack) error {
 	// 04. Do Garbage collection.
 	d.GarbageCollect(pack.MinSyncedTicket)
 
-	log.Logger.Debugf("after apply %d changes: %s", len(pack.Changes), d.RootObject().Marshal())
+	if log.Core.Enabled(zap.DebugLevel) {
+		log.Logger.Debugf("after apply %d changes: %s", len(pack.Changes), d.RootObject().Marshal())
+	}
 	return nil
 }
 

--- a/pkg/document/internal_document.go
+++ b/pkg/document/internal_document.go
@@ -17,6 +17,8 @@
 package document
 
 import (
+	"go.uber.org/zap"
+
 	"github.com/yorkie-team/yorkie/api/converter"
 	"github.com/yorkie-team/yorkie/internal/log"
 	"github.com/yorkie-team/yorkie/pkg/document/change"
@@ -122,7 +124,9 @@ func (d *InternalDocument) ApplyChangePack(pack *change.Pack) error {
 	// 03. Update the checkpoint.
 	d.checkpoint = d.checkpoint.Forward(pack.Checkpoint)
 
-	log.Logger.Debugf("after apply %d changes: %s", len(pack.Changes), d.RootObject().Marshal())
+	if log.Core.Enabled(zap.DebugLevel) {
+		log.Logger.Debugf("after apply %d changes: %s", len(pack.Changes), d.RootObject().Marshal())
+	}
 	return nil
 }
 

--- a/pkg/document/json/rich_text.go
+++ b/pkg/document/json/rich_text.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"unicode/utf16"
 
+	"go.uber.org/zap"
+
 	"github.com/yorkie-team/yorkie/internal/log"
 	"github.com/yorkie-team/yorkie/pkg/document/time"
 )
@@ -218,11 +220,13 @@ func (t *RichText) Edit(
 		executedAt,
 	)
 
-	log.Logger.Debugf(
-		"EDIT: '%s' edits %s",
-		executedAt.ActorID().String(),
-		t.rgaTreeSplit.AnnotatedString(),
-	)
+	if log.Core.Enabled(zap.DebugLevel) {
+		log.Logger.Debugf(
+			"EDIT: '%s' edits %s",
+			executedAt.ActorID().String(),
+			t.rgaTreeSplit.AnnotatedString(),
+		)
+	}
 
 	return cursorPos, latestCreatedAtMapByActor
 }
@@ -247,11 +251,13 @@ func (t *RichText) SetStyle(
 		}
 	}
 
-	log.Logger.Debugf(
-		"STYL: '%s' styles %s",
-		executedAt.ActorID().String(),
-		t.rgaTreeSplit.AnnotatedString(),
-	)
+	if log.Core.Enabled(zap.DebugLevel) {
+		log.Logger.Debugf(
+			"STYL: '%s' styles %s",
+			executedAt.ActorID().String(),
+			t.rgaTreeSplit.AnnotatedString(),
+		)
+	}
 }
 
 // Select stores that the given range has been selected.
@@ -263,11 +269,13 @@ func (t *RichText) Select(
 	if prev, ok := t.selectionMap[executedAt.ActorIDHex()]; !ok || executedAt.After(prev.updatedAt) {
 		t.selectionMap[executedAt.ActorIDHex()] = newSelection(from, to, executedAt)
 
-		log.Logger.Debugf(
-			"SELT: '%s' selects %s",
-			executedAt.ActorID().String(),
-			t.rgaTreeSplit.AnnotatedString(),
-		)
+		if log.Core.Enabled(zap.DebugLevel) {
+			log.Logger.Debugf(
+				"SELT: '%s' selects %s",
+				executedAt.ActorID().String(),
+				t.rgaTreeSplit.AnnotatedString(),
+			)
+		}
 	}
 }
 

--- a/pkg/document/json/text.go
+++ b/pkg/document/json/text.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"unicode/utf16"
 
+	"go.uber.org/zap"
+
 	"github.com/yorkie-team/yorkie/internal/log"
 	"github.com/yorkie-team/yorkie/pkg/document/time"
 )
@@ -175,11 +177,15 @@ func (t *Text) Edit(
 		NewTextValue(content),
 		executedAt,
 	)
-	log.Logger.Debugf(
-		"EDIT: '%s' edits %s",
-		executedAt.ActorID().String(),
-		t.rgaTreeSplit.AnnotatedString(),
-	)
+
+	if log.Core.Enabled(zap.DebugLevel) {
+		log.Logger.Debugf(
+			"EDIT: '%s' edits %s",
+			executedAt.ActorID().String(),
+			t.rgaTreeSplit.AnnotatedString(),
+		)
+	}
+
 	return cursorPos, latestCreatedAtMapByActor
 }
 
@@ -196,11 +202,13 @@ func (t *Text) Select(
 
 	prevSelection := t.selectionMap[executedAt.ActorIDHex()]
 	if executedAt.After(prevSelection.updatedAt) {
-		log.Logger.Debugf(
-			"SELT: '%s' selects %s",
-			executedAt.ActorID().String(),
-			t.rgaTreeSplit.AnnotatedString(),
-		)
+		if log.Core.Enabled(zap.DebugLevel) {
+			log.Logger.Debugf(
+				"SELT: '%s' selects %s",
+				executedAt.ActorID().String(),
+				t.rgaTreeSplit.AnnotatedString(),
+			)
+		}
 
 		t.selectionMap[executedAt.ActorIDHex()] = newSelection(from, to, executedAt)
 	}

--- a/pkg/document/proxy/rich_text_proxy.go
+++ b/pkg/document/proxy/rich_text_proxy.go
@@ -17,6 +17,8 @@
 package proxy
 
 import (
+	"go.uber.org/zap"
+
 	"github.com/yorkie-team/yorkie/internal/log"
 	"github.com/yorkie-team/yorkie/pkg/document/change"
 	"github.com/yorkie-team/yorkie/pkg/document/json"
@@ -43,10 +45,13 @@ func (p *RichTextProxy) Edit(from, to int, content string, attributes map[string
 		panic("from should be less than or equal to to")
 	}
 	fromPos, toPos := p.RichText.CreateRange(from, to)
-	log.Logger.Debugf(
-		"EDIT: f:%d->%s, t:%d->%s, c:%s, attrs:%v",
-		from, fromPos.AnnotatedString(), to, toPos.AnnotatedString(), content,
-	)
+
+	if log.Core.Enabled(zap.DebugLevel) {
+		log.Logger.Debugf(
+			"EDIT: f:%d->%s, t:%d->%s, c:%s, attrs:%v",
+			from, fromPos.AnnotatedString(), to, toPos.AnnotatedString(), content,
+		)
+	}
 
 	ticket := p.context.IssueTimeTicket()
 	_, maxCreationMapByActor := p.RichText.Edit(
@@ -80,10 +85,13 @@ func (p *RichTextProxy) SetStyle(from, to int, attributes map[string]string) *Ri
 		panic("from should be less than or equal to to")
 	}
 	fromPos, toPos := p.RichText.CreateRange(from, to)
-	log.Logger.Debugf(
-		"STYL: f:%d->%s, t:%d->%s, attrs:%v",
-		from, fromPos.AnnotatedString(), to, toPos.AnnotatedString(), attributes,
-	)
+
+	if log.Core.Enabled(zap.DebugLevel) {
+		log.Logger.Debugf(
+			"STYL: f:%d->%s, t:%d->%s, attrs:%v",
+			from, fromPos.AnnotatedString(), to, toPos.AnnotatedString(), attributes,
+		)
+	}
 
 	ticket := p.context.IssueTimeTicket()
 	p.RichText.SetStyle(

--- a/pkg/document/proxy/text_proxy.go
+++ b/pkg/document/proxy/text_proxy.go
@@ -17,6 +17,8 @@
 package proxy
 
 import (
+	"go.uber.org/zap"
+
 	"github.com/yorkie-team/yorkie/internal/log"
 	"github.com/yorkie-team/yorkie/pkg/document/change"
 	"github.com/yorkie-team/yorkie/pkg/document/json"
@@ -43,10 +45,13 @@ func (p *TextProxy) Edit(from, to int, content string) *TextProxy {
 		panic("from should be less than or equal to to")
 	}
 	fromPos, toPos := p.Text.CreateRange(from, to)
-	log.Logger.Debugf(
-		"EDIT: f:%d->%s, t:%d->%s c:%s",
-		from, fromPos.AnnotatedString(), to, toPos.AnnotatedString(), content,
-	)
+
+	if log.Core.Enabled(zap.DebugLevel) {
+		log.Logger.Debugf(
+			"EDIT: f:%d->%s, t:%d->%s c:%s",
+			from, fromPos.AnnotatedString(), to, toPos.AnnotatedString(), content,
+		)
+	}
 
 	ticket := p.context.IssueTimeTicket()
 	_, maxCreationMapByActor := p.Text.Edit(
@@ -77,10 +82,13 @@ func (p *TextProxy) Select(from, to int) *TextProxy {
 		panic("from should be less than or equal to to")
 	}
 	fromPos, toPos := p.Text.CreateRange(from, to)
-	log.Logger.Debugf(
-		"SELT: f:%d->%s, t:%d->%s",
-		from, fromPos.AnnotatedString(), to, toPos.AnnotatedString(),
-	)
+
+	if log.Core.Enabled(zap.DebugLevel) {
+		log.Logger.Debugf(
+			"SELT: f:%d->%s, t:%d->%s",
+			from, fromPos.AnnotatedString(), to, toPos.AnnotatedString(),
+		)
+	}
 
 	ticket := p.context.IssueTimeTicket()
 	p.Text.Select(

--- a/test/bench/text_editing_bench_test.go
+++ b/test/bench/text_editing_bench_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
+	"runtime/pprof"
 	"testing"
 	"time"
 
@@ -47,9 +48,14 @@ func BenchmarkTextEditing(b *testing.B) {
 		return nil
 	})
 
+	f, err := os.Create("text-editing.prof")
+	assert.NoError(b, err)
+	assert.NoError(b, pprof.StartCPUProfile(f))
+	defer pprof.StopCPUProfile()
+
 	start := time.Now()
 	for i, edit := range editingTrace.Edits {
-		if i != 0 && i%1000 == 0 {
+		if i != 0 && i%10000 == 0 {
 			b.Log("processing...", i, time.Since(start))
 			start = time.Now()
 		}

--- a/yorkie/backend/sync/memory/pubsub.go
+++ b/yorkie/backend/sync/memory/pubsub.go
@@ -19,6 +19,8 @@ package memory
 import (
 	gosync "sync"
 
+	"go.uber.org/zap"
+
 	"github.com/yorkie-team/yorkie/internal/log"
 	"github.com/yorkie-team/yorkie/pkg/document/key"
 	"github.com/yorkie-team/yorkie/pkg/document/time"
@@ -85,11 +87,13 @@ func (m *PubSub) Subscribe(
 		return nil, sync.ErrEmptyDocKeys
 	}
 
-	log.Logger.Debugf(
-		`Subscribe(%s,%s) Start`,
-		keys[0].BSONKey(),
-		subscriber.ID.String(),
-	)
+	if log.Core.Enabled(zap.DebugLevel) {
+		log.Logger.Debugf(
+			`Subscribe(%s,%s) Start`,
+			keys[0].BSONKey(),
+			subscriber.ID.String(),
+		)
+	}
 
 	m.subscriptionsMapMu.Lock()
 	defer m.subscriptionsMapMu.Unlock()
@@ -105,11 +109,13 @@ func (m *PubSub) Subscribe(
 		m.subscriptionsMapByDocKey[bsonKey].Add(sub)
 	}
 
-	log.Logger.Debugf(
-		`Subscribe(%s,%s) End`,
-		keys[0].BSONKey(),
-		subscriber.ID.String(),
-	)
+	if log.Core.Enabled(zap.DebugLevel) {
+		log.Logger.Debugf(
+			`Subscribe(%s,%s) End`,
+			keys[0].BSONKey(),
+			subscriber.ID.String(),
+		)
+	}
 	return sub, nil
 }
 
@@ -135,11 +141,13 @@ func (m *PubSub) Unsubscribe(
 	m.subscriptionsMapMu.Lock()
 	defer m.subscriptionsMapMu.Unlock()
 
-	log.Logger.Debugf(
-		`Unsubscribe(%s,%s) Start`,
-		docKeys[0].BSONKey(),
-		sub.SubscriberID(),
-	)
+	if log.Core.Enabled(zap.DebugLevel) {
+		log.Logger.Debugf(
+			`Unsubscribe(%s,%s) Start`,
+			docKeys[0].BSONKey(),
+			sub.SubscriberID(),
+		)
+	}
 
 	sub.Close()
 
@@ -155,11 +163,13 @@ func (m *PubSub) Unsubscribe(
 		}
 	}
 
-	log.Logger.Debugf(
-		`Unsubscribe(%s,%s) End`,
-		docKeys[0].BSONKey(),
-		sub.SubscriberID(),
-	)
+	if log.Core.Enabled(zap.DebugLevel) {
+		log.Logger.Debugf(
+			`Unsubscribe(%s,%s) End`,
+			docKeys[0].BSONKey(),
+			sub.SubscriberID(),
+		)
+	}
 }
 
 // Publish publishes the given event.
@@ -173,7 +183,9 @@ func (m *PubSub) Publish(
 	for _, docKey := range event.DocumentKeys {
 		k := docKey.BSONKey()
 
-		log.Logger.Debugf(`Publish(%s,%s) Start`, k, publisherID.String())
+		if log.Core.Enabled(zap.DebugLevel) {
+			log.Logger.Debugf(`Publish(%s,%s) Start`, k, publisherID.String())
+		}
 
 		if subs, ok := m.subscriptionsMapByDocKey[k]; ok {
 			for _, sub := range subs.Map() {
@@ -181,16 +193,20 @@ func (m *PubSub) Publish(
 					continue
 				}
 
-				log.Logger.Debugf(
-					`Publish(%s,%s) to %s`,
-					k,
-					publisherID.String(),
-					sub.SubscriberID(),
-				)
+				if log.Core.Enabled(zap.DebugLevel) {
+					log.Logger.Debugf(
+						`Publish(%s,%s) to %s`,
+						k,
+						publisherID.String(),
+						sub.SubscriberID(),
+					)
+				}
 				sub.Events() <- event
 			}
 		}
-		log.Logger.Debugf(`Publish(%s,%s) End`, k, publisherID.String())
+		if log.Core.Enabled(zap.DebugLevel) {
+			log.Logger.Debugf(`Publish(%s,%s) End`, k, publisherID.String())
+		}
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Check the level before writing debug messages.

Performance was dropping to generate unnecessary debug messages. To avoid this, check the level before outputting a debug message.

```
goos: darwin
goarch: amd64
pkg: github.com/yorkie-team/yorkie/test/bench
cpu: Intel(R) Core(TM) i5-4690 CPU @ 3.50GHz
BenchmarkTextEditing
    text_editing_bench_test.go:59: processing... 10000 174.504879ms
    text_editing_bench_test.go:59: processing... 20000 109.470337ms
    text_editing_bench_test.go:59: processing... 30000 4.806405038s
    text_editing_bench_test.go:59: processing... 40000 216.480363ms
    text_editing_bench_test.go:59: processing... 50000 112.252058ms
    text_editing_bench_test.go:59: processing... 60000 808.748392ms
    text_editing_bench_test.go:59: processing... 70000 667.073535ms
    text_editing_bench_test.go:59: processing... 80000 9.17087822s
    text_editing_bench_test.go:59: processing... 90000 2.180935603s
    text_editing_bench_test.go:59: processing... 100000 1.731117444s
    text_editing_bench_test.go:59: processing... 110000 1.056575369s
    text_editing_bench_test.go:59: processing... 120000 124.693308ms
    text_editing_bench_test.go:59: processing... 130000 513.933027ms
    text_editing_bench_test.go:59: processing... 140000 54.806386806s
    text_editing_bench_test.go:59: processing... 150000 1m54.853097078s
    text_editing_bench_test.go:59: processing... 160000 1.055604723s
    text_editing_bench_test.go:59: processing... 170000 941.902282ms
    text_editing_bench_test.go:59: processing... 180000 15.575431116s
    text_editing_bench_test.go:59: processing... 190000 1.674996829s
    text_editing_bench_test.go:59: processing... 200000 15.967675598s
    text_editing_bench_test.go:59: processing... 210000 224.987399ms
    text_editing_bench_test.go:59: processing... 220000 154.559864ms
    text_editing_bench_test.go:59: processing... 230000 155.082594ms
    text_editing_bench_test.go:59: processing... 240000 1.347651533s
    text_editing_bench_test.go:59: processing... 250000 4.099265955s
BenchmarkTextEditing-4   	       1	240883800421 ns/op
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Address #251

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
