### PR TITLE
fix: lru cache expired when same key update

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -72,7 +72,7 @@ func (c *LRUExpireCache) Add(
 	if ok {
 		c.evictionList.MoveToFront(oldElement)
 		oldElement.Value.(*cacheEntry).value = value
-		oldElement.Value.(*cacheEntry).expireTime = time.Now()
+		oldElement.Value.(*cacheEntry).expireTime = time.Now().Add(ttl)
 		return
 	}
 

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -52,4 +52,22 @@ func TestCache(t *testing.T) {
 		assert.False(t, ok)
 		assert.Nil(t, response)
 	})
+
+	t.Run("update expired cache test", func(t *testing.T) {
+		lruCache, err := cache.NewLRUExpireCache(1)
+		assert.NoError(t, err)
+
+		var ttl time.Duration
+		ttl = time.Minute
+		lruCache.Add("request", "response1", ttl)
+		response1, ok := lruCache.Get("request")
+		assert.True(t, ok)
+		assert.Equal(t, "response1", response1)
+
+		ttl = time.Minute
+		lruCache.Add("request", "response2", ttl)
+		response2, ok := lruCache.Get("request")
+		assert.True(t, ok)
+		assert.Equal(t, "response2", response2)
+	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

missing function updating ttl in lru cache
 

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
