### PR TITLE
Introduce ServerPack to reduce type conversion in Agent

### DIFF
--- a/api/converter/to_bytes.go
+++ b/api/converter/to_bytes.go
@@ -70,9 +70,9 @@ func toJSONObject(obj *json.Object) (*api.JSONElement, error) {
 	pbElem := &api.JSONElement{
 		Body: &api.JSONElement_JsonObject{JsonObject: &api.JSONElement_JSONObject{
 			Nodes:     pbRHTNodes,
-			CreatedAt: toTimeTicket(obj.CreatedAt()),
-			MovedAt:   toTimeTicket(obj.MovedAt()),
-			RemovedAt: toTimeTicket(obj.RemovedAt()),
+			CreatedAt: ToTimeTicket(obj.CreatedAt()),
+			MovedAt:   ToTimeTicket(obj.MovedAt()),
+			RemovedAt: ToTimeTicket(obj.RemovedAt()),
 		}},
 	}
 	return pbElem, nil
@@ -87,9 +87,9 @@ func toJSONArray(arr *json.Array) (*api.JSONElement, error) {
 	pbElem := &api.JSONElement{
 		Body: &api.JSONElement_JsonArray{JsonArray: &api.JSONElement_JSONArray{
 			Nodes:     pbRGANodes,
-			CreatedAt: toTimeTicket(arr.CreatedAt()),
-			MovedAt:   toTimeTicket(arr.MovedAt()),
-			RemovedAt: toTimeTicket(arr.RemovedAt()),
+			CreatedAt: ToTimeTicket(arr.CreatedAt()),
+			MovedAt:   ToTimeTicket(arr.MovedAt()),
+			RemovedAt: ToTimeTicket(arr.RemovedAt()),
 		}},
 	}
 	return pbElem, nil
@@ -105,9 +105,9 @@ func toPrimitive(primitive *json.Primitive) (*api.JSONElement, error) {
 		Body: &api.JSONElement_Primitive_{Primitive: &api.JSONElement_Primitive{
 			Type:      pbValueType,
 			Value:     primitive.Bytes(),
-			CreatedAt: toTimeTicket(primitive.CreatedAt()),
-			MovedAt:   toTimeTicket(primitive.MovedAt()),
-			RemovedAt: toTimeTicket(primitive.RemovedAt()),
+			CreatedAt: ToTimeTicket(primitive.CreatedAt()),
+			MovedAt:   ToTimeTicket(primitive.MovedAt()),
+			RemovedAt: ToTimeTicket(primitive.RemovedAt()),
 		}},
 	}, nil
 }
@@ -116,9 +116,9 @@ func toText(text *json.Text) *api.JSONElement {
 	return &api.JSONElement{
 		Body: &api.JSONElement_Text_{Text: &api.JSONElement_Text{
 			Nodes:     toTextNodes(text.Nodes()),
-			CreatedAt: toTimeTicket(text.CreatedAt()),
-			MovedAt:   toTimeTicket(text.MovedAt()),
-			RemovedAt: toTimeTicket(text.RemovedAt()),
+			CreatedAt: ToTimeTicket(text.CreatedAt()),
+			MovedAt:   ToTimeTicket(text.MovedAt()),
+			RemovedAt: ToTimeTicket(text.RemovedAt()),
 		}},
 	}
 }
@@ -127,9 +127,9 @@ func toRichText(text *json.RichText) *api.JSONElement {
 	return &api.JSONElement{
 		Body: &api.JSONElement_RichText_{RichText: &api.JSONElement_RichText{
 			Nodes:     toRichTextNodes(text.Nodes()),
-			CreatedAt: toTimeTicket(text.CreatedAt()),
-			MovedAt:   toTimeTicket(text.MovedAt()),
-			RemovedAt: toTimeTicket(text.RemovedAt()),
+			CreatedAt: ToTimeTicket(text.CreatedAt()),
+			MovedAt:   ToTimeTicket(text.MovedAt()),
+			RemovedAt: ToTimeTicket(text.RemovedAt()),
 		}},
 	}
 }
@@ -144,9 +144,9 @@ func toCounter(counter *json.Counter) (*api.JSONElement, error) {
 		Body: &api.JSONElement_Counter_{Counter: &api.JSONElement_Counter{
 			Type:      pbCounterType,
 			Value:     counter.Bytes(),
-			CreatedAt: toTimeTicket(counter.CreatedAt()),
-			MovedAt:   toTimeTicket(counter.MovedAt()),
-			RemovedAt: toTimeTicket(counter.RemovedAt()),
+			CreatedAt: ToTimeTicket(counter.CreatedAt()),
+			MovedAt:   ToTimeTicket(counter.MovedAt()),
+			RemovedAt: ToTimeTicket(counter.RemovedAt()),
 		}},
 	}, nil
 }
