### PR TITLE
Load changes gradually when creating a snapshot

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -295,6 +295,12 @@ func init() {
 		yorkie.DefaultSnapshotInterval,
 		"Interval of changes to create a snapshot.",
 	)
+	cmd.Flags().Uint64Var(
+		&conf.Backend.ChangesChunkSize,
+		"backend-changes-chunk-size",
+		yorkie.DefaultChangesChunkSize,
+		"Chunk size of changes to load gradually when creating a snapshot",
+	)
 	cmd.Flags().StringVar(
 		&conf.Backend.AuthWebhookURL,
 		"auth-webhook-url",

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -50,6 +50,7 @@ const (
 	MongoConnectionTimeout = "5s"
 	MongoPingTimeout       = "5s"
 	SnapshotThreshold      = 10
+	ChangesChunkSize       = 2
 	Collection             = "test-collection"
 
 	AuthWebhookMaxWaitInterval = 3 * gotime.Millisecond
@@ -111,6 +112,7 @@ func TestConfig(authWebhook string) *yorkie.Config {
 		},
 		Backend: &backend.Config{
 			SnapshotThreshold:          SnapshotThreshold,
+			ChangesChunkSize:           ChangesChunkSize,
 			AuthWebhookURL:             authWebhook,
 			AuthWebhookMaxWaitInterval: AuthWebhookMaxWaitInterval.String(),
 			AuthWebhookCacheSize:       AuthWebhookSize,

--- a/yorkie/backend/config.go
+++ b/yorkie/backend/config.go
@@ -32,6 +32,9 @@ type Config struct {
 	// SnapshotInterval is the interval of changes to create a snapshot.
 	SnapshotInterval uint64 `yaml:"SnapshotInterval"`
 
+	// ChangesChunkSize is the chunk size of changes to load gradually when creating a snapshot.
+	ChangesChunkSize uint64 `yaml:"ChangesChunkSize"`
+
 	// AuthWebhookURL is the url of the authorization webhook.
 	AuthWebhookURL string `yaml:"AuthWebhookURL"`
 

--- a/yorkie/config.go
+++ b/yorkie/config.go
@@ -51,6 +51,7 @@ const (
 
 	DefaultSnapshotThreshold = 500
 	DefaultSnapshotInterval  = 1000
+	DefaultChangesChunkSize  = 100
 
 	DefaultAuthWebhookMaxRetries      = 10
 	DefaultAuthWebhookMaxWaitInterval = 3000 * time.Millisecond
@@ -149,6 +150,10 @@ func (c *Config) ensureDefaultValue() {
 
 	if c.Backend.SnapshotInterval == 0 {
 		c.Backend.SnapshotInterval = DefaultSnapshotInterval
+	}
+
+	if c.Backend.ChangesChunkSize == 0 {
+		c.Backend.ChangesChunkSize = DefaultChangesChunkSize
 	}
 
 	if c.Backend.AuthWebhookCacheSize == 0 {

--- a/yorkie/config.sample.yml
+++ b/yorkie/config.sample.yml
@@ -40,6 +40,9 @@ Backend:
   # SnapshotInterval is the number of changes to create a snapshot.
   SnapshotInterval: 1000
 
+  # ChangesChunkSize is the chunk size of changes to load gradually when creating a snapshot.
+  ChangesChunkSize: 100
+
   # AuthWebhookURL is the URL to send authorization requests to.
   AuthWebhookURL: ""
 

--- a/yorkie/config_test.go
+++ b/yorkie/config_test.go
@@ -64,6 +64,7 @@ func TestNewConfigFromFile(t *testing.T) {
 		assert.Equal(t, pingTimeout, yorkie.DefaultMongoPingTimeout)
 		assert.Equal(t, conf.Backend.SnapshotThreshold, uint64(yorkie.DefaultSnapshotThreshold))
 		assert.Equal(t, conf.Backend.SnapshotInterval, uint64(yorkie.DefaultSnapshotInterval))
+		assert.Equal(t, conf.Backend.ChangesChunkSize, uint64(yorkie.DefaultChangesChunkSize))
 		assert.Equal(t, conf.Backend.AuthWebhookURL, "")
 		assert.Equal(t, conf.Backend.AuthWebhookMaxRetries, uint64(yorkie.DefaultAuthWebhookMaxRetries))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**: 
We have to load changes gradually from DB when a large number of changes are accumulated.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #228

**Special notes for your reviewer**:

I create a draft PR to ask for help.
I have two questions while trying to fix the issue. 😅 

1. How to determine the right chunk size of changes.
Is there any way to test the performance depending on the chunk size of changes in my local environment?

2. How to write test code to make it arrive at the code I changed.
I wrote test code referring to other one in `TestSnapshot`, but I noticed my code does not arrive at 195 line of `pushpull.go`. I don't know how to set up the situation in the test code.

Thanks in advance.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [ ] Didn't break anything
