### PR TITLE
rebuild : applying split tree range isolation

### DIFF
--- a/pkg/document/json/rga_tree_split.go
+++ b/pkg/document/json/rga_tree_split.go
@@ -484,8 +484,8 @@ func (s *RGATreeSplit[V]) deleteNodes(
 	}
 
 	// There are 2 types of nodes in `candidates` : should delete, should not delete.
-    // `nodesToKeep` contains nodes should not delete,
-    // then is used to find the boundary of the range to be deleted.
+	// `nodesToKeep` contains nodes should not delete,
+	// then is used to find the boundary of the range to be deleted.
 	var nodesToKeep []*RGATreeSplitNode[V]
 	leftEdge, rightEdge := s.findEdgesOfCandidates(candidates)
 	nodesToKeep = append(nodesToKeep, leftEdge)

--- a/pkg/document/json/rga_tree_split.go
+++ b/pkg/document/json/rga_tree_split.go
@@ -506,7 +506,6 @@ func (s *RGATreeSplit[V]) deleteNodes(
 		}
 
 		if node.Remove(editedAt, latestCreatedAt) {
-			s.treeByIndex.Splay(node.indexNode)
 			latestCreatedAt := createdAtMapByActor[actorIDHex]
 			createdAt := node.id.createdAt
 			if latestCreatedAt == nil || createdAt.After(latestCreatedAt) {

--- a/pkg/splay/splay.go
+++ b/pkg/splay/splay.go
@@ -316,7 +316,9 @@ func (t *Tree[V]) checkRangeSeparation(leftBoundary, rightBoundary *Node[V]) {
 		panic("Invalid argument for Boundary")
 	}
 	// rightBoundary must be root.right or root.right.right
-	if t.root.right != rightBoundary && t.root.right.right != rightBoundary {
+	if t.root.right == nil ||
+		(t.root.right != rightBoundary &&
+			t.root.right.right != rightBoundary) {
 		panic("Invalid argument for Boundary")
 	}
 }

--- a/pkg/splay/splay.go
+++ b/pkg/splay/splay.go
@@ -14,345 +14,389 @@
  * limitations under the License.
  */
 
-package splay
+ package splay
 
-import (
-	"fmt"
-	"strings"
-)
-
-// Value represents the data stored in the nodes of Tree.
-type Value interface {
-	Len() int
-	String() string
-}
-
-// Node is a node of Tree.
-type Node[V Value] struct {
-	value  V
-	weight int
-
-	left   *Node[V]
-	right  *Node[V]
-	parent *Node[V]
-}
-
-// NewNode creates a new instance of Node.
-func NewNode[V Value](value V) *Node[V] {
-	n := &Node[V]{
-		value: value,
-	}
-	n.initWeight()
-	return n
-}
-
-// Value returns the value of this Node.
-func (t *Node[V]) Value() V {
-	return t.value
-}
-
-func (t *Node[V]) leftWeight() int {
-	if t.left == nil {
-		return 0
-	}
-	return t.left.weight
-}
-
-func (t *Node[V]) rightWeight() int {
-	if t.right == nil {
-		return 0
-	}
-	return t.right.weight
-}
-
-func (t *Node[V]) initWeight() {
-	t.weight = t.value.Len()
-}
-
-func (t *Node[V]) increaseWeight(weight int) {
-	t.weight += weight
-}
-
-func (t *Node[V]) unlink() {
-	t.parent = nil
-	t.right = nil
-	t.left = nil
-}
-
-func (t *Node[V]) hasLinks() bool {
-	return t.parent != nil || t.left != nil || t.right != nil
-}
-
-// Tree is weighted binary search tree which is based on Splay tree.
-// original paper on Splay Trees:
-//  - https://www.cs.cmu.edu/~sleator/papers/self-adjusting.pdf
-type Tree[V Value] struct {
-	root *Node[V]
-}
-
-// NewTree creates a new instance of Tree.
-func NewTree[V Value](root *Node[V]) *Tree[V] {
-	return &Tree[V]{
-		root: root,
-	}
-}
-
-// Insert inserts the node at the last.
-func (t *Tree[V]) Insert(node *Node[V]) *Node[V] {
-	if t.root == nil {
-		t.root = node
-		return node
-	}
-
-	return t.InsertAfter(t.root, node)
-}
-
-// InsertAfter inserts the node after the given previous node.
-func (t *Tree[V]) InsertAfter(prev *Node[V], node *Node[V]) *Node[V] {
-	t.Splay(prev)
-	t.root = node
-	node.right = prev.right
-	if prev.right != nil {
-		prev.right.parent = node
-	}
-	node.left = prev
-	prev.parent = node
-	prev.right = nil
-
-	t.UpdateWeight(prev)
-	t.UpdateWeight(node)
-
-	return node
-}
-
-// Splay moves the given node to the root.
-func (t *Tree[V]) Splay(node *Node[V]) {
-	if node == nil {
-		return
-	}
-
-	for {
-		if isLeftChild(node.parent) && isRightChild(node) {
-			// zig-zag
-			t.rotateLeft(node)
-			t.rotateRight(node)
-		} else if isRightChild(node.parent) && isLeftChild(node) {
-			// zig-zag
-			t.rotateRight(node)
-			t.rotateLeft(node)
-		} else if isLeftChild(node.parent) && isLeftChild(node) {
-			// zig-zig
-			t.rotateRight(node.parent)
-			t.rotateRight(node)
-		} else if isRightChild(node.parent) && isRightChild(node) {
-			// zig-zig
-			t.rotateLeft(node.parent)
-			t.rotateLeft(node)
-		} else {
-			// zig
-			if isLeftChild(node) {
-				t.rotateRight(node)
-			} else if isRightChild(node) {
-				t.rotateLeft(node)
-			}
-			return
-		}
-	}
-}
-
-// IndexOf Find the index of the given node.
-func (t *Tree[V]) IndexOf(node *Node[V]) int {
-	if node == nil || !node.hasLinks() {
-		return -1
-	}
-
-	index := 0
-	current := node
-	var prev *Node[V]
-	for current != nil {
-		if prev == nil || prev == current.right {
-			index += current.value.Len() + current.leftWeight()
-		}
-		prev = current
-		current = current.parent
-	}
-	return index - node.value.Len()
-}
-
-// Find returns the Node and offset of the given index.
-func (t *Tree[V]) Find(index int) (*Node[V], int) {
-	if t.root == nil {
-		return nil, 0
-	}
-
-	node := t.root
-	offset := index
-	for {
-		if node.left != nil && offset <= node.leftWeight() {
-			node = node.left
-		} else if node.right != nil && node.leftWeight()+node.value.Len() < offset {
-			offset -= node.leftWeight() + node.value.Len()
-			node = node.right
-		} else {
-			offset -= node.leftWeight()
-			break
-		}
-	}
-
-	if offset > node.value.Len() {
-		panic(fmt.Sprintf(
-			"out of bound of text index: node.length %d, pos %d",
-			node.value.Len(),
-			offset,
-		))
-	}
-
-	return node, offset
-}
-
-// String returns a string containing node values.
-func (t *Tree[V]) String() string {
-	var builder strings.Builder
-	traverseInOrder(t.root, func(node *Node[V]) {
-		builder.WriteString(node.value.String())
-	})
-	return builder.String()
-}
-
-// AnnotatedString returns a string containing the metadata of the Node
-// for debugging purpose.
-func (t *Tree[V]) AnnotatedString() string {
-	var builder strings.Builder
-
-	traverseInOrder(t.root, func(node *Node[V]) {
-		builder.WriteString(fmt.Sprintf(
-			"[%d,%d]%s",
-			node.weight,
-			node.value.Len(),
-			node.value.String(),
-		))
-	})
-	return builder.String()
-}
-
-// UpdateWeight recalculates the weight of this node with the value and children.
-func (t *Tree[V]) UpdateWeight(node *Node[V]) {
-	node.initWeight()
-
-	if node.left != nil {
-		node.increaseWeight(node.leftWeight())
-	}
-
-	if node.right != nil {
-		node.increaseWeight(node.rightWeight())
-	}
-}
-
-// Delete deletes the given node from this Tree.
-func (t *Tree[V]) Delete(node *Node[V]) {
-	t.Splay(node)
-
-	leftTree := NewTree(node.left)
-	if leftTree.root != nil {
-		leftTree.root.parent = nil
-	}
-
-	rightTree := NewTree(node.right)
-	if rightTree.root != nil {
-		rightTree.root.parent = nil
-	}
-
-	if leftTree.root != nil {
-		maxNode := leftTree.maximum()
-		leftTree.Splay(maxNode)
-		leftTree.root.right = rightTree.root
-		if rightTree.root != nil {
-			rightTree.root.parent = leftTree.root
-		}
-		t.root = leftTree.root
-	} else {
-		t.root = rightTree.root
-	}
-
-	node.unlink()
-	if t.root != nil {
-		t.UpdateWeight(t.root)
-	}
-}
-
-func (t *Tree[V]) rotateLeft(pivot *Node[V]) {
-	root := pivot.parent
-	if root.parent != nil {
-		if root == root.parent.left {
-			root.parent.left = pivot
-		} else {
-			root.parent.right = pivot
-		}
-	} else {
-		t.root = pivot
-	}
-
-	pivot.parent = root.parent
-
-	root.right = pivot.left
-	if root.right != nil {
-		root.right.parent = root
-	}
-
-	pivot.left = root
-	pivot.left.parent = pivot
-
-	t.UpdateWeight(root)
-	t.UpdateWeight(pivot)
-}
-
-func (t *Tree[V]) rotateRight(pivot *Node[V]) {
-	root := pivot.parent
-	if root.parent != nil {
-		if root == root.parent.left {
-			root.parent.left = pivot
-		} else {
-			root.parent.right = pivot
-		}
-	} else {
-		t.root = pivot
-	}
-	pivot.parent = root.parent
-
-	root.left = pivot.right
-	if root.left != nil {
-		root.left.parent = root
-	}
-
-	pivot.right = root
-	pivot.right.parent = pivot
-
-	t.UpdateWeight(root)
-	t.UpdateWeight(pivot)
-}
-
-func (t *Tree[V]) maximum() *Node[V] {
-	node := t.root
-	for node.right != nil {
-		node = node.right
-	}
-	return node
-}
-
-func traverseInOrder[V Value](node *Node[V], callback func(node *Node[V])) {
-	if node == nil {
-		return
-	}
-
-	traverseInOrder(node.left, callback)
-	callback(node)
-	traverseInOrder(node.right, callback)
-}
-
-func isLeftChild[V Value](node *Node[V]) bool {
-	return node != nil && node.parent != nil && node.parent.left == node
-}
-
-func isRightChild[V Value](node *Node[V]) bool {
-	return node != nil && node.parent != nil && node.parent.right == node
-}
+ import (
+	 "fmt"
+	 "strings"
+ )
+ 
+ // Value represents the data stored in the nodes of Tree.
+ type Value interface {
+	 Len() int
+	 String() string
+ }
+ 
+ // Node is a node of Tree.
+ type Node[V Value] struct {
+	 value  V
+	 weight int
+ 
+	 left   *Node[V]
+	 right  *Node[V]
+	 parent *Node[V]
+ }
+ 
+ // NewNode creates a new instance of Node.
+ func NewNode[V Value](value V) *Node[V] {
+	 n := &Node[V]{
+		 value: value,
+	 }
+	 n.initWeight()
+	 return n
+ }
+ 
+ // Value returns the value of this Node.
+ func (t *Node[V]) Value() V {
+	 return t.value
+ }
+ 
+ func (t *Node[V]) leftWeight() int {
+	 if t.left == nil {
+		 return 0
+	 }
+	 return t.left.weight
+ }
+ 
+ func (t *Node[V]) rightWeight() int {
+	 if t.right == nil {
+		 return 0
+	 }
+	 return t.right.weight
+ }
+ 
+ func (t *Node[V]) initWeight() {
+	 t.weight = t.value.Len()
+ }
+ 
+ func (t *Node[V]) increaseWeight(weight int) {
+	 t.weight += weight
+ }
+ 
+ func (t *Node[V]) unlink() {
+	 t.parent = nil
+	 t.right = nil
+	 t.left = nil
+ }
+ 
+ func (t *Node[V]) hasLinks() bool {
+	 return t.parent != nil || t.left != nil || t.right != nil
+ }
+ 
+ // Tree is weighted binary search tree which is based on Splay tree.
+ // original paper on Splay Trees:
+ //  - https://www.cs.cmu.edu/~sleator/papers/self-adjusting.pdf
+ type Tree[V Value] struct {
+	 root *Node[V]
+ }
+ 
+ // NewTree creates a new instance of Tree.
+ func NewTree[V Value](root *Node[V]) *Tree[V] {
+	 return &Tree[V]{
+		 root: root,
+	 }
+ }
+ 
+ // Insert inserts the node at the last.
+ func (t *Tree[V]) Insert(node *Node[V]) *Node[V] {
+	 if t.root == nil {
+		 t.root = node
+		 return node
+	 }
+ 
+	 return t.InsertAfter(t.root, node)
+ }
+ 
+ // InsertAfter inserts the node after the given previous node.
+ func (t *Tree[V]) InsertAfter(prev *Node[V], node *Node[V]) *Node[V] {
+	 t.Splay(prev)
+	 t.root = node
+	 node.right = prev.right
+	 if prev.right != nil {
+		 prev.right.parent = node
+	 }
+	 node.left = prev
+	 prev.parent = node
+	 prev.right = nil
+ 
+	 t.UpdateWeight(prev)
+	 t.UpdateWeight(node)
+ 
+	 return node
+ }
+ 
+ // Splay moves the given node to the root.
+ func (t *Tree[V]) Splay(node *Node[V]) {
+	 if node == nil {
+		 return
+	 }
+ 
+	 for {
+		 if isLeftChild(node.parent) && isRightChild(node) {
+			 // zig-zag
+			 t.rotateLeft(node)
+			 t.rotateRight(node)
+		 } else if isRightChild(node.parent) && isLeftChild(node) {
+			 // zig-zag
+			 t.rotateRight(node)
+			 t.rotateLeft(node)
+		 } else if isLeftChild(node.parent) && isLeftChild(node) {
+			 // zig-zig
+			 t.rotateRight(node.parent)
+			 t.rotateRight(node)
+		 } else if isRightChild(node.parent) && isRightChild(node) {
+			 // zig-zig
+			 t.rotateLeft(node.parent)
+			 t.rotateLeft(node)
+		 } else {
+			 // zig
+			 if isLeftChild(node) {
+				 t.rotateRight(node)
+			 } else if isRightChild(node) {
+				 t.rotateLeft(node)
+			 }
+			 return
+		 }
+	 }
+ }
+ 
+ // IndexOf Find the index of the given node.
+ func (t *Tree[V]) IndexOf(node *Node[V]) int {
+	 if node == nil || !node.hasLinks() {
+		 return -1
+	 }
+ 
+	 index := 0
+	 current := node
+	 var prev *Node[V]
+	 for current != nil {
+		 if prev == nil || prev == current.right {
+			 index += current.value.Len() + current.leftWeight()
+		 }
+		 prev = current
+		 current = current.parent
+	 }
+	 return index - node.value.Len()
+ }
+ 
+ // Find returns the Node and offset of the given index.
+ func (t *Tree[V]) Find(index int) (*Node[V], int) {
+	 if t.root == nil {
+		 return nil, 0
+	 }
+ 
+	 node := t.root
+	 offset := index
+	 for {
+		 if node.left != nil && offset <= node.leftWeight() {
+			 node = node.left
+		 } else if node.right != nil && node.leftWeight()+node.value.Len() < offset {
+			 offset -= node.leftWeight() + node.value.Len()
+			 node = node.right
+		 } else {
+			 offset -= node.leftWeight()
+			 break
+		 }
+	 }
+ 
+	 if offset > node.value.Len() {
+		 panic(fmt.Sprintf(
+			 "out of bound of text index: node.length %d, pos %d",
+			 node.value.Len(),
+			 offset,
+		 ))
+	 }
+ 
+	 return node, offset
+ }
+ 
+ // String returns a string containing node values.
+ func (t *Tree[V]) String() string {
+	 var builder strings.Builder
+	 traverseInOrder(t.root, func(node *Node[V]) {
+		 builder.WriteString(node.value.String())
+	 })
+	 return builder.String()
+ }
+ 
+ // AnnotatedString returns a string containing the metadata of the Node
+ // for debugging purpose.
+ func (t *Tree[V]) AnnotatedString() string {
+	 var builder strings.Builder
+ 
+	 traverseInOrder(t.root, func(node *Node[V]) {
+		 builder.WriteString(fmt.Sprintf(
+			 "[%d,%d]%s",
+			 node.weight,
+			 node.value.Len(),
+			 node.value.String(),
+		 ))
+	 })
+	 return builder.String()
+ }
+ 
+ // UpdateWeight recalculates the weight of this node with the value and children.
+ func (t *Tree[V]) UpdateWeight(node *Node[V]) {
+	 node.initWeight()
+ 
+	 if node.left != nil {
+		 node.increaseWeight(node.leftWeight())
+	 }
+ 
+	 if node.right != nil {
+		 node.increaseWeight(node.rightWeight())
+	 }
+ }
+ 
+ 
+ // Delete deletes the given node from this Tree.
+ func (t *Tree[V]) Delete(node *Node[V]) {
+	 t.Splay(node)
+ 
+	 leftTree := NewTree(node.left)
+	 if leftTree.root != nil {
+		 leftTree.root.parent = nil
+	 }
+ 
+	 rightTree := NewTree(node.right)
+	 if rightTree.root != nil {
+		 rightTree.root.parent = nil
+	 }
+ 
+	 if leftTree.root != nil {
+		 maxNode := leftTree.maximum()
+		 leftTree.Splay(maxNode)
+		 leftTree.root.right = rightTree.root
+		 if rightTree.root != nil {
+			 rightTree.root.parent = leftTree.root
+		 }
+		 t.root = leftTree.root
+	 } else {
+		 t.root = rightTree.root
+	 }
+ 
+	 node.unlink()
+	 if t.root != nil {
+		 t.UpdateWeight(t.root)
+	 }
+ }
+ 
+ // CutOffRange cuts the range between given 2 boundaries from this Tree.
+ // This function separates the range as a subtree
+ // by splaying outer nodes (then cuts the subtree but not yet implemented).
+ // leftBoundary, rightBoundary are not included in the range to cut,
+ // and they could be nil, meaning to delete to the end of the tree.
+ func (t *Tree[V]) CutOffRange(leftBoundary, rightBoundary *Node[V]) {
+	 if leftBoundary == nil && rightBoundary == nil {
+		 // Absence of both boundaries means the deletion of the entire.
+		 t.root = nil
+		 return
+	 }
+	 if leftBoundary == nil {
+		 // Absence of leftBoundary means the deletion
+		   // from start of the tree to rightBoundary.
+		 t.Splay(rightBoundary)
+		 return
+	 }
+	 if rightBoundary == nil {
+		 // Absence of rightBoundary means the deletion
+		  // from leftBoundary to the end of the tree.
+		 t.Splay(leftBoundary)
+		 return
+	 }
+	 // The other cases, separate range as a subtree to splay 2 boundaries.
+	 t.Splay(rightBoundary)
+	 t.Splay(leftBoundary)
+	 t.checkRangeSeparation(leftBoundary, rightBoundary)
+ 
+ }
+ 
+ func (t *Tree[V]) checkRangeSeparation(leftBoundary, rightBoundary *Node[V]) {
+	 // leftBoundary must be root
+	 if t.root != leftBoundary {
+		 panic("Invalid argument for Boundary")
+	 }
+	 // rightBoundary must be root.right or root.right.right
+	 if t.root.right != rightBoundary && t.root.right.right != rightBoundary {
+		 panic("Invalid argument for Boundary")
+	 }
+ }
+ 
+ 
+ func (t *Tree[V]) rotateLeft(pivot *Node[V]) {
+	 root := pivot.parent
+	 if root.parent != nil {
+		 if root == root.parent.left {
+			 root.parent.left = pivot
+		 } else {
+			 root.parent.right = pivot
+		 }
+	 } else {
+		 t.root = pivot
+	 }
+ 
+	 pivot.parent = root.parent
+ 
+	 root.right = pivot.left
+	 if root.right != nil {
+		 root.right.parent = root
+	 }
+ 
+	 pivot.left = root
+	 pivot.left.parent = pivot
+ 
+	 t.UpdateWeight(root)
+	 t.UpdateWeight(pivot)
+ }
+ 
+ func (t *Tree[V]) rotateRight(pivot *Node[V]) {
+	 root := pivot.parent
+	 if root.parent != nil {
+		 if root == root.parent.left {
+			 root.parent.left = pivot
+		 } else {
+			 root.parent.right = pivot
+		 }
+	 } else {
+		 t.root = pivot
+	 }
+	 pivot.parent = root.parent
+ 
+	 root.left = pivot.right
+	 if root.left != nil {
+		 root.left.parent = root
+	 }
+ 
+	 pivot.right = root
+	 pivot.right.parent = pivot
+ 
+	 t.UpdateWeight(root)
+	 t.UpdateWeight(pivot)
+ }
+ 
+ func (t *Tree[V]) maximum() *Node[V] {
+	 node := t.root
+	 for node.right != nil {
+		 node = node.right
+	 }
+	 return node
+ }
+ 
+ func traverseInOrder[V Value](node *Node[V], callback func(node *Node[V])) {
+	 if node == nil {
+		 return
+	 }
+ 
+	 traverseInOrder(node.left, callback)
+	 callback(node)
+	 traverseInOrder(node.right, callback)
+ }
+ 
+ func isLeftChild[V Value](node *Node[V]) bool {
+	 return node != nil && node.parent != nil && node.parent.left == node
+ }
+ 
+ func isRightChild[V Value](node *Node[V]) bool {
+	 return node != nil && node.parent != nil && node.parent.right == node
+ }
+ 

--- a/pkg/splay/splay.go
+++ b/pkg/splay/splay.go
@@ -248,6 +248,14 @@ func (t *Tree[V]) UpdateWeight(node *Node[V]) {
 	}
 }
 
+// FreeWeight set the weiht is 0. This function only uses in range deletion.
+func (t *Tree[V]) FreeWeight(node *Node[V]) {
+	node.initWeight()
+	if node.weight != 0 {
+		panic("node is not removed")
+	}
+}
+
 // Delete deletes the given node from this Tree.
 func (t *Tree[V]) Delete(node *Node[V]) {
 	t.Splay(node)

--- a/pkg/splay/splay.go
+++ b/pkg/splay/splay.go
@@ -14,389 +14,386 @@
  * limitations under the License.
  */
 
- package splay
+package splay
 
- import (
-	 "fmt"
-	 "strings"
- )
- 
- // Value represents the data stored in the nodes of Tree.
- type Value interface {
-	 Len() int
-	 String() string
- }
- 
- // Node is a node of Tree.
- type Node[V Value] struct {
-	 value  V
-	 weight int
- 
-	 left   *Node[V]
-	 right  *Node[V]
-	 parent *Node[V]
- }
- 
- // NewNode creates a new instance of Node.
- func NewNode[V Value](value V) *Node[V] {
-	 n := &Node[V]{
-		 value: value,
-	 }
-	 n.initWeight()
-	 return n
- }
- 
- // Value returns the value of this Node.
- func (t *Node[V]) Value() V {
-	 return t.value
- }
- 
- func (t *Node[V]) leftWeight() int {
-	 if t.left == nil {
-		 return 0
-	 }
-	 return t.left.weight
- }
- 
- func (t *Node[V]) rightWeight() int {
-	 if t.right == nil {
-		 return 0
-	 }
-	 return t.right.weight
- }
- 
- func (t *Node[V]) initWeight() {
-	 t.weight = t.value.Len()
- }
- 
- func (t *Node[V]) increaseWeight(weight int) {
-	 t.weight += weight
- }
- 
- func (t *Node[V]) unlink() {
-	 t.parent = nil
-	 t.right = nil
-	 t.left = nil
- }
- 
- func (t *Node[V]) hasLinks() bool {
-	 return t.parent != nil || t.left != nil || t.right != nil
- }
- 
- // Tree is weighted binary search tree which is based on Splay tree.
- // original paper on Splay Trees:
- //  - https://www.cs.cmu.edu/~sleator/papers/self-adjusting.pdf
- type Tree[V Value] struct {
-	 root *Node[V]
- }
- 
- // NewTree creates a new instance of Tree.
- func NewTree[V Value](root *Node[V]) *Tree[V] {
-	 return &Tree[V]{
-		 root: root,
-	 }
- }
- 
- // Insert inserts the node at the last.
- func (t *Tree[V]) Insert(node *Node[V]) *Node[V] {
-	 if t.root == nil {
-		 t.root = node
-		 return node
-	 }
- 
-	 return t.InsertAfter(t.root, node)
- }
- 
- // InsertAfter inserts the node after the given previous node.
- func (t *Tree[V]) InsertAfter(prev *Node[V], node *Node[V]) *Node[V] {
-	 t.Splay(prev)
-	 t.root = node
-	 node.right = prev.right
-	 if prev.right != nil {
-		 prev.right.parent = node
-	 }
-	 node.left = prev
-	 prev.parent = node
-	 prev.right = nil
- 
-	 t.UpdateWeight(prev)
-	 t.UpdateWeight(node)
- 
-	 return node
- }
- 
- // Splay moves the given node to the root.
- func (t *Tree[V]) Splay(node *Node[V]) {
-	 if node == nil {
-		 return
-	 }
- 
-	 for {
-		 if isLeftChild(node.parent) && isRightChild(node) {
-			 // zig-zag
-			 t.rotateLeft(node)
-			 t.rotateRight(node)
-		 } else if isRightChild(node.parent) && isLeftChild(node) {
-			 // zig-zag
-			 t.rotateRight(node)
-			 t.rotateLeft(node)
-		 } else if isLeftChild(node.parent) && isLeftChild(node) {
-			 // zig-zig
-			 t.rotateRight(node.parent)
-			 t.rotateRight(node)
-		 } else if isRightChild(node.parent) && isRightChild(node) {
-			 // zig-zig
-			 t.rotateLeft(node.parent)
-			 t.rotateLeft(node)
-		 } else {
-			 // zig
-			 if isLeftChild(node) {
-				 t.rotateRight(node)
-			 } else if isRightChild(node) {
-				 t.rotateLeft(node)
-			 }
-			 return
-		 }
-	 }
- }
- 
- // IndexOf Find the index of the given node.
- func (t *Tree[V]) IndexOf(node *Node[V]) int {
-	 if node == nil || !node.hasLinks() {
-		 return -1
-	 }
- 
-	 index := 0
-	 current := node
-	 var prev *Node[V]
-	 for current != nil {
-		 if prev == nil || prev == current.right {
-			 index += current.value.Len() + current.leftWeight()
-		 }
-		 prev = current
-		 current = current.parent
-	 }
-	 return index - node.value.Len()
- }
- 
- // Find returns the Node and offset of the given index.
- func (t *Tree[V]) Find(index int) (*Node[V], int) {
-	 if t.root == nil {
-		 return nil, 0
-	 }
- 
-	 node := t.root
-	 offset := index
-	 for {
-		 if node.left != nil && offset <= node.leftWeight() {
-			 node = node.left
-		 } else if node.right != nil && node.leftWeight()+node.value.Len() < offset {
-			 offset -= node.leftWeight() + node.value.Len()
-			 node = node.right
-		 } else {
-			 offset -= node.leftWeight()
-			 break
-		 }
-	 }
- 
-	 if offset > node.value.Len() {
-		 panic(fmt.Sprintf(
-			 "out of bound of text index: node.length %d, pos %d",
-			 node.value.Len(),
-			 offset,
-		 ))
-	 }
- 
-	 return node, offset
- }
- 
- // String returns a string containing node values.
- func (t *Tree[V]) String() string {
-	 var builder strings.Builder
-	 traverseInOrder(t.root, func(node *Node[V]) {
-		 builder.WriteString(node.value.String())
-	 })
-	 return builder.String()
- }
- 
- // AnnotatedString returns a string containing the metadata of the Node
- // for debugging purpose.
- func (t *Tree[V]) AnnotatedString() string {
-	 var builder strings.Builder
- 
-	 traverseInOrder(t.root, func(node *Node[V]) {
-		 builder.WriteString(fmt.Sprintf(
-			 "[%d,%d]%s",
-			 node.weight,
-			 node.value.Len(),
-			 node.value.String(),
-		 ))
-	 })
-	 return builder.String()
- }
- 
- // UpdateWeight recalculates the weight of this node with the value and children.
- func (t *Tree[V]) UpdateWeight(node *Node[V]) {
-	 node.initWeight()
- 
-	 if node.left != nil {
-		 node.increaseWeight(node.leftWeight())
-	 }
- 
-	 if node.right != nil {
-		 node.increaseWeight(node.rightWeight())
-	 }
- }
- 
- 
- // Delete deletes the given node from this Tree.
- func (t *Tree[V]) Delete(node *Node[V]) {
-	 t.Splay(node)
- 
-	 leftTree := NewTree(node.left)
-	 if leftTree.root != nil {
-		 leftTree.root.parent = nil
-	 }
- 
-	 rightTree := NewTree(node.right)
-	 if rightTree.root != nil {
-		 rightTree.root.parent = nil
-	 }
- 
-	 if leftTree.root != nil {
-		 maxNode := leftTree.maximum()
-		 leftTree.Splay(maxNode)
-		 leftTree.root.right = rightTree.root
-		 if rightTree.root != nil {
-			 rightTree.root.parent = leftTree.root
-		 }
-		 t.root = leftTree.root
-	 } else {
-		 t.root = rightTree.root
-	 }
- 
-	 node.unlink()
-	 if t.root != nil {
-		 t.UpdateWeight(t.root)
-	 }
- }
- 
- // CutOffRange cuts the range between given 2 boundaries from this Tree.
- // This function separates the range as a subtree
- // by splaying outer nodes (then cuts the subtree but not yet implemented).
- // leftBoundary, rightBoundary are not included in the range to cut,
- // and they could be nil, meaning to delete to the end of the tree.
- func (t *Tree[V]) CutOffRange(leftBoundary, rightBoundary *Node[V]) {
-	 if leftBoundary == nil && rightBoundary == nil {
-		 // Absence of both boundaries means the deletion of the entire.
-		 t.root = nil
-		 return
-	 }
-	 if leftBoundary == nil {
-		 // Absence of leftBoundary means the deletion
-		   // from start of the tree to rightBoundary.
-		 t.Splay(rightBoundary)
-		 return
-	 }
-	 if rightBoundary == nil {
-		 // Absence of rightBoundary means the deletion
-		  // from leftBoundary to the end of the tree.
-		 t.Splay(leftBoundary)
-		 return
-	 }
-	 // The other cases, separate range as a subtree to splay 2 boundaries.
-	 t.Splay(rightBoundary)
-	 t.Splay(leftBoundary)
-	 t.checkRangeSeparation(leftBoundary, rightBoundary)
- 
- }
- 
- func (t *Tree[V]) checkRangeSeparation(leftBoundary, rightBoundary *Node[V]) {
-	 // leftBoundary must be root
-	 if t.root != leftBoundary {
-		 panic("Invalid argument for Boundary")
-	 }
-	 // rightBoundary must be root.right or root.right.right
-	 if t.root.right != rightBoundary && t.root.right.right != rightBoundary {
-		 panic("Invalid argument for Boundary")
-	 }
- }
- 
- 
- func (t *Tree[V]) rotateLeft(pivot *Node[V]) {
-	 root := pivot.parent
-	 if root.parent != nil {
-		 if root == root.parent.left {
-			 root.parent.left = pivot
-		 } else {
-			 root.parent.right = pivot
-		 }
-	 } else {
-		 t.root = pivot
-	 }
- 
-	 pivot.parent = root.parent
- 
-	 root.right = pivot.left
-	 if root.right != nil {
-		 root.right.parent = root
-	 }
- 
-	 pivot.left = root
-	 pivot.left.parent = pivot
- 
-	 t.UpdateWeight(root)
-	 t.UpdateWeight(pivot)
- }
- 
- func (t *Tree[V]) rotateRight(pivot *Node[V]) {
-	 root := pivot.parent
-	 if root.parent != nil {
-		 if root == root.parent.left {
-			 root.parent.left = pivot
-		 } else {
-			 root.parent.right = pivot
-		 }
-	 } else {
-		 t.root = pivot
-	 }
-	 pivot.parent = root.parent
- 
-	 root.left = pivot.right
-	 if root.left != nil {
-		 root.left.parent = root
-	 }
- 
-	 pivot.right = root
-	 pivot.right.parent = pivot
- 
-	 t.UpdateWeight(root)
-	 t.UpdateWeight(pivot)
- }
- 
- func (t *Tree[V]) maximum() *Node[V] {
-	 node := t.root
-	 for node.right != nil {
-		 node = node.right
-	 }
-	 return node
- }
- 
- func traverseInOrder[V Value](node *Node[V], callback func(node *Node[V])) {
-	 if node == nil {
-		 return
-	 }
- 
-	 traverseInOrder(node.left, callback)
-	 callback(node)
-	 traverseInOrder(node.right, callback)
- }
- 
- func isLeftChild[V Value](node *Node[V]) bool {
-	 return node != nil && node.parent != nil && node.parent.left == node
- }
- 
- func isRightChild[V Value](node *Node[V]) bool {
-	 return node != nil && node.parent != nil && node.parent.right == node
- }
- 
+import (
+	"fmt"
+	"strings"
+)
+
+// Value represents the data stored in the nodes of Tree.
+type Value interface {
+	Len() int
+	String() string
+}
+
+// Node is a node of Tree.
+type Node[V Value] struct {
+	value  V
+	weight int
+
+	left   *Node[V]
+	right  *Node[V]
+	parent *Node[V]
+}
+
+// NewNode creates a new instance of Node.
+func NewNode[V Value](value V) *Node[V] {
+	n := &Node[V]{
+		value: value,
+	}
+	n.initWeight()
+	return n
+}
+
+// Value returns the value of this Node.
+func (t *Node[V]) Value() V {
+	return t.value
+}
+
+func (t *Node[V]) leftWeight() int {
+	if t.left == nil {
+		return 0
+	}
+	return t.left.weight
+}
+
+func (t *Node[V]) rightWeight() int {
+	if t.right == nil {
+		return 0
+	}
+	return t.right.weight
+}
+
+func (t *Node[V]) initWeight() {
+	t.weight = t.value.Len()
+}
+
+func (t *Node[V]) increaseWeight(weight int) {
+	t.weight += weight
+}
+
+func (t *Node[V]) unlink() {
+	t.parent = nil
+	t.right = nil
+	t.left = nil
+}
+
+func (t *Node[V]) hasLinks() bool {
+	return t.parent != nil || t.left != nil || t.right != nil
+}
+
+// Tree is weighted binary search tree which is based on Splay tree.
+// original paper on Splay Trees:
+//  - https://www.cs.cmu.edu/~sleator/papers/self-adjusting.pdf
+type Tree[V Value] struct {
+	root *Node[V]
+}
+
+// NewTree creates a new instance of Tree.
+func NewTree[V Value](root *Node[V]) *Tree[V] {
+	return &Tree[V]{
+		root: root,
+	}
+}
+
+// Insert inserts the node at the last.
+func (t *Tree[V]) Insert(node *Node[V]) *Node[V] {
+	if t.root == nil {
+		t.root = node
+		return node
+	}
+
+	return t.InsertAfter(t.root, node)
+}
+
+// InsertAfter inserts the node after the given previous node.
+func (t *Tree[V]) InsertAfter(prev *Node[V], node *Node[V]) *Node[V] {
+	t.Splay(prev)
+	t.root = node
+	node.right = prev.right
+	if prev.right != nil {
+		prev.right.parent = node
+	}
+	node.left = prev
+	prev.parent = node
+	prev.right = nil
+
+	t.UpdateWeight(prev)
+	t.UpdateWeight(node)
+
+	return node
+}
+
+// Splay moves the given node to the root.
+func (t *Tree[V]) Splay(node *Node[V]) {
+	if node == nil {
+		return
+	}
+
+	for {
+		if isLeftChild(node.parent) && isRightChild(node) {
+			// zig-zag
+			t.rotateLeft(node)
+			t.rotateRight(node)
+		} else if isRightChild(node.parent) && isLeftChild(node) {
+			// zig-zag
+			t.rotateRight(node)
+			t.rotateLeft(node)
+		} else if isLeftChild(node.parent) && isLeftChild(node) {
+			// zig-zig
+			t.rotateRight(node.parent)
+			t.rotateRight(node)
+		} else if isRightChild(node.parent) && isRightChild(node) {
+			// zig-zig
+			t.rotateLeft(node.parent)
+			t.rotateLeft(node)
+		} else {
+			// zig
+			if isLeftChild(node) {
+				t.rotateRight(node)
+			} else if isRightChild(node) {
+				t.rotateLeft(node)
+			}
+			return
+		}
+	}
+}
+
+// IndexOf Find the index of the given node.
+func (t *Tree[V]) IndexOf(node *Node[V]) int {
+	if node == nil || !node.hasLinks() {
+		return -1
+	}
+
+	index := 0
+	current := node
+	var prev *Node[V]
+	for current != nil {
+		if prev == nil || prev == current.right {
+			index += current.value.Len() + current.leftWeight()
+		}
+		prev = current
+		current = current.parent
+	}
+	return index - node.value.Len()
+}
+
+// Find returns the Node and offset of the given index.
+func (t *Tree[V]) Find(index int) (*Node[V], int) {
+	if t.root == nil {
+		return nil, 0
+	}
+
+	node := t.root
+	offset := index
+	for {
+		if node.left != nil && offset <= node.leftWeight() {
+			node = node.left
+		} else if node.right != nil && node.leftWeight()+node.value.Len() < offset {
+			offset -= node.leftWeight() + node.value.Len()
+			node = node.right
+		} else {
+			offset -= node.leftWeight()
+			break
+		}
+	}
+
+	if offset > node.value.Len() {
+		panic(fmt.Sprintf(
+			"out of bound of text index: node.length %d, pos %d",
+			node.value.Len(),
+			offset,
+		))
+	}
+
+	return node, offset
+}
+
+// String returns a string containing node values.
+func (t *Tree[V]) String() string {
+	var builder strings.Builder
+	traverseInOrder(t.root, func(node *Node[V]) {
+		builder.WriteString(node.value.String())
+	})
+	return builder.String()
+}
+
+// AnnotatedString returns a string containing the metadata of the Node
+// for debugging purpose.
+func (t *Tree[V]) AnnotatedString() string {
+	var builder strings.Builder
+
+	traverseInOrder(t.root, func(node *Node[V]) {
+		builder.WriteString(fmt.Sprintf(
+			"[%d,%d]%s",
+			node.weight,
+			node.value.Len(),
+			node.value.String(),
+		))
+	})
+	return builder.String()
+}
+
+// UpdateWeight recalculates the weight of this node with the value and children.
+func (t *Tree[V]) UpdateWeight(node *Node[V]) {
+	node.initWeight()
+
+	if node.left != nil {
+		node.increaseWeight(node.leftWeight())
+	}
+
+	if node.right != nil {
+		node.increaseWeight(node.rightWeight())
+	}
+}
+
+// Delete deletes the given node from this Tree.
+func (t *Tree[V]) Delete(node *Node[V]) {
+	t.Splay(node)
+
+	leftTree := NewTree(node.left)
+	if leftTree.root != nil {
+		leftTree.root.parent = nil
+	}
+
+	rightTree := NewTree(node.right)
+	if rightTree.root != nil {
+		rightTree.root.parent = nil
+	}
+
+	if leftTree.root != nil {
+		maxNode := leftTree.maximum()
+		leftTree.Splay(maxNode)
+		leftTree.root.right = rightTree.root
+		if rightTree.root != nil {
+			rightTree.root.parent = leftTree.root
+		}
+		t.root = leftTree.root
+	} else {
+		t.root = rightTree.root
+	}
+
+	node.unlink()
+	if t.root != nil {
+		t.UpdateWeight(t.root)
+	}
+}
+
+// CutOffRange cuts the range between given 2 boundaries from this Tree.
+// This function separates the range as a subtree
+// by splaying outer nodes (then cuts the subtree but not yet implemented).
+// leftBoundary, rightBoundary are not included in the range to cut,
+// and they could be nil, meaning to delete to the end of the tree.
+func (t *Tree[V]) CutOffRange(leftBoundary, rightBoundary *Node[V]) {
+	if leftBoundary == nil && rightBoundary == nil {
+		// Absence of both boundaries means the deletion of the entire.
+		t.root = nil
+		return
+	}
+	if leftBoundary == nil {
+		// Absence of leftBoundary means the deletion
+		// from start of the tree to rightBoundary.
+		t.Splay(rightBoundary)
+		return
+	}
+	if rightBoundary == nil {
+		// Absence of rightBoundary means the deletion
+		// from leftBoundary to the end of the tree.
+		t.Splay(leftBoundary)
+		return
+	}
+	// The other cases, separate range as a subtree to splay 2 boundaries.
+	t.Splay(rightBoundary)
+	t.Splay(leftBoundary)
+	t.checkRangeSeparation(leftBoundary, rightBoundary)
+
+}
+
+func (t *Tree[V]) checkRangeSeparation(leftBoundary, rightBoundary *Node[V]) {
+	// leftBoundary must be root
+	if t.root != leftBoundary {
+		panic("Invalid argument for Boundary")
+	}
+	// rightBoundary must be root.right or root.right.right
+	if t.root.right != rightBoundary && t.root.right.right != rightBoundary {
+		panic("Invalid argument for Boundary")
+	}
+}
+
+func (t *Tree[V]) rotateLeft(pivot *Node[V]) {
+	root := pivot.parent
+	if root.parent != nil {
+		if root == root.parent.left {
+			root.parent.left = pivot
+		} else {
+			root.parent.right = pivot
+		}
+	} else {
+		t.root = pivot
+	}
+
+	pivot.parent = root.parent
+
+	root.right = pivot.left
+	if root.right != nil {
+		root.right.parent = root
+	}
+
+	pivot.left = root
+	pivot.left.parent = pivot
+
+	t.UpdateWeight(root)
+	t.UpdateWeight(pivot)
+}
+
+func (t *Tree[V]) rotateRight(pivot *Node[V]) {
+	root := pivot.parent
+	if root.parent != nil {
+		if root == root.parent.left {
+			root.parent.left = pivot
+		} else {
+			root.parent.right = pivot
+		}
+	} else {
+		t.root = pivot
+	}
+	pivot.parent = root.parent
+
+	root.left = pivot.right
+	if root.left != nil {
+		root.left.parent = root
+	}
+
+	pivot.right = root
+	pivot.right.parent = pivot
+
+	t.UpdateWeight(root)
+	t.UpdateWeight(pivot)
+}
+
+func (t *Tree[V]) maximum() *Node[V] {
+	node := t.root
+	for node.right != nil {
+		node = node.right
+	}
+	return node
+}
+
+func traverseInOrder[V Value](node *Node[V], callback func(node *Node[V])) {
+	if node == nil {
+		return
+	}
+
+	traverseInOrder(node.left, callback)
+	callback(node)
+	traverseInOrder(node.right, callback)
+}
+
+func isLeftChild[V Value](node *Node[V]) bool {
+	return node != nil && node.parent != nil && node.parent.left == node
+}
+
+func isRightChild[V Value](node *Node[V]) bool {
+	return node != nil && node.parent != nil && node.parent.right == node
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

From the stable version, range isolation in splay tree is applied.
By not applying node deletion yet, it is expected that removed
nodes return correct index.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
