### PR TITLE
Introduce generics to priority queue

### DIFF
--- a/pkg/document/json/rht_pq_map.go
+++ b/pkg/document/json/rht_pq_map.go
@@ -69,14 +69,14 @@ func (n *RHTPQMapNode) Element() Element {
 // Max Heap, the recently inserted value from the logical clock is returned
 // to the outside.
 type RHTPriorityQueueMap struct {
-	nodeQueueMapByKey  map[string]*pq.PriorityQueue
+	nodeQueueMapByKey  map[string]*pq.PriorityQueue[*RHTPQMapNode]
 	nodeMapByCreatedAt map[string]*RHTPQMapNode
 }
 
 // NewRHTPriorityQueueMap creates a new instance of RHTPriorityQueueMap.
 func NewRHTPriorityQueueMap() *RHTPriorityQueueMap {
 	return &RHTPriorityQueueMap{
-		nodeQueueMapByKey:  make(map[string]*pq.PriorityQueue),
+		nodeQueueMapByKey:  make(map[string]*pq.PriorityQueue[*RHTPQMapNode]),
 		nodeMapByCreatedAt: make(map[string]*RHTPQMapNode),
 	}
 }
@@ -88,7 +88,7 @@ func (rht *RHTPriorityQueueMap) Get(key string) Element {
 		return nil
 	}
 
-	node := queue.Peek().(*RHTPQMapNode)
+	node := queue.Peek()
 	if node.isRemoved() {
 		return nil
 	}
@@ -102,7 +102,7 @@ func (rht *RHTPriorityQueueMap) Has(key string) bool {
 		return false
 	}
 
-	node := queue.Peek().(*RHTPQMapNode)
+	node := queue.Peek()
 	return node != nil && !node.isRemoved()
 }
 
