### PR TITLE
Fix the problem local changes were applied twice

### DIFF
--- a/pkg/document/internal_document.go
+++ b/pkg/document/internal_document.go
@@ -196,14 +196,6 @@ func (d *InternalDocument) applySnapshot(snapshot []byte, serverSeq uint64) erro
 	}
 
 	d.root = json.NewRoot(rootObj)
-
-	if d.HasLocalChanges() {
-		for _, c := range d.localChanges {
-			if err := c.Execute(d.root); err != nil {
-				return err
-			}
-		}
-	}
 	d.changeID = d.changeID.SyncLamport(serverSeq)
 
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

When a client receives a remote snapshot, the concurrent local changes
were apllied twice.
client.syncInternal first sends local changes to server, and then
receives remote ChangePack. So the snapshot in given ChangePack
is of the time when the local changes were already applied.

By deleting change.execute in applySnapshot, fix above problem.

https://github.com/yorkie-team/yorkie-js-sdk/pull/356

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
