### PR TITLE
Improve node id

### DIFF
--- a/pkg/document/json/rga_tree_split.go
+++ b/pkg/document/json/rga_tree_split.go
@@ -27,6 +27,7 @@ type RGATreeSplitValue interface {
 type RGATreeSplitNodeID struct {
 	createdAt *time.Ticket
 	offset    int
+	key       string
 }
 
 // NewRGATreeSplitNodeID creates a new instance of RGATreeSplitNodeID.
@@ -90,8 +91,14 @@ func (t *RGATreeSplitNodeID) hasSameCreatedAt(id *RGATreeSplitNodeID) bool {
 	return t.createdAt.Compare(id.createdAt) == 0
 }
 
-func (t *RGATreeSplitNodeID) key() string {
-	return t.CreatedAt().Key() + ":" + strconv.FormatUint(uint64(t.offset), 10)
+// Key returns a string representation of the ID. The result will be
+// cached in the key field to prevent instantiation of a new string.
+func (t *RGATreeSplitNodeID) Key() string {
+	if t.key == "" {
+		t.key = t.createdAt.Key() + ":" + strconv.FormatUint(uint64(t.offset), 10)
+	}
+
+	return t.key
 }
 
 // RGATreeSplitNodePos is the position of the text inside the node.
@@ -491,7 +498,7 @@ func (s *RGATreeSplit) deleteNodes(
 				createdAtMapByActor[actorIDHex] = createdAt
 			}
 
-			removedNodeMap[node.id.key()] = node
+			removedNodeMap[node.id.Key()] = node
 		}
 	}
 
