### PR TITLE
Detach the attached documents when deactivating the client

### DIFF
--- a/server/rpc/yorkie_server.go
+++ b/server/rpc/yorkie_server.go
@@ -62,7 +62,7 @@ func (s *yorkieServer) ActivateClient(
 		return nil, err
 	}
 
-	cli, err := clients.Activate(ctx, s.backend, projects.From(ctx), req.ClientKey)
+	cli, err := clients.Activate(ctx, s.backend.DB, projects.From(ctx), req.ClientKey)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +94,12 @@ func (s *yorkieServer) DeactivateClient(
 		return nil, err
 	}
 
-	cli, err := clients.Deactivate(ctx, s.backend, projects.From(ctx), actorID)
+	cli, err := clients.Deactivate(
+		ctx,
+		s.backend.DB,
+		projects.From(ctx).ID,
+		types.IDFromActorID(actorID),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +157,7 @@ func (s *yorkieServer) AttachDocument(
 
 	clientInfo, err := clients.FindClientInfo(
 		ctx,
-		s.backend,
+		s.backend.DB,
 		projects.From(ctx),
 		actorID,
 	)
@@ -233,7 +238,7 @@ func (s *yorkieServer) DetachDocument(
 
 	clientInfo, err := clients.FindClientInfo(
 		ctx,
-		s.backend,
+		s.backend.DB,
 		projects.From(ctx),
 		actorID,
 	)
@@ -319,7 +324,7 @@ func (s *yorkieServer) PushPull(
 
 	clientInfo, err := clients.FindClientInfo(
 		ctx,
-		s.backend,
+		s.backend.DB,
 		projects.From(ctx),
 		actorID,
 	)
@@ -386,7 +391,7 @@ func (s *yorkieServer) WatchDocuments(
 
 	if _, err = clients.FindClientInfo(
 		stream.Context(),
-		s.backend,
+		s.backend.DB,
 		projects.From(stream.Context()),
 		cli.ID,
 	); err != nil {
@@ -488,7 +493,12 @@ func (s *yorkieServer) ListChanges(
 		return nil, err
 	}
 
-	clientInfo, err := clients.FindClientInfo(ctx, s.backend, projects.From(ctx), actorID)
+	clientInfo, err := clients.FindClientInfo(
+		ctx,
+		s.backend.DB,
+		projects.From(ctx),
+		actorID,
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Detach the attached documents when deactivating the client

The detaching documents logic when deactivating the client in the RPC
was missing. I think the cause of the problem is duplicate code.

So this commit extracted the deactivation logic from `housekeeping`
package into `clients` package and use the logic in both the RPC and
housekeeping.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
