### PR TITLE
Run tests using monkey patch only on amd64

### DIFF
--- a/yorkie/backend/db/memory/db_test.go
+++ b/yorkie/backend/db/memory/db_test.go
@@ -20,9 +20,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	gotime "time"
 
-	"bou.ke/monkey"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/yorkie-team/yorkie/pkg/document"
@@ -180,31 +178,5 @@ func TestDB(t *testing.T) {
 		snapshot, err = memdb.FindLastSnapshotInfo(ctx, docInfo.ID)
 		assert.NoError(t, err)
 		assert.Equal(t, uint64(1), snapshot.ServerSeq)
-	})
-
-	t.Run("housekeeping test", func(t *testing.T) {
-		ctx := context.Background()
-
-		yesterday := gotime.Now().Add(-24 * gotime.Hour)
-		guard := monkey.Patch(gotime.Now, func() gotime.Time { return yesterday })
-		clientA, err := memdb.ActivateClient(ctx, fmt.Sprintf("%s-A", t.Name()))
-		assert.NoError(t, err)
-		clientB, err := memdb.ActivateClient(ctx, fmt.Sprintf("%s-B", t.Name()))
-		assert.NoError(t, err)
-		guard.Unpatch()
-
-		clientC, err := memdb.ActivateClient(ctx, fmt.Sprintf("%s-C", t.Name()))
-		assert.NoError(t, err)
-
-		candidates, err := memdb.FindDeactivateCandidates(
-			ctx,
-			gotime.Hour,
-			10,
-		)
-		assert.NoError(t, err)
-		assert.Len(t, candidates, 2)
-		assert.Contains(t, candidates, clientA)
-		assert.Contains(t, candidates, clientB)
-		assert.NotContains(t, candidates, clientC)
 	})
 }

--- a/yorkie/backend/db/memory/housekeeping_test.go
+++ b/yorkie/backend/db/memory/housekeeping_test.go
@@ -1,0 +1,62 @@
+//go:build amd64
+
+/*
+ * Copyright 2022 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memory_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	gotime "time"
+
+	"bou.ke/monkey"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/yorkie/backend/db/memory"
+)
+
+func TestHousekeeping(t *testing.T) {
+	memdb, err := memory.New()
+	assert.NoError(t, err)
+
+	t.Run("housekeeping test", func(t *testing.T) {
+		ctx := context.Background()
+
+		yesterday := gotime.Now().Add(-24 * gotime.Hour)
+		guard := monkey.Patch(gotime.Now, func() gotime.Time { return yesterday })
+		clientA, err := memdb.ActivateClient(ctx, fmt.Sprintf("%s-A", t.Name()))
+		assert.NoError(t, err)
+		clientB, err := memdb.ActivateClient(ctx, fmt.Sprintf("%s-B", t.Name()))
+		assert.NoError(t, err)
+		guard.Unpatch()
+
+		clientC, err := memdb.ActivateClient(ctx, fmt.Sprintf("%s-C", t.Name()))
+		assert.NoError(t, err)
+
+		candidates, err := memdb.FindDeactivateCandidates(
+			ctx,
+			gotime.Hour,
+			10,
+		)
+		assert.NoError(t, err)
+		assert.Len(t, candidates, 2)
+		assert.Contains(t, candidates, clientA)
+		assert.Contains(t, candidates, clientB)
+		assert.NotContains(t, candidates, clientC)
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Run tests using monkey patch only on amd64

We use bouk/monkey for monkey patching. And jmpToFunctionValue is
implemented only in monkey_amd64.go and monkey_386.go, not arm64.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #292

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
