### PR TITLE
Cache the key of TimeTicket to prevent instantiation

### DIFF
--- a/pkg/document/time/ticket.go
+++ b/pkg/document/time/ticket.go
@@ -52,6 +52,9 @@ type Ticket struct {
 	lamport   uint64
 	delimiter uint32
 	actorID   ActorID
+
+	// cachedKey is the cache of the string representation of the ticket.
+	cachedKey string
 }
 
 // NewTicket creates an instance of Ticket.
@@ -77,11 +80,16 @@ func (t *Ticket) AnnotatedString() string {
 
 // Key returns the key string for this Ticket.
 func (t *Ticket) Key() string {
-	return strconv.FormatUint(t.lamport, 10) +
-		":" +
-		strconv.FormatUint(uint64(t.delimiter), 10) +
-		":" +
-		t.actorID.String()
+	if t.cachedKey == "" {
+		t.cachedKey = strconv.FormatUint(t.lamport, 10) +
+			":" +
+			strconv.FormatUint(uint64(t.delimiter), 10) +
+			":" +
+			t.actorID.String()
+
+	}
+
+	return t.cachedKey
 }
 
 // Lamport returns the lamport value.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Cache the key of TimeTicket to prevent instantiation

Before:
```
go test -tags bench -benchmem -bench=. ./test/bench
goos: darwin
goarch: amd64
pkg: github.com/yorkie-team/yorkie/test/bench
cpu: Intel(R) Core(TM) i5-4690 CPU @ 3.50GHz
BenchmarkDocument/constructor_test-4         	  710023	      1613 ns/op	     848 B/op	      15 allocs/op
BenchmarkDocument/status_test-4              	 1252372	       866.2 ns/op	     816 B/op	      13 allocs/op
BenchmarkDocument/equals_test-4              	  134947	      8385 ns/op	    5761 B/op	     114 allocs/op
BenchmarkDocument/nested_update_test-4       	   43810	     26231 ns/op	   13212 B/op	     338 allocs/op
BenchmarkDocument/delete_test-4              	   37515	     39677 ns/op	   15869 B/op	     399 allocs/op
BenchmarkDocument/object_test-4              	  105336	     12986 ns/op	    6594 B/op	     134 allocs/op
BenchmarkDocument/array_test-4               	   24628	     52800 ns/op	   14981 B/op	     400 allocs/op
BenchmarkDocument/text_test-4                	   36248	     42421 ns/op	   13692 B/op	     422 allocs/op
BenchmarkDocument/text_composition_test-4    	   27217	     51125 ns/op	   18622 B/op	     489 allocs/op
BenchmarkDocument/rich_text_test-4           	    9169	    174621 ns/op	   46606 B/op	    1351 allocs/op
BenchmarkDocument/counter_test-4             	   35565	     41549 ns/op	   14477 B/op	     415 allocs/op
BenchmarkDocument/text_edit_gc_100-4         	     180	   7924256 ns/op	 2066117 B/op	   40725 allocs/op
BenchmarkDocument/text_edit_gc_1000-4        	       2	 591094689 ns/op	184101804 B/op	 2696275 allocs/op
BenchmarkDocument/text_split_gc_100-4        	     172	   6404521 ns/op	 2593025 B/op	   41178 allocs/op
BenchmarkDocument/text_split_gc_1000-4       	       2	 540437500 ns/op	250055660 B/op	 2708062 allocs/op
BenchmarkDocument/text_100-4                 	    4148	    397114 ns/op	  117099 B/op	    4788 allocs/op
BenchmarkDocument/text_1000-4                	     331	   3394225 ns/op	 1123182 B/op	   47091 allocs/op
BenchmarkDocument/array_1000-4               	     338	   3293091 ns/op	 1610782 B/op	   36398 allocs/op
BenchmarkDocument/array_10000-4              	      24	  55232881 ns/op	15361632 B/op	  370255 allocs/op
BenchmarkDocument/array_gc_100-4             	    3718	    389210 ns/op	  165546 B/op	    3905 allocs/op
BenchmarkDocument/array_gc_1000-4            	     291	   3830658 ns/op	 1827419 B/op	   45266 allocs/op
BenchmarkDocument/counter_1000-4             	    2842	    483609 ns/op	  239833 B/op	    8540 allocs/op
BenchmarkDocument/counter_10000-4            	     277	   4966895 ns/op	 2905062 B/op	   89549 allocs/op
BenchmarkDocument/rich_text_100-4            	    3824	    348127 ns/op	  140937 B/op	    4547 allocs/op
BenchmarkDocument/rich_text_1000-4           	     312	   3832865 ns/op	 1346822 B/op	   44150 allocs/op
BenchmarkDocument/object_1000-4              	     278	   4850248 ns/op	 2039137 B/op	   36429 allocs/op
BenchmarkDocument/object_10000-4             	      21	  49811057 ns/op	19072811 B/op	  370745 allocs/op
2022-04-03T15:51:01.965+0900	INFO	default	etcd connected, URI: [localhost:2379]
BenchmarkSync/memory_sync_10_test-4          	  141531	      8318 ns/op	    1084 B/op	      28 allocs/op
BenchmarkSync/memory_sync_100_test-4         	   15975	     76332 ns/op	    5848 B/op	     145 allocs/op
BenchmarkSync/memory_sync_1000_test-4        	    1761	    745221 ns/op	   51647 B/op	    1158 allocs/op
BenchmarkSync/memory_sync_10000_test-4       	      87	  13858540 ns/op	  559523 B/op	   11437 allocs/op
BenchmarkSync/etcd_sync_100_test-4           	       1	1003731735 ns/op	 6359960 B/op	  104965 allocs/op
BenchmarkTextEditing-4                       	       1	49967220092 ns/op	11546211520 B/op	141502485 allocs/op
PASS
ok  	github.com/yorkie-team/yorkie/test/bench	107.446s
```

After:
```
go test -tags bench -benchmem -bench=. ./test/bench
goos: darwin
goarch: amd64
pkg: github.com/yorkie-team/yorkie/test/bench
cpu: Intel(R) Core(TM) i5-4690 CPU @ 3.50GHz
BenchmarkDocument/constructor_test-4         	  835401	      1886 ns/op	     768 B/op	      12 allocs/op
BenchmarkDocument/status_test-4              	 1222231	       959.4 ns/op	     736 B/op	      10 allocs/op
BenchmarkDocument/equals_test-4              	  167748	      7300 ns/op	    5145 B/op	      90 allocs/op
BenchmarkDocument/nested_update_test-4       	   61309	     21177 ns/op	   10715 B/op	     239 allocs/op
BenchmarkDocument/delete_test-4              	   42348	     25901 ns/op	   13076 B/op	     288 allocs/op
BenchmarkDocument/object_test-4              	  130309	      9639 ns/op	    5681 B/op	      98 allocs/op
BenchmarkDocument/array_test-4               	   35664	     33012 ns/op	   11628 B/op	     268 allocs/op
BenchmarkDocument/text_test-4                	   39453	     33741 ns/op	   12884 B/op	     389 allocs/op
BenchmarkDocument/text_composition_test-4    	   36744	     31923 ns/op	   16869 B/op	     417 allocs/op
BenchmarkDocument/rich_text_test-4           	    9540	    118393 ns/op	   45093 B/op	    1288 allocs/op
BenchmarkDocument/counter_test-4             	   41127	     29097 ns/op	   12252 B/op	     310 allocs/op
BenchmarkDocument/text_edit_gc_100-4         	     188	   5747164 ns/op	 2030038 B/op	   39199 allocs/op
BenchmarkDocument/text_edit_gc_1000-4        	       3	 485260031 ns/op	183686434 B/op	 2680065 allocs/op
BenchmarkDocument/text_split_gc_100-4        	     170	   6865294 ns/op	 2555425 B/op	   39657 allocs/op
BenchmarkDocument/text_split_gc_1000-4       	       2	 501251364 ns/op	249757448 B/op	 2693403 allocs/op
BenchmarkDocument/text_100-4                 	    4519	    267960 ns/op	  111043 B/op	    4470 allocs/op
BenchmarkDocument/text_1000-4                	     409	   3070803 ns/op	 1066725 B/op	   44073 allocs/op
BenchmarkDocument/array_1000-4               	     584	   1718863 ns/op	 1138430 B/op	   13863 allocs/op
BenchmarkDocument/array_10000-4              	      66	  17414384 ns/op	10605624 B/op	  140721 allocs/op
BenchmarkDocument/array_gc_100-4             	    6782	    173489 ns/op	  102440 B/op	    1436 allocs/op
BenchmarkDocument/array_gc_1000-4            	     660	   1833260 ns/op	 1188640 B/op	   14897 allocs/op
BenchmarkDocument/counter_1000-4             	    4660	    247035 ns/op	  183377 B/op	    5522 allocs/op
BenchmarkDocument/counter_10000-4            	     432	   2735880 ns/op	 2344606 B/op	   59531 allocs/op
BenchmarkDocument/rich_text_100-4            	    3991	    287664 ns/op	  134881 B/op	    4229 allocs/op
BenchmarkDocument/rich_text_1000-4           	     397	   3022740 ns/op	 1290366 B/op	   41132 allocs/op
BenchmarkDocument/object_1000-4              	     510	   2334312 ns/op	 1567664 B/op	   13927 allocs/op
BenchmarkDocument/object_10000-4             	      37	  27719541 ns/op	14319644 B/op	  141249 allocs/op
2022-04-03T15:44:35.213+0900	INFO	default	etcd connected, URI: [localhost:2379]
BenchmarkSync/memory_sync_10_test-4          	  152412	      7788 ns/op	    1079 B/op	      28 allocs/op
BenchmarkSync/memory_sync_100_test-4         	   16106	     81215 ns/op	    5750 B/op	     139 allocs/op
BenchmarkSync/memory_sync_1000_test-4        	    1358	    969594 ns/op	   52466 B/op	    1202 allocs/op
BenchmarkSync/memory_sync_10000_test-4       	      82	  12319602 ns/op	  537320 B/op	   10701 allocs/op
BenchmarkSync/etcd_sync_100_test-4           	       4	 305514006 ns/op	 1431180 B/op	   24631 allocs/op
BenchmarkTextEditing-4                       	       1	50569014830 ns/op	11512138088 B/op	139949028 allocs/op
PASS
ok  	github.com/yorkie-team/yorkie/test/bench	103.174s
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Address #305

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
