### PR TITLE
Add makeUp func to client.Option for clean code

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -28,13 +28,16 @@ import (
 
 func TestClient(t *testing.T) {
 	t.Run("create instance test", func(t *testing.T) {
-		opts := client.Option{
+		opt := client.Option{
 			Token:    xid.New().String(),
 			Metadata: types.Metadata{"Name": "ClientName"},
 		}
-		cli, err := client.NewClient(opts)
+		assert.Empty(t, opt.Key)
+
+		cli, err := client.NewClient(opt)
 		assert.NoError(t, err)
 
-		assert.Equal(t, opts.Metadata, cli.Metadata())
+		assert.Equal(t, opt.Metadata, cli.Metadata())
+		assert.Empty(t, opt.Key)
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**: Clean code

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:  
<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- 

- [x]  Added relevant tests or not required

- [x] Didn't break anything

* My system is not using port 2380. But I have the following problem. So I don't know that etcd relate tests pass.(passed other tests).
```
➜  yorkie git:(master) docker-compose -f docker/docker-compose-ci.yml up etcd --build -d
[+] Running 0/1
 ⠋ Container etcd  Starting                                                                                                                                                                                                                              0.1s
Error response from daemon: driver failed programming external connectivity on endpoint etcd (9ef0938cf020b663d862ef8d22d23726be988216c1f7776529024eb55671e4b1): listen tcp4 0.0.0.0:2380: bind: address already in use
➜  yorkie git:(master) sudo lsof -PiTCP -sTCP:LISTEN | awk '{print $9}'
NAME
*:22
*:22
*:22
*:22
[fe80:4::aede:48ff:fe00:1122]:49154
[fe80:4::aede:48ff:fe00:1122]:49155
[fe80:4::aede:48ff:fe00:1122]:49156
[fe80:4::aede:48ff:fe00:1122]:49157
[fe80:4::aede:48ff:fe00:1122]:49158
*:29919
localhost:631
localhost:631
localhost:6443
*:27017
localhost:3350
localhost:57228
localhost:58863
```
