### PR TITLE
Use struct for non-nullable tickets

### DIFF
--- a/api/converter/converter_test.go
+++ b/api/converter/converter_test.go
@@ -180,7 +180,7 @@ func TestConverter(t *testing.T) {
 
 		pack, err := converter.FromChangePack(pbPack)
 		assert.NoError(t, err)
-		pack.MinSyncedTicket = time.MaxTicket
+		pack.MinSyncedTicket = &time.MaxTicket
 
 		d2 := document.New("c1", "d1")
 		err = d2.ApplyChangePack(pack)

--- a/api/converter/from_bytes.go
+++ b/api/converter/from_bytes.go
@@ -91,7 +91,7 @@ func fromJSONObject(pbObj *api.JSONElement_JSONObject) (*json.Object, error) {
 
 	obj := json.NewObject(
 		members,
-		createdAt,
+		*createdAt,
 	)
 	obj.SetMovedAt(movedAt)
 	obj.SetRemovedAt(removedAt)
@@ -124,7 +124,7 @@ func fromJSONArray(pbArr *api.JSONElement_JSONArray) (*json.Array, error) {
 
 	arr := json.NewArray(
 		elements,
-		createdAt,
+		*createdAt,
 	)
 	arr.SetMovedAt(movedAt)
 	arr.SetRemovedAt(removedAt)
@@ -153,7 +153,7 @@ func fromJSONPrimitive(
 
 	primitive := json.NewPrimitive(
 		json.ValueFromBytes(valueType, pbPrim.Value),
-		createdAt,
+		*createdAt,
 	)
 	primitive.SetMovedAt(movedAt)
 	primitive.SetRemovedAt(removedAt)
@@ -188,7 +188,7 @@ func fromJSONText(pbText *api.JSONElement_Text) (*json.Text, error) {
 			return nil, err
 		}
 		if insPrevID != nil {
-			insPrevNode := rgaTreeSplit.FindNode(insPrevID)
+			insPrevNode := rgaTreeSplit.FindNode(*insPrevID)
 			if insPrevNode == nil {
 				panic("insPrevNode should be presence")
 			}
@@ -198,7 +198,7 @@ func fromJSONText(pbText *api.JSONElement_Text) (*json.Text, error) {
 
 	text := json.NewText(
 		rgaTreeSplit,
-		createdAt,
+		*createdAt,
 	)
 	text.SetMovedAt(movedAt)
 	text.SetRemovedAt(removedAt)
@@ -236,7 +236,7 @@ func fromJSONRichText(
 			return nil, err
 		}
 		if insPrevID != nil {
-			insPrevNode := rgaTreeSplit.FindNode(insPrevID)
+			insPrevNode := rgaTreeSplit.FindNode(*insPrevID)
 			if insPrevNode == nil {
 				panic("insPrevNode should be presence")
 			}
@@ -246,7 +246,7 @@ func fromJSONRichText(
 
 	text := json.NewRichText(
 		rgaTreeSplit,
-		createdAt,
+		*createdAt,
 	)
 	text.SetMovedAt(movedAt)
 	text.SetRemovedAt(removedAt)
@@ -274,7 +274,7 @@ func fromJSONCounter(pbCnt *api.JSONElement_Counter) (*json.Counter, error) {
 
 	counter := json.NewCounter(
 		json.CounterValueFromBytes(counterType, pbCnt.Value),
-		createdAt,
+		*createdAt,
 	)
 	counter.SetMovedAt(movedAt)
 	counter.SetRemovedAt(removedAt)
@@ -288,7 +288,7 @@ func fromTextNode(pbTextNode *api.TextNode) (*json.RGATreeSplitNode, error) {
 		return nil, err
 	}
 	textNode := json.NewRGATreeSplitNode(
-		id,
+		*id,
 		json.NewTextValue(pbTextNode.Value),
 	)
 	if pbTextNode.RemovedAt != nil {
@@ -315,11 +315,11 @@ func fromRichTextNode(
 		if err != nil {
 			return nil, err
 		}
-		attrs.Set(pbAttr.Key, pbAttr.Value, updatedAt)
+		attrs.Set(pbAttr.Key, pbAttr.Value, *updatedAt)
 	}
 
 	textNode := json.NewRGATreeSplitNode(
-		id,
+		*id,
 		json.NewRichTextValue(attrs, pbNode.Value),
 	)
 	if pbNode.RemovedAt != nil {
@@ -344,8 +344,10 @@ func fromTextNodeID(
 		return nil, err
 	}
 
-	return json.NewRGATreeSplitNodeID(
-		createdAt,
+	id := json.NewRGATreeSplitNodeID(
+		*createdAt,
 		int(pbTextNodeID.Offset),
-	), nil
+	)
+
+	return &id, nil
 }

--- a/api/converter/from_pb.go
+++ b/api/converter/from_pb.go
@@ -236,10 +236,10 @@ func fromSet(pbSet *api.Operation_Set) (*operations.Set, error) {
 	}
 
 	return operations.NewSet(
-		parentCreatedAt,
+		*parentCreatedAt,
 		pbSet.Key,
 		elem,
-		executedAt,
+		*executedAt,
 	), nil
 }
 
@@ -261,10 +261,10 @@ func fromAdd(pbAdd *api.Operation_Add) (*operations.Add, error) {
 		return nil, err
 	}
 	return operations.NewAdd(
-		parentCreatedAt,
-		prevCreatedAt,
+		*parentCreatedAt,
+		*prevCreatedAt,
 		elem,
-		executedAt,
+		*executedAt,
 	), nil
 }
 
@@ -286,10 +286,10 @@ func fromMove(pbMove *api.Operation_Move) (*operations.Move, error) {
 		return nil, err
 	}
 	return operations.NewMove(
-		parentCreatedAt,
-		prevCreatedAt,
-		createdAt,
-		executedAt,
+		*parentCreatedAt,
+		*prevCreatedAt,
+		*createdAt,
+		*executedAt,
 	), nil
 }
 
@@ -307,9 +307,9 @@ func fromRemove(pbRemove *api.Operation_Remove) (*operations.Remove, error) {
 		return nil, err
 	}
 	return operations.NewRemove(
-		parentCreatedAt,
-		createdAt,
-		executedAt,
+		*parentCreatedAt,
+		*createdAt,
+		*executedAt,
 	), nil
 }
 
@@ -337,12 +337,12 @@ func fromEdit(pbEdit *api.Operation_Edit) (*operations.Edit, error) {
 		return nil, err
 	}
 	return operations.NewEdit(
-		parentCreatedAt,
+		*parentCreatedAt,
 		from,
 		to,
 		createdAtMapByActor,
 		pbEdit.Content,
-		executedAt,
+		*executedAt,
 	), nil
 }
 
@@ -364,10 +364,10 @@ func fromSelect(pbSelect *api.Operation_Select) (*operations.Select, error) {
 		return nil, err
 	}
 	return operations.NewSelect(
-		parentCreatedAt,
+		*parentCreatedAt,
 		from,
 		to,
-		executedAt,
+		*executedAt,
 	), nil
 }
 
@@ -395,13 +395,13 @@ func fromRichEdit(pbEdit *api.Operation_RichEdit) (*operations.RichEdit, error) 
 		return nil, err
 	}
 	return operations.NewRichEdit(
-		parentCreatedAt,
+		*parentCreatedAt,
 		from,
 		to,
 		createdAtMapByActor,
 		pbEdit.Content,
 		pbEdit.Attributes,
-		executedAt,
+		*executedAt,
 	), nil
 }
 
@@ -423,11 +423,11 @@ func fromStyle(pbStyle *api.Operation_Style) (*operations.Style, error) {
 		return nil, err
 	}
 	return operations.NewStyle(
-		parentCreatedAt,
+		*parentCreatedAt,
 		from,
 		to,
 		pbStyle.Attributes,
-		executedAt,
+		*executedAt,
 	), nil
 }
 
@@ -445,9 +445,9 @@ func fromIncrease(pbInc *api.Operation_Increase) (*operations.Increase, error) {
 		return nil, err
 	}
 	return operations.NewIncrease(
-		parentCreatedAt,
+		*parentCreatedAt,
 		elem,
-		executedAt,
+		*executedAt,
 	), nil
 }
 