@@ -188,7 +188,7 @@ func toTextNodes(textNodes []*json.RGATreeSplitNode) []*api.TextNode {
 		pbTextNode := &api.TextNode{
 			Id:        toTextNodeID(textNode.ID()),
 			Value:     textNode.String(),
-			RemovedAt: toTimeTicket(textNode.RemovedAt()),
+			RemovedAt: ToTimeTicket(textNode.RemovedAt()),
 		}
 
 		if textNode.InsPrevID() != nil {
@@ -210,7 +210,7 @@ func toRichTextNodes(textNodes []*json.RGATreeSplitNode) []*api.RichTextNode {
 			attrs[node.Key()] = &api.RichTextNodeAttr{
 				Key:       node.Key(),
 				Value:     node.Value(),
-				UpdatedAt: toTimeTicket(node.UpdatedAt()),
+				UpdatedAt: ToTimeTicket(node.UpdatedAt()),
 			}
 		}
 
@@ -218,7 +218,7 @@ func toRichTextNodes(textNodes []*json.RGATreeSplitNode) []*api.RichTextNode {
 			Id:         toTextNodeID(textNode.ID()),
 			Attributes: attrs,
 			Value:      value.Value(),
-			RemovedAt:  toTimeTicket(textNode.RemovedAt()),
+			RemovedAt:  ToTimeTicket(textNode.RemovedAt()),
 		}
 
 		if textNode.InsPrevID() != nil {
@@ -232,7 +232,7 @@ func toRichTextNodes(textNodes []*json.RGATreeSplitNode) []*api.RichTextNode {
 
 func toTextNodeID(id *json.RGATreeSplitNodeID) *api.TextNodeID {
 	return &api.TextNodeID{
-		CreatedAt: toTimeTicket(id.CreatedAt()),
+		CreatedAt: ToTimeTicket(id.CreatedAt()),
 		Offset:    int32(id.Offset()),
 	}
 }

--- a/api/converter/to_pb.go
+++ b/api/converter/to_pb.go
@@ -55,48 +55,32 @@ func ToChangePack(pack *change.Pack) (*api.ChangePack, error) {
 	}
 
 	return &api.ChangePack{
-		DocumentKey:     toDocumentKey(pack.DocumentKey),
-		Checkpoint:      toCheckpoint(pack.Checkpoint),
+		DocumentKey:     ToDocumentKey(pack.DocumentKey),
+		Checkpoint:      ToCheckpoint(pack.Checkpoint),
 		Changes:         pbChanges,
 		Snapshot:        pack.Snapshot,
-		MinSyncedTicket: toTimeTicket(pack.MinSyncedTicket),
+		MinSyncedTicket: ToTimeTicket(pack.MinSyncedTicket),
 	}, nil
 }
 
-func toDocumentKey(key *key.Key) *api.DocumentKey {
+// ToDocumentKey converts the given model format to Protobuf format.
+func ToDocumentKey(key *key.Key) *api.DocumentKey {
 	return &api.DocumentKey{
 		Collection: key.Collection,
 		Document:   key.Document,
 	}
 }
 
-func toCheckpoint(cp *checkpoint.Checkpoint) *api.Checkpoint {
+// ToCheckpoint converts the given model format to Protobuf format.
+func ToCheckpoint(cp *checkpoint.Checkpoint) *api.Checkpoint {
 	return &api.Checkpoint{
 		ServerSeq: cp.ServerSeq,
 		ClientSeq: cp.ClientSeq,
 	}
 }
 
-func toChanges(changes []*change.Change) ([]*api.Change, error) {
-	var pbChanges []*api.Change
-
-	for _, c := range changes {
-		pbOperations, err := ToOperations(c.Operations())
-		if err != nil {
-			return nil, err
-		}
-
-		pbChanges = append(pbChanges, &api.Change{
-			Id:         toChangeID(c.ID()),
-			Message:    c.Message(),
-			Operations: pbOperations,
-		})
-	}
-
-	return pbChanges, nil
-}
-
-func toChangeID(id *change.ID) *api.ChangeID {
+// ToChangeID converts the given model format to Protobuf format.
+func ToChangeID(id *change.ID) *api.ChangeID {
 	return &api.ChangeID{
 		ClientSeq: id.ClientSeq(),
 		Lamport:   id.Lamport(),
@@ -108,7 +92,7 @@ func toChangeID(id *change.ID) *api.ChangeID {
 func ToDocumentKeys(keys []*key.Key) []*api.DocumentKey {
 	var pbKeys []*api.DocumentKey
 	for _, k := range keys {
-		pbKeys = append(pbKeys, toDocumentKey(k))
+		pbKeys = append(pbKeys, ToDocumentKey(k))
 	}
 	return pbKeys
 }
@@ -199,6 +183,38 @@ func ToOperations(operations []operation.Operation) ([]*api.Operation, error) {
 	return pbOperations, nil
 }
 
+// ToTimeTicket converts the given model format to Protobuf format.
+func ToTimeTicket(ticket *time.Ticket) *api.TimeTicket {
+	if ticket == nil {
+		return nil
+	}
+
+	return &api.TimeTicket{
+		Lamport:   ticket.Lamport(),
+		Delimiter: ticket.Delimiter(),
+		ActorId:   ticket.ActorIDBytes(),
+	}
+}
+
+func toChanges(changes []*change.Change) ([]*api.Change, error) {
+	var pbChanges []*api.Change
+
+	for _, c := range changes {
+		pbOperations, err := ToOperations(c.Operations())
+		if err != nil {
+			return nil, err
+		}
+
+		pbChanges = append(pbChanges, &api.Change{
+			Id:         ToChangeID(c.ID()),
+			Message:    c.Message(),
+			Operations: pbOperations,
+		})
+	}
+
+	return pbChanges, nil
+}
+
 func toSet(set *operation.Set) (*api.Operation_Set_, error) {
 	pbElem, err := toJSONElementSimple(set.Value())
 	if err != nil {
@@ -207,10 +223,10 @@ func toSet(set *operation.Set) (*api.Operation_Set_, error) {
 
 	return &api.Operation_Set_{
 		Set: &api.Operation_Set{
-			ParentCreatedAt: toTimeTicket(set.ParentCreatedAt()),
+			ParentCreatedAt: ToTimeTicket(set.ParentCreatedAt()),
 			Key:             set.Key(),
 			Value:           pbElem,
-			ExecutedAt:      toTimeTicket(set.ExecutedAt()),
+			ExecutedAt:      ToTimeTicket(set.ExecutedAt()),
 		},
 	}, nil
 }
@@ -223,10 +239,10 @@ func toAdd(add *operation.Add) (*api.Operation_Add_, error) {
 
 	return &api.Operation_Add_{
 		Add: &api.Operation_Add{
-			ParentCreatedAt: toTimeTicket(add.ParentCreatedAt()),
-			PrevCreatedAt:   toTimeTicket(add.PrevCreatedAt()),
+			ParentCreatedAt: ToTimeTicket(add.ParentCreatedAt()),
+			PrevCreatedAt:   ToTimeTicket(add.PrevCreatedAt()),
 			Value:           pbElem,
-			ExecutedAt:      toTimeTicket(add.ExecutedAt()),
+			ExecutedAt:      ToTimeTicket(add.ExecutedAt()),
 		},
 	}, nil
 }
@@ -234,10 +250,10 @@ func toAdd(add *operation.Add) (*api.Operation_Add_, error) {
 func toMove(move *operation.Move) (*api.Operation_Move_, error) {
 	return &api.Operation_Move_{
 		Move: &api.Operation_Move{
-			ParentCreatedAt: toTimeTicket(move.ParentCreatedAt()),
-			PrevCreatedAt:   toTimeTicket(move.PrevCreatedAt()),
-			CreatedAt:       toTimeTicket(move.CreatedAt()),
-			ExecutedAt:      toTimeTicket(move.ExecutedAt()),
+			ParentCreatedAt: ToTimeTicket(move.ParentCreatedAt()),
+			PrevCreatedAt:   ToTimeTicket(move.PrevCreatedAt()),
+			CreatedAt:       ToTimeTicket(move.CreatedAt()),
+			ExecutedAt:      ToTimeTicket(move.ExecutedAt()),
 		},
 	}, nil
 }
@@ -245,9 +261,9 @@ func toMove(move *operation.Move) (*api.Operation_Move_, error) {
 func toRemove(remove *operation.Remove) (*api.Operation_Remove_, error) {
 	return &api.Operation_Remove_{
 		Remove: &api.Operation_Remove{
-			ParentCreatedAt: toTimeTicket(remove.ParentCreatedAt()),
-			CreatedAt:       toTimeTicket(remove.CreatedAt()),
-			ExecutedAt:      toTimeTicket(remove.ExecutedAt()),
+			ParentCreatedAt: ToTimeTicket(remove.ParentCreatedAt()),
+			CreatedAt:       ToTimeTicket(remove.CreatedAt()),
+			ExecutedAt:      ToTimeTicket(remove.ExecutedAt()),
 		},
 	}, nil
 }
@@ -255,12 +271,12 @@ func toRemove(remove *operation.Remove) (*api.Operation_Remove_, error) {
 func toEdit(edit *operation.Edit) (*api.Operation_Edit_, error) {
 	return &api.Operation_Edit_{
 		Edit: &api.Operation_Edit{
-			ParentCreatedAt:     toTimeTicket(edit.ParentCreatedAt()),
+			ParentCreatedAt:     ToTimeTicket(edit.ParentCreatedAt()),
 			From:                toTextNodePos(edit.From()),
 			To:                  toTextNodePos(edit.To()),
 			CreatedAtMapByActor: toCreatedAtMapByActor(edit.CreatedAtMapByActor()),
 			Content:             edit.Content(),
-			ExecutedAt:          toTimeTicket(edit.ExecutedAt()),
+			ExecutedAt:          ToTimeTicket(edit.ExecutedAt()),
 		},
 	}, nil
 }
@@ -268,10 +284,10 @@ func toEdit(edit *operation.Edit) (*api.Operation_Edit_, error) {
 func toSelect(s *operation.Select) (*api.Operation_Select_, error) {
 	return &api.Operation_Select_{
 		Select: &api.Operation_Select{
-			ParentCreatedAt: toTimeTicket(s.ParentCreatedAt()),
+			ParentCreatedAt: ToTimeTicket(s.ParentCreatedAt()),
 			From:            toTextNodePos(s.From()),
 			To:              toTextNodePos(s.To()),
-			ExecutedAt:      toTimeTicket(s.ExecutedAt()),
+			ExecutedAt:      ToTimeTicket(s.ExecutedAt()),
 		},
 	}, nil
 }
@@ -279,13 +295,13 @@ func toSelect(s *operation.Select) (*api.Operation_Select_, error) {
 func toRichEdit(richEdit *operation.RichEdit) (*api.Operation_RichEdit_, error) {
 	return &api.Operation_RichEdit_{
 		RichEdit: &api.Operation_RichEdit{
-			ParentCreatedAt:     toTimeTicket(richEdit.ParentCreatedAt()),
+			ParentCreatedAt:     ToTimeTicket(richEdit.ParentCreatedAt()),
 			From:                toTextNodePos(richEdit.From()),
 			To:                  toTextNodePos(richEdit.To()),
 			CreatedAtMapByActor: toCreatedAtMapByActor(richEdit.CreatedAtMapByActor()),
 			Content:             richEdit.Content(),
 			Attributes:          richEdit.Attributes(),
-			ExecutedAt:          toTimeTicket(richEdit.ExecutedAt()),
+			ExecutedAt:          ToTimeTicket(richEdit.ExecutedAt()),
 		},
 	}, nil
 }
@@ -293,11 +309,11 @@ func toRichEdit(richEdit *operation.RichEdit) (*api.Operation_RichEdit_, error) 
 func toStyle(style *operation.Style) (*api.Operation_Style_, error) {
 	return &api.Operation_Style_{
 		Style: &api.Operation_Style{
-			ParentCreatedAt: toTimeTicket(style.ParentCreatedAt()),
+			ParentCreatedAt: ToTimeTicket(style.ParentCreatedAt()),
 			From:            toTextNodePos(style.From()),
 			To:              toTextNodePos(style.To()),
 			Attributes:      style.Attributes(),
-			ExecutedAt:      toTimeTicket(style.ExecutedAt()),
+			ExecutedAt:      ToTimeTicket(style.ExecutedAt()),
 		},
 	}, nil
 }
@@ -310,9 +326,9 @@ func toIncrease(increase *operation.Increase) (*api.Operation_Increase_, error) 
 
 	return &api.Operation_Increase_{
 		Increase: &api.Operation_Increase{
-			ParentCreatedAt: toTimeTicket(increase.ParentCreatedAt()),
+			ParentCreatedAt: ToTimeTicket(increase.ParentCreatedAt()),
 			Value:           pbElem,
-			ExecutedAt:      toTimeTicket(increase.ExecutedAt()),
+			ExecutedAt:      ToTimeTicket(increase.ExecutedAt()),
 		},
 	}, nil
 }
@@ -322,12 +338,12 @@ func toJSONElementSimple(elem json.Element) (*api.JSONElementSimple, error) {
 	case *json.Object:
 		return &api.JSONElementSimple{
 			Type:      api.ValueType_JSON_OBJECT,
-			CreatedAt: toTimeTicket(elem.CreatedAt()),
+			CreatedAt: ToTimeTicket(elem.CreatedAt()),
 		}, nil
 	case *json.Array:
 		return &api.JSONElementSimple{
 			Type:      api.ValueType_JSON_ARRAY,
-			CreatedAt: toTimeTicket(elem.CreatedAt()),
+			CreatedAt: ToTimeTicket(elem.CreatedAt()),
 		}, nil
 	case *json.Primitive:
 		pbValueType, err := toValueType(elem.ValueType())
@@ -337,18 +353,18 @@ func toJSONElementSimple(elem json.Element) (*api.JSONElementSimple, error) {
 
 		return &api.JSONElementSimple{
 			Type:      pbValueType,
-			CreatedAt: toTimeTicket(elem.CreatedAt()),
+			CreatedAt: ToTimeTicket(elem.CreatedAt()),
 			Value:     elem.Bytes(),
 		}, nil
 	case *json.Text:
 		return &api.JSONElementSimple{
 			Type:      api.ValueType_TEXT,
-			CreatedAt: toTimeTicket(elem.CreatedAt()),
+			CreatedAt: ToTimeTicket(elem.CreatedAt()),
 		}, nil
 	case *json.RichText:
 		return &api.JSONElementSimple{
 			Type:      api.ValueType_RICH_TEXT,
-			CreatedAt: toTimeTicket(elem.CreatedAt()),
+			CreatedAt: ToTimeTicket(elem.CreatedAt()),
 		}, nil
 	case *json.Counter:
 		pbCounterType, err := toCounterType(elem.ValueType())
@@ -358,7 +374,7 @@ func toJSONElementSimple(elem json.Element) (*api.JSONElementSimple, error) {
 
 		return &api.JSONElementSimple{
 			Type:      pbCounterType,
-			CreatedAt: toTimeTicket(elem.CreatedAt()),
+			CreatedAt: ToTimeTicket(elem.CreatedAt()),
 			Value:     elem.Bytes(),
 		}, nil
 	}
@@ -368,7 +384,7 @@ func toJSONElementSimple(elem json.Element) (*api.JSONElementSimple, error) {
 
 func toTextNodePos(pos *json.RGATreeSplitNodePos) *api.TextNodePos {
 	return &api.TextNodePos{
-		CreatedAt:      toTimeTicket(pos.ID().CreatedAt()),
+		CreatedAt:      ToTimeTicket(pos.ID().CreatedAt()),
 		Offset:         int32(pos.ID().Offset()),
 		RelativeOffset: int32(pos.RelativeOffset()),
 	}
@@ -379,21 +395,9 @@ func toCreatedAtMapByActor(
 ) map[string]*api.TimeTicket {
 	pbCreatedAtMapByActor := make(map[string]*api.TimeTicket)
 	for actor, createdAt := range createdAtMapByActor {
-		pbCreatedAtMapByActor[actor] = toTimeTicket(createdAt)
+		pbCreatedAtMapByActor[actor] = ToTimeTicket(createdAt)
 	}
 	return pbCreatedAtMapByActor
-}
-
-func toTimeTicket(ticket *time.Ticket) *api.TimeTicket {
-	if ticket == nil {
-		return nil
-	}
-
-	return &api.TimeTicket{
-		Lamport:   ticket.Lamport(),
-		Delimiter: ticket.Delimiter(),
-		ActorId:   ticket.ActorIDBytes(),
-	}
 }
 
 func toValueType(valueType json.ValueType) (api.ValueType, error) {

--- a/pkg/document/internal_document.go
+++ b/pkg/document/internal_document.go
@@ -125,7 +125,13 @@ func (d *InternalDocument) ApplyChangePack(pack *change.Pack) error {
 	d.checkpoint = d.checkpoint.Forward(pack.Checkpoint)
 
 	if log.Core.Enabled(zap.DebugLevel) {
-		log.Logger.Debugf("after apply %d changes: %s", len(pack.Changes), d.RootObject().Marshal())
+		log.Logger.Debugf(
+			"after apply %d changes: elements: %d removeds: %d, %s",
+			len(pack.Changes),
+			d.root.ElementMapLen(),
+			d.root.RemovedElementLen(),
+			d.RootObject().Marshal(),
+		)
 	}
 	return nil
 }

--- a/pkg/document/json/root.go
+++ b/pkg/document/json/root.go
@@ -120,6 +120,16 @@ func (r *Root) GarbageCollect(ticket *time.Ticket) int {
 	return count
 }
 
+// ElementMapLen returns the size of element map.
+func (r *Root) ElementMapLen() int {
+	return len(r.elementMapByCreatedAt)
+}
+
+// RemovedElementLen returns the size of removed element map.
+func (r *Root) RemovedElementLen() int {
+	return len(r.removedElementPairMapByCreatedAt)
+}
+
 // GarbageLen returns the count of removed elements.
 func (r *Root) GarbageLen() int {
 	count := 0

--- a/yorkie/backend/db/db.go
+++ b/yorkie/backend/db/db.go
@@ -93,6 +93,14 @@ type DB interface {
 		to uint64,
 	) ([]*change.Change, error)
 
+	// FindChangeInfosBetweenServerSeqs returns the changeInfos between two server sequences.
+	FindChangeInfosBetweenServerSeqs(
+		ctx context.Context,
+		docID ID,
+		from uint64,
+		to uint64,
+	) ([]*ChangeInfo, error)
+
 	// UpdateAndFindMinSyncedTicket updates the given serverSeq of the given client
 	// and returns the min synced ticket.
 	UpdateAndFindMinSyncedTicket(

--- a/yorkie/packs/packs.go
+++ b/yorkie/packs/packs.go
@@ -48,7 +48,7 @@ func PushPull(
 	clientInfo *db.ClientInfo,
 	docInfo *db.DocInfo,
 	reqPack *change.Pack,
-) (*change.Pack, error) {
+) (*ServerPack, error) {
 	// TODO: Changes may be reordered or missing during communication on the network.
 	// We should check the change.pack with checkpoint to make sure the changes are in the correct order.
 	initialServerSeq := docInfo.ServerSeq

--- a/yorkie/packs/serverpack.go
+++ b/yorkie/packs/serverpack.go
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package packs
+
+import (
+	"github.com/yorkie-team/yorkie/api"
+	"github.com/yorkie-team/yorkie/api/converter"
+	"github.com/yorkie-team/yorkie/internal/log"
+	"github.com/yorkie-team/yorkie/pkg/document/change"
+	"github.com/yorkie-team/yorkie/pkg/document/checkpoint"
+	"github.com/yorkie-team/yorkie/pkg/document/key"
+	"github.com/yorkie-team/yorkie/pkg/document/time"
+	"github.com/yorkie-team/yorkie/yorkie/backend/db"
+)
+
+// ServerPack is similar to change.Pack, but has ChangeInfos instead of Changes
+// to reduce type conversion in Agent.
+type ServerPack struct {
+	// DocumentKey is key of the document.
+	DocumentKey *key.Key
+
+	// Checkpoint is used to determine the client received changes.
+	Checkpoint *checkpoint.Checkpoint
+
+	// ChangeInfos represents a unit of modification in the document.
+	ChangeInfos []*db.ChangeInfo
+
+	// Snapshot is a byte array that encode the document.
+	Snapshot []byte
+
+	// MinSyncedTicket is the minimum logical time taken by clients who attach the document.
+	// It used to collect garbage on the replica on the client.
+	MinSyncedTicket *time.Ticket
+}
+
+// NewServerPack creates a new instance of ServerPack.
+func NewServerPack(
+	key *key.Key,
+	cp *checkpoint.Checkpoint,
+	changeInfos []*db.ChangeInfo,
+	snapshot []byte,
+) *ServerPack {
+	return &ServerPack{
+		DocumentKey: key,
+		Checkpoint:  cp,
+		ChangeInfos: changeInfos,
+		Snapshot:    snapshot,
+	}
+}
+
+// ToPBChangePack converts the given model format to Protobuf format.
+func (p *ServerPack) ToPBChangePack() (*api.ChangePack, error) {
+	var pbChanges []*api.Change
+	for _, changeInfo := range p.ChangeInfos {
+		actorID, err := time.ActorIDFromHex(changeInfo.Actor.String())
+		if err != nil {
+			return nil, err
+		}
+		changeID := change.NewID(changeInfo.ClientSeq, changeInfo.Lamport, actorID)
+
+		var pbOps []*api.Operation
+		for _, bytesOp := range changeInfo.Operations {
+			pbOp := api.Operation{}
+			if err := pbOp.Unmarshal(bytesOp); err != nil {
+				log.Logger.Error(err)
+				return nil, err
+			}
+			pbOps = append(pbOps, &pbOp)
+		}
+
+		pbChanges = append(pbChanges, &api.Change{
+			Id:         converter.ToChangeID(changeID),
+			Message:    changeInfo.Message,
+			Operations: pbOps,
+		})
+	}
+
+	return &api.ChangePack{
+		DocumentKey:     converter.ToDocumentKey(p.DocumentKey),
+		Checkpoint:      converter.ToCheckpoint(p.Checkpoint),
+		Changes:         pbChanges,
+		Snapshot:        p.Snapshot,
+		MinSyncedTicket: converter.ToTimeTicket(p.MinSyncedTicket),
+	}, nil
+}

--- a/yorkie/rpc/yorkie_server.go
+++ b/yorkie/rpc/yorkie_server.go
@@ -151,7 +151,7 @@ func (s *yorkieServer) AttachDocument(
 		return nil, err
 	}
 
-	pbChangePack, err := converter.ToChangePack(pulled)
+	pbChangePack, err := pulled.ToPBChangePack()
 	if err != nil {
 		return nil, err
 	}
@@ -219,7 +219,7 @@ func (s *yorkieServer) DetachDocument(
 		return nil, err
 	}
 
-	pbChangePack, err := converter.ToChangePack(pulled)
+	pbChangePack, err := pulled.ToPBChangePack()
 	if err != nil {
 		return nil, err
 	}
@@ -289,7 +289,7 @@ func (s *yorkieServer) PushPull(
 		return nil, err
 	}
 
-	pbChangePack, err := converter.ToChangePack(pulled)
+	pbChangePack, err := pulled.ToPBChangePack()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Introduce ServerPack to reduce type conversion in Agent

When Agent generates the response pack of the Push Pull API, Agent does
not convert ChangeInfos read from DB into pure model, but directly
converts it to protobuf messages.

Target:
A document with quite a lot of elements(387,329) including tombstones.

Before:
<img width="457" alt="Screen Shot 2021-11-10 at 1 19 46 AM" src="https://user-images.githubusercontent.com/2059311/140962881-43a61b5a-56ff-4af2-8f0f-dbab1a3c3781.png">

After:
<img width="523" alt="Screen Shot 2021-11-10 at 1 18 59 AM" src="https://user-images.githubusercontent.com/2059311/140962707-815f8b8f-52ec-4099-bda4-000c86b70a33.png">


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
