### PR TITLE
Add document list command

### DIFF
--- a/admin/client.go
+++ b/admin/client.go
@@ -160,6 +160,21 @@ func (c *Client) UpdateProject(
 	return converter.FromProject(response.Project)
 }
 
+// ListDocuments lists documents.
+func (c *Client) ListDocuments(ctx context.Context, projectName string) ([]*types.DocumentSummary, error) {
+	response, err := c.client.ListDocuments(
+		ctx,
+		&api.ListDocumentsRequest{
+			ProjectName: projectName,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return converter.FromDocumentSummaries(response.Documents)
+}
+
 // ListChangeSummaries returns the change summaries of the given document.
 func (c *Client) ListChangeSummaries(
 	ctx context.Context,

--- a/api/converter/from_pb.go
+++ b/api/converter/from_pb.go
@@ -66,6 +66,43 @@ func FromProject(pbProject *api.Project) (*types.Project, error) {
 	}, nil
 }
 
+// FromDocumentSummaries converts the given Protobuf formats to model format.
+func FromDocumentSummaries(pbSummaries []*api.DocumentSummary) ([]*types.DocumentSummary, error) {
+	var summaries []*types.DocumentSummary
+	for _, pbSummary := range pbSummaries {
+		summary, err := FromDocumentSummary(pbSummary)
+		if err != nil {
+			return nil, err
+		}
+		summaries = append(summaries, summary)
+	}
+	return summaries, nil
+}
+
+// FromDocumentSummary converts the given Protobuf formats to model format.
+func FromDocumentSummary(pbSummary *api.DocumentSummary) (*types.DocumentSummary, error) {
+	createdAt, err := protoTypes.TimestampFromProto(pbSummary.CreatedAt)
+	if err != nil {
+		return nil, err
+	}
+	accessedAt, err := protoTypes.TimestampFromProto(pbSummary.AccessedAt)
+	if err != nil {
+		return nil, err
+	}
+	updatedAt, err := protoTypes.TimestampFromProto(pbSummary.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &types.DocumentSummary{
+		ID:         types.ID(pbSummary.Id),
+		Key:        key.Key(pbSummary.Key),
+		CreatedAt:  createdAt,
+		AccessedAt: accessedAt,
+		UpdatedAt:  updatedAt,
+		Snapshot:   pbSummary.Snapshot,
+	}, nil
+}
+
 // FromClient converts the given Protobuf formats to model format.
 func FromClient(pbClient *api.Client) (*types.Client, error) {
 	id, err := time.ActorIDFromBytes(pbClient.Id)

--- a/api/converter/to_pb.go
+++ b/api/converter/to_pb.go
@@ -69,6 +69,19 @@ func ToProject(project *types.Project) (*api.Project, error) {
 	}, nil
 }
 
+// ToDocumentSummaries converts the given model to Protobuf.
+func ToDocumentSummaries(summaries []*types.DocumentSummary) ([]*api.DocumentSummary, error) {
+	var pbSummaries []*api.DocumentSummary
+	for _, summary := range summaries {
+		pbSummary, err := ToDocumentSummary(summary)
+		if err != nil {
+			return nil, err
+		}
+		pbSummaries = append(pbSummaries, pbSummary)
+	}
+	return pbSummaries, nil
+}
+
 // ToDocumentSummary converts the given model to Protobuf format.
 func ToDocumentSummary(summary *types.DocumentSummary) (*api.DocumentSummary, error) {
 	pbCreatedAt, err := protoTypes.TimestampProto(summary.CreatedAt)
@@ -92,19 +105,6 @@ func ToDocumentSummary(summary *types.DocumentSummary) (*api.DocumentSummary, er
 		UpdatedAt:  pbUpdatedAt,
 		Snapshot:   summary.Snapshot,
 	}, nil
-}
-
-// ToDocumentSummaries converts the given model to Protobuf.
-func ToDocumentSummaries(summaries []*types.DocumentSummary) ([]*api.DocumentSummary, error) {
-	var pbSummaries []*api.DocumentSummary
-	for _, summary := range summaries {
-		pbSummary, err := ToDocumentSummary(summary)
-		if err != nil {
-			return nil, err
-		}
-		pbSummaries = append(pbSummaries, pbSummary)
-	}
-	return pbSummaries, nil
 }
 
 // ToClient converts the given model to Protobuf format.

--- a/cmd/yorkie/commands.go
+++ b/cmd/yorkie/commands.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/yorkie-team/yorkie/cmd/yorkie/config"
+	"github.com/yorkie-team/yorkie/cmd/yorkie/document"
 	"github.com/yorkie-team/yorkie/cmd/yorkie/project"
 )
 
@@ -39,6 +40,7 @@ func Run() int {
 
 func init() {
 	rootCmd.AddCommand(project.SubCmd)
+	rootCmd.AddCommand(document.SubCmd)
 	// TODO(chacha912): set adminAddr from env using viper.
 	// https://github.com/spf13/cobra/blob/main/user_guide.md#bind-flags-with-config
 	rootCmd.PersistentFlags().StringVar(&config.AdminAddr, "admin-addr", "localhost:11103", "Address of the admin server")

--- a/cmd/yorkie/document/document.go
+++ b/cmd/yorkie/document/document.go
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package document
+
+import "github.com/spf13/cobra"
+
+var (
+	// SubCmd represents the document command
+	SubCmd = &cobra.Command{
+		Use:   "document",
+		Short: "Manage documents",
+	}
+)

--- a/cmd/yorkie/document/list.go
+++ b/cmd/yorkie/document/list.go
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package document
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+
+	"github.com/yorkie-team/yorkie/admin"
+	"github.com/yorkie-team/yorkie/cmd/yorkie/config"
+	"github.com/yorkie-team/yorkie/pkg/units"
+)
+
+func newListCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "ls [project]",
+		Short: "List all documents in the project",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return errors.New("project is required")
+			}
+
+			projectName := args[0]
+			cli, err := admin.Dial(config.AdminAddr)
+			if err != nil {
+				return err
+			}
+			defer func() {
+				_ = cli.Close()
+			}()
+
+			ctx := context.Background()
+			documents, err := cli.ListDocuments(ctx, projectName)
+			if err != nil {
+				return err
+			}
+
+			tw := table.NewWriter()
+			tw.Style().Options.DrawBorder = false
+			tw.Style().Options.SeparateColumns = false
+			tw.Style().Options.SeparateFooter = false
+			tw.Style().Options.SeparateHeader = false
+			tw.Style().Options.SeparateRows = false
+			tw.AppendHeader(table.Row{
+				"ID",
+				"KEY",
+				"CREATED AT",
+				"ACCESSED AT",
+				"UPDATED AT",
+				"SNAPSHOT",
+			})
+			for _, document := range documents {
+				tw.AppendRow(table.Row{
+					document.ID,
+					document.Key,
+					units.HumanDuration(time.Now().UTC().Sub(document.CreatedAt)),
+					units.HumanDuration(time.Now().UTC().Sub(document.AccessedAt)),
+					units.HumanDuration(time.Now().UTC().Sub(document.UpdatedAt)),
+					document.Snapshot,
+				})
+			}
+			cmd.Printf("%s\n", tw.Render())
+
+			return nil
+		},
+	}
+}
+
+func init() {
+	SubCmd.AddCommand(newListCommand())
+}

