### PR TITLE
Cache removed elements when creating a document from a snapshot

### DIFF
--- a/pkg/document/json/root.go
+++ b/pkg/document/json/root.go
@@ -52,6 +52,10 @@ func NewRoot(root *Object) *Root {
 
 	root.Descendants(func(elem Element, parent Container) bool {
 		r.RegisterElement(elem)
+		if elem.RemovedAt() != nil {
+			r.RegisterRemovedElementPair(parent, elem)
+		}
+		// TODO(hackerwins): Register text elements with garbage
 		return false
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Cache removed elements when creating a document from a snapshot

Some tombstones were not purged by GC in snapshots because GC runs on
the removed element cache.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
