### PR TITLE
Introduce`buf`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,20 +7,6 @@ on:
     branches: [ main ]
 
 jobs:
-  lint-protos:
-    name: lint-protos
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Check out code
-      uses: actions/checkout@v2
-
-    - name: Setup buf action
-      uses: bufbuild/buf-setup-action@v1
-
-    - name: Lint protos
-      uses: bufbuild/buf-lint-action@v1
-
   build:
     name: build
     runs-on: ubuntu-latest
@@ -34,11 +20,17 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
 
+    - name: Setup buf action
+      uses: bufbuild/buf-setup-action@v1
+
     - name: Get tools dependencies
       run: make tools
 
     - name: Lint
       run: make lint
+
+    - name: Lint protos
+      uses: bufbuild/buf-lint-action@v1
 
     - name: Build
       run: make build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,19 @@ on:
     branches: [ main ]
 
 jobs:
+  lint-protos:
+    name: lint-protos
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Setup buf action
+      uses: bufbuild/buf-setup-action@v1
+
+    - name: Lint protos
+      uses: bufbuild/buf-lint-action@v1
 
   build:
     name: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         go-version: ^1.17
 
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup buf action
       uses: bufbuild/buf-setup-action@v1

--- a/api/admin.proto
+++ b/api/admin.proto
@@ -17,7 +17,7 @@ syntax = "proto3";
 
 package api;
 
-import "resources.proto";
+import "api/resources.proto";
 
 // Admin is a service that provides a API for Admin.
 service Admin {

--- a/api/cluster.proto
+++ b/api/cluster.proto
@@ -17,7 +17,7 @@ syntax = "proto3";
 
 package api;
 
-import "resources.proto";
+import "api/resources.proto";
 
 // Cluster is a service that provides a API used by Yorkie Cluster.
 service Cluster {

--- a/api/yorkie.proto
+++ b/api/yorkie.proto
@@ -18,7 +18,7 @@ syntax = "proto3";
 
 package api;
 
-import "resources.proto";
+import "api/resources.proto";
 
 // Yorkie is a service that provides a API for SDKs.
 service Yorkie {

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,0 +1,7 @@
+version: v1
+breaking:
+  use:
+    - FILE
+lint:
+  use:
+    - DEFAULT


### PR DESCRIPTION
**What this PR does / why we need it**:
- Introduce [buf](https://buf.build/)
- There is a violation of the [protocol-buffers style guide](https://developers.google.com/protocol-buffers/docs/style#enums). But it's hard to remember all these rules. So, it's better to have linter, like `golangci-lint`.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:
- [Slack thread](https://dev-yorkie.slack.com/archives/C014BTGCBJS/p1658576462364749?thread_ts=1658560179.994979&cid=C014BTGCBJS)
- [Buf Introduction](https://docs.buf.build/tour/introduction/)
- [Avoiding Common Protobuf’s Pitfalls with Buf](https://earthly.dev/blog/buf-protobuf/)

FYI, `buf lint` says
```
api/admin.proto:18:1:Package name "api" should be suffixed with a correctly formed version, such as "api.v1".
api/admin.proto:23:9:Service name "Admin" should be suffixed with "Service".
api/cluster.proto:18:1:Package name "api" should be suffixed with a correctly formed version, such as "api.v1".
api/cluster.proto:23:9:Service name "Cluster" should be suffixed with "Service".
api/resources.proto:21:1:Package name "api" should be suffixed with a correctly formed version, such as "api.v1".
api/resources.proto:173:9:Oneof name "Body" should be lower_snake_case, such as "body".
api/resources.proto:285:3:Enum value name "NULL" should be prefixed with "VALUE_TYPE_".
api/resources.proto:285:3:Enum zero value name "NULL" should be suffixed with "_UNSPECIFIED".
api/resources.proto:286:3:Enum value name "BOOLEAN" should be prefixed with "VALUE_TYPE_".
api/resources.proto:287:3:Enum value name "INTEGER" should be prefixed with "VALUE_TYPE_".
api/resources.proto:288:3:Enum value name "LONG" should be prefixed with "VALUE_TYPE_".
api/resources.proto:289:3:Enum value name "DOUBLE" should be prefixed with "VALUE_TYPE_".
api/resources.proto:290:3:Enum value name "STRING" should be prefixed with "VALUE_TYPE_".
api/resources.proto:291:3:Enum value name "BYTES" should be prefixed with "VALUE_TYPE_".
api/resources.proto:292:3:Enum value name "DATE" should be prefixed with "VALUE_TYPE_".
api/resources.proto:293:3:Enum value name "JSON_OBJECT" should be prefixed with "VALUE_TYPE_".
api/resources.proto:294:3:Enum value name "JSON_ARRAY" should be prefixed with "VALUE_TYPE_".
api/resources.proto:295:3:Enum value name "TEXT" should be prefixed with "VALUE_TYPE_".
api/resources.proto:296:3:Enum value name "RICH_TEXT" should be prefixed with "VALUE_TYPE_".
api/resources.proto:297:3:Enum value name "INTEGER_CNT" should be prefixed with "VALUE_TYPE_".
api/resources.proto:298:3:Enum value name "LONG_CNT" should be prefixed with "VALUE_TYPE_".
api/resources.proto:299:3:Enum value name "DOUBLE_CNT" should be prefixed with "VALUE_TYPE_".
api/resources.proto:303:3:Enum value name "DOCUMENTS_CHANGED" should be prefixed with "DOC_EVENT_TYPE_".
api/resources.proto:303:3:Enum zero value name "DOCUMENTS_CHANGED" should be suffixed with "_UNSPECIFIED".
api/resources.proto:304:3:Enum value name "DOCUMENTS_WATCHED" should be prefixed with "DOC_EVENT_TYPE_".
api/resources.proto:305:3:Enum value name "DOCUMENTS_UNWATCHED" should be prefixed with "DOC_EVENT_TYPE_".
api/resources.proto:306:3:Enum value name "PRESENCE_CHANGED" should be prefixed with "DOC_EVENT_TYPE_".
api/yorkie.proto:19:1:Package name "api" should be suffixed with a correctly formed version, such as "api.v1".
api/yorkie.proto:24:9:Service name "Yorkie" should be suffixed with "Service".
```
**Does this PR introduce a user-facing change?**:
- Now, you can lint your `proto` files using `buf` cli.
```bash
brew install bufbuild/buf/buf
buf lint
```
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**:
- [X] Added relevant tests or not required
- [ ] Didn't break anything