@@ -111,7 +111,7 @@ func (rht *RHTPriorityQueueMap) Set(k string, v Element) Element {
 	var removed Element
 
 	if queue, ok := rht.nodeQueueMapByKey[k]; ok && queue.Len() > 0 {
-		node := queue.Peek().(*RHTPQMapNode)
+		node := queue.Peek()
 		if !node.isRemoved() && node.Remove(v.CreatedAt()) {
 			removed = node.elem
 		}
@@ -124,7 +124,7 @@ func (rht *RHTPriorityQueueMap) Set(k string, v Element) Element {
 // SetInternal sets the value of the given key.
 func (rht *RHTPriorityQueueMap) SetInternal(k string, v Element) {
 	if _, ok := rht.nodeQueueMapByKey[k]; !ok {
-		rht.nodeQueueMapByKey[k] = pq.NewPriorityQueue()
+		rht.nodeQueueMapByKey[k] = pq.NewPriorityQueue[*RHTPQMapNode]()
 	}
 
 	node := newRHTPQMapNode(k, v)
@@ -139,7 +139,7 @@ func (rht *RHTPriorityQueueMap) Delete(k string, deletedAt *time.Ticket) Element
 		return nil
 	}
 
-	node := queue.Peek().(*RHTPQMapNode)
+	node := queue.Peek()
 	if !node.Remove(deletedAt) {
 		return nil
 	}
@@ -169,7 +169,7 @@ func (rht *RHTPriorityQueueMap) Elements() map[string]Element {
 		if queue.Len() == 0 {
 			continue
 		}
-		if node := queue.Peek().(*RHTPQMapNode); !node.isRemoved() {
+		if node := queue.Peek(); !node.isRemoved() {
 			members[node.key] = node.elem
 		}
 	}
@@ -183,7 +183,7 @@ func (rht *RHTPriorityQueueMap) Nodes() []*RHTPQMapNode {
 	var nodes []*RHTPQMapNode
 	for _, queue := range rht.nodeQueueMapByKey {
 		for _, value := range queue.Values() {
-			nodes = append(nodes, value.(*RHTPQMapNode))
+			nodes = append(nodes, value)
 		}
 	}
 

--- a/pkg/pq/priority_queue.go
+++ b/pkg/pq/priority_queue.go
@@ -26,7 +26,7 @@ type PriorityQueue[V comparableValue] struct {
 }
 
 // NewPriorityQueue creates an instance of NewPriorityQueue.
-func NewPriorityQueue[V comparableValue] () *PriorityQueue[V] {
+func NewPriorityQueue[V comparableValue]() *PriorityQueue[V] {
 	pq := &internalQueue[V]{}
 	heap.Init(pq)
 

--- a/pkg/pq/priority_queue.go
+++ b/pkg/pq/priority_queue.go
@@ -21,43 +21,43 @@ import (
 )
 
 // PriorityQueue is a priority queue implemented with max heap.
-type PriorityQueue struct {
-	queue *internalQueue
+type PriorityQueue[V ComparableValue] struct {
+	queue *internalQueue[V]
 }
 
 // NewPriorityQueue creates an instance of NewPriorityQueue.
-func NewPriorityQueue() *PriorityQueue {
-	pq := &internalQueue{}
+func NewPriorityQueue[V ComparableValue] () *PriorityQueue[V] {
+	pq := &internalQueue[V]{}
 	heap.Init(pq)
 
-	return &PriorityQueue{
+	return &PriorityQueue[V]{
 		queue: pq,
 	}
 }
 
 // Peek returns the maximum element from this PriorityQueue.
-func (pq *PriorityQueue) Peek() Value {
-	return pq.queue.Peek().(*pqItem).value
+func (pq *PriorityQueue[V]) Peek() V {
+	return pq.queue.Peek().(*pqItem[V]).value
 }
 
 // Pop removes and returns the maximum element from this PriorityQueue.
-func (pq *PriorityQueue) Pop() Value {
-	return heap.Pop(pq.queue).(*pqItem).value
+func (pq *PriorityQueue[V]) Pop() V {
+	return heap.Pop(pq.queue).(*pqItem[V]).value
 }
 
 // Push pushes the element x onto this PriorityQueue.
-func (pq *PriorityQueue) Push(value Value) {
+func (pq *PriorityQueue[V]) Push(value V) {
 	item := newPQItem(value)
 	heap.Push(pq.queue, item)
 }
 
 // Len is the number of elements in this PriorityQueue.
-func (pq *PriorityQueue) Len() int {
+func (pq *PriorityQueue[V]) Len() int {
 	return pq.queue.Len()
 }
 
 // Release deletes the given value from this PriorityQueue.
-func (pq *PriorityQueue) Release(value Value) {
+func (pq *PriorityQueue[V]) Release(value V) {
 	idx := -1
 	for i, item := range *pq.queue {
 		if item.value == value {
@@ -74,8 +74,8 @@ func (pq *PriorityQueue) Release(value Value) {
 }
 
 // Values returns the values of this PriorityQueue.
-func (pq *PriorityQueue) Values() []Value {
-	var values []Value
+func (pq *PriorityQueue[V]) Values() []V {
+	var values []V
 	for _, item := range *pq.queue {
 		values = append(values, item.value)
 	}
@@ -87,49 +87,55 @@ type Value interface {
 	Less(other Value) bool
 }
 
+type ComparableValue interface {
+	Value
+	comparable
+}
+
+
 // pqItem is something we manage in a priority queue.
-type pqItem struct {
-	value Value
+type pqItem[V ComparableValue] struct {
+	value V
 	index int
 }
 
-func newPQItem(value Value) *pqItem {
-	return &pqItem{
+func newPQItem[V ComparableValue](value V) *pqItem[V] {
+	return &pqItem[V]{
 		value: value,
 		index: -1,
 	}
 }
 
 // A internalQueue implements heap.Interface and holds Items.
-type internalQueue []*pqItem
+type internalQueue[V ComparableValue] []*pqItem[V]
 
 // Len is the number of elements in this internalQueue.
-func (pq internalQueue) Len() int { return len(pq) }
+func (pq internalQueue[V]) Len() int { return len(pq) }
 
 // Less reports whether the element with
 // index i should sort before the element with index j.
-func (pq internalQueue) Less(i, j int) bool {
+func (pq internalQueue[V]) Less(i, j int) bool {
 	// We want Pop to give us the highest priority, not the lowest, so we use greater than here.
 	return pq[i].value.Less(pq[j].value)
 }
 
 // Swap swaps the elements with indexes i and j.
-func (pq internalQueue) Swap(i, j int) {
+func (pq internalQueue[V]) Swap(i, j int) {
 	pq[i], pq[j] = pq[j], pq[i]
 	pq[i].index = i
 	pq[j].index = j
 }
 
 // Push pushes the element x onto this internalQueue.
-func (pq *internalQueue) Push(x interface{}) {
+func (pq *internalQueue[V]) Push(x interface{}) {
 	n := len(*pq)
-	item := x.(*pqItem)
+	item := x.(*pqItem[V])
 	item.index = n
 	*pq = append(*pq, item)
 }
 
 // Pop removes and returns the maximum element from this internalQueue.
-func (pq *internalQueue) Pop() interface{} {
+func (pq *internalQueue[V]) Pop() interface{} {
 	old := *pq
 	n := len(old)
 	item := old[n-1]
@@ -140,6 +146,6 @@ func (pq *internalQueue) Pop() interface{} {
 }
 
 // Peek returns the maximum element from this internalQueue.
-func (pq *internalQueue) Peek() interface{} {
+func (pq *internalQueue[V]) Peek() interface{} {
 	return (*pq)[0]
 }

--- a/pkg/pq/priority_queue.go
+++ b/pkg/pq/priority_queue.go
@@ -21,12 +21,12 @@ import (
 )
 
 // PriorityQueue is a priority queue implemented with max heap.
-type PriorityQueue[V comparableValue] struct {
+type PriorityQueue[V Value] struct {
 	queue *internalQueue[V]
 }
 
 // NewPriorityQueue creates an instance of NewPriorityQueue.
-func NewPriorityQueue[V comparableValue]() *PriorityQueue[V] {
+func NewPriorityQueue[V Value]() *PriorityQueue[V] {
 	pq := &internalQueue[V]{}
 	heap.Init(pq)
 
@@ -60,7 +60,7 @@ func (pq *PriorityQueue[V]) Len() int {
 func (pq *PriorityQueue[V]) Release(value V) {
 	idx := -1
 	for i, item := range *pq.queue {
-		if item.value == value {
+		if !item.value.Less(value) && !value.Less(item.value) {
 			idx = i
 			break
 		}
@@ -87,18 +87,15 @@ type Value interface {
 	Less(other Value) bool
 }
 
-type comparableValue interface {
-	Value
-	comparable
-}
+
 
 // pqItem is something we manage in a priority queue.
-type pqItem[V comparableValue] struct {
+type pqItem[V Value] struct {
 	value V
 	index int
 }
 
-func newPQItem[V comparableValue](value V) *pqItem[V] {
+func newPQItem[V Value](value V) *pqItem[V] {
 	return &pqItem[V]{
 		value: value,
 		index: -1,
@@ -106,7 +103,7 @@ func newPQItem[V comparableValue](value V) *pqItem[V] {
 }
 
 // A internalQueue implements heap.Interface and holds Items.
-type internalQueue[V comparableValue] []*pqItem[V]
+type internalQueue[V Value] []*pqItem[V]
 
 // Len is the number of elements in this internalQueue.
 func (pq internalQueue[V]) Len() int { return len(pq) }

--- a/pkg/pq/priority_queue.go
+++ b/pkg/pq/priority_queue.go
@@ -92,7 +92,6 @@ type comparableValue interface {
 	comparable
 }
 
-
 // pqItem is something we manage in a priority queue.
 type pqItem[V comparableValue] struct {
 	value V

--- a/pkg/pq/priority_queue.go
+++ b/pkg/pq/priority_queue.go
@@ -21,12 +21,12 @@ import (
 )
 
 // PriorityQueue is a priority queue implemented with max heap.
-type PriorityQueue[V ComparableValue] struct {
+type PriorityQueue[V comparableValue] struct {
 	queue *internalQueue[V]
 }
 
 // NewPriorityQueue creates an instance of NewPriorityQueue.
-func NewPriorityQueue[V ComparableValue] () *PriorityQueue[V] {
+func NewPriorityQueue[V comparableValue] () *PriorityQueue[V] {
 	pq := &internalQueue[V]{}
 	heap.Init(pq)
 
@@ -87,19 +87,19 @@ type Value interface {
 	Less(other Value) bool
 }
 
-type ComparableValue interface {
+type comparableValue interface {
 	Value
 	comparable
 }
 
 
 // pqItem is something we manage in a priority queue.
-type pqItem[V ComparableValue] struct {
+type pqItem[V comparableValue] struct {
 	value V
 	index int
 }
 
-func newPQItem[V ComparableValue](value V) *pqItem[V] {
+func newPQItem[V comparableValue](value V) *pqItem[V] {
 	return &pqItem[V]{
 		value: value,
 		index: -1,
@@ -107,7 +107,7 @@ func newPQItem[V ComparableValue](value V) *pqItem[V] {
 }
 
 // A internalQueue implements heap.Interface and holds Items.
-type internalQueue[V ComparableValue] []*pqItem[V]
+type internalQueue[V comparableValue] []*pqItem[V]
 
 // Len is the number of elements in this internalQueue.
 func (pq internalQueue[V]) Len() int { return len(pq) }

--- a/pkg/pq/priority_queue.go
+++ b/pkg/pq/priority_queue.go
@@ -87,8 +87,6 @@ type Value interface {
 	Less(other Value) bool
 }
 
-
-
 // pqItem is something we manage in a priority queue.
 type pqItem[V Value] struct {
 	value V

--- a/pkg/pq/priority_queue_test.go
+++ b/pkg/pq/priority_queue_test.go
@@ -39,11 +39,10 @@ func newTestValue(value int) testValue {
 	}
 }
 
-func exist(toFind int, values []pq.Value) bool {
+func exist(toFind int, values []testValue) bool {
 	ret := false
 	for _, value := range values {
-		v := value.(testValue)
-		if v.value == toFind {
+		if value.value == toFind {
 			ret = true
 			break
 		}
@@ -51,8 +50,8 @@ func exist(toFind int, values []pq.Value) bool {
 	return ret
 }
 
-func setUpTestNums() *pq.PriorityQueue {
-	queue := pq.NewPriorityQueue()
+func setUpTestNums() *pq.PriorityQueue[testValue] {
+	queue := pq.NewPriorityQueue[testValue]()
 	testNums := []int{10, 7, 1, 9, 4, 11, 5, 3, 6, 12, 8, 2}
 	for _, testNum := range testNums {
 		queue.Push(newTestValue(testNum))
@@ -88,7 +87,7 @@ func TestPQ(t *testing.T) {
 
 		var tmp []int
 		for queue.Len() != 0 {
-			tmp = append(tmp, (queue.Pop()).(testValue).value)
+			tmp = append(tmp, (queue.Pop()).value)
 		}
 
 		assert.EqualValues(t, tmp, []int{3, 4, 5, 6, 7, 8, 9, 10, 11, 12})
@@ -148,7 +147,7 @@ func TestPQRelease(t *testing.T) {
 	})
 
 	t.Run("if a heap has one node", func(t *testing.T) {
-		queue := pq.NewPriorityQueue()
+		queue := pq.NewPriorityQueue[testValue]()
 		node := newTestValue(0)
 
 		queue.Push(node)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Introduce generics to priority queue

To apply generics to priority queue, make interface "ComparableValue"
which is a 'Value' and comaparable and apply generic to all structs
and functions refer to 'Value'.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Address #304

**Special notes for your reviewer**:

First, I applyed generic to Value but there was un error in using '==' operator in func Release.
So I tried to push 'comparable' in interface Value but it didn't work.
So instead, I implemented interface ComparableValue which is a Value and comparable.
I'm not sure this is right way, please give an advice if there's a better.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
