### PR TITLE
Fix history command authentication error

### DIFF
--- a/cmd/yorkie/history.go
+++ b/cmd/yorkie/history.go
@@ -43,7 +43,12 @@ func newHistoryCmd() *cobra.Command {
 				return errors.New("project name and document key are required")
 			}
 
-			cli, err := admin.Dial(config.AdminAddr)
+			token, err := config.LoadToken(config.AdminAddr)
+			if err != nil {
+				return err
+			}
+
+			cli, err := admin.Dial(config.AdminAddr, admin.WithToken(token))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix history command authentication error.
Now can use the history command after login.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #396

**Special notes for your reviewer**:

Add missing authentication token load to `cmd/yorkie/history.go`

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
