### PR TITLE
Return an error when the project already exists at creation

### DIFF
--- a/server/admin/interceptors/default.go
+++ b/server/admin/interceptors/default.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Yorkie Authors. All rights reserved.
+ * Copyright 2022 The Yorkie Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,12 +46,12 @@ func (i *DefaultInterceptor) Unary() grpc.UnaryServerInterceptor {
 		resp, err := handler(ctx, req)
 		reqLogger := logging.From(ctx)
 		if err != nil {
-			reqLogger.Warnf("RPC : %q %s: %q => %q", info.FullMethod, gotime.Since(start), req, err)
+			reqLogger.Warnf("ADMN: %q %s: %q => %q", info.FullMethod, gotime.Since(start), req, err)
 			return nil, grpchelper.ToStatusError(err)
 		}
 
 		if gotime.Since(start) > 100*gotime.Millisecond {
-			reqLogger.Infof("RPC : %q %s", info.FullMethod, gotime.Since(start))
+			reqLogger.Infof("ADMN: %q %s", info.FullMethod, gotime.Since(start))
 		}
 		return resp, nil
 	}
@@ -70,11 +70,11 @@ func (i *DefaultInterceptor) Stream() grpc.StreamServerInterceptor {
 		start := gotime.Now()
 		err := handler(srv, ss)
 		if err != nil {
-			reqLogger.Warnf("RPC : stream %q %s => %q", info.FullMethod, gotime.Since(start), err.Error())
+			reqLogger.Warnf("ADMN: stream %q %s => %q", info.FullMethod, gotime.Since(start), err.Error())
 			return grpchelper.ToStatusError(err)
 		}
 
-		reqLogger.Infof("RPC : stream %q %s", info.FullMethod, gotime.Since(start))
+		reqLogger.Infof("ADMN: stream %q %s", info.FullMethod, gotime.Since(start))
 		return nil
 	}
 }

