### PR TITLE
Replace hex.EncodeTostring with ActorID.key in Text and RichText

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -393,7 +393,7 @@ func (c *Client) Watch(
 
 				attachment := c.attachments[docID]
 				for _, cli := range clients {
-					attachment.peers[cli.ID.String()] = cli.MetadataInfo
+					attachment.peers[cli.ID.Hex()] = cli.MetadataInfo
 				}
 			}
 
@@ -420,12 +420,12 @@ func (c *Client) Watch(
 					attachment := c.attachments[k.BSONKey()]
 					if eventType == types.DocumentsWatchedEvent ||
 						eventType == types.MetadataChangedEvent {
-						if info, ok := attachment.peers[cli.ID.String()]; ok {
+						if info, ok := attachment.peers[cli.ID.Hex()]; ok {
 							cli.MetadataInfo.Update(info)
 						}
-						attachment.peers[cli.ID.String()] = cli.MetadataInfo
+						attachment.peers[cli.ID.Hex()] = cli.MetadataInfo
 					} else {
-						delete(attachment.peers, cli.ID.String())
+						delete(attachment.peers, cli.ID.Hex())
 					}
 				}
 				return &WatchResponse{

--- a/pkg/document/json/rga_tree_split.go
+++ b/pkg/document/json/rga_tree_split.go
@@ -475,13 +475,13 @@ func (s *RGATreeSplit) deleteNodes(
 	removedNodeMap := make(map[string]*RGATreeSplitNode)
 
 	for _, node := range candidates {
-		actorIDHex := node.createdAt().ActorIDHex()
+		actorIDKey := node.createdAt().ActorIDKey()
 
 		var latestCreatedAt *time.Ticket
 		if latestCreatedAtMapByActor == nil {
 			latestCreatedAt = time.MaxTicket
 		} else {
-			createdAt, ok := latestCreatedAtMapByActor[actorIDHex]
+			createdAt, ok := latestCreatedAtMapByActor[actorIDKey]
 			if ok {
 				latestCreatedAt = createdAt
 			} else {
@@ -491,10 +491,10 @@ func (s *RGATreeSplit) deleteNodes(
 
 		if node.Remove(editedAt, latestCreatedAt) {
 			s.treeByIndex.Splay(node.indexNode)
-			latestCreatedAt := createdAtMapByActor[actorIDHex]
+			latestCreatedAt := createdAtMapByActor[actorIDKey]
 			createdAt := node.id.createdAt
 			if latestCreatedAt == nil || createdAt.After(latestCreatedAt) {
-				createdAtMapByActor[actorIDHex] = createdAt
+				createdAtMapByActor[actorIDKey] = createdAt
 			}
 
 			removedNodeMap[node.id.key()] = node

--- a/pkg/document/json/rich_text.go
+++ b/pkg/document/json/rich_text.go
@@ -223,7 +223,7 @@ func (t *RichText) Edit(
 	if log.Core.Enabled(zap.DebugLevel) {
 		log.Logger.Debugf(
 			"EDIT: '%s' edits %s",
-			executedAt.ActorID().String(),
+			executedAt.ActorID().Hex(),
 			t.rgaTreeSplit.AnnotatedString(),
 		)
 	}
@@ -254,7 +254,7 @@ func (t *RichText) SetStyle(
 	if log.Core.Enabled(zap.DebugLevel) {
 		log.Logger.Debugf(
 			"STYL: '%s' styles %s",
-			executedAt.ActorID().String(),
+			executedAt.ActorID().Hex(),
 			t.rgaTreeSplit.AnnotatedString(),
 		)
 	}
@@ -266,13 +266,13 @@ func (t *RichText) Select(
 	to *RGATreeSplitNodePos,
 	executedAt *time.Ticket,
 ) {
-	if prev, ok := t.selectionMap[executedAt.ActorIDHex()]; !ok || executedAt.After(prev.updatedAt) {
-		t.selectionMap[executedAt.ActorIDHex()] = newSelection(from, to, executedAt)
+	if prev, ok := t.selectionMap[executedAt.ActorIDKey()]; !ok || executedAt.After(prev.updatedAt) {
+		t.selectionMap[executedAt.ActorIDKey()] = newSelection(from, to, executedAt)
 
 		if log.Core.Enabled(zap.DebugLevel) {
 			log.Logger.Debugf(
 				"SELT: '%s' selects %s",
-				executedAt.ActorID().String(),
+				executedAt.ActorID().Hex(),
 				t.rgaTreeSplit.AnnotatedString(),
 			)
 		}

--- a/pkg/document/json/text.go
+++ b/pkg/document/json/text.go
@@ -181,7 +181,7 @@ func (t *Text) Edit(
 	if log.Core.Enabled(zap.DebugLevel) {
 		log.Logger.Debugf(
 			"EDIT: '%s' edits %s",
-			executedAt.ActorID().String(),
+			executedAt.ActorID().Hex(),
 			t.rgaTreeSplit.AnnotatedString(),
 		)
 	}
@@ -195,22 +195,22 @@ func (t *Text) Select(
 	to *RGATreeSplitNodePos,
 	executedAt *time.Ticket,
 ) {
-	if _, ok := t.selectionMap[executedAt.ActorIDHex()]; !ok {
-		t.selectionMap[executedAt.ActorIDHex()] = newSelection(from, to, executedAt)
+	if _, ok := t.selectionMap[executedAt.ActorIDKey()]; !ok {
+		t.selectionMap[executedAt.ActorIDKey()] = newSelection(from, to, executedAt)
 		return
 	}
 
-	prevSelection := t.selectionMap[executedAt.ActorIDHex()]
+	prevSelection := t.selectionMap[executedAt.ActorIDKey()]
 	if executedAt.After(prevSelection.updatedAt) {
 		if log.Core.Enabled(zap.DebugLevel) {
 			log.Logger.Debugf(
 				"SELT: '%s' selects %s",
-				executedAt.ActorID().String(),
+				executedAt.ActorID().Hex(),
 				t.rgaTreeSplit.AnnotatedString(),
 			)
 		}
 
-		t.selectionMap[executedAt.ActorIDHex()] = newSelection(from, to, executedAt)
+		t.selectionMap[executedAt.ActorIDKey()] = newSelection(from, to, executedAt)
 	}
 }
 

--- a/pkg/document/time/actor_id.go
+++ b/pkg/document/time/actor_id.go
@@ -89,9 +89,18 @@ func ActorIDFromBytes(bytes []byte) (*ActorID, error) {
 	return &actorID, nil
 }
 
-// String returns the hexadecimal encoding of ActorID.
+// Key returns the string of ActorID.
+func (id *ActorID) Key() string {
+	if id == nil {
+		return ""
+	}
+
+	return string(id[:])
+}
+
+// Hex returns the hexadecimal encoding of ActorID.
 // If the receiver is nil, it would return empty string.
-func (id *ActorID) String() string {
+func (id *ActorID) Hex() string {
 	if id == nil {
 		return ""
 	}

--- a/pkg/document/time/actor_id_test.go
+++ b/pkg/document/time/actor_id_test.go
@@ -16,11 +16,11 @@ func TestActorID(t *testing.T) {
 		_, err := rand.Read(actorID[:])
 		assert.NoError(t, err)
 
-		expectedID := actorID.String()
+		expectedID := actorID.Hex()
 		actualID, err := time.ActorIDFromHex(expectedID)
 
 		assert.NoError(t, err)
-		assert.Equal(t, expectedID, actualID.String())
+		assert.Equal(t, expectedID, actualID.Hex())
 	})
 
 	t.Run("get ActorID from hex on invalid hexadecimal string test", func(t *testing.T) {

--- a/pkg/document/time/ticket.go
+++ b/pkg/document/time/ticket.go
@@ -75,7 +75,7 @@ func (t *Ticket) AnnotatedString() string {
 	}
 
 	return fmt.Sprintf(
-		"%d:%d:%s", t.lamport, t.delimiter, t.actorID.String()[22:24],
+		"%d:%d:%s", t.lamport, t.delimiter, t.actorID.Hex()[22:24],
 	)
 }
 
@@ -92,7 +92,7 @@ func (t *Ticket) Key() string {
 		":" +
 		strconv.FormatUint(uint64(t.delimiter), 10) +
 		":" +
-		t.actorID.String()
+		t.actorID.Key()
 }
 
 // Lamport returns the lamport value.
@@ -110,9 +110,14 @@ func (t *Ticket) ActorID() *ActorID {
 	return t.actorID
 }
 
+// ActorIDKey returns the actorID's string value.
+func (t *Ticket) ActorIDKey() string {
+	return t.actorID.Key()
+}
+
 // ActorIDHex returns the actorID's hex value.
 func (t *Ticket) ActorIDHex() string {
-	return t.actorID.String()
+	return t.actorID.Hex()
 }
 
 // ActorIDBytes returns the actorID's bytes value.

--- a/pkg/document/time/ticket_test.go
+++ b/pkg/document/time/ticket_test.go
@@ -12,7 +12,7 @@ func TestTicket(t *testing.T) {
 	t.Run("get hex from actorId of ticket test", func(t *testing.T) {
 		actorID, _ := time.ActorIDFromHex("0123456789abcdef01234567")
 		ticket := time.NewTicket(0, 0, actorID)
-		assert.Equal(t, actorID.String(), ticket.ActorIDHex())
+		assert.Equal(t, actorID.Hex(), ticket.ActorIDHex())
 	})
 
 	t.Run("get bytes from actorId of ticket test", func(t *testing.T) {
@@ -29,9 +29,7 @@ func TestTicket(t *testing.T) {
 		assert.Equal(t, uint32(1), ticket.Delimiter())
 		assert.Equal(t, actorID, ticket.ActorID())
 
-		assert.Equal(t, "0:1:"+ticket.ActorIDHex(), ticket.Key())
-		assert.Equal(t, "0:1:"+ticket.ActorIDHex()[22:24],
-			ticket.AnnotatedString())
+		assert.Equal(t, "0:1:"+ticket.ActorIDHex()[22:24], ticket.AnnotatedString())
 		ticket = ticket.SetActorID(nil)
 		assert.Equal(t, "0:1:", ticket.Key())
 		assert.Equal(t, "0:1:nil", ticket.AnnotatedString())

--- a/test/integration/cluster_mode_test.go
+++ b/test/integration/cluster_mode_test.go
@@ -159,8 +159,8 @@ func TestClusterMode(t *testing.T) {
 			expected = append(expected, watchResponsePair{
 				Type: client.PeersChanged,
 				Peers: map[string]types.Metadata{
-					c1.ID().String(): c1.Metadata(),
-					c2.ID().String(): c2.Metadata(),
+					c1.ID().Hex(): c1.Metadata(),
+					c2.ID().Hex(): c2.Metadata(),
 				},
 			})
 
@@ -173,8 +173,8 @@ func TestClusterMode(t *testing.T) {
 			expected = append(expected, watchResponsePair{
 				Type: client.PeersChanged,
 				Peers: map[string]types.Metadata{
-					c1.ID().String(): c1.Metadata(),
-					c2.ID().String(): c2.Metadata(),
+					c1.ID().Hex(): c1.Metadata(),
+					c2.ID().Hex(): c2.Metadata(),
 				},
 			})
 
@@ -182,7 +182,7 @@ func TestClusterMode(t *testing.T) {
 			expected = append(expected, watchResponsePair{
 				Type: client.PeersChanged,
 				Peers: map[string]types.Metadata{
-					c1.ID().String(): c1.Metadata(),
+					c1.ID().Hex(): c1.Metadata(),
 				},
 			})
 			cancel2()

--- a/test/integration/peer_awareness_test.go
+++ b/test/integration/peer_awareness_test.go
@@ -92,8 +92,8 @@ func TestPeerAwareness(t *testing.T) {
 		expected = append(expected, watchResponsePair{
 			Type: client.PeersChanged,
 			Peers: map[string]types.Metadata{
-				c1.ID().String(): c1.Metadata(),
-				c2.ID().String(): c2.Metadata(),
+				c1.ID().Hex(): c1.Metadata(),
+				c2.ID().Hex(): c2.Metadata(),
 			},
 		})
 		watch2Ctx, cancel2 := context.WithCancel(ctx)
@@ -105,8 +105,8 @@ func TestPeerAwareness(t *testing.T) {
 		expected = append(expected, watchResponsePair{
 			Type: client.PeersChanged,
 			Peers: map[string]types.Metadata{
-				c1.ID().String(): c1.Metadata(),
-				c2.ID().String(): c2.Metadata(),
+				c1.ID().Hex(): c1.Metadata(),
+				c2.ID().Hex(): c2.Metadata(),
 			},
 		})
 
@@ -114,7 +114,7 @@ func TestPeerAwareness(t *testing.T) {
 		expected = append(expected, watchResponsePair{
 			Type: client.PeersChanged,
 			Peers: map[string]types.Metadata{
-				c1.ID().String(): c1.Metadata(),
+				c1.ID().Hex(): c1.Metadata(),
 			},
 		})
 		cancel2()

--- a/yorkie/backend/db/change_info_test.go
+++ b/yorkie/backend/db/change_info_test.go
@@ -16,13 +16,13 @@ func TestChangeInfo(t *testing.T) {
 		_, err := rand.Read(actorID[:])
 		assert.NoError(t, err)
 
-		expectedID := actorID.String()
+		expectedID := actorID.Hex()
 		changeInfo := db.ChangeInfo{
 			Actor: db.ID(expectedID),
 		}
 
 		change, err := changeInfo.ToChange()
 		assert.NoError(t, err)
-		assert.Equal(t, change.ID().Actor().String(), expectedID)
+		assert.Equal(t, change.ID().Actor().Hex(), expectedID)
 	})
 }

--- a/yorkie/backend/sync/memory/pubsub.go
+++ b/yorkie/backend/sync/memory/pubsub.go
@@ -91,7 +91,7 @@ func (m *PubSub) Subscribe(
 		log.Logger.Debugf(
 			`Subscribe(%s,%s) Start`,
 			keys[0].BSONKey(),
-			subscriber.ID.String(),
+			subscriber.ID.Hex(),
 		)
 	}
 
@@ -113,7 +113,7 @@ func (m *PubSub) Subscribe(
 		log.Logger.Debugf(
 			`Subscribe(%s,%s) End`,
 			keys[0].BSONKey(),
-			subscriber.ID.String(),
+			subscriber.ID.Hex(),
 		)
 	}
 	return sub, nil
@@ -184,7 +184,7 @@ func (m *PubSub) Publish(
 		k := docKey.BSONKey()
 
 		if log.Core.Enabled(zap.DebugLevel) {
-			log.Logger.Debugf(`Publish(%s,%s) Start`, k, publisherID.String())
+			log.Logger.Debugf(`Publish(%s,%s) Start`, k, publisherID.Hex())
 		}
 
 		if subs, ok := m.subscriptionsMapByDocKey[k]; ok {
@@ -197,7 +197,7 @@ func (m *PubSub) Publish(
 					log.Logger.Debugf(
 						`Publish(%s,%s) to %s`,
 						k,
-						publisherID.String(),
+						publisherID.Hex(),
 						sub.SubscriberID(),
 					)
 				}
@@ -205,7 +205,7 @@ func (m *PubSub) Publish(
 			}
 		}
 		if log.Core.Enabled(zap.DebugLevel) {
-			log.Logger.Debugf(`Publish(%s,%s) End`, k, publisherID.String())
+			log.Logger.Debugf(`Publish(%s,%s) End`, k, publisherID.Hex())
 		}
 	}
 }
@@ -218,7 +218,7 @@ func (m *PubSub) UpdateMetadata(
 	m.subscriptionsMapMu.Lock()
 	defer m.subscriptionsMapMu.Unlock()
 
-	sub, ok := m.subscriptionMapBySubscriber[publisher.ID.String()]
+	sub, ok := m.subscriptionMapBySubscriber[publisher.ID.Hex()]
 	if !ok {
 		return nil
 	}

--- a/yorkie/backend/sync/pubsub.go
+++ b/yorkie/backend/sync/pubsub.go
@@ -64,7 +64,7 @@ func (s *Subscription) Subscriber() types.Client {
 
 // SubscriberID returns string representation of the subscriber.
 func (s *Subscription) SubscriberID() string {
-	return s.subscriber.ID.String()
+	return s.subscriber.ID.Hex()
 }
 
 // UpdateMetadata updates the metadata of the subscriber.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Replace `hex.EncodeTostring` with `ActorID.key` in `Text` and `RichText`.

Before:

<img width="998" alt="Screen Shot 2021-10-05 at 5 26 50 PM" src="https://user-images.githubusercontent.com/2059311/135987735-c24d5228-5cce-4127-afea-c1e8eaa9b243.png">

After:

<img width="1141" alt="Screen Shot 2021-10-05 at 5 22 00 PM" src="https://user-images.githubusercontent.com/2059311/135987009-e31cfc33-9354-4f46-9404-540fccb88e88.png">


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Address #251

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
