### PR TITLE
Skip storing the initial ticket to prevent GC interruption

### DIFF
--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -687,6 +687,16 @@ func (d *DB) UpdateSyncedSeq(
 		return err
 	}
 
+	// NOTE: skip storing the initial ticket to prevent GC interruption.
+	//       Documents in this state do not need to be saved because they do not
+	//       have any tombstones to be referenced by other documents.
+	//
+	//       (The initial ticket is used as the creation time of the root
+	//       element that operations can not remove.)
+	if ticket.Compare(time.InitialTicket) == 0 {
+		return nil
+	}
+
 	raw, err := txn.First(
 		tblSyncedSeqs,
 		"doc_id_client_id",

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -829,6 +829,16 @@ func (c *Client) UpdateSyncedSeq(
 		return err
 	}
 
+	// NOTE: skip storing the initial ticket to prevent GC interruption.
+	//       Documents in this state do not need to be saved because they do not
+	//       have any tombstones to be referenced by other documents.
+	//
+	//       (The initial ticket is used as the creation time of the root
+	//       element that operations can not remove.)
+	if ticket.Compare(time.InitialTicket) == 0 {
+		return nil
+	}
+
 	if _, err = c.collection(colSyncedSeqs).UpdateOne(ctx, bson.M{
 		"doc_id":    encodedDocID,
 		"client_id": encodedClientID,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Skip storing the initial ticket to prevent GC interruption

Documents in this state do not need to be saved because they do not
have any tombstones to be referenced by other documents.

The initial ticket is used as the creation time of the root
element that operations can not remove.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
