### PR TITLE
Fix bugs in text deletion

### DIFF
--- a/pkg/document/json/rga_tree_split.go
+++ b/pkg/document/json/rga_tree_split.go
@@ -524,14 +524,14 @@ func (s *RGATreeSplit[V]) findEdgesOfCandidates(
 	candidates []*RGATreeSplitNode[V],
 ) (*RGATreeSplitNode[V], *RGATreeSplitNode[V]) {
 	leftEdge := candidates[0].prev
-    for leftEdge != nil && leftEdge.removedAt != nil {
-      leftEdge = leftEdge.prev
-    }
+	for leftEdge != nil && leftEdge.removedAt != nil {
+		leftEdge = leftEdge.prev
+	}
 
-    rightEdge := candidates[len(candidates) - 1].next
-    for rightEdge != nil && rightEdge.removedAt != nil {
-      rightEdge = rightEdge.next
-    }
+	rightEdge := candidates[len(candidates)-1].next
+	for rightEdge != nil && rightEdge.removedAt != nil {
+		rightEdge = rightEdge.next
+	}
 
 	return leftEdge, rightEdge
 }

--- a/pkg/document/json/rga_tree_split.go
+++ b/pkg/document/json/rga_tree_split.go
@@ -483,8 +483,9 @@ func (s *RGATreeSplit[V]) deleteNodes(
 		return createdAtMapByActor, removedNodeMap
 	}
 
-	var deletionBoundaries []*RGATreeSplitNode[V]
-	deletionBoundaries = append(deletionBoundaries, candidates[0].prev)
+	var nodesToKeep []*RGATreeSplitNode[V]
+	leftEdge, rightEdge := s.findEdgesOfCandidates(candidates)
+	nodesToKeep = append(nodesToKeep, leftEdge)
 
 	for _, node := range candidates {
 		actorIDHex := node.createdAt().ActorIDHex()
@@ -505,37 +506,45 @@ func (s *RGATreeSplit[V]) deleteNodes(
 				createdAtMapByActor[actorIDHex] = createdAt
 			}
 			removedNodeMap[node.id.key()] = node
-		} else {
-			deletionBoundaries = append(deletionBoundaries, node)
+		} else if node.removedAt == nil {
+			nodesToKeep = append(nodesToKeep, node)
 		}
 	}
 
-	deletionBoundaries = append(deletionBoundaries, candidates[len(candidates)-1].next)
-	s.deleteIndexNodes(deletionBoundaries)
+	nodesToKeep = append(nodesToKeep, rightEdge)
+	s.deleteIndexNodes(nodesToKeep)
 
 	return createdAtMapByActor, removedNodeMap