--- a/cmd/yorkie/document/list.go
+++ b/cmd/yorkie/document/list.go
@@ -19,6 +19,7 @@ package document
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/jedib0t/go-pretty/v6/table"
@@ -78,7 +79,6 @@ func newListCommand() *cobra.Command {
 				})
 			}
 			cmd.Printf("%s\n", tw.Render())
-
 			return nil
 		},
 	}

--- a/cmd/yorkie/document/list.go
+++ b/cmd/yorkie/document/list.go
@@ -19,7 +19,6 @@ package document
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/jedib0t/go-pretty/v6/table"

--- a/cmd/yorkie/document/list.go
+++ b/cmd/yorkie/document/list.go
@@ -31,7 +31,7 @@ import (
 
 func newListCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "ls [project]",
+		Use:   "ls [project name]",
 		Short: "List all documents in the project",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {

--- a/server/documents/documents.go
+++ b/server/documents/documents.go
@@ -46,7 +46,7 @@ func ListDocumentSummaries(
 		if err != nil {
 			return nil, err
 		}
-		
+
 		var snapshot string
 		fullSnapshot := doc.Marshal()
 		snapshotCutline := 50
@@ -54,7 +54,7 @@ func ListDocumentSummaries(
 		if len(fullSnapshot) < snapshotCutline {
 			snapshot = fullSnapshot
 		} else {
-			snapshot = fullSnapshot[:snapshotCutline]
+			snapshot = fullSnapshot[:snapshotCutline] + " ..."
 		}
 
 		summaries = append(summaries, &types.DocumentSummary{

--- a/server/documents/documents.go
+++ b/server/documents/documents.go
@@ -46,13 +46,24 @@ func ListDocumentSummaries(
 		if err != nil {
 			return nil, err
 		}
+		
+		var snapshot string
+		fullSnapshot := doc.Marshal()
+		snapshotCutline := 50
+
+		if len(fullSnapshot) < snapshotCutline {
+			snapshot = fullSnapshot
+		} else {
+			snapshot = fullSnapshot[:snapshotCutline]
+		}
+
 		summaries = append(summaries, &types.DocumentSummary{
 			ID:         docInfo.ID,
 			Key:        docInfo.Key,
 			CreatedAt:  docInfo.CreatedAt,
 			AccessedAt: docInfo.AccessedAt,
 			UpdatedAt:  docInfo.UpdatedAt,
-			Snapshot:   doc.Marshal(),
+			Snapshot:   snapshot,
 		})
 	}
 

--- a/server/documents/documents.go
+++ b/server/documents/documents.go
@@ -42,12 +42,17 @@ func ListDocumentSummaries(
 
 	var summaries []*types.DocumentSummary
 	for _, docInfo := range docInfo {
+		doc, err := packs.BuildDocumentForServerSeq(ctx, be, docInfo, docInfo.ServerSeq)
+		if err != nil {
+			return nil, err
+		}
 		summaries = append(summaries, &types.DocumentSummary{
 			ID:         docInfo.ID,
 			Key:        docInfo.Key,
 			CreatedAt:  docInfo.CreatedAt,
 			AccessedAt: docInfo.AccessedAt,
 			UpdatedAt:  docInfo.UpdatedAt,
+			Snapshot:   doc.Marshal(),
 		})
 	}
 


### PR DESCRIPTION
This commit adds document list command.
It can use by `yorkie document ls [ProjectName]`

```
$ ./bin/yorkie document ls default
 ID  KEY  CREATED AT  ACCESSED AT  UPDATED AT  SNAPSHOT 

```

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #273 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Users can view documents using CLI.
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
