### PR TITLE
Replace fmt.Sprintf with strconv

### DIFF
--- a/pkg/document/json/rga_tree_split.go
+++ b/pkg/document/json/rga_tree_split.go
@@ -2,6 +2,7 @@ package json
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/yorkie-team/yorkie/internal/log"
@@ -91,7 +92,7 @@ func (t *RGATreeSplitNodeID) hasSameCreatedAt(id *RGATreeSplitNodeID) bool {
 }
 
 func (t *RGATreeSplitNodeID) key() string {
-	return fmt.Sprintf("%s:%d", t.createdAt.Key(), t.offset)
+	return t.CreatedAt().Key() + ":" + strconv.FormatUint(uint64(t.offset), 10)
 }
 
 // RGATreeSplitNodePos is the position of the text inside the node.

--- a/pkg/document/time/ticket.go
+++ b/pkg/document/time/ticket.go
@@ -19,6 +19,7 @@ package time
 import (
 	"fmt"
 	"math"
+	"strconv"
 )
 
 const (
@@ -81,12 +82,17 @@ func (t *Ticket) AnnotatedString() string {
 // Key returns the key string for this Ticket.
 func (t *Ticket) Key() string {
 	if t.actorID == nil {
-		return fmt.Sprintf("%d:%d:", t.lamport, t.delimiter)
+		return strconv.FormatUint(t.lamport, 10) +
+			":" +
+			strconv.FormatUint(uint64(t.delimiter), 10) +
+			":"
 	}
 
-	return fmt.Sprintf(
-		"%d:%d:%s", t.lamport, t.delimiter, t.actorID.String(),
-	)
+	return strconv.FormatUint(t.lamport, 10) +
+		":" +
+		strconv.FormatUint(uint64(t.delimiter), 10) +
+		":" +
+		t.actorID.String()
 }
 
 // Lamport returns the lamport value.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Replace `fmt.Sprintf` with `strconv`.

Before

<img width="516" alt="Screen Shot 2021-10-05 at 12 04 00 PM" src="https://user-images.githubusercontent.com/2059311/135953598-f2cf1649-3a1e-4f43-b1ce-c5c2436ff2f5.png">

After

<img width="793" alt="Screen Shot 2021-10-05 at 12 05 16 PM" src="https://user-images.githubusercontent.com/2059311/135953686-07af7699-056b-45be-a83d-a4f7b5950b65.png">


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Address #251

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