+}
+
+// findEdgesOfCandidates finds the 2 edges outside `candidates`,
+// which has not already been deleted, or be undefined.
+// right edge is undefined means `candidates` contains the end of text.
+func (s *RGATreeSplit[V]) findEdgesOfCandidates(
+	candidates []*RGATreeSplitNode[V],
+) (*RGATreeSplitNode[V], *RGATreeSplitNode[V]) {
+	leftEdge := candidates[0].prev
+    for leftEdge != nil && leftEdge.removedAt != nil {
+      leftEdge = leftEdge.prev
+    }
+
+    rightEdge := candidates[len(candidates) - 1].next
+    for rightEdge != nil && rightEdge.removedAt != nil {
+      rightEdge = rightEdge.next
+    }
+
+	return leftEdge, rightEdge
 }
 
 // deleteIndexNodes clears the index nodes of the given deletion boundaries.
 // The boundaries mean the nodes that will not be deleted in the range.
 func (s *RGATreeSplit[V]) deleteIndexNodes(boundaries []*RGATreeSplitNode[V]) {
 	for i := 0; i < len(boundaries)-1; i++ {
-		leftBoundary := boundaries[i]
-		rightBoundary := boundaries[i+1]
-
-		var toInner *splay.Node[*RGATreeSplitNode[V]]
-		var toOuter *splay.Node[*RGATreeSplitNode[V]]
-		if rightBoundary != nil {
-			toInner = rightBoundary.prev.indexNode
-			toOuter = rightBoundary.indexNode
+		if boundaries[i+1] != nil {
+			s.treeByIndex.CutOffRange(boundaries[i].indexNode, boundaries[i+1].indexNode)
+		} else {
+			s.treeByIndex.CutOffRange(boundaries[i].indexNode, nil)
 		}
-
-		s.treeByIndex.CutOffRange(
-			leftBoundary.indexNode,
-			leftBoundary.next.indexNode,
-			toInner,
-			toOuter,
-		)
 	}
 }
 
@@ -607,7 +616,7 @@ func (s *RGATreeSplit[V]) purgeTextNodesWithGarbage(ticket *time.Ticket) int {
 	count := 0
 	for _, node := range s.removedNodeMap {
 		if node.removedAt != nil && ticket.Compare(node.removedAt) >= 0 {
-			s.treeByIndex.Delete(node.indexNode)
+			node.indexNode.Unlink()
 			s.purge(node)
 			s.treeByID.Remove(node.id)
 			delete(s.removedNodeMap, node.id.key())

--- a/pkg/splay/splay.go
+++ b/pkg/splay/splay.go
@@ -73,7 +73,7 @@ func (t *Node[V]) increaseWeight(weight int) {
 	t.weight += weight
 }
 
-func (t *Node[V]) unlink() {
+func (t *Node[V]) Unlink() {
 	t.parent = nil
 	t.right = nil
 	t.left = nil
@@ -283,41 +283,40 @@ func (t *Tree[V]) Delete(node *Node[V]) {
 		t.root = rightTree.root
 	}
 
-	node.unlink()
+	node.Unlink()
 	if t.root != nil {
 		t.UpdateWeight(t.root)
 	}
 }
 
-// CutOffRange cuts the given range from this Tree.
-// This function separates the range from `fromInner` to `toInner` as a subtree
-// by splaying outer nodes then cuts the subtree. 'xxxOuter' could be nil and
-// means to delete the entire subtree in that direction.
-//
-// CAUTION: This function does not filter out invalid argument inputs,
-// such as non-consecutive indices in fromOuter and fromInner.
-func (t *Tree[V]) CutOffRange(fromOuter, fromInner, toInner, toOuter *Node[V]) {
-	t.Splay(toInner)
-	t.Splay(fromInner)
-
-	if fromOuter == nil && toOuter == nil {
+// CutOffRange cuts the range between given 2 boundaries from this Tree.
+// This function separates the range as a subtree
+// by splaying outer nodes then cuts the subtree.
+// leftBoundary, rightBoundary are not included in the range to cut,
+// and they could be nil, meaning to delete to the end of the tree.
+func (t *Tree[V]) CutOffRange(leftBoundary, rightBoundary *Node[V]) {
+	if leftBoundary == nil && rightBoundary == nil {
 		t.root = nil
 		return
 	}
-	if fromOuter == nil {
-		t.Splay(toOuter)
-		t.cutOffLeft(toOuter)
+	if leftBoundary == nil {
+		t.Splay(rightBoundary)
+		t.cutOffLeft(rightBoundary)
 		return
 	}
-	if toOuter == nil {
-		t.Splay(fromOuter)
-		t.cutOffRight(fromOuter)
+	if rightBoundary == nil {
+		t.Splay(leftBoundary)
+		t.cutOffRight(leftBoundary)
 		return
 	}
 
-	t.Splay(toOuter)
-	t.Splay(fromOuter)
-	t.cutOffLeft(toOuter)
+	t.Splay(rightBoundary)
+	t.Splay(leftBoundary)
+	t.cutOffLeft(rightBoundary)
+	if leftBoundary.right != rightBoundary {
+		t.cutOffLeft(leftBoundary.right)
+		t.Delete(leftBoundary.right)
+	}
 }
 
 // cutOffLeft cut off left subtree of node.

--- a/pkg/splay/splay_test.go
+++ b/pkg/splay/splay_test.go
@@ -104,43 +104,43 @@ func TestSplayTree(t *testing.T) {
 	t.Run("range separation test", func(t *testing.T) {
 		tree := splay.NewTree[*stringValue](nil)
 
-		nodeA := tree.Insert(newSplayNode("A"))
+		tree.Insert(newSplayNode("A"))
 		assert.Equal(t, "[1,1]A", tree.AnnotatedString())
 		nodeB := tree.Insert(newSplayNode("BB"))
 		assert.Equal(t, "[1,1]A[3,2]BB", tree.AnnotatedString())
-		nodeC := tree.Insert(newSplayNode("CCC"))
+		tree.Insert(newSplayNode("CCC"))
 		assert.Equal(t, "[1,1]A[3,2]BB[6,3]CCC", tree.AnnotatedString())
 		nodeD := tree.Insert(newSplayNode("DDDD"))
 		assert.Equal(t, "[1,1]A[3,2]BB[6,3]CCC[10,4]DDDD", tree.AnnotatedString())
-		nodeE := tree.Insert(newSplayNode("EEEEE"))
+		tree.Insert(newSplayNode("EEEEE"))
 		assert.Equal(t, "[1,1]A[3,2]BB[6,3]CCC[10,4]DDDD[15,5]EEEEE", tree.AnnotatedString())
 		nodeF := tree.Insert(newSplayNode("FFFF"))
 		assert.Equal(t, "[1,1]A[3,2]BB[6,3]CCC[10,4]DDDD[15,5]EEEEE[19,4]FFFF", tree.AnnotatedString())
-		nodeG := tree.Insert(newSplayNode("GGG"))
+		tree.Insert(newSplayNode("GGG"))
 		assert.Equal(t, "[1,1]A[3,2]BB[6,3]CCC[10,4]DDDD[15,5]EEEEE[19,4]FFFF[22,3]GGG", tree.AnnotatedString())
 		nodeH := tree.Insert(newSplayNode("HH"))
 		assert.Equal(t, "[1,1]A[3,2]BB[6,3]CCC[10,4]DDDD[15,5]EEEEE[19,4]FFFF[22,3]GGG[24,2]HH", tree.AnnotatedString())
-		nodeI := tree.Insert(newSplayNode("I"))
+		tree.Insert(newSplayNode("I"))
 		assert.Equal(t,
 			"[1,1]A[3,2]BB[6,3]CCC[10,4]DDDD[15,5]EEEEE[19,4]FFFF[22,3]GGG[24,2]HH[25,1]I",
 			tree.AnnotatedString())
 
-		tree.CutOffRange(nil, nil, nodeA, nodeB)
-		assert.Equal(t, "[24,2]BB[3,3]CCC[19,4]DDDD[5,5]EEEEE[12,4]FFFF[3,3]GGG[22,2]HH[1,1]I", tree.AnnotatedString())
+		tree.CutOffRange(nil, nodeB)
+		assert.Equal(t, "[24,2]BB[7,3]CCC[4,4]DDDD[16,5]EEEEE[4,4]FFFF[21,3]GGG[2,2]HH[22,1]I", tree.AnnotatedString())
 
-		tree.CutOffRange(nil, nodeB, nodeC, nodeD)
-		assert.Equal(t, "[19,4]DDDD[5,5]EEEEE[12,4]FFFF[3,3]GGG[15,2]HH[1,1]I", tree.AnnotatedString())
+		tree.CutOffRange(nil, nodeD)
+		assert.Equal(t, "[19,4]DDDD[9,5]EEEEE[4,4]FFFF[15,3]GGG[2,2]HH[3,1]I", tree.AnnotatedString())
 
-		tree.CutOffRange(nodeH, nodeI, nil, nil)
-		assert.Equal(t, "[16,4]DDDD[5,5]EEEEE[12,4]FFFF[3,3]GGG[18,2]HH", tree.AnnotatedString())
+		tree.CutOffRange(nodeH, nil)
+		assert.Equal(t, "[16,4]DDDD[9,5]EEEEE[4,4]FFFF[12,3]GGG[18,2]HH", tree.AnnotatedString())
 
-		tree.CutOffRange(nodeF, nodeG, nodeH, nil)
+		tree.CutOffRange(nodeF, nil)
 		assert.Equal(t, "[9,4]DDDD[5,5]EEEEE[13,4]FFFF", tree.AnnotatedString())
 
-		tree.CutOffRange(nodeD, nodeE, nodeE, nodeF)
-		assert.Equal(t, "[13,4]DDDD[9,5]EEEEE[4,4]FFFF", tree.AnnotatedString())
+		tree.CutOffRange(nodeD, nodeF)
+		assert.Equal(t, "[8,4]DDDD[4,4]FFFF", tree.AnnotatedString())
 
-		tree.CutOffRange(nil, nodeD, nodeF, nil)
+		tree.CutOffRange(nil, nil)
 		root, _ := tree.Find(0)
 		assert.Nil(t, root)
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This commit fix some bugs in text deletion, from malfunction of
splay tree range deletion and misfiltering for deleted nodes.

(https://github.com/yorkie-team/yorkie-js-sdk/pull/321)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
