### PR TITLE
Add `--auth-webhook-url, --name` flag

### DIFF
--- a/admin/client.go
+++ b/admin/client.go
@@ -175,6 +175,19 @@ func (c *Client) CreateProject(ctx context.Context, name string) (*types.Project
 	return converter.FromProject(response.Project)
 }
 
+// GetProject get project by name.
+func (c *Client) GetProject(ctx context.Context, name string) (*types.Project, error) {
+	response, err := c.client.GetProject(
+		ctx,
+		&api.GetProjectRequest{Name: name},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return converter.FromProject(response.Project)
+}
+
 // ListProjects lists all projects.
 func (c *Client) ListProjects(ctx context.Context) ([]*types.Project, error) {
 	response, err := c.client.ListProjects(

--- a/admin/client.go
+++ b/admin/client.go
@@ -175,7 +175,7 @@ func (c *Client) CreateProject(ctx context.Context, name string) (*types.Project
 	return converter.FromProject(response.Project)
 }
 
-// GetProject get project by name.
+// GetProject gets the project by name.
 func (c *Client) GetProject(ctx context.Context, name string) (*types.Project, error) {
 	response, err := c.client.GetProject(
 		ctx,

--- a/cmd/yorkie/project/update.go
+++ b/cmd/yorkie/project/update.go
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2022 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package project
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/yorkie-team/yorkie/admin"
+	"github.com/yorkie-team/yorkie/api/types"
+)
+
+var (
+	flagAuthWebHookUrl string
+)
+
+func newUpdateCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:     "update [name]",
+		Short:   "Update a project",
+		Example: "yorkie project update name [flags]",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return errors.New("project name is required")
+			}
+
+			id := "ID"
+			newName := args[0]
+			newAuthWebhookURL := flagAuthWebHookUrl
+			newAuthWebhookMethods := []string{
+				string(types.AttachDocument),
+				string(types.WatchDocuments),
+			}
+
+			updatableProjectFields := &types.UpdatableProjectFields{
+				Name:               &newName,
+				AuthWebhookURL:     &newAuthWebhookURL,
+				AuthWebhookMethods: &newAuthWebhookMethods,
+			}
+
+			// TODO(hackerwins): use adminAddr from env or addr flag.
+			cli, err := admin.Dial("localhost:11103")
+			if err != nil {
+				return err
+			}
+			defer func() {
+				_ = cli.Close()
+			}()
+
+			ctx := context.Background()
+			project, err := cli.UpdateProject(ctx, id, updatableProjectFields)
+			if err != nil {
+				return err
+			}
+
+			encoded, err := json.Marshal(project)
+			if err != nil {
+				return err
+			}
+
+			fmt.Println(string(encoded))
+
+			return nil
+		},
+	}
+}
+
+func init() {
+	cmd := newUpdateCommand()
+	cmd.Flags().StringVar(
+		&flagAuthWebHookUrl,
+		"auth-webhook-url",
+		"",
+		"authorization-webhook update url",
+	)
+	SubCmd.AddCommand(cmd)
+}

--- a/cmd/yorkie/project/update.go
+++ b/cmd/yorkie/project/update.go
@@ -60,19 +60,19 @@ func newUpdateCommand() *cobra.Command {
 			}()
 
 			ctx := context.Background()
-			existence, err := cli.GetProject(ctx, name)
+			project, err := cli.GetProject(ctx, name)
 			if err != nil {
 				return err
 			}
-			id := existence.ID.String()
+			id := project.ID.String()
 
 			newName := name