@@ -467,13 +467,13 @@ func fromCreatedAtMapByActor(
 
 func fromTextNodePos(
 	pbPos *api.TextNodePos,
-) (*json.RGATreeSplitNodePos, error) {
+) (json.RGATreeSplitNodePos, error) {
 	createdAt, err := fromTimeTicket(pbPos.CreatedAt)
 	if err != nil {
-		return nil, err
+		return json.InitialNodePos, err
 	}
 	return json.NewRGATreeSplitNodePos(
-		json.NewRGATreeSplitNodeID(createdAt, int(pbPos.Offset)),
+		json.NewRGATreeSplitNodeID(*createdAt, int(pbPos.Offset)),
 		int(pbPos.RelativeOffset),
 	), nil
 }
@@ -487,11 +487,13 @@ func fromTimeTicket(pbTicket *api.TimeTicket) (*time.Ticket, error) {
 	if err != nil {
 		return nil, err
 	}
-	return time.NewTicket(
+
+	ticket := time.NewTicket(
 		pbTicket.Lamport,
 		pbTicket.Delimiter,
 		&actorID,
-	), nil
+	)
+	return &ticket, nil
 }
 
 func fromElement(pbElement *api.JSONElementSimple) (json.Element, error) {
@@ -503,7 +505,7 @@ func fromElement(pbElement *api.JSONElementSimple) (json.Element, error) {
 		}
 		return json.NewObject(
 			json.NewRHTPriorityQueueMap(),
-			createdAt,
+			*createdAt,
 		), nil
 	case api.ValueType_JSON_ARRAY:
 		createdAt, err := fromTimeTicket(pbElement.CreatedAt)
@@ -512,7 +514,7 @@ func fromElement(pbElement *api.JSONElementSimple) (json.Element, error) {
 		}
 		return json.NewArray(
 			json.NewRGATreeList(),
-			createdAt,
+			*createdAt,
 		), nil
 	case api.ValueType_NULL:
 		fallthrough
@@ -539,7 +541,7 @@ func fromElement(pbElement *api.JSONElementSimple) (json.Element, error) {
 		}
 		return json.NewPrimitive(
 			json.ValueFromBytes(valueType, pbElement.Value),
-			createdAt,
+			*createdAt,
 		), nil
 	case api.ValueType_TEXT:
 		createdAt, err := fromTimeTicket(pbElement.CreatedAt)
@@ -548,7 +550,7 @@ func fromElement(pbElement *api.JSONElementSimple) (json.Element, error) {
 		}
 		return json.NewText(
 			json.NewRGATreeSplit(json.InitialTextNode()),
-			createdAt,
+			*createdAt,
 		), nil
 	case api.ValueType_RICH_TEXT:
 		createdAt, err := fromTimeTicket(pbElement.CreatedAt)
@@ -557,7 +559,7 @@ func fromElement(pbElement *api.JSONElementSimple) (json.Element, error) {
 		}
 		return json.NewInitialRichText(
 			json.NewRGATreeSplit(json.InitialRichTextNode()),
-			createdAt,
+			*createdAt,
 		), nil
 	case api.ValueType_INTEGER_CNT:
 		fallthrough
@@ -574,7 +576,7 @@ func fromElement(pbElement *api.JSONElementSimple) (json.Element, error) {
 		}
 		return json.NewCounter(
 			json.CounterValueFromBytes(counterType, pbElement.Value),
-			createdAt,
+			*createdAt,
 		), nil
 	}
 

--- a/api/converter/to_bytes.go
+++ b/api/converter/to_bytes.go
@@ -68,7 +68,7 @@ func toJSONObject(obj *json.Object) (*api.JSONElement, error) {
 	pbElem := &api.JSONElement{
 		Body: &api.JSONElement_JsonObject{JsonObject: &api.JSONElement_JSONObject{
 			Nodes:     pbRHTNodes,
-			CreatedAt: ToTimeTicket(obj.CreatedAt()),
+			CreatedAt: ToMustTimeTicket(obj.CreatedAt()),
 			MovedAt:   ToTimeTicket(obj.MovedAt()),
 			RemovedAt: ToTimeTicket(obj.RemovedAt()),
 		}},
@@ -85,7 +85,7 @@ func toJSONArray(arr *json.Array) (*api.JSONElement, error) {
 	pbElem := &api.JSONElement{
 		Body: &api.JSONElement_JsonArray{JsonArray: &api.JSONElement_JSONArray{
 			Nodes:     pbRGANodes,
-			CreatedAt: ToTimeTicket(arr.CreatedAt()),
+			CreatedAt: ToMustTimeTicket(arr.CreatedAt()),
 			MovedAt:   ToTimeTicket(arr.MovedAt()),
 			RemovedAt: ToTimeTicket(arr.RemovedAt()),
 		}},
@@ -103,7 +103,7 @@ func toPrimitive(primitive *json.Primitive) (*api.JSONElement, error) {
 		Body: &api.JSONElement_Primitive_{Primitive: &api.JSONElement_Primitive{
 			Type:      pbValueType,
 			Value:     primitive.Bytes(),
-			CreatedAt: ToTimeTicket(primitive.CreatedAt()),
+			CreatedAt: ToMustTimeTicket(primitive.CreatedAt()),
 			MovedAt:   ToTimeTicket(primitive.MovedAt()),
 			RemovedAt: ToTimeTicket(primitive.RemovedAt()),
 		}},
@@ -114,7 +114,7 @@ func toText(text *json.Text) *api.JSONElement {
 	return &api.JSONElement{
 		Body: &api.JSONElement_Text_{Text: &api.JSONElement_Text{
 			Nodes:     toTextNodes(text.Nodes()),
-			CreatedAt: ToTimeTicket(text.CreatedAt()),
+			CreatedAt: ToMustTimeTicket(text.CreatedAt()),
 			MovedAt:   ToTimeTicket(text.MovedAt()),
 			RemovedAt: ToTimeTicket(text.RemovedAt()),
 		}},
@@ -125,7 +125,7 @@ func toRichText(text *json.RichText) *api.JSONElement {
 	return &api.JSONElement{
 		Body: &api.JSONElement_RichText_{RichText: &api.JSONElement_RichText{
 			Nodes:     toRichTextNodes(text.Nodes()),
-			CreatedAt: ToTimeTicket(text.CreatedAt()),
+			CreatedAt: ToMustTimeTicket(text.CreatedAt()),
 			MovedAt:   ToTimeTicket(text.MovedAt()),
 			RemovedAt: ToTimeTicket(text.RemovedAt()),
 		}},
@@ -142,7 +142,7 @@ func toCounter(counter *json.Counter) (*api.JSONElement, error) {
 		Body: &api.JSONElement_Counter_{Counter: &api.JSONElement_Counter{
 			Type:      pbCounterType,
 			Value:     counter.Bytes(),
-			CreatedAt: ToTimeTicket(counter.CreatedAt()),
+			CreatedAt: ToMustTimeTicket(counter.CreatedAt()),
 			MovedAt:   ToTimeTicket(counter.MovedAt()),
 			RemovedAt: ToTimeTicket(counter.RemovedAt()),
 		}},
@@ -190,7 +190,7 @@ func toTextNodes(textNodes []*json.RGATreeSplitNode) []*api.TextNode {
 		}
 
 		if textNode.InsPrevID() != nil {
-			pbTextNode.InsPrevId = toTextNodeID(textNode.InsPrevID())
+			pbTextNode.InsPrevId = toTextNodeID(*textNode.InsPrevID())
 		}
 
 		pbTextNodes = append(pbTextNodes, pbTextNode)
@@ -208,7 +208,7 @@ func toRichTextNodes(textNodes []*json.RGATreeSplitNode) []*api.RichTextNode {
 			attrs[node.Key()] = &api.RichTextNodeAttr{
 				Key:       node.Key(),
 				Value:     node.Value(),
-				UpdatedAt: ToTimeTicket(node.UpdatedAt()),
+				UpdatedAt: ToMustTimeTicket(node.UpdatedAt()),
 			}
 		}
 
@@ -220,7 +220,7 @@ func toRichTextNodes(textNodes []*json.RGATreeSplitNode) []*api.RichTextNode {
 		}
 
 		if textNode.InsPrevID() != nil {
-			pbTextNode.InsPrevId = toTextNodeID(textNode.InsPrevID())
+			pbTextNode.InsPrevId = toTextNodeID(*textNode.InsPrevID())
 		}
 
 		pbTextNodes = append(pbTextNodes, pbTextNode)
@@ -228,9 +228,9 @@ func toRichTextNodes(textNodes []*json.RGATreeSplitNode) []*api.RichTextNode {
 	return pbTextNodes
 }
 
-func toTextNodeID(id *json.RGATreeSplitNodeID) *api.TextNodeID {
+func toTextNodeID(id json.RGATreeSplitNodeID) *api.TextNodeID {
 	return &api.TextNodeID{
-		CreatedAt: ToTimeTicket(id.CreatedAt()),
+		CreatedAt: ToMustTimeTicket(id.CreatedAt()),
 		Offset:    int32(id.Offset()),
 	}
 }

--- a/api/converter/to_pb.go
+++ b/api/converter/to_pb.go
@@ -182,6 +182,15 @@ func ToOperations(ops []operations.Operation) ([]*api.Operation, error) {
 	return pbOperations, nil
 }
 
+// ToMustTimeTicket converts the given model format to Protobuf format.
+func ToMustTimeTicket(ticket time.Ticket) *api.TimeTicket {
+	return &api.TimeTicket{
+		Lamport:   ticket.Lamport(),
+		Delimiter: ticket.Delimiter(),
+		ActorId:   ticket.ActorIDBytes(),
+	}
+}
+
 // ToTimeTicket converts the given model format to Protobuf format.
 func ToTimeTicket(ticket *time.Ticket) *api.TimeTicket {
 	if ticket == nil {
@@ -223,10 +232,10 @@ func toSet(set *operations.Set) (*api.Operation_Set_, error) {
 
 	return &api.Operation_Set_{
 		Set: &api.Operation_Set{
-			ParentCreatedAt: ToTimeTicket(set.ParentCreatedAt()),
+			ParentCreatedAt: ToMustTimeTicket(set.ParentCreatedAt()),
 			Key:             set.Key(),
 			Value:           pbElem,
-			ExecutedAt:      ToTimeTicket(set.ExecutedAt()),
+			ExecutedAt:      ToMustTimeTicket(set.ExecutedAt()),
 		},
 	}, nil
 }
@@ -239,10 +248,10 @@ func toAdd(add *operations.Add) (*api.Operation_Add_, error) {
 
 	return &api.Operation_Add_{
 		Add: &api.Operation_Add{
-			ParentCreatedAt: ToTimeTicket(add.ParentCreatedAt()),
-			PrevCreatedAt:   ToTimeTicket(add.PrevCreatedAt()),
+			ParentCreatedAt: ToMustTimeTicket(add.ParentCreatedAt()),
+			PrevCreatedAt:   ToMustTimeTicket(add.PrevCreatedAt()),
 			Value:           pbElem,
-			ExecutedAt:      ToTimeTicket(add.ExecutedAt()),
+			ExecutedAt:      ToMustTimeTicket(add.ExecutedAt()),
 		},
 	}, nil
 }
@@ -250,10 +259,10 @@ func toAdd(add *operations.Add) (*api.Operation_Add_, error) {
 func toMove(move *operations.Move) (*api.Operation_Move_, error) {
 	return &api.Operation_Move_{
 		Move: &api.Operation_Move{
-			ParentCreatedAt: ToTimeTicket(move.ParentCreatedAt()),
-			PrevCreatedAt:   ToTimeTicket(move.PrevCreatedAt()),
-			CreatedAt:       ToTimeTicket(move.CreatedAt()),
-			ExecutedAt:      ToTimeTicket(move.ExecutedAt()),
+			ParentCreatedAt: ToMustTimeTicket(move.ParentCreatedAt()),
+			PrevCreatedAt:   ToMustTimeTicket(move.PrevCreatedAt()),
+			CreatedAt:       ToMustTimeTicket(move.CreatedAt()),
+			ExecutedAt:      ToMustTimeTicket(move.ExecutedAt()),
 		},
 	}, nil
 }
@@ -261,9 +270,9 @@ func toMove(move *operations.Move) (*api.Operation_Move_, error) {
 func toRemove(remove *operations.Remove) (*api.Operation_Remove_, error) {
 	return &api.Operation_Remove_{
 		Remove: &api.Operation_Remove{
-			ParentCreatedAt: ToTimeTicket(remove.ParentCreatedAt()),
-			CreatedAt:       ToTimeTicket(remove.CreatedAt()),
-			ExecutedAt:      ToTimeTicket(remove.ExecutedAt()),
+			ParentCreatedAt: ToMustTimeTicket(remove.ParentCreatedAt()),
+			CreatedAt:       ToMustTimeTicket(remove.CreatedAt()),
+			ExecutedAt:      ToMustTimeTicket(remove.ExecutedAt()),
 		},
 	}, nil
 }
@@ -271,12 +280,12 @@ func toRemove(remove *operations.Remove) (*api.Operation_Remove_, error) {
 func toEdit(edit *operations.Edit) (*api.Operation_Edit_, error) {
 	return &api.Operation_Edit_{
 		Edit: &api.Operation_Edit{
-			ParentCreatedAt:     ToTimeTicket(edit.ParentCreatedAt()),
+			ParentCreatedAt:     ToMustTimeTicket(edit.ParentCreatedAt()),
 			From:                toTextNodePos(edit.From()),
 			To:                  toTextNodePos(edit.To()),
 			CreatedAtMapByActor: toCreatedAtMapByActor(edit.CreatedAtMapByActor()),
 			Content:             edit.Content(),
-			ExecutedAt:          ToTimeTicket(edit.ExecutedAt()),
+			ExecutedAt:          ToMustTimeTicket(edit.ExecutedAt()),
 		},
 	}, nil
 }
@@ -284,10 +293,10 @@ func toEdit(edit *operations.Edit) (*api.Operation_Edit_, error) {
 func toSelect(s *operations.Select) (*api.Operation_Select_, error) {
 	return &api.Operation_Select_{
 		Select: &api.Operation_Select{
-			ParentCreatedAt: ToTimeTicket(s.ParentCreatedAt()),
+			ParentCreatedAt: ToMustTimeTicket(s.ParentCreatedAt()),
 			From:            toTextNodePos(s.From()),
 			To:              toTextNodePos(s.To()),
-			ExecutedAt:      ToTimeTicket(s.ExecutedAt()),
+			ExecutedAt:      ToMustTimeTicket(s.ExecutedAt()),
 		},
 	}, nil
 }
@@ -295,13 +304,13 @@ func toSelect(s *operations.Select) (*api.Operation_Select_, error) {
 func toRichEdit(richEdit *operations.RichEdit) (*api.Operation_RichEdit_, error) {
 	return &api.Operation_RichEdit_{
 		RichEdit: &api.Operation_RichEdit{
-			ParentCreatedAt:     ToTimeTicket(richEdit.ParentCreatedAt()),
+			ParentCreatedAt:     ToMustTimeTicket(richEdit.ParentCreatedAt()),
 			From:                toTextNodePos(richEdit.From()),
 			To:                  toTextNodePos(richEdit.To()),
 			CreatedAtMapByActor: toCreatedAtMapByActor(richEdit.CreatedAtMapByActor()),
 			Content:             richEdit.Content(),
 			Attributes:          richEdit.Attributes(),
-			ExecutedAt:          ToTimeTicket(richEdit.ExecutedAt()),
+			ExecutedAt:          ToMustTimeTicket(richEdit.ExecutedAt()),
 		},
 	}, nil
 }
@@ -309,11 +318,11 @@ func toRichEdit(richEdit *operations.RichEdit) (*api.Operation_RichEdit_, error)
 func toStyle(style *operations.Style) (*api.Operation_Style_, error) {
 	return &api.Operation_Style_{
 		Style: &api.Operation_Style{
-			ParentCreatedAt: ToTimeTicket(style.ParentCreatedAt()),
+			ParentCreatedAt: ToMustTimeTicket(style.ParentCreatedAt()),
 			From:            toTextNodePos(style.From()),
 			To:              toTextNodePos(style.To()),
 			Attributes:      style.Attributes(),
-			ExecutedAt:      ToTimeTicket(style.ExecutedAt()),
+			ExecutedAt:      ToMustTimeTicket(style.ExecutedAt()),
 		},
 	}, nil
 }
@@ -326,9 +335,9 @@ func toIncrease(increase *operations.Increase) (*api.Operation_Increase_, error)
 
 	return &api.Operation_Increase_{
 		Increase: &api.Operation_Increase{
-			ParentCreatedAt: ToTimeTicket(increase.ParentCreatedAt()),
+			ParentCreatedAt: ToMustTimeTicket(increase.ParentCreatedAt()),
 			Value:           pbElem,
-			ExecutedAt:      ToTimeTicket(increase.ExecutedAt()),
+			ExecutedAt:      ToMustTimeTicket(increase.ExecutedAt()),
 		},
 	}, nil
 }
@@ -338,12 +347,12 @@ func toJSONElementSimple(elem json.Element) (*api.JSONElementSimple, error) {
 	case *json.Object:
 		return &api.JSONElementSimple{
 			Type:      api.ValueType_JSON_OBJECT,
-			CreatedAt: ToTimeTicket(elem.CreatedAt()),
+			CreatedAt: ToMustTimeTicket(elem.CreatedAt()),
 		}, nil
 	case *json.Array:
 		return &api.JSONElementSimple{
 			Type:      api.ValueType_JSON_ARRAY,
-			CreatedAt: ToTimeTicket(elem.CreatedAt()),
+			CreatedAt: ToMustTimeTicket(elem.CreatedAt()),
 		}, nil
 	case *json.Primitive:
 		pbValueType, err := toValueType(elem.ValueType())
@@ -353,18 +362,18 @@ func toJSONElementSimple(elem json.Element) (*api.JSONElementSimple, error) {
 
 		return &api.JSONElementSimple{
 			Type:      pbValueType,
-			CreatedAt: ToTimeTicket(elem.CreatedAt()),
+			CreatedAt: ToMustTimeTicket(elem.CreatedAt()),
 			Value:     elem.Bytes(),
 		}, nil
 	case *json.Text:
 		return &api.JSONElementSimple{
 			Type:      api.ValueType_TEXT,
-			CreatedAt: ToTimeTicket(elem.CreatedAt()),
+			CreatedAt: ToMustTimeTicket(elem.CreatedAt()),
 		}, nil
 	case *json.RichText:
 		return &api.JSONElementSimple{
 			Type:      api.ValueType_RICH_TEXT,
-			CreatedAt: ToTimeTicket(elem.CreatedAt()),
+			CreatedAt: ToMustTimeTicket(elem.CreatedAt()),
 		}, nil
 	case *json.Counter:
 		pbCounterType, err := toCounterType(elem.ValueType())
@@ -374,7 +383,7 @@ func toJSONElementSimple(elem json.Element) (*api.JSONElementSimple, error) {
 
 		return &api.JSONElementSimple{
 			Type:      pbCounterType,
-			CreatedAt: ToTimeTicket(elem.CreatedAt()),
+			CreatedAt: ToMustTimeTicket(elem.CreatedAt()),
 			Value:     elem.Bytes(),
 		}, nil
 	}
@@ -382,9 +391,9 @@ func toJSONElementSimple(elem json.Element) (*api.JSONElementSimple, error) {
 	return nil, fmt.Errorf("%v, %w", reflect.TypeOf(elem), ErrUnsupportedElement)
 }
 
-func toTextNodePos(pos *json.RGATreeSplitNodePos) *api.TextNodePos {
+func toTextNodePos(pos json.RGATreeSplitNodePos) *api.TextNodePos {
 	return &api.TextNodePos{
-		CreatedAt:      ToTimeTicket(pos.ID().CreatedAt()),
+		CreatedAt:      ToMustTimeTicket(pos.ID().CreatedAt()),
 		Offset:         int32(pos.ID().Offset()),
 		RelativeOffset: int32(pos.RelativeOffset()),
 	}

--- a/pkg/document/change/context.go
+++ b/pkg/document/change/context.go
@@ -58,7 +58,7 @@ func (c *Context) HasOperations() bool {
 }
 
 // IssueTimeTicket creates a time ticket to be used to create a new operation.
-func (c *Context) IssueTimeTicket() *time.Ticket {
+func (c *Context) IssueTimeTicket() time.Ticket {
 	c.delimiter++
 	return c.id.NewTimeTicket(c.delimiter)
 }

--- a/pkg/document/change/id.go
+++ b/pkg/document/change/id.go
@@ -73,7 +73,7 @@ func (id ID) Next() ID {
 }
 
 // NewTimeTicket creates a ticket of the given delimiter.
-func (id ID) NewTimeTicket(delimiter uint32) *time.Ticket {
+func (id ID) NewTimeTicket(delimiter uint32) time.Ticket {
 	return time.NewTicket(
 		id.lamport,
 		delimiter,

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -117,7 +117,9 @@ func (d *Document) ApplyChangePack(pack *change.Pack) error {
 	d.doc.checkpoint = d.doc.checkpoint.Forward(pack.Checkpoint)
 
 	// 04. Do Garbage collection.
-	d.GarbageCollect(pack.MinSyncedTicket)
+	if pack.MinSyncedTicket != nil {
+		d.GarbageCollect(*pack.MinSyncedTicket)
+	}
 
 	return nil
 }
@@ -187,7 +189,7 @@ func (d *Document) Root() *proxy.ObjectProxy {
 }
 
 // GarbageCollect purge elements that were removed before the given time.
-func (d *Document) GarbageCollect(ticket *time.Ticket) int {
+func (d *Document) GarbageCollect(ticket time.Ticket) int {
 	if d.clone != nil {
 		d.clone.GarbageCollect(ticket)
 	}

--- a/pkg/document/internal_document.go
+++ b/pkg/document/internal_document.go
@@ -120,14 +120,14 @@ func (d *InternalDocument) ApplyChangePack(pack *change.Pack) error {
 	d.checkpoint = d.checkpoint.Forward(pack.Checkpoint)
 
 	if pack.MinSyncedTicket != nil {
-		d.GarbageCollect(pack.MinSyncedTicket)
+		d.GarbageCollect(*pack.MinSyncedTicket)
 	}
 
 	return nil
 }
 
 // GarbageCollect purge elements that were removed before the given time.
-func (d *InternalDocument) GarbageCollect(ticket *time.Ticket) int {
+func (d *InternalDocument) GarbageCollect(ticket time.Ticket) int {
 	return d.root.GarbageCollect(ticket)
 }
 

--- a/pkg/document/json/array.go
+++ b/pkg/document/json/array.go
@@ -24,13 +24,13 @@ import (
 // Array implements Element interface.
 type Array struct {
 	elements  *RGATreeList
-	createdAt *time.Ticket
+	createdAt time.Ticket
 	movedAt   *time.Ticket
 	removedAt *time.Ticket
 }
 
 // NewArray creates a new instance of Array.
-func NewArray(elements *RGATreeList, createdAt *time.Ticket) *Array {
+func NewArray(elements *RGATreeList, createdAt time.Ticket) *Array {
 	return &Array{
 		elements:  elements,
 		createdAt: createdAt,
@@ -55,7 +55,7 @@ func (a *Array) Get(idx int) Element {
 
 // FindPrevCreatedAt returns the creation time of the previous element of the
 // given element.
-func (a *Array) FindPrevCreatedAt(createdAt *time.Ticket) *time.Ticket {
+func (a *Array) FindPrevCreatedAt(createdAt time.Ticket) time.Ticket {
 	return a.elements.FindPrevCreatedAt(createdAt)
 }
 
@@ -66,7 +66,7 @@ func (a *Array) Delete(idx int, deletedAt *time.Ticket) Element {
 
 // MoveAfter moves the given `createdAt` element after the `prevCreatedAt`
 // element.
-func (a *Array) MoveAfter(prevCreatedAt, createdAt, executedAt *time.Ticket) {
+func (a *Array) MoveAfter(prevCreatedAt, createdAt, executedAt time.Ticket) {
 	a.elements.MoveAfter(prevCreatedAt, createdAt, executedAt)
 }
 
@@ -108,7 +108,7 @@ func (a *Array) DeepCopy() Element {
 }
 
 // CreatedAt returns the creation time of this array.
-func (a *Array) CreatedAt() *time.Ticket {
+func (a *Array) CreatedAt() time.Ticket {
 	return a.createdAt
 }
 
@@ -135,7 +135,7 @@ func (a *Array) SetRemovedAt(removedAt *time.Ticket) {
 // Remove removes this array.
 func (a *Array) Remove(removedAt *time.Ticket) bool {
 	if (removedAt != nil && removedAt.After(a.createdAt)) &&
-		(a.removedAt == nil || removedAt.After(a.removedAt)) {
+		(a.removedAt == nil || removedAt.After(*a.removedAt)) {
 		a.removedAt = removedAt
 		return true
 	}
@@ -143,17 +143,17 @@ func (a *Array) Remove(removedAt *time.Ticket) bool {
 }
 
 // LastCreatedAt returns the creation time of the last element.
-func (a *Array) LastCreatedAt() *time.Ticket {
+func (a *Array) LastCreatedAt() time.Ticket {
 	return a.elements.LastCreatedAt()
 }
 
 // InsertAfter inserts the given element after the given previous element.
-func (a *Array) InsertAfter(prevCreatedAt *time.Ticket, element Element) {
+func (a *Array) InsertAfter(prevCreatedAt time.Ticket, element Element) {
 	a.elements.InsertAfter(prevCreatedAt, element)
 }
 
 // DeleteByCreatedAt deletes the given element.
-func (a *Array) DeleteByCreatedAt(createdAt *time.Ticket, deletedAt *time.Ticket) Element {
+func (a *Array) DeleteByCreatedAt(createdAt time.Ticket, deletedAt *time.Ticket) Element {
 	return a.elements.DeleteByCreatedAt(createdAt, deletedAt).elem
 }
 

--- a/pkg/document/json/counter.go
+++ b/pkg/document/json/counter.go
@@ -53,13 +53,13 @@ func CounterValueFromBytes(counterType CounterType, value []byte) interface{} {
 type Counter struct {
 	valueType CounterType
 	value     interface{}
-	createdAt *time.Ticket
+	createdAt time.Ticket
 	movedAt   *time.Ticket
 	removedAt *time.Ticket
 }
 
 // NewCounter creates a new instance of Counter.
-func NewCounter(value interface{}, createdAt *time.Ticket) *Counter {
+func NewCounter(value interface{}, createdAt time.Ticket) *Counter {
 	switch val := value.(type) {
 	case int:
 		if math.MaxInt32 < val || math.MinInt32 > val {
@@ -132,7 +132,7 @@ func (p *Counter) DeepCopy() Element {
 }
 
 // CreatedAt returns the creation time.
-func (p *Counter) CreatedAt() *time.Ticket {
+func (p *Counter) CreatedAt() time.Ticket {
 	return p.createdAt
 }
 
@@ -159,7 +159,7 @@ func (p *Counter) SetRemovedAt(removedAt *time.Ticket) {
 // Remove removes this element.
 func (p *Counter) Remove(removedAt *time.Ticket) bool {
 	if (removedAt != nil && removedAt.After(p.createdAt)) &&
-		(p.removedAt == nil || removedAt.After(p.removedAt)) {
+		(p.removedAt == nil || removedAt.After(*p.removedAt)) {
 		p.removedAt = removedAt
 		return true
 	}

--- a/pkg/document/json/element.go
+++ b/pkg/document/json/element.go
@@ -31,14 +31,14 @@ type Container interface {
 	Descendants(callback func(elem Element, parent Container) bool)
 
 	// DeleteByCreatedAt removes the given element from this container.
-	DeleteByCreatedAt(createdAt *time.Ticket, deletedAt *time.Ticket) Element
+	DeleteByCreatedAt(createdAt time.Ticket, deletedAt *time.Ticket) Element
 }
 
 // TextElement represents Text or RichText.
 type TextElement interface {
 	Element
 	removedNodesLen() int
-	purgeTextNodesWithGarbage(ticket *time.Ticket) int
+	purgeTextNodesWithGarbage(ticket time.Ticket) int
 }
 
 // Element represents JSON element.
@@ -50,7 +50,7 @@ type Element interface {
 	DeepCopy() Element
 
 	// CreatedAt returns the creation time of this element.
-	CreatedAt() *time.Ticket
+	CreatedAt() time.Ticket
 
 	// MovedAt returns the move time of this element.
 	MovedAt() *time.Ticket

--- a/pkg/document/json/object.go
+++ b/pkg/document/json/object.go
@@ -24,13 +24,13 @@ import (
 // tickets which is created by logical clock.
 type Object struct {
 	memberNodes *RHTPriorityQueueMap
-	createdAt   *time.Ticket
+	createdAt   time.Ticket
 	movedAt     *time.Ticket
 	removedAt   *time.Ticket
 }
 
 // NewObject creates a new instance of Object.
-func NewObject(memberNodes *RHTPriorityQueueMap, createdAt *time.Ticket) *Object {
+func NewObject(memberNodes *RHTPriorityQueueMap, createdAt time.Ticket) *Object {
 	return &Object{
 		memberNodes: memberNodes,
 		createdAt:   createdAt,
@@ -63,7 +63,7 @@ func (o *Object) Has(k string) bool {
 }
 
 // DeleteByCreatedAt deletes the element of the given creation time.
-func (o *Object) DeleteByCreatedAt(createdAt *time.Ticket, deletedAt *time.Ticket) Element {
+func (o *Object) DeleteByCreatedAt(createdAt time.Ticket, deletedAt *time.Ticket) Element {
 	return o.memberNodes.DeleteByCreatedAt(createdAt, deletedAt)
 }
 
@@ -107,7 +107,7 @@ func (o *Object) DeepCopy() Element {
 }
 
 // CreatedAt returns the creation time of this object.
-func (o *Object) CreatedAt() *time.Ticket {
+func (o *Object) CreatedAt() time.Ticket {
 	return o.createdAt
 }
 
@@ -134,7 +134,7 @@ func (o *Object) SetRemovedAt(removedAt *time.Ticket) {
 // Remove removes this object.
 func (o *Object) Remove(removedAt *time.Ticket) bool {
 	if (removedAt != nil && removedAt.After(o.createdAt)) &&
-		(o.removedAt == nil || removedAt.After(o.removedAt)) {
+		(o.removedAt == nil || removedAt.After(*o.removedAt)) {
 		o.removedAt = removedAt
 		return true
 	}

--- a/pkg/document/json/object_test.go
+++ b/pkg/document/json/object_test.go
@@ -36,7 +36,8 @@ func TestObject(t *testing.T) {
 		assert.Equal(t, `{"k1":"v1"}`, obj.Marshal())
 		obj.Set("k2", json.NewPrimitive("v2", ctx.IssueTimeTicket()))
 		assert.Equal(t, `{"k1":"v1","k2":"v2"}`, obj.Marshal())
-		obj.Delete("k1", ctx.IssueTimeTicket())
+		ticket := ctx.IssueTimeTicket()
+		obj.Delete("k1", &ticket)
 		assert.Equal(t, `{"k2":"v2"}`, obj.Marshal())
 	})
 }

--- a/pkg/document/json/primitive.go
+++ b/pkg/document/json/primitive.go
@@ -73,13 +73,13 @@ func ValueFromBytes(valueType ValueType, value []byte) interface{} {
 type Primitive struct {
 	valueType ValueType
 	value     interface{}
-	createdAt *time.Ticket
+	createdAt time.Ticket
 	movedAt   *time.Ticket
 	removedAt *time.Ticket
 }
 
 // NewPrimitive creates a new instance of Primitive.
-func NewPrimitive(value interface{}, createdAt *time.Ticket) *Primitive {
+func NewPrimitive(value interface{}, createdAt time.Ticket) *Primitive {
 	if value == nil {
 		return &Primitive{
 			valueType: Null,
@@ -213,7 +213,7 @@ func (p *Primitive) DeepCopy() Element {
 }
 
 // CreatedAt returns the creation time.
-func (p *Primitive) CreatedAt() *time.Ticket {
+func (p *Primitive) CreatedAt() time.Ticket {
 	return p.createdAt
 }
 
@@ -240,7 +240,7 @@ func (p *Primitive) SetRemovedAt(removedAt *time.Ticket) {
 // Remove removes this element.
 func (p *Primitive) Remove(removedAt *time.Ticket) bool {
 	if (removedAt != nil && removedAt.After(p.createdAt)) &&
-		(p.removedAt == nil || removedAt.After(p.removedAt)) {
+		(p.removedAt == nil || removedAt.After(*p.removedAt)) {
 		p.removedAt = removedAt
 		return true
 	}

--- a/pkg/document/json/primitive_test.go
+++ b/pkg/document/json/primitive_test.go
@@ -57,7 +57,8 @@ func TestPrimitive(t *testing.T) {
 			assert.Equal(t, prim.Marshal(), copied.Marshal())
 
 			actorID, _ := time.ActorIDFromHex("0")
-			prim.SetMovedAt(time.NewTicket(0, 0, &actorID))
+			movedAt := time.NewTicket(0, 0, &actorID)
+			prim.SetMovedAt(&movedAt)
 			assert.NotEqual(t, prim.MovedAt(), copied.MovedAt())
 		}
 		longPrim := json.NewPrimitive(math.MaxInt32+1, time.InitialTicket)

--- a/pkg/document/json/rga_tree_list.go
+++ b/pkg/document/json/rga_tree_list.go
@@ -63,14 +63,14 @@ func (n *RGATreeListNode) Element() Element {
 }
 
 // CreatedAt returns the creation time of this element.
-func (n *RGATreeListNode) CreatedAt() *time.Ticket {
+func (n *RGATreeListNode) CreatedAt() time.Ticket {
 	return n.elem.CreatedAt()
 }
 
 // PositionedAt returns the time this element was positioned.
-func (n *RGATreeListNode) PositionedAt() *time.Ticket {
+func (n *RGATreeListNode) PositionedAt() time.Ticket {
 	if n.elem.MovedAt() != nil {
-		return n.elem.MovedAt()
+		return *n.elem.MovedAt()
 	}
 
 	return n.elem.CreatedAt()
@@ -108,7 +108,7 @@ type RGATreeList struct {
 // NewRGATreeList creates a new instance of RGATreeList.
 func NewRGATreeList() *RGATreeList {
 	dummyValue := NewPrimitive(0, time.InitialTicket)
-	dummyValue.SetRemovedAt(time.InitialTicket)
+	dummyValue.SetRemovedAt(&time.InitialTicket)
 	dummyHead := newRGATreeListNode(dummyValue)
 	nodeMapByIndex := splay.NewTree(dummyHead.indexNode)
 	nodeMapByCreatedAt := make(map[string]*RGATreeListNode)
@@ -174,12 +174,12 @@ func (a *RGATreeList) Nodes() []*RGATreeListNode {
 }
 
 // LastCreatedAt returns the creation time of last elements.
-func (a *RGATreeList) LastCreatedAt() *time.Ticket {
+func (a *RGATreeList) LastCreatedAt() time.Ticket {
 	return a.last.CreatedAt()
 }
 
 // InsertAfter inserts the given element after the given previous element.
-func (a *RGATreeList) InsertAfter(prevCreatedAt *time.Ticket, elem Element) {
+func (a *RGATreeList) InsertAfter(prevCreatedAt time.Ticket, elem Element) {
 	a.insertAfter(prevCreatedAt, elem, elem.CreatedAt())
 }
 
@@ -208,7 +208,7 @@ func (a *RGATreeList) Get(idx int) *RGATreeListNode {
 }
 
 // DeleteByCreatedAt deletes the given element.
-func (a *RGATreeList) DeleteByCreatedAt(createdAt *time.Ticket, deletedAt *time.Ticket) *RGATreeListNode {
+func (a *RGATreeList) DeleteByCreatedAt(createdAt time.Ticket, deletedAt *time.Ticket) *RGATreeListNode {
 	node, ok := a.nodeMapByCreatedAt[createdAt.Key()]
 	if !ok {
 		panic("fail to find the given createdAt: " + createdAt.Key())
@@ -241,7 +241,7 @@ func (a *RGATreeList) Delete(idx int, deletedAt *time.Ticket) *RGATreeListNode {
 
 // MoveAfter moves the given `createdAt` element after the `prevCreatedAt`
 // element.
-func (a *RGATreeList) MoveAfter(prevCreatedAt, createdAt, executedAt *time.Ticket) {
+func (a *RGATreeList) MoveAfter(prevCreatedAt, createdAt, executedAt time.Ticket) {
 	prevNode, ok := a.nodeMapByCreatedAt[prevCreatedAt.Key()]
 	if !ok {
 		panic("fail to find the given prevCreatedAt: " + prevCreatedAt.Key())
@@ -252,16 +252,16 @@ func (a *RGATreeList) MoveAfter(prevCreatedAt, createdAt, executedAt *time.Ticke
 		panic("fail to find the given createdAt: " + createdAt.Key())
 	}
 
-	if node.elem.MovedAt() == nil || executedAt.After(node.elem.MovedAt()) {
+	if node.elem.MovedAt() == nil || executedAt.After(*node.elem.MovedAt()) {
 		a.release(node)
 		a.insertAfter(prevNode.CreatedAt(), node.elem, executedAt)
-		node.elem.SetMovedAt(executedAt)
+		node.elem.SetMovedAt(&executedAt)
 	}
 }
 
 // FindPrevCreatedAt returns the creation time of the previous element of the
 // given element.
-func (a *RGATreeList) FindPrevCreatedAt(createdAt *time.Ticket) *time.Ticket {
+func (a *RGATreeList) FindPrevCreatedAt(createdAt time.Ticket) time.Ticket {
 	node, ok := a.nodeMapByCreatedAt[createdAt.Key()]
 	if !ok {
 		panic("fail to find the given prevCreatedAt: " + createdAt.Key())
@@ -288,8 +288,8 @@ func (a *RGATreeList) purge(elem Element) {
 }
 
 func (a *RGATreeList) findNextBeforeExecutedAt(
-	createdAt *time.Ticket,
-	executedAt *time.Ticket,
+	createdAt time.Ticket,
+	executedAt time.Ticket,
 ) *RGATreeListNode {
 	node, ok := a.nodeMapByCreatedAt[createdAt.Key()]
 	if !ok {
@@ -323,9 +323,9 @@ func (a *RGATreeList) release(node *RGATreeListNode) {
 }
 
 func (a *RGATreeList) insertAfter(
-	prevCreatedAt *time.Ticket,
+	prevCreatedAt time.Ticket,
 	value Element,
-	executedAt *time.Ticket,
+	executedAt time.Ticket,
 ) {
 	prevNode := a.findNextBeforeExecutedAt(prevCreatedAt, executedAt)
 	newNode := newRGATreeListNodeAfter(prevNode, value)

--- a/pkg/document/json/rga_tree_split.go
+++ b/pkg/document/json/rga_tree_split.go
@@ -11,7 +11,11 @@ import (
 )
 
 var (
-	initialNodeID = NewRGATreeSplitNodeID(time.InitialTicket, 0)
+	// InitialNodeID is the initial node ID.
+	InitialNodeID = NewRGATreeSplitNodeID(time.InitialTicket, 0)
+
+	// InitialNodePos is the initial node position.
+	InitialNodePos = NewRGATreeSplitNodePos(InitialNodeID, 0)
 )
 
 // RGATreeSplitValue is a value of RGATreeSplitNode.
@@ -25,13 +29,13 @@ type RGATreeSplitValue interface {
 
 // RGATreeSplitNodeID is an ID of RGATreeSplitNode.
 type RGATreeSplitNodeID struct {
-	createdAt *time.Ticket
+	createdAt time.Ticket
 	offset    int
 }
 
 // NewRGATreeSplitNodeID creates a new instance of RGATreeSplitNodeID.
-func NewRGATreeSplitNodeID(createdAt *time.Ticket, offset int) *RGATreeSplitNodeID {
-	return &RGATreeSplitNodeID{
+func NewRGATreeSplitNodeID(createdAt time.Ticket, offset int) RGATreeSplitNodeID {
+	return RGATreeSplitNodeID{
 		createdAt: createdAt,
 		offset:    offset,
 	}
@@ -40,12 +44,8 @@ func NewRGATreeSplitNodeID(createdAt *time.Ticket, offset int) *RGATreeSplitNode
 // Compare returns an integer comparing two ID. The result will be 0 if
 // id==other, -1 if id < other, and +1 if id > other. If the receiver or
 // argument is nil, it would panic at runtime.
-func (t *RGATreeSplitNodeID) Compare(other llrb.Key) int {
-	if t == nil || other == nil {
-		panic("RGATreeSplitNodeID cannot be null")
-	}
-
-	o := other.(*RGATreeSplitNodeID)
+func (t RGATreeSplitNodeID) Compare(other llrb.Key) int {
+	o := other.(RGATreeSplitNodeID)
 	compare := t.createdAt.Compare(o.createdAt)
 	if compare != 0 {
 		return compare
@@ -61,72 +61,72 @@ func (t *RGATreeSplitNodeID) Compare(other llrb.Key) int {
 }
 
 // Equal returns whether given ID equals to this ID or not.
-func (t *RGATreeSplitNodeID) Equal(other llrb.Key) bool {
+func (t RGATreeSplitNodeID) Equal(other llrb.Key) bool {
 	return t.Compare(other) == 0
 }
 
 // CreatedAt returns the creation time of this ID.
-func (t *RGATreeSplitNodeID) CreatedAt() *time.Ticket {
+func (t RGATreeSplitNodeID) CreatedAt() time.Ticket {
 	return t.createdAt
 }
 
 // Offset returns the offset of this ID.
-func (t *RGATreeSplitNodeID) Offset() int {
+func (t RGATreeSplitNodeID) Offset() int {
 	return t.offset
 }
 
 // Split creates a new ID with an offset from this ID.
-func (t *RGATreeSplitNodeID) Split(offset int) *RGATreeSplitNodeID {
+func (t RGATreeSplitNodeID) Split(offset int) RGATreeSplitNodeID {
 	return NewRGATreeSplitNodeID(t.createdAt, t.offset+offset)
 }
 
 // AnnotatedString returns a String containing the metadata of the node id
 // for debugging purpose.
-func (t *RGATreeSplitNodeID) AnnotatedString() string {
+func (t RGATreeSplitNodeID) AnnotatedString() string {
 	return fmt.Sprintf("%s:%d", t.createdAt.AnnotatedString(), t.offset)
 }
 
-func (t *RGATreeSplitNodeID) hasSameCreatedAt(id *RGATreeSplitNodeID) bool {
+func (t RGATreeSplitNodeID) hasSameCreatedAt(id RGATreeSplitNodeID) bool {
 	return t.createdAt.Compare(id.createdAt) == 0
 }
 
-func (t *RGATreeSplitNodeID) key() string {
+func (t RGATreeSplitNodeID) key() string {
 	return t.CreatedAt().Key() + ":" + strconv.FormatUint(uint64(t.offset), 10)
 }
 
 // RGATreeSplitNodePos is the position of the text inside the node.
 type RGATreeSplitNodePos struct {
-	id             *RGATreeSplitNodeID
+	id             RGATreeSplitNodeID
 	relativeOffset int
 }
 
 // NewRGATreeSplitNodePos creates a new instance of RGATreeSplitNodePos.
-func NewRGATreeSplitNodePos(id *RGATreeSplitNodeID, offset int) *RGATreeSplitNodePos {
-	return &RGATreeSplitNodePos{id, offset}
+func NewRGATreeSplitNodePos(id RGATreeSplitNodeID, offset int) RGATreeSplitNodePos {
+	return RGATreeSplitNodePos{id, offset}
 }
 
-func (pos *RGATreeSplitNodePos) getAbsoluteID() *RGATreeSplitNodeID {
+func (pos RGATreeSplitNodePos) getAbsoluteID() RGATreeSplitNodeID {
 	return NewRGATreeSplitNodeID(pos.id.createdAt, pos.id.offset+pos.relativeOffset)
 }
 
 // AnnotatedString returns a String containing the metadata of the position
 // for debugging purpose.
-func (pos *RGATreeSplitNodePos) AnnotatedString() string {
+func (pos RGATreeSplitNodePos) AnnotatedString() string {
 	return fmt.Sprintf("%s:%d", pos.id.AnnotatedString(), pos.relativeOffset)
 }
 
 // ID returns the ID of this RGATreeSplitNodePos.
-func (pos *RGATreeSplitNodePos) ID() *RGATreeSplitNodeID {
+func (pos RGATreeSplitNodePos) ID() RGATreeSplitNodeID {
 	return pos.id
 }
 
 // RelativeOffset returns the relative offset of this RGATreeSplitNodePos.
-func (pos *RGATreeSplitNodePos) RelativeOffset() int {
+func (pos RGATreeSplitNodePos) RelativeOffset() int {
 	return pos.relativeOffset
 }
 
 // Equal returns the whether the given pos equals or not.
-func (pos *RGATreeSplitNodePos) Equal(other *RGATreeSplitNodePos) bool {
+func (pos RGATreeSplitNodePos) Equal(other RGATreeSplitNodePos) bool {
 	if !pos.id.Equal(other.id) {
 		return false
 	}
@@ -135,12 +135,12 @@ func (pos *RGATreeSplitNodePos) Equal(other *RGATreeSplitNodePos) bool {
 
 // Selection represents the selection of text range in the editor.
 type Selection struct {
-	from      *RGATreeSplitNodePos
-	to        *RGATreeSplitNodePos
-	updatedAt *time.Ticket
+	from      RGATreeSplitNodePos
+	to        RGATreeSplitNodePos
+	updatedAt time.Ticket
 }
 
-func newSelection(from, to *RGATreeSplitNodePos, updatedAt *time.Ticket) *Selection {
+func newSelection(from, to RGATreeSplitNodePos, updatedAt time.Ticket) *Selection {
 	return &Selection{
 		from,
 		to,
@@ -150,7 +150,7 @@ func newSelection(from, to *RGATreeSplitNodePos, updatedAt *time.Ticket) *Select
 
 // RGATreeSplitNode is a node of RGATreeSplit.
 type RGATreeSplitNode struct {
-	id        *RGATreeSplitNodeID
+	id        RGATreeSplitNodeID
 	indexNode *splay.Node
 	value     RGATreeSplitValue
 	removedAt *time.Ticket
@@ -162,7 +162,7 @@ type RGATreeSplitNode struct {
 }
 
 // NewRGATreeSplitNode creates a new instance of RGATreeSplit.
-func NewRGATreeSplitNode(id *RGATreeSplitNodeID, value RGATreeSplitValue) *RGATreeSplitNode {
+func NewRGATreeSplitNode(id RGATreeSplitNodeID, value RGATreeSplitValue) *RGATreeSplitNode {
 	node := &RGATreeSplitNode{
 		id:    id,
 		value: value,
@@ -173,7 +173,7 @@ func NewRGATreeSplitNode(id *RGATreeSplitNodeID, value RGATreeSplitValue) *RGATr
 }
 
 // ID returns the ID of this RGATreeSplitNode.
-func (t *RGATreeSplitNode) ID() *RGATreeSplitNodeID {
+func (t *RGATreeSplitNode) ID() RGATreeSplitNodeID {
 	return t.id
 }
 
@@ -183,7 +183,7 @@ func (t *RGATreeSplitNode) InsPrevID() *RGATreeSplitNodeID {
 		return nil
 	}
 
-	return t.insPrev.id
+	return &t.insPrev.id
 }
 
 func (t *RGATreeSplitNode) contentLen() int {
@@ -238,7 +238,7 @@ func (t *RGATreeSplitNode) split(offset int) *RGATreeSplitNode {
 	)
 }
 
-func (t *RGATreeSplitNode) createdAt() *time.Ticket {
+func (t *RGATreeSplitNode) createdAt() time.Ticket {
 	return t.id.createdAt
 }
 
@@ -250,9 +250,9 @@ func (t *RGATreeSplitNode) annotatedString() string {
 
 // Remove removes this node if it created before the time of deletion are
 // deleted. It only marks the deleted time (tombstone).
-func (t *RGATreeSplitNode) Remove(removedAt *time.Ticket, latestCreatedAt *time.Ticket) bool {
+func (t *RGATreeSplitNode) Remove(removedAt *time.Ticket, latestCreatedAt time.Ticket) bool {
 	if !t.createdAt().After(latestCreatedAt) &&
-		(t.removedAt == nil || removedAt.After(t.removedAt)) {
+		(t.removedAt == nil || removedAt.After(*t.removedAt)) {
 		t.removedAt = removedAt
 		return true
 	}
@@ -292,7 +292,7 @@ func NewRGATreeSplit(initialHead *RGATreeSplitNode) *RGATreeSplit {
 	}
 }
 
-func (s *RGATreeSplit) createRange(from, to int) (*RGATreeSplitNodePos, *RGATreeSplitNodePos) {
+func (s *RGATreeSplit) createRange(from, to int) (RGATreeSplitNodePos, RGATreeSplitNodePos) {
 	fromPos := s.findNodePos(from)
 	if from == to {
 		return fromPos, fromPos
@@ -301,18 +301,18 @@ func (s *RGATreeSplit) createRange(from, to int) (*RGATreeSplitNodePos, *RGATree
 	return fromPos, s.findNodePos(to)
 }
 
-func (s *RGATreeSplit) findNodePos(index int) *RGATreeSplitNodePos {
+func (s *RGATreeSplit) findNodePos(index int) RGATreeSplitNodePos {
 	splayNode, offset := s.treeByIndex.Find(index)
 	node := splayNode.Value().(*RGATreeSplitNode)
-	return &RGATreeSplitNodePos{
+	return RGATreeSplitNodePos{
 		id:             node.ID(),
 		relativeOffset: offset,
 	}
 }
 
 func (s *RGATreeSplit) findNodeWithSplit(
-	pos *RGATreeSplitNodePos,
-	updatedAt *time.Ticket,
+	pos RGATreeSplitNodePos,
+	updatedAt time.Ticket,
 ) (*RGATreeSplitNode, *RGATreeSplitNode) {
 	absoluteID := pos.getAbsoluteID()
 	node := s.findFloorNodePreferToLeft(absoluteID)
@@ -328,7 +328,7 @@ func (s *RGATreeSplit) findNodeWithSplit(
 	return node, node.next
 }
 
-func (s *RGATreeSplit) findFloorNodePreferToLeft(id *RGATreeSplitNodeID) *RGATreeSplitNode {
+func (s *RGATreeSplit) findFloorNodePreferToLeft(id RGATreeSplitNodeID) *RGATreeSplitNode {
 	node := s.findFloorNode(id)
 	if node == nil {
 		panic("the node of the given id should be found: " + s.AnnotatedString())
@@ -389,21 +389,17 @@ func (s *RGATreeSplit) InitialHead() *RGATreeSplitNode {
 }
 
 // FindNode returns the node of the given ID.
-func (s *RGATreeSplit) FindNode(id *RGATreeSplitNodeID) *RGATreeSplitNode {
-	if id == nil {
-		return nil
-	}
-
+func (s *RGATreeSplit) FindNode(id RGATreeSplitNodeID) *RGATreeSplitNode {
 	return s.findFloorNode(id)
 }
 
-func (s *RGATreeSplit) findFloorNode(id *RGATreeSplitNodeID) *RGATreeSplitNode {
+func (s *RGATreeSplit) findFloorNode(id RGATreeSplitNodeID) *RGATreeSplitNode {
 	key, value := s.treeByID.Floor(id)
 	if key == nil {
 		return nil
 	}
 
-	foundID := key.(*RGATreeSplitNodeID)
+	foundID := key.(RGATreeSplitNodeID)
 	foundValue := value.(*RGATreeSplitNode)
 
 	if !foundID.Equal(id) && !foundID.hasSameCreatedAt(id) {
@@ -414,12 +410,12 @@ func (s *RGATreeSplit) findFloorNode(id *RGATreeSplitNodeID) *RGATreeSplitNode {
 }
 
 func (s *RGATreeSplit) edit(
-	from *RGATreeSplitNodePos,
-	to *RGATreeSplitNodePos,
+	from RGATreeSplitNodePos,
+	to RGATreeSplitNodePos,
 	latestCreatedAtMapByActor map[string]*time.Ticket,
 	content RGATreeSplitValue,
-	editedAt *time.Ticket,
-) (*RGATreeSplitNodePos, map[string]*time.Ticket) {
+	editedAt time.Ticket,
+) (RGATreeSplitNodePos, map[string]*time.Ticket) {
 	// 01. Split nodes with from and to
 	toLeft, toRight := s.findNodeWithSplit(to, editedAt)
 	fromLeft, fromRight := s.findNodeWithSplit(from, editedAt)
@@ -428,7 +424,7 @@ func (s *RGATreeSplit) edit(
 	nodesToDelete := s.findBetween(fromRight, toRight)
 	latestCreatedAtMap, removedNodeMapByNodeKey := s.deleteNodes(nodesToDelete, latestCreatedAtMapByActor, editedAt)
 
-	var caretID *RGATreeSplitNodeID
+	var caretID RGATreeSplitNodeID
 	if toRight == nil {
 		caretID = toLeft.id
 	} else {
@@ -463,7 +459,7 @@ func (s *RGATreeSplit) findBetween(from *RGATreeSplitNode, to *RGATreeSplitNode)
 func (s *RGATreeSplit) deleteNodes(
 	candidates []*RGATreeSplitNode,
 	latestCreatedAtMapByActor map[string]*time.Ticket,
-	editedAt *time.Ticket,
+	editedAt time.Ticket,
 ) (map[string]*time.Ticket, map[string]*RGATreeSplitNode) {
 	createdAtMapByActor := make(map[string]*time.Ticket)
 	removedNodeMap := make(map[string]*RGATreeSplitNode)
@@ -471,24 +467,24 @@ func (s *RGATreeSplit) deleteNodes(
 	for _, node := range candidates {
 		actorIDHex := node.createdAt().ActorIDHex()
 
-		var latestCreatedAt *time.Ticket
+		var latestCreatedAt time.Ticket
 		if latestCreatedAtMapByActor == nil {
 			latestCreatedAt = time.MaxTicket
 		} else {
 			createdAt, ok := latestCreatedAtMapByActor[actorIDHex]
 			if ok {
-				latestCreatedAt = createdAt
+				latestCreatedAt = *createdAt
 			} else {
 				latestCreatedAt = time.InitialTicket
 			}
 		}
 
-		if node.Remove(editedAt, latestCreatedAt) {
+		if node.Remove(&editedAt, latestCreatedAt) {
 			s.treeByIndex.Splay(node.indexNode)
 			latestCreatedAt := createdAtMapByActor[actorIDHex]
 			createdAt := node.id.createdAt
-			if latestCreatedAt == nil || createdAt.After(latestCreatedAt) {
-				createdAtMapByActor[actorIDHex] = createdAt
+			if latestCreatedAt == nil || createdAt.After(*latestCreatedAt) {
+				createdAtMapByActor[actorIDHex] = &createdAt
 			}
 
 			removedNodeMap[node.id.key()] = node
@@ -555,10 +551,10 @@ func (s *RGATreeSplit) removedNodesLen() int {
 }
 
 // purgeTextNodesWithGarbage physically purges nodes that have been removed.
-func (s *RGATreeSplit) purgeTextNodesWithGarbage(ticket *time.Ticket) int {
+func (s *RGATreeSplit) purgeTextNodesWithGarbage(ticket time.Ticket) int {
 	count := 0
 	for _, node := range s.removedNodeMap {
-		if node.removedAt != nil && ticket.Compare(node.removedAt) >= 0 {
+		if node.removedAt != nil && ticket.Compare(*node.removedAt) >= 0 {
 			s.treeByIndex.Delete(node.indexNode)
 			s.purge(node)
 			s.treeByID.Remove(node.id)

--- a/pkg/document/json/rht.go
+++ b/pkg/document/json/rht.go
@@ -28,11 +28,11 @@ import (
 type RHTNode struct {
 	key       string
 	val       string
-	updatedAt *time.Ticket
+	updatedAt time.Ticket
 	removedAt *time.Ticket
 }
 
-func newRHTNode(key, val string, updatedAt *time.Ticket) *RHTNode {
+func newRHTNode(key, val string, updatedAt time.Ticket) *RHTNode {
 	return &RHTNode{
 		key:       key,
 		val:       val,
@@ -42,7 +42,7 @@ func newRHTNode(key, val string, updatedAt *time.Ticket) *RHTNode {
 
 // Remove removes this node. It only marks the deleted time (tombstone).
 func (n *RHTNode) Remove(removedAt *time.Ticket) {
-	if n.removedAt == nil || removedAt.After(n.removedAt) {
+	if n.removedAt == nil || removedAt.After(*n.removedAt) {
 		n.removedAt = removedAt
 	}
 }
@@ -62,7 +62,7 @@ func (n *RHTNode) Value() string {
 }
 
 // UpdatedAt returns the last update time.
-func (n *RHTNode) UpdatedAt() *time.Ticket {
+func (n *RHTNode) UpdatedAt() time.Ticket {
 	return n.updatedAt
 }
 
@@ -108,7 +108,7 @@ func (rht *RHT) Has(key string) bool {
 }
 
 // Set sets the value of the given key.
-func (rht *RHT) Set(k, v string, executedAt *time.Ticket) {
+func (rht *RHT) Set(k, v string, executedAt time.Ticket) {
 	if node, ok := rht.nodeMapByKey[k]; !ok || executedAt.After(node.updatedAt) {
 		newNode := newRHTNode(k, v, executedAt)
 		rht.nodeMapByKey[k] = newNode
@@ -118,7 +118,7 @@ func (rht *RHT) Set(k, v string, executedAt *time.Ticket) {
 
 // Remove removes the Element of the given key.
 func (rht *RHT) Remove(k string, executedAt *time.Ticket) string {
-	if node, ok := rht.nodeMapByKey[k]; ok && executedAt.After(node.removedAt) {
+	if node, ok := rht.nodeMapByKey[k]; ok && executedAt.After(*node.removedAt) {
 		node.Remove(executedAt)
 		return node.val
 	}

--- a/pkg/document/json/rht_pq_map.go
+++ b/pkg/document/json/rht_pq_map.go
@@ -112,7 +112,8 @@ func (rht *RHTPriorityQueueMap) Set(k string, v Element) Element {
 
 	if queue, ok := rht.nodeQueueMapByKey[k]; ok && queue.Len() > 0 {
 		node := queue.Peek().(*RHTPQMapNode)
-		if !node.isRemoved() && node.Remove(v.CreatedAt()) {
+		createdAt := v.CreatedAt()
+		if !node.isRemoved() && node.Remove(&createdAt) {
 			removed = node.elem
 		}
 	}
@@ -148,7 +149,7 @@ func (rht *RHTPriorityQueueMap) Delete(k string, deletedAt *time.Ticket) Element
 }
 
 // DeleteByCreatedAt deletes the Element of the given creation time.
-func (rht *RHTPriorityQueueMap) DeleteByCreatedAt(createdAt *time.Ticket, deletedAt *time.Ticket) Element {
+func (rht *RHTPriorityQueueMap) DeleteByCreatedAt(createdAt time.Ticket, deletedAt *time.Ticket) Element {
 	node, ok := rht.nodeMapByCreatedAt[createdAt.Key()]
 	if !ok {
 		return nil

--- a/pkg/document/json/root.go
+++ b/pkg/document/json/root.go
@@ -64,7 +64,7 @@ func (r *Root) Object() *Object {
 }
 
 // FindByCreatedAt returns the element of given creation time.
-func (r *Root) FindByCreatedAt(createdAt *time.Ticket) Element {
+func (r *Root) FindByCreatedAt(createdAt time.Ticket) Element {
 	return r.elementMapByCreatedAt[createdAt.Key()]
 }
 
@@ -99,11 +99,11 @@ func (r *Root) DeepCopy() *Root {
 }
 
 // GarbageCollect purge elements that were removed before the given time.
-func (r *Root) GarbageCollect(ticket *time.Ticket) int {
+func (r *Root) GarbageCollect(ticket time.Ticket) int {
 	count := 0
 
 	for _, pair := range r.removedElementPairMapByCreatedAt {
-		if pair.elem.RemovedAt() != nil && ticket.Compare(pair.elem.RemovedAt()) >= 0 {
+		if pair.elem.RemovedAt() != nil && ticket.Compare(*pair.elem.RemovedAt()) >= 0 {
 			pair.parent.Purge(pair.elem)
 			count += r.garbageCollect(pair.elem)
 		}

--- a/pkg/document/json/root_test.go
+++ b/pkg/document/json/root_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/yorkie-team/yorkie/test/helper"
 )
 
-func registerTextElementWithGarbage(fromPos, toPos *json.RGATreeSplitNodePos, root *json.Root, text json.TextElement) {
+func registerTextElementWithGarbage(fromPos, toPos json.RGATreeSplitNodePos, root *json.Root, text json.TextElement) {
 	if !fromPos.Equal(toPos) {
 		root.RegisterTextElementWithGarbage(text)
 	}
@@ -44,7 +44,8 @@ func TestRoot(t *testing.T) {
 		assert.Equal(t, "[0,1,2]", array.Marshal())
 
 		targetElement := array.Get(1)
-		array.DeleteByCreatedAt(targetElement.CreatedAt(), ctx.IssueTimeTicket())
+		ticket := ctx.IssueTimeTicket()
+		array.DeleteByCreatedAt(targetElement.CreatedAt(), &ticket)
 		root.RegisterRemovedElementPair(array, targetElement)
 		assert.Equal(t, "[0,2]", array.Marshal())
 		assert.Equal(t, 1, root.GarbageLen())
@@ -174,7 +175,8 @@ func TestRoot(t *testing.T) {
 		obj.Set("3", json.NewPrimitive(3, ctx.IssueTimeTicket()))
 		assert.Equal(t, `{"1":1,"2":[1,2,3],"3":3}`, root.Object().Marshal())
 
-		deleted := obj.Delete("2", ctx.IssueTimeTicket())
+		ticket := ctx.IssueTimeTicket()
+		deleted := obj.Delete("2", &ticket)
 		root.RegisterRemovedElementPair(obj, deleted)
 		assert.Equal(t, `{"1":1,"3":3}`, obj.Marshal())
 		assert.Equal(t, 4, root.GarbageLen())
@@ -182,7 +184,8 @@ func TestRoot(t *testing.T) {
 		assert.Equal(t, 4, root.GarbageCollect(time.MaxTicket))
 		assert.Equal(t, 0, root.GarbageLen())
 
-		deleted = obj.Delete("3", ctx.IssueTimeTicket())
+		ticket = ctx.IssueTimeTicket()
+		deleted = obj.Delete("3", &ticket)
 		root.RegisterRemovedElementPair(obj, deleted)
 		assert.Equal(t, `{"1":1}`, obj.Marshal())
 		assert.Equal(t, 1, root.GarbageLen())

--- a/pkg/document/json/text.go
+++ b/pkg/document/json/text.go
@@ -26,7 +26,7 @@ import (
 // InitialTextNode creates an initial node of Text. The text is edited
 // as this node is split into multiple nodes.
 func InitialTextNode() *RGATreeSplitNode {
-	return NewRGATreeSplitNode(initialNodeID, &TextValue{
+	return NewRGATreeSplitNode(InitialNodeID, &TextValue{
 		value: "",
 	})
 }
@@ -80,13 +80,13 @@ func (t *TextValue) DeepCopy() RGATreeSplitValue {
 type Text struct {
 	rgaTreeSplit *RGATreeSplit
 	selectionMap map[string]*Selection
-	createdAt    *time.Ticket
+	createdAt    time.Ticket
 	movedAt      *time.Ticket
 	removedAt    *time.Ticket
 }
 
 // NewText creates a new instance of Text.
-func NewText(elements *RGATreeSplit, createdAt *time.Ticket) *Text {
+func NewText(elements *RGATreeSplit, createdAt time.Ticket) *Text {
 	return &Text{
 		rgaTreeSplit: elements,
 		selectionMap: make(map[string]*Selection),
@@ -108,7 +108,7 @@ func (t *Text) DeepCopy() Element {
 		current = rgaTreeSplit.InsertAfter(current, node.DeepCopy())
 		insPrevID := node.InsPrevID()
 		if insPrevID != nil {
-			insPrevNode := rgaTreeSplit.FindNode(insPrevID)
+			insPrevNode := rgaTreeSplit.FindNode(*insPrevID)
 			if insPrevNode == nil {
 				panic("insPrevNode should be presence")
 			}
@@ -120,7 +120,7 @@ func (t *Text) DeepCopy() Element {
 }
 
 // CreatedAt returns the creation time of this Text.
-func (t *Text) CreatedAt() *time.Ticket {
+func (t *Text) CreatedAt() time.Ticket {
 	return t.createdAt
 }
 
@@ -147,7 +147,7 @@ func (t *Text) SetRemovedAt(removedAt *time.Ticket) {
 // Remove removes this Text.
 func (t *Text) Remove(removedAt *time.Ticket) bool {
 	if (removedAt != nil && removedAt.After(t.createdAt)) &&
-		(t.removedAt == nil || removedAt.After(t.removedAt)) {
+		(t.removedAt == nil || removedAt.After(*t.removedAt)) {
 		t.removedAt = removedAt
 		return true
 	}
@@ -155,18 +155,18 @@ func (t *Text) Remove(removedAt *time.Ticket) bool {
 }
 
 // CreateRange returns a pair of RGATreeSplitNodePos of the given integer offsets.
-func (t *Text) CreateRange(from, to int) (*RGATreeSplitNodePos, *RGATreeSplitNodePos) {
+func (t *Text) CreateRange(from, to int) (RGATreeSplitNodePos, RGATreeSplitNodePos) {
 	return t.rgaTreeSplit.createRange(from, to)
 }
 
 // Edit edits the given range with the given content.
 func (t *Text) Edit(
 	from,
-	to *RGATreeSplitNodePos,
+	to RGATreeSplitNodePos,
 	latestCreatedAtMapByActor map[string]*time.Ticket,
 	content string,
-	executedAt *time.Ticket,
-) (*RGATreeSplitNodePos, map[string]*time.Ticket) {
+	executedAt time.Ticket,
+) (RGATreeSplitNodePos, map[string]*time.Ticket) {
 	cursorPos, latestCreatedAtMapByActor := t.rgaTreeSplit.edit(
 		from,
 		to,
@@ -180,9 +180,9 @@ func (t *Text) Edit(
 
 // Select stores that the given range has been selected.
 func (t *Text) Select(
-	from *RGATreeSplitNodePos,
-	to *RGATreeSplitNodePos,
-	executedAt *time.Ticket,
+	from RGATreeSplitNodePos,
+	to RGATreeSplitNodePos,
+	executedAt time.Ticket,
 ) {
 	if _, ok := t.selectionMap[executedAt.ActorIDHex()]; !ok {
 		t.selectionMap[executedAt.ActorIDHex()] = newSelection(from, to, executedAt)
@@ -212,6 +212,6 @@ func (t *Text) removedNodesLen() int {
 }
 
 // purgeTextNodesWithGarbage physically purges nodes that have been removed.
-func (t *Text) purgeTextNodesWithGarbage(ticket *time.Ticket) int {
+func (t *Text) purgeTextNodesWithGarbage(ticket time.Ticket) int {
 	return t.rgaTreeSplit.purgeTextNodesWithGarbage(ticket)
 }

--- a/pkg/document/operations/add.go
+++ b/pkg/document/operations/add.go
@@ -24,24 +24,24 @@ import (
 // Add is an operation representing adding an element to an Array.
 type Add struct {
 	// parentCreatedAt is the creation time of the Array that executes Add.
-	parentCreatedAt *time.Ticket
+	parentCreatedAt time.Ticket
 
 	// prevCreatedAt is the creation time of the previous element.
-	prevCreatedAt *time.Ticket
+	prevCreatedAt time.Ticket
 
 	// value is an element added by the insert operations.
 	value json.Element
 
 	// executedAt is the time the operation was executed.
-	executedAt *time.Ticket
+	executedAt time.Ticket
 }
 
 // NewAdd creates a new instance of Add.
 func NewAdd(
-	parentCreatedAt *time.Ticket,
-	prevCreatedAt *time.Ticket,
+	parentCreatedAt time.Ticket,
+	prevCreatedAt time.Ticket,
 	value json.Element,
-	executedAt *time.Ticket,
+	executedAt time.Ticket,
 ) *Add {
 	return &Add{
 		parentCreatedAt: parentCreatedAt,
@@ -73,12 +73,12 @@ func (o *Add) Value() json.Element {
 }
 
 // ParentCreatedAt returns the creation time of the Array.
-func (o *Add) ParentCreatedAt() *time.Ticket {
+func (o *Add) ParentCreatedAt() time.Ticket {
 	return o.parentCreatedAt
 }
 
 // ExecutedAt returns execution time of this operation.
-func (o *Add) ExecutedAt() *time.Ticket {
+func (o *Add) ExecutedAt() time.Ticket {
 	return o.executedAt
 }
 
@@ -88,6 +88,6 @@ func (o *Add) SetActor(actorID time.ActorID) {
 }
 
 // PrevCreatedAt returns the creation time of previous element.
-func (o *Add) PrevCreatedAt() *time.Ticket {
+func (o *Add) PrevCreatedAt() time.Ticket {
 	return o.prevCreatedAt
 }

--- a/pkg/document/operations/edit.go
+++ b/pkg/document/operations/edit.go
@@ -24,13 +24,13 @@ import (
 // Edit is an operation representing editing Text.
 type Edit struct {
 	// parentCreatedAt is the creation time of the Text that executes Edit.
-	parentCreatedAt *time.Ticket
+	parentCreatedAt time.Ticket
 
 	// from represents the start point of the editing range.
-	from *json.RGATreeSplitNodePos
+	from json.RGATreeSplitNodePos
 
 	// to represents the end point of the editing range.
-	to *json.RGATreeSplitNodePos
+	to json.RGATreeSplitNodePos
 
 	// latestCreatedAtMapByActor is a map that stores the latest creation time
 	// by actor for the nodes included in the editing range.
@@ -40,17 +40,17 @@ type Edit struct {
 	content string
 
 	// executedAt is the time the operation was executed.
-	executedAt *time.Ticket
+	executedAt time.Ticket
 }
 
 // NewEdit creates a new instance of Edit.
 func NewEdit(
-	parentCreatedAt *time.Ticket,
-	from *json.RGATreeSplitNodePos,
-	to *json.RGATreeSplitNodePos,
+	parentCreatedAt time.Ticket,
+	from json.RGATreeSplitNodePos,
+	to json.RGATreeSplitNodePos,
 	latestCreatedAtMapByActor map[string]*time.Ticket,
 	content string,
-	executedAt *time.Ticket,
+	executedAt time.Ticket,
 ) *Edit {
 	return &Edit{
 		parentCreatedAt:           parentCreatedAt,
@@ -80,17 +80,17 @@ func (e *Edit) Execute(root *json.Root) error {
 }
 
 // From returns the start point of the editing range.
-func (e *Edit) From() *json.RGATreeSplitNodePos {
+func (e *Edit) From() json.RGATreeSplitNodePos {
 	return e.from
 }
 
 // To returns the end point of the editing range.
-func (e *Edit) To() *json.RGATreeSplitNodePos {
+func (e *Edit) To() json.RGATreeSplitNodePos {
 	return e.to
 }
 
 // ExecutedAt returns execution time of this operation.
-func (e *Edit) ExecutedAt() *time.Ticket {
+func (e *Edit) ExecutedAt() time.Ticket {
 	return e.executedAt
 }
 
@@ -100,7 +100,7 @@ func (e *Edit) SetActor(actorID time.ActorID) {
 }
 
 // ParentCreatedAt returns the creation time of the Text.
-func (e *Edit) ParentCreatedAt() *time.Ticket {
+func (e *Edit) ParentCreatedAt() time.Ticket {
 	return e.parentCreatedAt
 }
 

--- a/pkg/document/operations/increase.go
+++ b/pkg/document/operations/increase.go
@@ -24,16 +24,16 @@ import (
 // Increase represents an operation that increments a numeric value to Counter.
 // Among Primitives, numeric types Integer, Long, and Double are used as values.
 type Increase struct {
-	parentCreatedAt *time.Ticket
+	parentCreatedAt time.Ticket
 	value           json.Element
-	executedAt      *time.Ticket
+	executedAt      time.Ticket
 }
 
 // NewIncrease creates the increase instance.
 func NewIncrease(
-	parentCreatedAt *time.Ticket,
+	parentCreatedAt time.Ticket,
 	value json.Element,
-	executedAt *time.Ticket,
+	executedAt time.Ticket,
 ) *Increase {
 	return &Increase{
 		parentCreatedAt: parentCreatedAt,
@@ -62,12 +62,12 @@ func (o *Increase) Value() json.Element {
 }
 
 // ParentCreatedAt returns the creation time of Counter.
-func (o *Increase) ParentCreatedAt() *time.Ticket {
+func (o *Increase) ParentCreatedAt() time.Ticket {
 	return o.parentCreatedAt
 }
 
 // ExecutedAt returns execution time of this operation.
-func (o *Increase) ExecutedAt() *time.Ticket {
+func (o *Increase) ExecutedAt() time.Ticket {
 	return o.executedAt
 }
 

--- a/pkg/document/operations/move.go
+++ b/pkg/document/operations/move.go
@@ -24,24 +24,24 @@ import (
 // Move is an operation representing moving an element to an Array.
 type Move struct {
 	// parentCreatedAt is the creation time of the Array that executes Move.
-	parentCreatedAt *time.Ticket
+	parentCreatedAt time.Ticket
 
 	// prevCreatedAt is the creation time of the previous element.
-	prevCreatedAt *time.Ticket
+	prevCreatedAt time.Ticket
 
 	// createdAt is the creation time of the target element to move.
-	createdAt *time.Ticket
+	createdAt time.Ticket
 
 	// executedAt is the time the operation was executed.
-	executedAt *time.Ticket
+	executedAt time.Ticket
 }
 
 // NewMove creates a new instance of Move.
 func NewMove(
-	parentCreatedAt *time.Ticket,
-	prevCreatedAt *time.Ticket,
-	createdAt *time.Ticket,
-	executedAt *time.Ticket,
+	parentCreatedAt time.Ticket,
+	prevCreatedAt time.Ticket,
+	createdAt time.Ticket,
+	executedAt time.Ticket,
 ) *Move {
 	return &Move{
 		parentCreatedAt: parentCreatedAt,
@@ -66,17 +66,17 @@ func (o *Move) Execute(root *json.Root) error {
 }
 
 // CreatedAt returns the creation time of the target element.
-func (o *Move) CreatedAt() *time.Ticket {
+func (o *Move) CreatedAt() time.Ticket {
 	return o.createdAt
 }
 
 // ParentCreatedAt returns the creation time of the Array.
-func (o *Move) ParentCreatedAt() *time.Ticket {
+func (o *Move) ParentCreatedAt() time.Ticket {
 	return o.parentCreatedAt
 }
 
 // ExecutedAt returns execution time of this operation.
-func (o *Move) ExecutedAt() *time.Ticket {
+func (o *Move) ExecutedAt() time.Ticket {
 	return o.executedAt
 }
 
@@ -86,6 +86,6 @@ func (o *Move) SetActor(actorID time.ActorID) {
 }
 
 // PrevCreatedAt returns the creation time of previous element.
-func (o *Move) PrevCreatedAt() *time.Ticket {
+func (o *Move) PrevCreatedAt() time.Ticket {
 	return o.prevCreatedAt
 }

--- a/pkg/document/operations/operation.go
+++ b/pkg/document/operations/operation.go
@@ -35,12 +35,12 @@ type Operation interface {
 	Execute(root *json.Root) error
 
 	// ExecutedAt returns execution time of this operation.
-	ExecutedAt() *time.Ticket
+	ExecutedAt() time.Ticket
 
 	// SetActor sets the given actor to this operation.
 	SetActor(id time.ActorID)
 
 	// ParentCreatedAt returns the creation time of the target element to
 	// execute the operation.
-	ParentCreatedAt() *time.Ticket
+	ParentCreatedAt() time.Ticket
 }

--- a/pkg/document/operations/remove.go
+++ b/pkg/document/operations/remove.go
@@ -25,20 +25,20 @@ import (
 type Remove struct {
 	// parentCreatedAt is the creation time of the Container that executes
 	// Remove.
-	parentCreatedAt *time.Ticket
+	parentCreatedAt time.Ticket
 
 	// createdAt is the creation time of the target element to remove.
-	createdAt *time.Ticket
+	createdAt time.Ticket
 
 	// executedAt is the time the operation was executed.
-	executedAt *time.Ticket
+	executedAt time.Ticket
 }
 
 // NewRemove creates a new instance of Remove.
 func NewRemove(
-	parentCreatedAt *time.Ticket,
-	createdAt *time.Ticket,
-	executedAt *time.Ticket,
+	parentCreatedAt time.Ticket,
+	createdAt time.Ticket,
+	executedAt time.Ticket,
 ) *Remove {
 	return &Remove{
 		parentCreatedAt: parentCreatedAt,
@@ -53,7 +53,8 @@ func (o *Remove) Execute(root *json.Root) error {
 
 	switch parent := parentElem.(type) {
 	case json.Container:
-		elem := parent.DeleteByCreatedAt(o.createdAt, o.executedAt)
+		executedAt := o.executedAt
+		elem := parent.DeleteByCreatedAt(o.createdAt, &executedAt)
 		if elem != nil {
 			root.RegisterRemovedElementPair(parent, elem)
 		}
@@ -65,12 +66,12 @@ func (o *Remove) Execute(root *json.Root) error {
 }
 
 // ParentCreatedAt returns the creation time of the Container.
-func (o *Remove) ParentCreatedAt() *time.Ticket {
+func (o *Remove) ParentCreatedAt() time.Ticket {
 	return o.parentCreatedAt
 }
 
 // ExecutedAt returns execution time of this operation.
-func (o *Remove) ExecutedAt() *time.Ticket {
+func (o *Remove) ExecutedAt() time.Ticket {
 	return o.executedAt
 }
 
@@ -80,6 +81,6 @@ func (o *Remove) SetActor(actorID time.ActorID) {
 }
 
 // CreatedAt returns the creation time of the target element.
-func (o *Remove) CreatedAt() *time.Ticket {
+func (o *Remove) CreatedAt() time.Ticket {
 	return o.createdAt
 }

--- a/pkg/document/operations/rich_edit.go
+++ b/pkg/document/operations/rich_edit.go
@@ -26,13 +26,13 @@ import (
 type RichEdit struct {
 	// parentCreatedAt is the creation time of the RichText that executes
 	// RichEdit.
-	parentCreatedAt *time.Ticket
+	parentCreatedAt time.Ticket
 
 	// from represents the start point of the editing range.
-	from *json.RGATreeSplitNodePos
+	from json.RGATreeSplitNodePos
 
 	// to represents the end point of the editing range.
-	to *json.RGATreeSplitNodePos
+	to json.RGATreeSplitNodePos
 
 	// latestCreatedAtMapByActor is a map that stores the latest creation time
 	// by actor for the nodes included in the editing range.
@@ -45,18 +45,18 @@ type RichEdit struct {
 	attributes map[string]string
 
 	// executedAt is the time the operation was executed.
-	executedAt *time.Ticket
+	executedAt time.Ticket
 }
 
 // NewRichEdit creates a new instance of RichEdit.
 func NewRichEdit(
-	parentCreatedAt *time.Ticket,
-	from *json.RGATreeSplitNodePos,
-	to *json.RGATreeSplitNodePos,
+	parentCreatedAt time.Ticket,
+	from json.RGATreeSplitNodePos,
+	to json.RGATreeSplitNodePos,
 	latestCreatedAtMapByActor map[string]*time.Ticket,
 	content string,
 	attributes map[string]string,
-	executedAt *time.Ticket,
+	executedAt time.Ticket,
 ) *RichEdit {
 	return &RichEdit{
 		parentCreatedAt:           parentCreatedAt,
@@ -87,17 +87,17 @@ func (e *RichEdit) Execute(root *json.Root) error {
 }
 
 // From returns the start point of the editing range.
-func (e *RichEdit) From() *json.RGATreeSplitNodePos {
+func (e *RichEdit) From() json.RGATreeSplitNodePos {
 	return e.from
 }
 
 // To returns the end point of the editing range.
-func (e *RichEdit) To() *json.RGATreeSplitNodePos {
+func (e *RichEdit) To() json.RGATreeSplitNodePos {
 	return e.to
 }
 
 // ExecutedAt returns execution time of this operation.
-func (e *RichEdit) ExecutedAt() *time.Ticket {
+func (e *RichEdit) ExecutedAt() time.Ticket {
 	return e.executedAt
 }
 
@@ -107,7 +107,7 @@ func (e *RichEdit) SetActor(actorID time.ActorID) {
 }
 
 // ParentCreatedAt returns the creation time of the RichText.
-func (e *RichEdit) ParentCreatedAt() *time.Ticket {
+func (e *RichEdit) ParentCreatedAt() time.Ticket {
 	return e.parentCreatedAt
 }
 

--- a/pkg/document/operations/select.go
+++ b/pkg/document/operations/select.go
@@ -24,24 +24,24 @@ import (
 // Select represents an operation that selects an area in the text.
 type Select struct {
 	// parentCreatedAt is the creation time of the Text that executes Select.
-	parentCreatedAt *time.Ticket
+	parentCreatedAt time.Ticket
 
 	// from represents the start point of the selection.
-	from *json.RGATreeSplitNodePos
+	from json.RGATreeSplitNodePos
 
 	// to represents the end point of the selection.
-	to *json.RGATreeSplitNodePos
+	to json.RGATreeSplitNodePos
 
 	// executedAt is the time the operation was executed.
-	executedAt *time.Ticket
+	executedAt time.Ticket
 }
 
 // NewSelect creates a new instance of Select.
 func NewSelect(
-	parentCreatedAt *time.Ticket,
-	from *json.RGATreeSplitNodePos,
-	to *json.RGATreeSplitNodePos,
-	executedAt *time.Ticket,
+	parentCreatedAt time.Ticket,
+	from json.RGATreeSplitNodePos,
+	to json.RGATreeSplitNodePos,
+	executedAt time.Ticket,
 ) *Select {
 	return &Select{
 		parentCreatedAt: parentCreatedAt,
@@ -68,17 +68,17 @@ func (s *Select) Execute(root *json.Root) error {
 }
 
 // From returns the start point of the selection.
-func (s *Select) From() *json.RGATreeSplitNodePos {
+func (s *Select) From() json.RGATreeSplitNodePos {
 	return s.from
 }
 
 // To returns the end point of the selection.
-func (s *Select) To() *json.RGATreeSplitNodePos {
+func (s *Select) To() json.RGATreeSplitNodePos {
 	return s.to
 }
 
 // ExecutedAt returns execution time of this operation.
-func (s *Select) ExecutedAt() *time.Ticket {
+func (s *Select) ExecutedAt() time.Ticket {
 	return s.executedAt
 }
 
@@ -88,6 +88,6 @@ func (s *Select) SetActor(actorID time.ActorID) {
 }
 
 // ParentCreatedAt returns the creation time of the Text.
-func (s *Select) ParentCreatedAt() *time.Ticket {
+func (s *Select) ParentCreatedAt() time.Ticket {
 	return s.parentCreatedAt
 }

--- a/pkg/document/operations/set.go
+++ b/pkg/document/operations/set.go
@@ -25,7 +25,7 @@ import (
 // given key in the Object.
 type Set struct {
 	// parentCreatedAt is the creation time of the Object that executes Set.
-	parentCreatedAt *time.Ticket
+	parentCreatedAt time.Ticket
 
 	// key corresponds to the key of the object to set the value.
 	key string
@@ -34,15 +34,15 @@ type Set struct {
 	value json.Element
 
 	// executedAt is the time the operation was executed.
-	executedAt *time.Ticket
+	executedAt time.Ticket
 }
 
 // NewSet creates a new instance of Set.
 func NewSet(
-	parentCreatedAt *time.Ticket,
+	parentCreatedAt time.Ticket,
 	key string,
 	value json.Element,
-	executedAt *time.Ticket,
+	executedAt time.Ticket,
 ) *Set {
 	return &Set{
 		key:             key,
@@ -71,12 +71,12 @@ func (o *Set) Execute(root *json.Root) error {
 }
 
 // ParentCreatedAt returns the creation time of the Object.
-func (o *Set) ParentCreatedAt() *time.Ticket {
+func (o *Set) ParentCreatedAt() time.Ticket {
 	return o.parentCreatedAt
 }
 
 // ExecutedAt returns execution time of this operation.
-func (o *Set) ExecutedAt() *time.Ticket {
+func (o *Set) ExecutedAt() time.Ticket {
 	return o.executedAt
 }
 

--- a/pkg/document/operations/style.go
+++ b/pkg/document/operations/style.go
@@ -24,28 +24,28 @@ import (
 // Style is an operation applies the style of the given range to RichText.
 type Style struct {
 	// parentCreatedAt is the creation time of the RichText that executes Style.
-	parentCreatedAt *time.Ticket
+	parentCreatedAt time.Ticket
 
 	// from is the starting point of the range to apply the style to.
-	from *json.RGATreeSplitNodePos
+	from json.RGATreeSplitNodePos
 
 	// to is the end point of the range to apply the style to.
-	to *json.RGATreeSplitNodePos
+	to json.RGATreeSplitNodePos
 
 	// attributes represents the text style.
 	attributes map[string]string
 
 	// executedAt is the time the operation was executed.
-	executedAt *time.Ticket
+	executedAt time.Ticket
 }
 
 // NewStyle creates a new instance of Style.
 func NewStyle(
-	parentCreatedAt *time.Ticket,
-	from *json.RGATreeSplitNodePos,
-	to *json.RGATreeSplitNodePos,
+	parentCreatedAt time.Ticket,
+	from json.RGATreeSplitNodePos,
+	to json.RGATreeSplitNodePos,
 	attributes map[string]string,
-	executedAt *time.Ticket,
+	executedAt time.Ticket,
 ) *Style {
 	return &Style{
 		parentCreatedAt: parentCreatedAt,
@@ -69,17 +69,17 @@ func (e *Style) Execute(root *json.Root) error {
 }
 
 // From returns the start point of the editing range.
-func (e *Style) From() *json.RGATreeSplitNodePos {
+func (e *Style) From() json.RGATreeSplitNodePos {
 	return e.from
 }
 
 // To returns the end point of the editing range.
-func (e *Style) To() *json.RGATreeSplitNodePos {
+func (e *Style) To() json.RGATreeSplitNodePos {
 	return e.to
 }
 
 // ExecutedAt returns execution time of this operation.
-func (e *Style) ExecutedAt() *time.Ticket {
+func (e *Style) ExecutedAt() time.Ticket {
 	return e.executedAt
 }
 
@@ -89,7 +89,7 @@ func (e *Style) SetActor(actorID time.ActorID) {
 }
 
 // ParentCreatedAt returns the creation time of the RichText.
-func (e *Style) ParentCreatedAt() *time.Ticket {
+func (e *Style) ParentCreatedAt() time.Ticket {
 	return e.parentCreatedAt
 }
 

--- a/pkg/document/proxy/array_proxy.go
+++ b/pkg/document/proxy/array_proxy.go
@@ -41,7 +41,7 @@ func NewArrayProxy(ctx *change.Context, array *json.Array) *ArrayProxy {
 
 // AddNull adds the null at the last.
 func (p *ArrayProxy) AddNull() *ArrayProxy {
-	p.addInternal(func(ticket *time.Ticket) json.Element {
+	p.addInternal(func(ticket time.Ticket) json.Element {
 		return json.NewPrimitive(nil, ticket)
 	})
 
@@ -51,7 +51,7 @@ func (p *ArrayProxy) AddNull() *ArrayProxy {
 // AddBool adds the given boolean at the last.
 func (p *ArrayProxy) AddBool(values ...bool) *ArrayProxy {
 	for _, value := range values {
-		p.addInternal(func(ticket *time.Ticket) json.Element {
+		p.addInternal(func(ticket time.Ticket) json.Element {
 			return json.NewPrimitive(value, ticket)
 		})
 	}
@@ -62,7 +62,7 @@ func (p *ArrayProxy) AddBool(values ...bool) *ArrayProxy {
 // AddInteger adds the given integer at the last.
 func (p *ArrayProxy) AddInteger(values ...int) *ArrayProxy {
 	for _, value := range values {
-		p.addInternal(func(ticket *time.Ticket) json.Element {
+		p.addInternal(func(ticket time.Ticket) json.Element {
 			return json.NewPrimitive(value, ticket)
 		})
 	}
@@ -73,7 +73,7 @@ func (p *ArrayProxy) AddInteger(values ...int) *ArrayProxy {
 // AddLong adds the given long at the last.
 func (p *ArrayProxy) AddLong(values ...int64) *ArrayProxy {
 	for _, value := range values {
-		p.addInternal(func(ticket *time.Ticket) json.Element {
+		p.addInternal(func(ticket time.Ticket) json.Element {
 			return json.NewPrimitive(value, ticket)
 		})
 	}
@@ -84,7 +84,7 @@ func (p *ArrayProxy) AddLong(values ...int64) *ArrayProxy {
 // AddDouble adds the given double at the last.
 func (p *ArrayProxy) AddDouble(values ...float64) *ArrayProxy {
 	for _, value := range values {
-		p.addInternal(func(ticket *time.Ticket) json.Element {
+		p.addInternal(func(ticket time.Ticket) json.Element {
 			return json.NewPrimitive(value, ticket)
 		})
 	}
@@ -95,7 +95,7 @@ func (p *ArrayProxy) AddDouble(values ...float64) *ArrayProxy {
 // AddString adds the given string at the last.
 func (p *ArrayProxy) AddString(values ...string) *ArrayProxy {
 	for _, value := range values {
-		p.addInternal(func(ticket *time.Ticket) json.Element {
+		p.addInternal(func(ticket time.Ticket) json.Element {
 			return json.NewPrimitive(value, ticket)
 		})
 	}
@@ -106,7 +106,7 @@ func (p *ArrayProxy) AddString(values ...string) *ArrayProxy {
 // AddBytes adds the given bytes at the last.
 func (p *ArrayProxy) AddBytes(values ...[]byte) *ArrayProxy {
 	for _, value := range values {
-		p.addInternal(func(ticket *time.Ticket) json.Element {
+		p.addInternal(func(ticket time.Ticket) json.Element {
 			return json.NewPrimitive(value, ticket)
 		})
 	}
@@ -117,7 +117,7 @@ func (p *ArrayProxy) AddBytes(values ...[]byte) *ArrayProxy {
 // AddDate adds the given date at the last.
 func (p *ArrayProxy) AddDate(values ...gotime.Time) *ArrayProxy {
 	for _, value := range values {
-		p.addInternal(func(ticket *time.Ticket) json.Element {
+		p.addInternal(func(ticket time.Ticket) json.Element {
 			return json.NewPrimitive(value, ticket)
 		})
 	}
@@ -127,7 +127,7 @@ func (p *ArrayProxy) AddDate(values ...gotime.Time) *ArrayProxy {
 
 // AddNewArray adds a new array at the last.
 func (p *ArrayProxy) AddNewArray() *ArrayProxy {
-	v := p.addInternal(func(ticket *time.Ticket) json.Element {
+	v := p.addInternal(func(ticket time.Ticket) json.Element {
 		return NewArrayProxy(p.context, json.NewArray(json.NewRGATreeList(), ticket))
 	})
 
@@ -135,14 +135,14 @@ func (p *ArrayProxy) AddNewArray() *ArrayProxy {
 }
 
 // MoveBefore moves the given element to its new position before the given next element.
-func (p *ArrayProxy) MoveBefore(nextCreatedAt, createdAt *time.Ticket) {
+func (p *ArrayProxy) MoveBefore(nextCreatedAt, createdAt time.Ticket) {
 	p.moveBeforeInternal(nextCreatedAt, createdAt)
 }
 
 // InsertIntegerAfter inserts the given integer after the given previous
 // element.
 func (p *ArrayProxy) InsertIntegerAfter(index int, v int) *ArrayProxy {
-	p.insertAfterInternal(p.Get(index).CreatedAt(), func(ticket *time.Ticket) json.Element {
+	p.insertAfterInternal(p.Get(index).CreatedAt(), func(ticket time.Ticket) json.Element {
 		return json.NewPrimitive(v, ticket)
 	})
 
@@ -156,7 +156,7 @@ func (p *ArrayProxy) Delete(idx int) json.Element {
 	}
 
 	ticket := p.context.IssueTimeTicket()
-	deleted := p.Array.Delete(idx, ticket)
+	deleted := p.Array.Delete(idx, &ticket)
 	p.context.Push(operations.NewRemove(
 		p.CreatedAt(),
 		deleted.CreatedAt(),
@@ -172,14 +172,14 @@ func (p *ArrayProxy) Len() int {
 }
 
 func (p *ArrayProxy) addInternal(
-	creator func(ticket *time.Ticket) json.Element,
+	creator func(ticket time.Ticket) json.Element,
 ) json.Element {
 	return p.insertAfterInternal(p.Array.LastCreatedAt(), creator)
 }
 
 func (p *ArrayProxy) insertAfterInternal(
-	prevCreatedAt *time.Ticket,
-	creator func(ticket *time.Ticket) json.Element,
+	prevCreatedAt time.Ticket,
+	creator func(ticket time.Ticket) json.Element,
 ) json.Element {
 	ticket := p.context.IssueTimeTicket()
 	proxy := creator(ticket)
@@ -198,7 +198,7 @@ func (p *ArrayProxy) insertAfterInternal(
 	return proxy
 }
 
-func (p *ArrayProxy) moveBeforeInternal(nextCreatedAt, createdAt *time.Ticket) {
+func (p *ArrayProxy) moveBeforeInternal(nextCreatedAt, createdAt time.Ticket) {
 	ticket := p.context.IssueTimeTicket()
 
 	prevCreatedAt := p.FindPrevCreatedAt(nextCreatedAt)

--- a/pkg/document/proxy/object_proxy.go
+++ b/pkg/document/proxy/object_proxy.go
@@ -41,7 +41,7 @@ func NewObjectProxy(ctx *change.Context, root *json.Object) *ObjectProxy {
 
 // SetNewObject sets a new Object for the given key.
 func (p *ObjectProxy) SetNewObject(k string) *ObjectProxy {
-	v := p.setInternal(k, func(ticket *time.Ticket) json.Element {
+	v := p.setInternal(k, func(ticket time.Ticket) json.Element {
 		return NewObjectProxy(p.context, json.NewObject(json.NewRHTPriorityQueueMap(), ticket))
 	})
 
@@ -50,7 +50,7 @@ func (p *ObjectProxy) SetNewObject(k string) *ObjectProxy {
 
 // SetNewArray sets a new Array for the given key.
 func (p *ObjectProxy) SetNewArray(k string) *ArrayProxy {
-	v := p.setInternal(k, func(ticket *time.Ticket) json.Element {
+	v := p.setInternal(k, func(ticket time.Ticket) json.Element {
 		return NewArrayProxy(p.context, json.NewArray(json.NewRGATreeList(), ticket))
 	})
 
@@ -59,7 +59,7 @@ func (p *ObjectProxy) SetNewArray(k string) *ArrayProxy {
 
 // SetNewText sets a new Text for the given key.
 func (p *ObjectProxy) SetNewText(k string) *TextProxy {
-	v := p.setInternal(k, func(ticket *time.Ticket) json.Element {
+	v := p.setInternal(k, func(ticket time.Ticket) json.Element {
 		return NewTextProxy(
 			p.context,
 			json.NewText(json.NewRGATreeSplit(json.InitialTextNode()), ticket),
@@ -71,7 +71,7 @@ func (p *ObjectProxy) SetNewText(k string) *TextProxy {
 
 // SetNewRichText sets a new RichText for the given key.
 func (p *ObjectProxy) SetNewRichText(k string) *RichTextProxy {
-	v := p.setInternal(k, func(ticket *time.Ticket) json.Element {
+	v := p.setInternal(k, func(ticket time.Ticket) json.Element {
 		return NewRichTextProxy(
 			p.context,
 			json.NewInitialRichText(json.NewRGATreeSplit(json.InitialRichTextNode()), ticket),
@@ -83,7 +83,7 @@ func (p *ObjectProxy) SetNewRichText(k string) *RichTextProxy {
 
 // SetNewCounter sets a new NewCounter for the given key.
 func (p *ObjectProxy) SetNewCounter(k string, n interface{}) *CounterProxy {
-	v := p.setInternal(k, func(ticket *time.Ticket) json.Element {
+	v := p.setInternal(k, func(ticket time.Ticket) json.Element {
 		return NewCounterProxy(
 			p.context,
 			json.NewCounter(n, ticket),
@@ -95,7 +95,7 @@ func (p *ObjectProxy) SetNewCounter(k string, n interface{}) *CounterProxy {
 
 // SetNull sets the null for the given key.
 func (p *ObjectProxy) SetNull(k string) *ObjectProxy {
-	p.setInternal(k, func(ticket *time.Ticket) json.Element {
+	p.setInternal(k, func(ticket time.Ticket) json.Element {
 		return json.NewPrimitive(nil, ticket)
 	})
 
@@ -104,7 +104,7 @@ func (p *ObjectProxy) SetNull(k string) *ObjectProxy {
 
 // SetBool sets the given boolean for the given key.
 func (p *ObjectProxy) SetBool(k string, v bool) *ObjectProxy {
-	p.setInternal(k, func(ticket *time.Ticket) json.Element {
+	p.setInternal(k, func(ticket time.Ticket) json.Element {
 		return json.NewPrimitive(v, ticket)
 	})
 
@@ -113,7 +113,7 @@ func (p *ObjectProxy) SetBool(k string, v bool) *ObjectProxy {
 
 // SetInteger sets the given integer for the given key.
 func (p *ObjectProxy) SetInteger(k string, v int) *ObjectProxy {
-	p.setInternal(k, func(ticket *time.Ticket) json.Element {
+	p.setInternal(k, func(ticket time.Ticket) json.Element {
 		return json.NewPrimitive(v, ticket)
 	})
 
@@ -122,7 +122,7 @@ func (p *ObjectProxy) SetInteger(k string, v int) *ObjectProxy {
 
 // SetLong sets the given long for the given key.
 func (p *ObjectProxy) SetLong(k string, v int64) *ObjectProxy {
-	p.setInternal(k, func(ticket *time.Ticket) json.Element {
+	p.setInternal(k, func(ticket time.Ticket) json.Element {
 		return json.NewPrimitive(v, ticket)
 	})
 
@@ -131,7 +131,7 @@ func (p *ObjectProxy) SetLong(k string, v int64) *ObjectProxy {
 
 // SetDouble sets the given double for the given key.
 func (p *ObjectProxy) SetDouble(k string, v float64) *ObjectProxy {
-	p.setInternal(k, func(ticket *time.Ticket) json.Element {
+	p.setInternal(k, func(ticket time.Ticket) json.Element {
 		return json.NewPrimitive(v, ticket)
 	})
 
@@ -140,7 +140,7 @@ func (p *ObjectProxy) SetDouble(k string, v float64) *ObjectProxy {
 
 // SetString sets the given string for the given key.
 func (p *ObjectProxy) SetString(k, v string) *ObjectProxy {
-	p.setInternal(k, func(ticket *time.Ticket) json.Element {
+	p.setInternal(k, func(ticket time.Ticket) json.Element {
 		return json.NewPrimitive(v, ticket)
 	})
 
@@ -149,7 +149,7 @@ func (p *ObjectProxy) SetString(k, v string) *ObjectProxy {
 
 // SetBytes sets the given bytes for the given key.
 func (p *ObjectProxy) SetBytes(k string, v []byte) *ObjectProxy {
-	p.setInternal(k, func(ticket *time.Ticket) json.Element {
+	p.setInternal(k, func(ticket time.Ticket) json.Element {
 		return json.NewPrimitive(v, ticket)
 	})
 
@@ -158,7 +158,7 @@ func (p *ObjectProxy) SetBytes(k string, v []byte) *ObjectProxy {
 
 // SetDate sets the given date for the given key.
 func (p *ObjectProxy) SetDate(k string, v gotime.Time) *ObjectProxy {
-	p.setInternal(k, func(ticket *time.Ticket) json.Element {
+	p.setInternal(k, func(ticket time.Ticket) json.Element {
 		return json.NewPrimitive(v, ticket)
 	})
 
@@ -172,7 +172,7 @@ func (p *ObjectProxy) Delete(k string) json.Element {
 	}
 
 	ticket := p.context.IssueTimeTicket()
-	deleted := p.Object.Delete(k, ticket)
+	deleted := p.Object.Delete(k, &ticket)
 	p.context.Push(operations.NewRemove(
 		p.CreatedAt(),
 		deleted.CreatedAt(),
@@ -269,7 +269,7 @@ func (p *ObjectProxy) GetCounter(k string) *CounterProxy {
 
 func (p *ObjectProxy) setInternal(
 	k string,
-	creator func(ticket *time.Ticket) json.Element,
+	creator func(ticket time.Ticket) json.Element,
 ) json.Element {
 	ticket := p.context.IssueTimeTicket()
 	proxy := creator(ticket)

--- a/pkg/document/time/ticket.go
+++ b/pkg/document/time/ticket.go
@@ -59,8 +59,8 @@ func NewTicket(
 	lamport uint64,
 	delimiter uint32,
 	actorID *ActorID,
-) *Ticket {
-	return &Ticket{
+) Ticket {
+	return Ticket{
 		lamport:   lamport,
 		delimiter: delimiter,
 		actorID:   actorID,
@@ -69,7 +69,7 @@ func NewTicket(
 
 // AnnotatedString returns a string containing the metadata of the ticket
 // for debugging purpose.
-func (t *Ticket) AnnotatedString() string {
+func (t Ticket) AnnotatedString() string {
 	if t.actorID == nil {
 		return fmt.Sprintf("%d:%d:nil", t.lamport, t.delimiter)
 	}
@@ -80,7 +80,7 @@ func (t *Ticket) AnnotatedString() string {
 }
 
 // Key returns the key string for this Ticket.
-func (t *Ticket) Key() string {
+func (t Ticket) Key() string {
 	if t.actorID == nil {
 		return strconv.FormatUint(t.lamport, 10) +
 			":" +
@@ -96,39 +96,39 @@ func (t *Ticket) Key() string {
 }
 
 // Lamport returns the lamport value.
-func (t *Ticket) Lamport() uint64 {
+func (t Ticket) Lamport() uint64 {
 	return t.lamport
 }
 
 // Delimiter returns the delimiter value.
-func (t *Ticket) Delimiter() uint32 {
+func (t Ticket) Delimiter() uint32 {
 	return t.delimiter
 }
 
 // ActorID returns the actorID value.
-func (t *Ticket) ActorID() *ActorID {
+func (t Ticket) ActorID() *ActorID {
 	return t.actorID
 }
 
 // ActorIDHex returns the actorID's hex value.
-func (t *Ticket) ActorIDHex() string {
+func (t Ticket) ActorIDHex() string {
 	return t.actorID.String()
 }
 
 // ActorIDBytes returns the actorID's bytes value.
-func (t *Ticket) ActorIDBytes() []byte {
+func (t Ticket) ActorIDBytes() []byte {
 	return t.actorID.Bytes()
 }
 
 // After returns whether the given ticket was created later.
-func (t *Ticket) After(other *Ticket) bool {
+func (t Ticket) After(other Ticket) bool {
 	return t.Compare(other) > 0
 }
 
 // Compare returns an integer comparing two Ticket.
 // The result will be 0 if id==other, -1 if id < other, and +1 if id > other.
 // If the receiver or argument is nil, it would panic at runtime.
-func (t *Ticket) Compare(other *Ticket) int {
+func (t Ticket) Compare(other Ticket) int {
 	if t.lamport > other.lamport {
 		return 1
 	} else if t.lamport < other.lamport {
@@ -150,8 +150,8 @@ func (t *Ticket) Compare(other *Ticket) int {
 }
 
 // SetActorID creates a new instance of Ticket with the given actorID.
-func (t *Ticket) SetActorID(actorID ActorID) *Ticket {
-	return &Ticket{
+func (t Ticket) SetActorID(actorID ActorID) Ticket {
+	return Ticket{
 		lamport:   t.lamport,
 		delimiter: t.delimiter,
 		actorID:   &actorID,

--- a/yorkie/backend/db/db.go
+++ b/yorkie/backend/db/db.go
@@ -109,7 +109,7 @@ type DB interface {
 		clientInfo *ClientInfo,
 		docID ID,
 		serverSeq uint64,
-	) (*time.Ticket, error)
+	) (time.Ticket, error)
 
 	// UpdateSyncedSeq updates the syncedSeq of the given client.
 	UpdateSyncedSeq(

--- a/yorkie/backend/db/memory/db.go
+++ b/yorkie/backend/db/memory/db.go
@@ -454,9 +454,9 @@ func (d *DB) UpdateAndFindMinSyncedTicket(
 	clientInfo *db.ClientInfo,
 	docID db.ID,
 	serverSeq uint64,
-) (*time.Ticket, error) {
+) (time.Ticket, error) {
 	if err := d.UpdateSyncedSeq(ctx, clientInfo, docID, serverSeq); err != nil {
-		return nil, err
+		return time.InitialTicket, err
 	}
 
 	txn := d.db.Txn(false)
@@ -470,7 +470,7 @@ func (d *DB) UpdateAndFindMinSyncedTicket(
 		time.InitialActorID.String(),
 	)
 	if err != nil {
-		return nil, err
+		return time.InitialTicket, err
 	}
 
 	var syncedSeqInfo *db.SyncedSeqInfo
@@ -487,7 +487,7 @@ func (d *DB) UpdateAndFindMinSyncedTicket(
 
 	actorID, err := time.ActorIDFromHex(syncedSeqInfo.ActorID.String())
 	if err != nil {
-		return nil, err
+		return time.InitialTicket, err
 	}
 
 	return time.NewTicket(
@@ -565,7 +565,7 @@ func (d *DB) findTicketByServerSeq(
 	txn *memdb.Txn,
 	docID db.ID,
 	serverSeq uint64,
-) (*time.Ticket, error) {
+) (time.Ticket, error) {
 	if serverSeq == 0 {
 		return time.InitialTicket, nil
 	}
@@ -577,10 +577,10 @@ func (d *DB) findTicketByServerSeq(
 		serverSeq,
 	)
 	if err != nil {
-		return nil, err
+		return time.InitialTicket, err
 	}
 	if raw == nil {
-		return nil, fmt.Errorf(
+		return time.InitialTicket, fmt.Errorf(
 			"docID %s, serverSeq %d: %w",
 			docID.String(),
 			serverSeq,
@@ -591,7 +591,7 @@ func (d *DB) findTicketByServerSeq(
 	changeInfo := raw.(*db.ChangeInfo)
 	actorID, err := time.ActorIDFromHex(changeInfo.ActorID.String())
 	if err != nil {
-		return nil, err
+		return time.InitialTicket, err
 	}
 
 	return time.NewTicket(

--- a/yorkie/packs/serverpacks.go
+++ b/yorkie/packs/serverpacks.go
@@ -43,7 +43,7 @@ type ServerPack struct {
 
 	// MinSyncedTicket is the minimum logical time taken by clients who attach the document.
 	// It used to collect garbage on the replica on the client.
-	MinSyncedTicket *time.Ticket
+	MinSyncedTicket time.Ticket
 }
 
 // NewServerPack creates a new instance of ServerPack.
@@ -112,6 +112,6 @@ func (p *ServerPack) ToPBChangePack() (*api.ChangePack, error) {
 		Checkpoint:      converter.ToCheckpoint(p.Checkpoint),
 		Changes:         pbChanges,
 		Snapshot:        p.Snapshot,
-		MinSyncedTicket: converter.ToTimeTicket(p.MinSyncedTicket),
+		MinSyncedTicket: converter.ToMustTimeTicket(p.MinSyncedTicket),
 	}, nil
 }

--- a/yorkie/packs/snapshots.go
+++ b/yorkie/packs/snapshots.go
@@ -31,7 +31,7 @@ func storeSnapshot(
 	ctx context.Context,
 	be *backend.Backend,
 	docInfo *db.DocInfo,
-	minSyncedTicket *time.Ticket,
+	minSyncedTicket time.Ticket,
 ) error {
 	// 01. get the last snapshot of this docInfo
 	// TODO: For performance issue, we only need to read the snapshot's metadata.
@@ -79,7 +79,7 @@ func storeSnapshot(
 		changes,
 		nil,
 	)
-	pack.MinSyncedTicket = minSyncedTicket
+	pack.MinSyncedTicket = &minSyncedTicket
 
 	if err := doc.ApplyChangePack(pack); err != nil {
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Use a struct instead of pointer: Ticket

Modified to use struct for non-nullable tickets.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #


It has been confirmed that performance is slightly lower when using struct in text.

Before: https://github.com/yorkie-team/yorkie/runs/5086458392?check_suite_focus=true
```
go test -tags bench -benchmem -bench=. ./test/bench
goos: linux
goarch: amd64
pkg: github.com/yorkie-team/yorkie/test/bench
cpu: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
BenchmarkDocument/constructor_test-2         	  681069	      1875 ns/op	     848 B/op	      15 allocs/op
BenchmarkDocument/status_test-2              	 1191621	       918.9 ns/op	     816 B/op	      13 allocs/op
BenchmarkDocument/equals_test-2              	  119319	     10497 ns/op	    5760 B/op	     114 allocs/op
BenchmarkDocument/nested_update_test-2       	   38211	     31059 ns/op	   13210 B/op	     338 allocs/op
BenchmarkDocument/delete_test-2              	   30632	     38714 ns/op	   15866 B/op	     399 allocs/op
BenchmarkDocument/object_test-2              	   85519	     14025 ns/op	    6592 B/op	     134 allocs/op
BenchmarkDocument/array_test-2               	   23938	     51220 ns/op	   14978 B/op	     400 allocs/op
BenchmarkDocument/text_test-2                	   28760	     40568 ns/op	   13434 B/op	     422 allocs/op
BenchmarkDocument/text_composition_test-2    	   28330	     42000 ns/op	   18042 B/op	     489 allocs/op
BenchmarkDocument/rich_text_test-2           	    8846	    139505 ns/op	   46001 B/op	    1351 allocs/op
BenchmarkDocument/counter_test-2             	   27414	     43597 ns/op	   14474 B/op	     415 allocs/op
BenchmarkDocument/text_edit_gc_100-2         	     124	   9513628 ns/op	 3178076 B/op	   81130 allocs/op
BenchmarkDocument/text_edit_gc_1000-2        	       2	 883677688 ns/op	298640928 B/op	 7514829 allocs/op
BenchmarkDocument/text_split_gc_100-2        	     100	  10439209 ns/op	 3711330 B/op	   81575 allocs/op
BenchmarkDocument/text_split_gc_1000-2       	       2	 936290228 ns/op	364663672 B/op	 7523082 allocs/op
BenchmarkDocument/text_100-2                 	    3793	    323769 ns/op	  107498 B/op	    4788 allocs/op
BenchmarkDocument/text_1000-2                	     345	   3538356 ns/op	 1027175 B/op	   47091 allocs/op
BenchmarkDocument/array_1000-2               	     363	   3216571 ns/op	 1610898 B/op	   36398 allocs/op
BenchmarkDocument/array_10000-2              	      32	  35283586 ns/op	15360816 B/op	  370251 allocs/op
BenchmarkDocument/array_gc_100-2             	    3336	    366763 ns/op	  165564 B/op	    3905 allocs/op
BenchmarkDocument/array_gc_1000-2            	     295	   4008854 ns/op	 1827322 B/op	   45265 allocs/op
BenchmarkDocument/counter_1000-2             	    2647	    455855 ns/op	  239832 B/op	    8540 allocs/op
BenchmarkDocument/counter_10000-2            	     248	   4861585 ns/op	 2905054 B/op	   89549 allocs/op
BenchmarkDocument/rich_text_100-2            	    3444	    354013 ns/op	  131288 B/op	    4547 allocs/op
BenchmarkDocument/rich_text_1000-2           	     320	   3795378 ns/op	 1250765 B/op	   44150 allocs/op
BenchmarkDocument/object_1000-2              	     285	   4131397 ns/op	 2039077 B/op	   36429 allocs/op
BenchmarkDocument/object_10000-2             	      21	  49542247 ns/op	19072846 B/op	  370746 allocs/op
2022-02-06T23:56:31.029Z	INFO	default	etcd connected, URI: [localhost:2379]
BenchmarkSync/memory_sync_10_test-2          	  166665	      7136 ns/op	    1101 B/op	      29 allocs/op
BenchmarkSync/memory_sync_100_test-2         	   20480	     58033 ns/op	    6635 B/op	     195 allocs/op
BenchmarkSync/memory_sync_1000_test-2        	    1971	    631441 ns/op	   60301 B/op	    1727 allocs/op
BenchmarkSync/memory_sync_10000_test-2       	     190	   6755378 ns/op	  638043 B/op	   18084 allocs/op
BenchmarkSync/etcd_sync_100_test-2           	1000000000	         0.3006 ns/op	       0 B/op	       0 allocs/op
BenchmarkTextEditing-2                       	       1	64405006102 ns/op	20547264024 B/op	447734689 allocs/op
```

After: https://github.com/yorkie-team/yorkie/runs/5092193950?check_suite_focus=true

```
go test -tags bench -benchmem -bench=. ./test/bench
goos: linux
goarch: amd64
pkg: github.com/yorkie-team/yorkie/test/bench
cpu: Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
BenchmarkDocument/constructor_test-2         	  628672	      1593 ns/op	     864 B/op	      15 allocs/op
BenchmarkDocument/status_test-2              	 1328878	      1075 ns/op	     832 B/op	      13 allocs/op
BenchmarkDocument/equals_test-2              	  111189	      9258 ns/op	    5880 B/op	     113 allocs/op
BenchmarkDocument/nested_update_test-2       	   41913	     28683 ns/op	   13658 B/op	     332 allocs/op
BenchmarkDocument/delete_test-2              	   33279	     35993 ns/op	   16394 B/op	     394 allocs/op
BenchmarkDocument/object_test-2              	   94874	     12757 ns/op	    6784 B/op	     134 allocs/op
BenchmarkDocument/array_test-2               	   25861	     46830 ns/op	   15554 B/op	     395 allocs/op
BenchmarkDocument/text_test-2                	   32386	     36870 ns/op	   14082 B/op	     412 allocs/op
BenchmarkDocument/text_composition_test-2    	   30500	     39592 ns/op	   19410 B/op	     471 allocs/op
BenchmarkDocument/rich_text_test-2           	    8750	    128792 ns/op	   47505 B/op	    1333 allocs/op
BenchmarkDocument/counter_test-2             	   32754	     36620 ns/op	   15178 B/op	     391 allocs/op
BenchmarkDocument/text_edit_gc_100-2         	     123	   9612078 ns/op	 3459262 B/op	   90533 allocs/op
BenchmarkDocument/text_edit_gc_1000-2        	       2	 901776328 ns/op	323056388 B/op	 8508877 allocs/op
BenchmarkDocument/text_split_gc_100-2        	     100	  10260963 ns/op	 3981973 B/op	   91373 allocs/op
BenchmarkDocument/text_split_gc_1000-2       	       2	 956459070 ns/op	388973632 B/op	 8521116 allocs/op
BenchmarkDocument/text_100-2                 	    3594	    327135 ns/op	  124530 B/op	    4390 allocs/op
BenchmarkDocument/text_1000-2                	     327	   3779483 ns/op	 1195407 B/op	   43093 allocs/op
BenchmarkDocument/array_1000-2               	     396	   2993891 ns/op	 1682963 B/op	   35397 allocs/op
BenchmarkDocument/array_10000-2              	      30	  34886607 ns/op	16081217 B/op	  360251 allocs/op
BenchmarkDocument/array_gc_100-2             	    3516	    341460 ns/op	  172966 B/op	    3805 allocs/op
BenchmarkDocument/array_gc_1000-2            	     325	   3731587 ns/op	 1899637 B/op	   44265 allocs/op
BenchmarkDocument/counter_1000-2             	    2822	    425490 ns/op	  263920 B/op	    7539 allocs/op
BenchmarkDocument/counter_10000-2            	     268	   4424467 ns/op	 3145141 B/op	   79548 allocs/op
BenchmarkDocument/rich_text_100-2            	    3435	    353501 ns/op	  148456 B/op	    4149 allocs/op
BenchmarkDocument/rich_text_1000-2           	     316	   3779964 ns/op	 1419134 B/op	   40152 allocs/op
BenchmarkDocument/object_1000-2              	     302	   3920395 ns/op	 2143240 B/op	   37427 allocs/op
BenchmarkDocument/object_10000-2             	      22	  50327887 ns/op	20115416 B/op	  380751 allocs/op
2022-02-07T11:24:28.942Z	INFO	default	etcd connected, URI: [localhost:2379]
BenchmarkSync/memory_sync_10_test-2          	  172804	      6531 ns/op	    1101 B/op	      29 allocs/op
BenchmarkSync/memory_sync_100_test-2         	   20998	     58038 ns/op	    6632 B/op	     195 allocs/op
BenchmarkSync/memory_sync_1000_test-2        	    1641	    694316 ns/op	   58652 B/op	    1627 allocs/op
BenchmarkSync/memory_sync_10000_test-2       	     166	   7177524 ns/op	  606979 B/op	   16828 allocs/op
BenchmarkSync/etcd_sync_100_test-2           	1000000000	         0.3034 ns/op	       0 B/op	       0 allocs/op
BenchmarkTextEditing-2                       	       1	75113485165 ns/op	22061126944 B/op	508174603 allocs/op
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