@@ -562,7 +569,7 @@ func (s *RGATreeSplit) purgeTextNodesWithGarbage(ticket *time.Ticket) int {
 			s.treeByIndex.Delete(node.indexNode)
 			s.purge(node)
 			s.treeByID.Remove(node.id)
-			delete(s.removedNodeMap, node.id.key())
+			delete(s.removedNodeMap, node.id.Key())
 			count++
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Improving the `key()` method to always create the same value to lower memory usage.
The information below is the result when I benchmarked it locally.

point:
```bash
# before
# after

BenchmarkDocument/text_edit_gc_100-16                182           6533067 ns/op         2921428 B/op      70425 allocs/op
BenchmarkDocument/text_edit_gc_100-16                259           4703047 ns/op         2139522 B/op      43127 allocs/op

BenchmarkDocument/text_edit_gc_1000-16                 2         587760503 ns/op        276227032 B/op   6508031 allocs/op
BenchmarkDocument/text_edit_gc_1000-16                 3         434004442 ns/op        186632456 B/op   2729490 allocs/op

BenchmarkDocument/text_split_gc_100-16               166           7116022 ns/op         3456733 B/op      70968 allocs/op
BenchmarkDocument/text_split_gc_100-16               218           5759216 ns/op         2634396 B/op      42486 allocs/op

BenchmarkDocument/text_split_gc_1000-16                2         638873046 ns/op        342324064 B/op   6517599 allocs/op
BenchmarkDocument/text_split_gc_1000-16                3         449692488 ns/op        252264274 B/op   2726905 allocs/op

# percentage improvement 33% | 39% | 62%
BenchmarkTextEditing-16                                1        39960228229 ns/op       18910145256 B/op        385913217 allocs/op
BenchmarkTextEditing-16                                1        26487031619 ns/op       11528545912 B/op        145924179 allocs/op
```

On the contrary, there were even worse results. It got worse when it was repeatedly edited to the from:0 and to:0 positions.
This is a natural result. With this PR modification, the cost of generating a key when creating a NodeID instance has been added.
Benchmarks can deteriorate when there is no overhead incurred by deleteNode().
```bash
BenchmarkDocument/rich_text_100-16                  3945            255564 ns/op          128722 B/op       4440 allocs/op
BenchmarkDocument/rich_text_100-16                  3134            359336 ns/op          191452 B/op       6253 allocs/op

# percentage deterioration 47% | 51% | 45%
BenchmarkDocument/rich_text_1000-16                  421           2641987 ns/op         1244281 B/op      43144 allocs/op
BenchmarkDocument/rich_text_1000-16                  318           3885989 ns/op         1879472 B/op      62957 allocs/op
```

result:
```bash
######################## before
goos: darwin
goarch: amd64
pkg: github.com/yorkie-team/yorkie/test/bench
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkDocument/constructor_test-16            1042274              1157 ns/op             824 B/op         14 allocs/op
BenchmarkDocument/status_test-16                 1732225               697.8 ns/op           792 B/op         12 allocs/op
BenchmarkDocument/equals_test-16                  152014              7189 ns/op            5550 B/op        105 allocs/op
BenchmarkDocument/nested_update_test-16            56026             21182 ns/op           12285 B/op        299 allocs/op
BenchmarkDocument/delete_test-16                   44479             26334 ns/op           14849 B/op        356 allocs/op
BenchmarkDocument/object_test-16                  118867              9381 ns/op            6263 B/op        120 allocs/op
BenchmarkDocument/array_test-16                    35440             33603 ns/op           13792 B/op        350 allocs/op
BenchmarkDocument/text_test-16                     38810             26947 ns/op           13134 B/op        409 allocs/op
BenchmarkDocument/text_composition_test-16         41635             28671 ns/op           17363 B/op        460 allocs/op
BenchmarkDocument/rich_text_test-16                13347             89922 ns/op           38487 B/op       1265 allocs/op
BenchmarkDocument/counter_test-16                  42183             27814 ns/op           13576 B/op        377 allocs/op
BenchmarkDocument/text_edit_gc_100-16                182           6533067 ns/op         2921428 B/op      70425 allocs/op
BenchmarkDocument/text_edit_gc_1000-16                 2         587760503 ns/op        276227032 B/op   6508031 allocs/op
BenchmarkDocument/text_split_gc_100-16               166           7116022 ns/op         3456733 B/op      70968 allocs/op
BenchmarkDocument/text_split_gc_1000-16                2         638873046 ns/op        342324064 B/op   6517599 allocs/op
BenchmarkDocument/text_100-16                       4795            230455 ns/op          104932 B/op       4681 allocs/op
BenchmarkDocument/text_1000-16                       464           2526399 ns/op         1020688 B/op      46085 allocs/op
BenchmarkDocument/array_1000-16                      528           2261642 ns/op         1460418 B/op      29389 allocs/op
BenchmarkDocument/array_10000-16                      52          22184571 ns/op        13541008 B/op     300244 allocs/op
BenchmarkDocument/array_gc_100-16                   3968            254048 ns/op          143480 B/op       2985 allocs/op
BenchmarkDocument/array_gc_1000-16                   414           2765434 ns/op         1646301 B/op      36249 allocs/op
BenchmarkDocument/counter_1000-16                   3196            336029 ns/op          233332 B/op       7534 allocs/op
BenchmarkDocument/counter_10000-16                   338           3468094 ns/op         2524237 B/op      79541 allocs/op
BenchmarkDocument/rich_text_100-16                  3945            255564 ns/op          128722 B/op       4440 allocs/op
BenchmarkDocument/rich_text_1000-16                  421           2641987 ns/op         1244281 B/op      43144 allocs/op
BenchmarkDocument/object_1000-16                     400           2937970 ns/op         1906206 B/op      29431 allocs/op
BenchmarkDocument/object_10000-16                     32          31254336 ns/op        17198240 B/op     300755 allocs/op
BenchmarkSync/memory_sync_10_test-16              130371              9081 ns/op            1317 B/op         38 allocs/op
BenchmarkSync/memory_sync_100_test-16              13684             88654 ns/op            7939 B/op        225 allocs/op
BenchmarkSync/memory_sync_1000_test-16              1390            851549 ns/op           73634 B/op       2035 allocs/op
BenchmarkSync/memory_sync_10000_test-16              110          10542995 ns/op          753553 B/op      20375 allocs/op
BenchmarkSync/etcd_sync_100_test-16             1000000000               0.7599 ns/op          0 B/op          0 allocs/op
BenchmarkTextEditing-16                                1        39960228229 ns/op       18910145256 B/op        385913217 allocs/op
PASS
ok      github.com/yorkie-team/yorkie/test/bench        118.033s

######################## after
goos: darwin
goarch: amd64
pkg: github.com/yorkie-team/yorkie/test/bench
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkDocument/constructor_test-16             994042              1269 ns/op             824 B/op         14 allocs/op
BenchmarkDocument/status_test-16                 1744617               683.3 ns/op           792 B/op         12 allocs/op
BenchmarkDocument/equals_test-16                  160006              6848 ns/op            5550 B/op        105 allocs/op
BenchmarkDocument/nested_update_test-16            58047             20489 ns/op           12286 B/op        299 allocs/op
BenchmarkDocument/delete_test-16                   45931             27174 ns/op           14849 B/op        356 allocs/op
BenchmarkDocument/object_test-16                  130483              9854 ns/op            6263 B/op        120 allocs/op
BenchmarkDocument/array_test-16                    34305             33790 ns/op           13792 B/op        350 allocs/op
BenchmarkDocument/text_test-16                     41161             29588 ns/op           14625 B/op        451 allocs/op
BenchmarkDocument/text_composition_test-16         35671             33730 ns/op           20406 B/op        544 allocs/op
BenchmarkDocument/rich_text_test-16                12560             95212 ns/op           42165 B/op       1370 allocs/op
BenchmarkDocument/counter_test-16                  44535             27050 ns/op           13576 B/op        377 allocs/op
BenchmarkDocument/text_edit_gc_100-16                259           4703047 ns/op         2139522 B/op      43127 allocs/op
BenchmarkDocument/text_edit_gc_1000-16                 3         434004442 ns/op        186632456 B/op   2729490 allocs/op
BenchmarkDocument/text_split_gc_100-16               218           5759216 ns/op         2634396 B/op      42486 allocs/op
BenchmarkDocument/text_split_gc_1000-16                3         449692488 ns/op        252264274 B/op   2726905 allocs/op
BenchmarkDocument/text_100-16                       3109            366142 ns/op          167369 B/op       6489 allocs/op
BenchmarkDocument/text_1000-16                       300           3829325 ns/op         1668266 B/op      69493 allocs/op
BenchmarkDocument/array_1000-16                      519           2155523 ns/op         1460417 B/op      29389 allocs/op
BenchmarkDocument/array_10000-16                      55          20974547 ns/op        13539630 B/op     300238 allocs/op
BenchmarkDocument/array_gc_100-16                   4906            243599 ns/op          143500 B/op       2986 allocs/op
BenchmarkDocument/array_gc_1000-16                   442           2679236 ns/op         1646190 B/op      36248 allocs/op
BenchmarkDocument/counter_1000-16                   3420            328345 ns/op          233331 B/op       7534 allocs/op
BenchmarkDocument/counter_10000-16                   357           3279321 ns/op         2524237 B/op      79541 allocs/op
BenchmarkDocument/rich_text_100-16                  3134            359336 ns/op          191452 B/op       6253 allocs/op
BenchmarkDocument/rich_text_1000-16                  318           3885989 ns/op         1879472 B/op      62957 allocs/op
BenchmarkDocument/object_1000-16                     390           2869957 ns/op         1906899 B/op      29434 allocs/op
BenchmarkDocument/object_10000-16                     36          29181288 ns/op        17197144 B/op     300752 allocs/op
BenchmarkSync/memory_sync_10_test-16              132164              8785 ns/op            1316 B/op         38 allocs/op
BenchmarkSync/memory_sync_100_test-16              13723             88515 ns/op            7924 B/op        224 allocs/op
BenchmarkSync/memory_sync_1000_test-16              1508            870064 ns/op           73762 B/op       2039 allocs/op
BenchmarkSync/memory_sync_10000_test-16              126          10190040 ns/op          754659 B/op      20383 allocs/op
BenchmarkSync/etcd_sync_100_test-16               705760              1430 ns/op               8 B/op          0 allocs/op
BenchmarkTextEditing-16                                1        26487031619 ns/op       11528545912 B/op        145924179 allocs/op
PASS
ok      github.com/yorkie-team/yorkie/test/bench        121.660s
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Address #305 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