-			if cmd.Flags().Lookup("name").Changed {
+			if flagName != "" {
 				newName = flagName
 			}
 
-			newAuthWebhookURL := existence.AuthWebhookURL
-			if cmd.Flags().Lookup("auth-webhook-url").Changed {
+			newAuthWebhookURL := project.AuthWebhookURL
+			if cmd.Flags().Lookup("auth-webhook-url").Changed { // allow empty string
 				newAuthWebhookURL = flagAuthWebhookURL
 			}
 
@@ -81,12 +81,12 @@ func newUpdateCommand() *cobra.Command {
 				AuthWebhookURL: &newAuthWebhookURL,
 			}
 
-			project, err := cli.UpdateProject(ctx, id, updatableProjectFields)
+			updated, err := cli.UpdateProject(ctx, id, updatableProjectFields)
 			if err != nil {
 				return err
 			}
 
-			encoded, err := json.Marshal(project)
+			encoded, err := json.Marshal(updated)
 			if err != nil {
 				return err
 			}

--- a/cmd/yorkie/project/update.go
+++ b/cmd/yorkie/project/update.go
@@ -29,6 +29,11 @@ import (
 	"github.com/yorkie-team/yorkie/cmd/yorkie/config"
 )
 
+const (
+	AUTH_WEBHOOK_URL string = "auth-webhook-url"
+	NAME             string = "name"
+)
+
 var (
 	flagAuthWebHookURL string
 	flagName           string
@@ -48,8 +53,12 @@ func newUpdateCommand() *cobra.Command {
 
 			name := args[0]
 
-			// TODO(hackerwins): use adminAddr from env or addr flag.
-			cli, err := admin.Dial(config.AdminAddr)
+			token, err := config.LoadToken(config.AdminAddr)
+			if err != nil {
+				return err
+			}
+
+			cli, err := admin.Dial(config.AdminAddr, admin.WithToken(token))
 			if err != nil {
 				return err
 			}
@@ -64,13 +73,13 @@ func newUpdateCommand() *cobra.Command {
 			}
 			id := exists.ID.String()
 
-			if flagName != "" {
+			if cmd.Flags().Lookup(NAME).Changed {
 				newName = flagName
 			} else {
 				newName = name
 			}
 
-			if flagAuthWebHookURL != "" {
+			if cmd.Flags().Lookup(AUTH_WEBHOOK_URL).Changed {
 				newAuthWebhookURL = flagAuthWebHookURL
 			} else {
 				newAuthWebhookURL = exists.AuthWebhookURL
@@ -108,13 +117,13 @@ func init() {
 	cmd := newUpdateCommand()
 	cmd.Flags().StringVar(
 		&flagAuthWebHookURL,
-		"auth-webhook-url",
+		AUTH_WEBHOOK_URL,
 		"",
 		"authorization-webhook update url",
 	)
 	cmd.Flags().StringVar(
 		&flagName,
-		"name",
+		NAME,
 		"",
 		"new project name",
 	)

--- a/cmd/yorkie/project/update.go
+++ b/cmd/yorkie/project/update.go
@@ -29,13 +29,8 @@ import (
 	"github.com/yorkie-team/yorkie/cmd/yorkie/config"
 )
 
-const (
-	AUTH_WEBHOOK_URL string = "auth-webhook-url"
-	NAME             string = "name"
-)
-
 var (
-	flagAuthWebHookURL string
+	flagAuthWebhookURL string
 	flagName           string
 	newName            string
 	newAuthWebhookURL  string
@@ -73,14 +68,14 @@ func newUpdateCommand() *cobra.Command {
 			}
 			id := exists.ID.String()
 
-			if cmd.Flags().Lookup(NAME).Changed {
+			if cmd.Flags().Lookup("name").Changed {
 				newName = flagName
 			} else {
 				newName = name
 			}
 
-			if cmd.Flags().Lookup(AUTH_WEBHOOK_URL).Changed {
-				newAuthWebhookURL = flagAuthWebHookURL
+			if cmd.Flags().Lookup("auth-webhook-url").Changed {
+				newAuthWebhookURL = flagAuthWebhookURL
 			} else {
 				newAuthWebhookURL = exists.AuthWebhookURL
 			}
@@ -116,16 +111,16 @@ func newUpdateCommand() *cobra.Command {
 func init() {
 	cmd := newUpdateCommand()
 	cmd.Flags().StringVar(
-		&flagAuthWebHookURL,
-		AUTH_WEBHOOK_URL,
-		"",
-		"authorization-webhook update url",
-	)
-	cmd.Flags().StringVar(
 		&flagName,
-		NAME,
+		"name",
 		"",
 		"new project name",
+	)
+	cmd.Flags().StringVar(
+		&flagAuthWebhookURL,
+		"auth-webhook-url",
+		"",
+		"authorization-webhook update url",
 	)
 	SubCmd.AddCommand(cmd)
 }

--- a/cmd/yorkie/project/update.go
+++ b/cmd/yorkie/project/update.go
@@ -32,8 +32,6 @@ import (
 var (
 	flagAuthWebhookURL string
 	flagName           string
-	newName            string
-	newAuthWebhookURL  string
 )
 
 func newUpdateCommand() *cobra.Command {
@@ -62,33 +60,25 @@ func newUpdateCommand() *cobra.Command {
 			}()
 
 			ctx := context.Background()
-			exists, err := cli.GetProject(ctx, name)
+			existence, err := cli.GetProject(ctx, name)
 			if err != nil {
 				return err
 			}
-			id := exists.ID.String()
+			id := existence.ID.String()
 
+			newName := name
 			if cmd.Flags().Lookup("name").Changed {
 				newName = flagName
-			} else {
-				newName = name
 			}
 
+			newAuthWebhookURL := existence.AuthWebhookURL
 			if cmd.Flags().Lookup("auth-webhook-url").Changed {
 				newAuthWebhookURL = flagAuthWebhookURL
-			} else {
-				newAuthWebhookURL = exists.AuthWebhookURL
-			}
-
-			newAuthWebhookMethods := []string{
-				string(types.AttachDocument),
-				string(types.WatchDocuments),
 			}
 
 			updatableProjectFields := &types.UpdatableProjectFields{
-				Name:               &newName,
-				AuthWebhookURL:     &newAuthWebhookURL,
-				AuthWebhookMethods: &newAuthWebhookMethods,
+				Name:           &newName,
+				AuthWebhookURL: &newAuthWebhookURL,
 			}
 
 			project, err := cli.UpdateProject(ctx, id, updatableProjectFields)

--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -186,11 +186,11 @@ func (d *DB) CreateProjectInfo(ctx context.Context, name string) (*database.Proj
 
 	// NOTE(hackerwins): Check if the project already exists.
 	// https://github.com/hashicorp/go-memdb/issues/7#issuecomment-270427642
-	existence, err := txn.First(tblProjects, "name", name)
+	existing, err := txn.First(tblProjects, "name", name)
 	if err != nil {
 		return nil, err
 	}
-	if existence != nil {
+	if existing != nil {
 		return nil, fmt.Errorf("%s: %w", name, database.ErrProjectAlreadyExists)
 	}
 
@@ -246,11 +246,11 @@ func (d *DB) UpdateProjectInfo(
 	info := raw.(*database.ProjectInfo).DeepCopy()
 
 	if fields.Name != nil {
-		existence, err := txn.First(tblProjects, "name", *fields.Name)
+		existing, err := txn.First(tblProjects, "name", *fields.Name)
 		if err != nil {
 			return nil, err
 		}
-		if existence != nil && info.Name != *fields.Name {
+		if existing != nil && info.Name != *fields.Name {
 			return nil, fmt.Errorf("%s: %w", *fields.Name, database.ErrProjectNameAlreadyExists)
 		}
 	}
@@ -274,11 +274,11 @@ func (d *DB) CreateUserInfo(
 	txn := d.db.Txn(true)
 	defer txn.Abort()
 
-	existence, err := txn.First(tblUsers, "username", username)
+	existing, err := txn.First(tblUsers, "username", username)
 	if err != nil {
 		return nil, err
 	}
-	if existence != nil {
+	if existing != nil {
 		return nil, fmt.Errorf("%s: %w", username, database.ErrUserAlreadyExists)
 	}
 

--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -235,16 +235,6 @@ func (d *DB) UpdateProjectInfo(
 	txn := d.db.Txn(true)
 	defer txn.Abort()
 
-	if fields.Name != nil {
-		exist, err := txn.First(tblProjects, "name", *fields.Name)
-		if err != nil {
-			return nil, err
-		}
-		if exist != nil {
-			return nil, fmt.Errorf("%s: %w", *fields.Name, database.ErrProjectNameAlreadyExists)
-		}
-	}
-
 	raw, err := txn.First(tblProjects, "id", id.String())
 	if err != nil {
 		return nil, err
@@ -254,6 +244,17 @@ func (d *DB) UpdateProjectInfo(
 	}
 
 	info := raw.(*database.ProjectInfo).DeepCopy()
+
+	if fields.Name != nil {
+		exist, err := txn.First(tblProjects, "name", *fields.Name)
+		if err != nil {
+			return nil, err
+		}
+		if exist != nil && info.Name != *fields.Name {
+			return nil, fmt.Errorf("%s: %w", *fields.Name, database.ErrProjectNameAlreadyExists)
+		}
+	}
+
 	info.UpdateFields(fields)
 	info.UpdatedAt = gotime.Now()
 	if err := txn.Insert(tblProjects, info); err != nil {

--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -186,11 +186,11 @@ func (d *DB) CreateProjectInfo(ctx context.Context, name string) (*database.Proj
 
 	// NOTE(hackerwins): Check if the project already exists.
 	// https://github.com/hashicorp/go-memdb/issues/7#issuecomment-270427642
-	existing, err := txn.First(tblProjects, "name", name)
+	existence, err := txn.First(tblProjects, "name", name)
 	if err != nil {
 		return nil, err
 	}
-	if existing != nil {
+	if existence != nil {
 		return nil, fmt.Errorf("%s: %w", name, database.ErrProjectAlreadyExists)
 	}
 
@@ -246,11 +246,11 @@ func (d *DB) UpdateProjectInfo(
 	info := raw.(*database.ProjectInfo).DeepCopy()
 
 	if fields.Name != nil {
-		exist, err := txn.First(tblProjects, "name", *fields.Name)
+		existence, err := txn.First(tblProjects, "name", *fields.Name)
 		if err != nil {
 			return nil, err
 		}
-		if exist != nil && info.Name != *fields.Name {
+		if existence != nil && info.Name != *fields.Name {
 			return nil, fmt.Errorf("%s: %w", *fields.Name, database.ErrProjectNameAlreadyExists)
 		}
 	}
@@ -274,11 +274,11 @@ func (d *DB) CreateUserInfo(
 	txn := d.db.Txn(true)
 	defer txn.Abort()
 
-	existing, err := txn.First(tblUsers, "username", username)
+	existence, err := txn.First(tblUsers, "username", username)
 	if err != nil {
 		return nil, err
 	}
-	if existing != nil {
+	if existence != nil {
 		return nil, fmt.Errorf("%s: %w", username, database.ErrUserAlreadyExists)
 	}
 

--- a/server/backend/database/memory/database_test.go
+++ b/server/backend/database/memory/database_test.go
@@ -355,7 +355,7 @@ func TestDB(t *testing.T) {
 		assert.Equal(t, newAuthWebhookURL, updateInfo.AuthWebhookURL)
 		assert.Equal(t, newAuthWebhookMethods, updateInfo.AuthWebhookMethods)
 
-		// update one field
+		// update name field
 		newName2 := newName + "2"
 		fields = &types.UpdatableProjectFields{
 			Name: &newName2,
@@ -378,5 +378,25 @@ func TestDB(t *testing.T) {
 		fields = &types.UpdatableProjectFields{Name: &existName}
 		_, err = db.UpdateProjectInfo(ctx, id, fields)
 		assert.ErrorIs(t, err, database.ErrProjectNameAlreadyExists)
+
+		// update auth-webhook-url field
+		newAuthWebhookURL2 := newAuthWebhookURL + "2"
+		fields = &types.UpdatableProjectFields{
+			AuthWebhookURL: &newAuthWebhookURL2,
+		}
+		err = fields.Validate()
+		assert.NoError(t, err)
+		res, err = db.UpdateProjectInfo(ctx, id, fields)
+		assert.NoError(t, err)
+
+		updateInfo, err = db.FindProjectInfoByID(ctx, id)
+		assert.NoError(t, err)
+
+		// check only auth-webhook-url is update
+		assert.Equal(t, res, updateInfo)
+		assert.Equal(t, newName2, updateInfo.Name)
+		assert.NotEqual(t, newAuthWebhookURL, updateInfo.AuthWebhookURL)
+		assert.Equal(t, newAuthWebhookMethods, updateInfo.AuthWebhookMethods)
+
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. You can update auth-webhook-url with cmd.
2. Updating is not possible unless you change the project name in yorkie-house.
I've worked on it to be able to update without changing the project name.

How to use: `yorkie project update [name] [flag(--auth-webhook-url)] [value]`

How to use: `yorkie project update [name] [flag(--name)] [value]`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #358 #355 #385

**Special notes for your reviewer**:
It was implemented to update the auth-webhook-url field with cmd, and the cmd test used VS Code's debugging.
```
"version": "0.2.0",
    "configurations": [
      {
        "name": "update project",
        "type": "go",
        "request": "launch",
        "mode": "auto",
        "program": "cmd/yorkie",
        "args": ["project", "update", "name", "--auth-webhook-url", "http://localhost:3000"]
      },
    ]
}
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