--- a/server/backend/database/database.go
+++ b/server/backend/database/database.go
@@ -29,6 +29,9 @@ import (
 )
 
 var (
+	// ErrProjectAlreadyExists is returned when the project already exists.
+	ErrProjectAlreadyExists = errors.New("project already exists")
+
 	// ErrProjectNotFound is returned when the project is not found.
 	ErrProjectNotFound = errors.New("project not found")
 

--- a/server/backend/database/memory/indexes.go
+++ b/server/backend/database/memory/indexes.go
@@ -37,6 +37,11 @@ var schema = &memdb.DBSchema{
 					Unique:  true,
 					Indexer: &memdb.StringFieldIndex{Field: "ID"},
 				},
+				"name": {
+					Name:    "name",
+					Unique:  true,
+					Indexer: &memdb.StringFieldIndex{Field: "Name"},
+				},
 				"public_key": {
 					Name:    "public_key",
 					Unique:  true,

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -139,6 +139,10 @@ func (c *Client) CreateProjectInfo(ctx context.Context, name string) (*database.
 		"created_at": gotime.Now(),
 	})
 	if err != nil {
+		if mongo.IsDuplicateKeyError(err) {
+			return nil, database.ErrProjectAlreadyExists
+		}
+
 		logging.From(ctx).Error(err)
 		return nil, err
 	}

--- a/server/backend/database/mongo/indexes.go
+++ b/server/backend/database/mongo/indexes.go
@@ -43,6 +43,9 @@ var collectionInfos = []collectionInfo{
 	{
 		name: colProjects,
 		indexes: []mongo.IndexModel{{
+			Keys:    bsonx.Doc{{Key: "name", Value: bsonx.Int32(1)}},
+			Options: options.Index().SetUnique(true),
+		}, {
 			Keys:    bsonx.Doc{{Key: "public_key", Value: bsonx.Int32(1)}},
 			Options: options.Index().SetUnique(true),
 		}, {

--- a/server/backend/database/project_info.go
+++ b/server/backend/database/project_info.go
@@ -58,7 +58,8 @@ type ProjectInfo struct {
 // NewProjectInfo creates a new ProjectInfo of the given name.
 func NewProjectInfo(name string) *ProjectInfo {
 	return &ProjectInfo{
-		Name:      name,
+		Name: name,
+		// TODO(hackerwins): Use random generated Key.
 		PublicKey: xid.New().String(),
 		SecretKey: xid.New().String(),
 		CreatedAt: time.Now(),

--- a/server/grpchelper/logging.go
+++ b/server/grpchelper/logging.go
@@ -1,4 +1,4 @@
-package interceptors
+package grpchelper
 
 import (
 	"context"

--- a/server/grpchelper/status.go
+++ b/server/grpchelper/status.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package interceptors
+package grpchelper
 
 import (
 	"errors"
@@ -31,10 +31,10 @@ import (
 	"github.com/yorkie-team/yorkie/server/rpc/auth"
 )
 
-// toStatusError returns a status.Error from the given logic error. If an error
+// ToStatusError returns a status.Error from the given logic error. If an error
 // occurs while executing logic in API handler, gRPC status.error should be
 // returned so that the client can know more about the status of the request.
-func toStatusError(err error) error {
+func ToStatusError(err error) error {
 	if errors.Is(err, auth.ErrNotAllowed) ||
 		errors.Is(err, auth.ErrUnexpectedStatusCode) ||
 		errors.Is(err, auth.ErrWebhookTimeout) {
@@ -63,6 +63,10 @@ func toStatusError(err error) error {
 		errors.Is(err, database.ErrClientNotFound) ||
 		errors.Is(err, database.ErrDocumentNotFound) {
 		return status.Error(codes.NotFound, err.Error())
+	}
+
+	if errors.Is(err, database.ErrProjectAlreadyExists) {
+		return status.Error(codes.AlreadyExists, err.Error())
 	}
 
 	if err == database.ErrClientNotActivated ||

--- a/server/profiling/prometheus/metrics.go
+++ b/server/profiling/prometheus/metrics.go
@@ -96,8 +96,7 @@ func NewMetrics() (*Metrics, error) {
 				Help: "The total count of operations included in request" +
 					" packs in PushPull.",
 			}),
-		pushPullSentOperationsTotal: promauto.With(reg).NewCounter(prometheus.
-			CounterOpts{
+		pushPullSentOperationsTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: "pushpull",
 			Name:      "sent_operations_total",

--- a/server/rpc/interceptors/context.go
+++ b/server/rpc/interceptors/context.go
@@ -24,9 +24,10 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	grpcmetadata "google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/status"
+	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/yorkie-team/yorkie/server/backend"
+	"github.com/yorkie-team/yorkie/server/grpchelper"
 	"github.com/yorkie-team/yorkie/server/projects"
 	"github.com/yorkie-team/yorkie/server/rpc/metadata"
 )
@@ -100,12 +101,12 @@ func (i *ContextInterceptor) buildContext(ctx context.Context) (context.Context,
 	md := metadata.Metadata{}
 	data, ok := grpcmetadata.FromIncomingContext(ctx)
 	if !ok {
-		return nil, status.Errorf(codes.Unauthenticated, "metadata is not provided")
+		return nil, grpcstatus.Errorf(codes.Unauthenticated, "metadata is not provided")
 	}
 
 	apiKey := data["x-api-key"]
 	if len(apiKey) == 0 && !i.backend.Config.UseDefaultProject {
-		return nil, status.Errorf(codes.Unauthenticated, "api key is not provided")
+		return nil, grpcstatus.Errorf(codes.Unauthenticated, "api key is not provided")
 	}
 	if len(apiKey) > 0 {
 		md.APIKey = apiKey[0]
@@ -122,7 +123,7 @@ func (i *ContextInterceptor) buildContext(ctx context.Context) (context.Context,
 	// Consider using a cache to store the info.
 	project, err := projects.GetProjectFromAPIKey(ctx, i.backend, md.APIKey)
 	if err != nil {
-		return nil, toStatusError(err)
+		return nil, grpchelper.ToStatusError(err)
 	}
 	ctx = projects.With(ctx, project)
 

--- a/server/rpc/server.go
+++ b/server/rpc/server.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/yorkie-team/yorkie/api"
 	"github.com/yorkie-team/yorkie/server/backend"
+	"github.com/yorkie-team/yorkie/server/grpchelper"
 	"github.com/yorkie-team/yorkie/server/logging"
 	"github.com/yorkie-team/yorkie/server/rpc/interceptors"
 )
@@ -43,7 +44,7 @@ type Server struct {
 
 // NewServer creates a new instance of Server.
 func NewServer(conf *Config, be *backend.Backend) (*Server, error) {
-	loggingInterceptor := interceptors.NewLoggingInterceptor()
+	loggingInterceptor := grpchelper.NewLoggingInterceptor()
 	contextInterceptor := interceptors.NewContextInterceptor(be)
 	defaultInterceptor := interceptors.NewDefaultInterceptor()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Return an error when the project already exists at creation

There is an issue that the same records are inserted even if the
unique field is specified in go-memdb. And the maintainer guides avoiding
this in the application.

https://github.com/hashicorp/go-memdb/issues/7#issuecomment-27042764

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
