### PR TITLE
Bind project and user with owner field

### DIFF
--- a/api/types/project.go
+++ b/api/types/project.go
@@ -28,6 +28,9 @@ type Project struct {
 	// Name is the name of this project.
 	Name string `json:"name"`
 
+	// Owner is the owner of this project.
+	Owner ID `json:"owner"`
+
 	// AuthWebhookURL is the url of the authorization webhook.
 	AuthWebhookURL string `json:"auth_webhook_url"`
 

--- a/server/admin/server.go
+++ b/server/admin/server.go
@@ -73,7 +73,7 @@ func NewServer(conf *Config, be *backend.Backend) *Server {
 	)
 
 	loggingInterceptor := grpchelper.NewLoggingInterceptor()
-	authInterceptor := interceptors.NewAuthInterceptor(tokenManager)
+	authInterceptor := interceptors.NewAuthInterceptor(be, tokenManager)
 	defaultInterceptor := interceptors.NewDefaultInterceptor()
 
 	opts := []grpc.ServerOption{
@@ -197,7 +197,8 @@ func (s *Server) CreateProject(
 	ctx context.Context,
 	req *api.CreateProjectRequest,
 ) (*api.CreateProjectResponse, error) {
-	project, err := projects.CreateProject(ctx, s.backend, req.Name)
+	user := users.From(ctx)
+	project, err := projects.CreateProject(ctx, s.backend, user.ID, req.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +217,8 @@ func (s *Server) ListProjects(
 	ctx context.Context,
 	req *api.ListProjectsRequest,
 ) (*api.ListProjectsResponse, error) {
-	projectList, err := projects.ListProjects(ctx, s.backend)
+	user := users.From(ctx)
+	projectList, err := projects.ListProjects(ctx, s.backend, user.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -236,7 +238,8 @@ func (s *Server) GetProject(
 	ctx context.Context,
 	req *api.GetProjectRequest,
 ) (*api.GetProjectResponse, error) {
-	project, err := projects.GetProject(ctx, s.backend, req.Name)
+	user := users.From(ctx)
+	project, err := projects.GetProject(ctx, s.backend, user.ID, req.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -263,9 +266,11 @@ func (s *Server) UpdateProject(
 		return nil, err
 	}
 
+	user := users.From(ctx)
 	project, err := projects.UpdateProject(
 		ctx,
 		s.backend,
+		user.ID,
 		types.ID(req.Id),
 		fields,
 	)
@@ -288,7 +293,8 @@ func (s *Server) GetDocument(
 	ctx context.Context,
 	req *api.GetDocumentRequest,
 ) (*api.GetDocumentResponse, error) {
-	project, err := projects.GetProject(ctx, s.backend, req.ProjectName)
+	user := users.From(ctx)
+	project, err := projects.GetProject(ctx, s.backend, user.ID, req.ProjectName)
 	if err != nil {
 		return nil, err
 	}
@@ -318,7 +324,8 @@ func (s *Server) GetSnapshotMeta(
 	ctx context.Context,
 	req *api.GetSnapshotMetaRequest,
 ) (*api.GetSnapshotMetaResponse, error) {
-	project, err := projects.GetProject(ctx, s.backend, req.ProjectName)
+	user := users.From(ctx)
+	project, err := projects.GetProject(ctx, s.backend, user.ID, req.ProjectName)
 	if err != nil {
 		return nil, err
 	}
@@ -350,7 +357,8 @@ func (s *Server) ListDocuments(
 	ctx context.Context,
 	req *api.ListDocumentsRequest,
 ) (*api.ListDocumentsResponse, error) {
-	project, err := projects.GetProject(ctx, s.backend, req.ProjectName)
+	user := users.From(ctx)
+	project, err := projects.GetProject(ctx, s.backend, user.ID, req.ProjectName)
 	if err != nil {
 		return nil, err
 	}
@@ -384,7 +392,8 @@ func (s *Server) SearchDocuments(
 	ctx context.Context,
 	req *api.SearchDocumentsRequest,
 ) (*api.SearchDocumentsResponse, error) {
-	project, err := projects.GetProject(ctx, s.backend, req.ProjectName)
+	user := users.From(ctx)
+	project, err := projects.GetProject(ctx, s.backend, user.ID, req.ProjectName)
 	if err != nil {
 		return nil, err
 	}
@@ -416,7 +425,8 @@ func (s *Server) ListChanges(
 	ctx context.Context,
 	req *api.ListChangesRequest,
 ) (*api.ListChangesResponse, error) {
-	project, err := projects.GetProject(ctx, s.backend, req.ProjectName)
+	user := users.From(ctx)
+	project, err := projects.GetProject(ctx, s.backend, user.ID, req.ProjectName)
 	if err != nil {
 		return nil, err
 	}

--- a/server/backend/database/database.go
+++ b/server/backend/database/database.go
@@ -60,15 +60,25 @@ type Database interface {
 	Close() error
 
 	// FindProjectInfoByPublicKey returns a project by public key.
-	FindProjectInfoByPublicKey(ctx context.Context, publicKey string) (*ProjectInfo, error)
+	FindProjectInfoByPublicKey(
+		ctx context.Context,
+		publicKey string,
+	) (*ProjectInfo, error)
 
 	// FindProjectInfoByName returns a project by the given name.
-	FindProjectInfoByName(ctx context.Context, name string) (*ProjectInfo, error)
+	FindProjectInfoByName(
+		ctx context.Context,
+		owner types.ID,
+		name string,
+	) (*ProjectInfo, error)
 
-	// FindProjectInfoByID returns a project by the given id.
+	// FindProjectInfoByID returns a project by the given id. It should not be
+	// used directly by clients because it is not checked if the project is
+	// permitted to be accessed by the admin client.
 	FindProjectInfoByID(ctx context.Context, id types.ID) (*ProjectInfo, error)
 
-	// EnsureDefaultUserAndProject ensures that the default user and project exists.
+	// EnsureDefaultUserAndProject ensures that the default user and project
+	// exists.
 	EnsureDefaultUserAndProject(
 		ctx context.Context,
 		username,
@@ -76,13 +86,22 @@ type Database interface {
 	) (*UserInfo, *ProjectInfo, error)
 
 	// CreateProjectInfo creates a new project.
-	CreateProjectInfo(ctx context.Context, name string) (*ProjectInfo, error)
+	CreateProjectInfo(
+		ctx context.Context,
+		name string,
+		owner types.ID,
+	) (*ProjectInfo, error)
 
 	// ListProjectInfos returns all projects.
-	ListProjectInfos(ctx context.Context) ([]*ProjectInfo, error)
+	ListProjectInfos(ctx context.Context, owner types.ID) ([]*ProjectInfo, error)
 
 	// UpdateProjectInfo updates the project.
-	UpdateProjectInfo(ctx context.Context, id types.ID, fields *types.UpdatableProjectFields) (*ProjectInfo, error)
+	UpdateProjectInfo(
+		ctx context.Context,
+		owner types.ID,
+		id types.ID,
+		fields *types.UpdatableProjectFields,
+	) (*ProjectInfo, error)
 
 	// CreateUserInfo creates a new user.
 	CreateUserInfo(

--- a/server/backend/database/memory/indexes.go
+++ b/server/backend/database/memory/indexes.go
@@ -38,6 +38,16 @@ var schema = &memdb.DBSchema{
 					Unique:  true,
 					Indexer: &memdb.StringFieldIndex{Field: "ID"},
 				},
+				"owner_id": {
+					Name:   "owner_id",
+					Unique: true,
+					Indexer: &memdb.CompoundIndex{
+						Indexes: []memdb.Indexer{
+							&memdb.StringFieldIndex{Field: "Owner"},
+							&memdb.StringFieldIndex{Field: "ID"},
+						},
+					},
+				},
 				"name": {
 					Name:    "name",
 					Unique:  true,

--- a/server/backend/database/mongo/client_test.go
+++ b/server/backend/database/mongo/client_test.go
@@ -41,11 +41,13 @@ func TestClient(t *testing.T) {
 	cli, err := mongo.Dial(config)
 	assert.NoError(t, err)
 
+	dummyOwnerID := types.ID("000000000000000000000000")
+
 	t.Run("UpdateProjectInfo test", func(t *testing.T) {
-		info, err := cli.CreateProjectInfo(ctx, t.Name())
+		info, err := cli.CreateProjectInfo(ctx, t.Name(), dummyOwnerID)
 		assert.NoError(t, err)
 		existName := "already"
-		_, err = cli.CreateProjectInfo(ctx, existName)
+		_, err = cli.CreateProjectInfo(ctx, existName, dummyOwnerID)
 		assert.NoError(t, err)
 
 		id := info.ID
@@ -65,7 +67,7 @@ func TestClient(t *testing.T) {
 
 		err = fields.Validate()
 		assert.NoError(t, err)
-		res, err := cli.UpdateProjectInfo(ctx, id, fields)
+		res, err := cli.UpdateProjectInfo(ctx, dummyOwnerID, id, fields)
 		assert.NoError(t, err)
 
 		updateInfo, err := cli.FindProjectInfoByID(ctx, id)
@@ -83,7 +85,7 @@ func TestClient(t *testing.T) {
 		}
 		err = fields.Validate()
 		assert.NoError(t, err)
-		res, err = cli.UpdateProjectInfo(ctx, id, fields)
+		res, err = cli.UpdateProjectInfo(ctx, dummyOwnerID, id, fields)
 		assert.NoError(t, err)
 
 		updateInfo, err = cli.FindProjectInfoByID(ctx, id)
@@ -97,7 +99,7 @@ func TestClient(t *testing.T) {
 
 		// check duplicate name error
 		fields = &types.UpdatableProjectFields{Name: &existName}
-		_, err = cli.UpdateProjectInfo(ctx, id, fields)
+		_, err = cli.UpdateProjectInfo(ctx, dummyOwnerID, id, fields)
 		assert.ErrorIs(t, err, database.ErrProjectNameAlreadyExists)
 	})
 }

--- a/server/backend/database/project_info.go
+++ b/server/backend/database/project_info.go
@@ -38,6 +38,9 @@ type ProjectInfo struct {
 	// Name is the name of this project.
 	Name string `bson:"name"`
 
+	// Owner is the owner of this project.
+	Owner types.ID `bson:"owner"`
+
 	// PublicKey is the API key of this project.
 	PublicKey string `bson:"public_key"`
 
@@ -58,9 +61,10 @@ type ProjectInfo struct {
 }
 
 // NewProjectInfo creates a new ProjectInfo of the given name.
-func NewProjectInfo(name string) *ProjectInfo {
+func NewProjectInfo(name string, owner types.ID) *ProjectInfo {
 	return &ProjectInfo{
-		Name: name,
+		Name:  name,
+		Owner: owner,
 		// TODO(hackerwins): Use random generated Key.
 		PublicKey: xid.New().String(),
 		SecretKey: xid.New().String(),
@@ -73,6 +77,7 @@ func ToProjectInfo(project *types.Project) *ProjectInfo {
 	return &ProjectInfo{
 		ID:                 project.ID,
 		Name:               project.Name,
+		Owner:              project.Owner,
 		PublicKey:          project.PublicKey,
 		SecretKey:          project.SecretKey,
 		AuthWebhookURL:     project.AuthWebhookURL,
@@ -91,6 +96,7 @@ func (i *ProjectInfo) DeepCopy() *ProjectInfo {
 	return &ProjectInfo{
 		ID:                 i.ID,
 		Name:               i.Name,
+		Owner:              i.Owner,
 		PublicKey:          i.PublicKey,
 		SecretKey:          i.SecretKey,
 		AuthWebhookURL:     i.AuthWebhookURL,
@@ -118,6 +124,7 @@ func (i *ProjectInfo) ToProject() *types.Project {
 	return &types.Project{
 		ID:                 i.ID,
 		Name:               i.Name,
+		Owner:              i.Owner,
 		AuthWebhookURL:     i.AuthWebhookURL,
 		AuthWebhookMethods: i.AuthWebhookMethods,
 		PublicKey:          i.PublicKey,

--- a/server/backend/database/project_info_test.go
+++ b/server/backend/database/project_info_test.go
@@ -27,7 +27,8 @@ import (
 
 func TestProjectInfo(t *testing.T) {
 	t.Run("update fields test", func(t *testing.T) {
-		project := database.NewProjectInfo(t.Name())
+		dummyOwnerID := types.ID("000000000000000000000000")
+		project := database.NewProjectInfo(t.Name(), dummyOwnerID)
 
 		testName := "testName"
 		testURL := "testUrl"
@@ -41,5 +42,6 @@ func TestProjectInfo(t *testing.T) {
 
 		project.UpdateFields(&types.UpdatableProjectFields{AuthWebhookMethods: &testMethods})
 		assert.Equal(t, testMethods, project.AuthWebhookMethods)
+		assert.Equal(t, dummyOwnerID, project.Owner)
 	})
 }

--- a/server/projects/projects.go
+++ b/server/projects/projects.go
@@ -28,9 +28,10 @@ import (
 func CreateProject(
 	ctx context.Context,
 	be *backend.Backend,
+	owner types.ID,
 	name string,
 ) (*types.Project, error) {
-	info, err := be.DB.CreateProjectInfo(ctx, name)
+	info, err := be.DB.CreateProjectInfo(ctx, name, owner)
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +43,9 @@ func CreateProject(
 func ListProjects(
 	ctx context.Context,
 	be *backend.Backend,
+	owner types.ID,
 ) ([]*types.Project, error) {
-	infos, err := be.DB.ListProjectInfos(ctx)
+	infos, err := be.DB.ListProjectInfos(ctx, owner)
 	if err != nil {
 		return nil, err
 	}
@@ -60,27 +62,10 @@ func ListProjects(
 func GetProject(
 	ctx context.Context,
 	be *backend.Backend,
+	owner types.ID,
 	name string,
 ) (*types.Project, error) {
-	info, err := be.DB.FindProjectInfoByName(ctx, name)
-	if err != nil {
-		return nil, err
-	}
-
-	return info.ToProject(), nil
-}
-
-// GetProjectFromAPIKey returns a project from an API key.
-func GetProjectFromAPIKey(ctx context.Context, be *backend.Backend, apiKey string) (*types.Project, error) {
-	if apiKey == "" {
-		info, err := be.DB.FindProjectInfoByName(ctx, database.DefaultProjectName)
-		if err != nil {
-			return nil, err
-		}
-		return info.ToProject(), nil
-	}
-
-	info, err := be.DB.FindProjectInfoByPublicKey(ctx, apiKey)
+	info, err := be.DB.FindProjectInfoByName(ctx, owner, name)
 	if err != nil {
 		return nil, err
 	}
@@ -92,10 +77,29 @@ func GetProjectFromAPIKey(ctx context.Context, be *backend.Backend, apiKey strin
 func UpdateProject(
 	ctx context.Context,
 	be *backend.Backend,
+	owner types.ID,
 	id types.ID,
 	fields *types.UpdatableProjectFields,
 ) (*types.Project, error) {
-	info, err := be.DB.UpdateProjectInfo(ctx, id, fields)
+	info, err := be.DB.UpdateProjectInfo(ctx, owner, id, fields)
+	if err != nil {
+		return nil, err
+	}
+
+	return info.ToProject(), nil
+}
+
+// GetProjectFromAPIKey returns a project from an API key.
+func GetProjectFromAPIKey(ctx context.Context, be *backend.Backend, apiKey string) (*types.Project, error) {
+	if apiKey == "" {
+		info, err := be.DB.FindProjectInfoByID(ctx, database.DefaultProjectID)
+		if err != nil {
+			return nil, err
+		}
+		return info.ToProject(), nil
+	}
+
+	info, err := be.DB.FindProjectInfoByPublicKey(ctx, apiKey)
 	if err != nil {
 		return nil, err
 	}

--- a/server/rpc/server_test.go
+++ b/server/rpc/server_test.go
@@ -85,7 +85,10 @@ func TestMain(m *testing.M) {
 		log.Fatal(err)
 	}
 
-	project, err := be.DB.FindProjectInfoByName(context.Background(), database.DefaultProjectName)
+	project, err := be.DB.FindProjectInfoByID(
+		context.Background(),
+		database.DefaultProjectID,
+	)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/server/users/context.go
+++ b/server/users/context.go
@@ -1,0 +1,20 @@
+package users
+
+import (
+	"context"
+
+	"github.com/yorkie-team/yorkie/api/types"
+)
+
+// userKey is the key for the context.Context.
+type userKey struct{}
+
+// From returns the user from the context.
+func From(ctx context.Context) *types.User {
+	return ctx.Value(userKey{}).(*types.User)
+}
+
+// With returns a new context with the given user.
+func With(ctx context.Context, user *types.User) context.Context {
+	return context.WithValue(ctx, userKey{}, user)
+}

--- a/server/users/users.go
+++ b/server/users/users.go
@@ -66,3 +66,17 @@ func IsCorrectPassword(
 
 	return info.ToUser(), nil
 }
+
+// GetUser returns a user by the given username.
+func GetUser(
+	ctx context.Context,
+	be *backend.Backend,
+	username string,
+) (*types.User, error) {
+	info, err := be.DB.FindUserInfo(ctx, username)
+	if err != nil {
+		return nil, err
+	}
+
+	return info.ToUser(), nil
+}

--- a/test/integration/history_test.go
+++ b/test/integration/history_test.go
@@ -1,4 +1,4 @@
-//go:build integration && amd64
+//go:build integration
 
 /*
  * Copyright 2022 The Yorkie Authors. All rights reserved.
@@ -20,39 +20,17 @@ package integration
 
 import (
 	"context"
-	"fmt"
-	"log"
-	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/yorkie-team/yorkie/api/types"
-	"github.com/yorkie-team/yorkie/client"
 	"github.com/yorkie-team/yorkie/pkg/document"
 	"github.com/yorkie-team/yorkie/pkg/document/json"
 	"github.com/yorkie-team/yorkie/pkg/document/key"
-	"github.com/yorkie-team/yorkie/server"
-	"github.com/yorkie-team/yorkie/server/backend/background"
-	"github.com/yorkie-team/yorkie/server/logging"
 	"github.com/yorkie-team/yorkie/test/helper"
 )
 
 func TestHistory(t *testing.T) {
-	var b *background.Background
-	monkey.PatchInstanceMethod(
-		reflect.TypeOf(b),
-		"AttachGoroutine",
-		func(_ *background.Background, f func(c context.Context)) {
-			f(context.Background())
-		},
-	)
-	defer monkey.UnpatchInstanceMethod(
-		reflect.TypeOf(b),
-		"AttachGoroutine",
-	)
-
 	clients := activeClients(t, 1)
 	cli := clients[0]
 	defer cleanupClients(t, clients)
@@ -97,70 +75,5 @@ func TestHistory(t *testing.T) {
 		assert.Equal(t, `{"todos":[]}`, changes[2].Snapshot)
 		assert.Equal(t, `{"todos":["buy coffee"]}`, changes[1].Snapshot)
 		assert.Equal(t, `{"todos":["buy coffee","buy bread"]}`, changes[0].Snapshot)
-	})
-
-	t.Run("history test with purging changes", func(t *testing.T) {
-		conf := helper.TestConfig()
-		conf.Backend.SnapshotWithPurgingChanges = true
-		testServer, err := server.New(conf)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		if err := testServer.Start(); err != nil {
-			logging.DefaultLogger().Fatal(err)
-		}
-
-		cli, err := client.Dial(
-			testServer.RPCAddr(),
-			client.WithPresence(types.Presence{"name": fmt.Sprintf("name-%d", 0)}),
-		)
-		assert.NoError(t, err)
-
-		err = cli.Activate(context.Background())
-		assert.NoError(t, err)
-		defer func() {
-			assert.NoError(t, cli.Deactivate(context.Background()))
-			assert.NoError(t, cli.Close())
-		}()
-
-		adminCli := helper.CreateAdminCli(t, testServer.AdminAddr())
-		assert.NoError(t, err)
-		defer func() { assert.NoError(t, adminCli.Close()) }()
-
-		ctx := context.Background()
-
-		doc := document.New(key.Key(t.Name()))
-		assert.NoError(t, cli.Attach(ctx, doc))
-		defer func() { assert.NoError(t, cli.Detach(ctx, doc)) }()
-
-		assert.NoError(t, doc.Update(func(root *json.Object) error {
-			root.SetNewArray("todos")
-			return nil
-		}, "create todos"))
-		assert.Equal(t, `{"todos":[]}`, doc.Marshal())
-
-		assert.NoError(t, doc.Update(func(root *json.Object) error {
-			root.GetArray("todos").AddString("buy coffee")
-			return nil
-		}, "buy coffee"))
-		assert.Equal(t, `{"todos":["buy coffee"]}`, doc.Marshal())
-
-		assert.NoError(t, doc.Update(func(root *json.Object) error {
-			root.GetArray("todos").AddString("buy bread")
-			return nil
-		}, "buy bread"))
-		assert.Equal(t, `{"todos":["buy coffee","buy bread"]}`, doc.Marshal())
-		assert.NoError(t, cli.Sync(ctx))
-
-		changes, err := adminCli.ListChangeSummaries(ctx, "default", doc.Key(), 0, 0, true)
-		assert.NoError(t, err)
-		assert.Len(t, changes, 3)
-
-		assert.NoError(t, cli.Sync(ctx))
-
-		changes2, err := adminCli.ListChangeSummaries(ctx, "default", doc.Key(), 0, 0, true)
-		assert.NoError(t, err)
-		assert.Len(t, changes2, 0)
 	})
 }

--- a/test/integration/retention_test.go
+++ b/test/integration/retention_test.go
@@ -1,0 +1,118 @@
+//go:build integration && amd64
+
+/*
+ * Copyright 2022 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/api/types"
+	"github.com/yorkie-team/yorkie/client"
+	"github.com/yorkie-team/yorkie/pkg/document"
+	"github.com/yorkie-team/yorkie/pkg/document/json"
+	"github.com/yorkie-team/yorkie/pkg/document/key"
+	"github.com/yorkie-team/yorkie/server"
+	"github.com/yorkie-team/yorkie/server/backend/background"
+	"github.com/yorkie-team/yorkie/server/logging"
+	"github.com/yorkie-team/yorkie/test/helper"
+)
+
+func TestRetention(t *testing.T) {
+	var b *background.Background
+	monkey.PatchInstanceMethod(
+		reflect.TypeOf(b),
+		"AttachGoroutine",
+		func(_ *background.Background, f func(c context.Context)) {
+			f(context.Background())
+		},
+	)
+	defer monkey.UnpatchInstanceMethod(
+		reflect.TypeOf(b),
+		"AttachGoroutine",
+	)
+
+	t.Run("history test with purging changes", func(t *testing.T) {
+		conf := helper.TestConfig()
+		conf.Backend.SnapshotWithPurgingChanges = true
+		testServer, err := server.New(conf)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if err := testServer.Start(); err != nil {
+			logging.DefaultLogger().Fatal(err)
+		}
+
+		cli, err := client.Dial(
+			testServer.RPCAddr(),
+			client.WithPresence(types.Presence{"name": fmt.Sprintf("name-%d", 0)}),
+		)
+		assert.NoError(t, err)
+		assert.NoError(t, cli.Activate(context.Background()))
+		defer func() {
+			assert.NoError(t, cli.Deactivate(context.Background()))
+			assert.NoError(t, cli.Close())
+		}()
+
+		adminCli := helper.CreateAdminCli(t, testServer.AdminAddr())
+		assert.NoError(t, err)
+		defer func() { assert.NoError(t, adminCli.Close()) }()
+
+		ctx := context.Background()
+
+		doc := document.New(key.Key(t.Name()))
+		assert.NoError(t, cli.Attach(ctx, doc))
+		defer func() { assert.NoError(t, cli.Detach(ctx, doc)) }()
+
+		assert.NoError(t, doc.Update(func(root *json.Object) error {
+			root.SetNewArray("todos")
+			return nil
+		}, "create todos"))
+		assert.Equal(t, `{"todos":[]}`, doc.Marshal())
+
+		assert.NoError(t, doc.Update(func(root *json.Object) error {
+			root.GetArray("todos").AddString("buy coffee")
+			return nil
+		}, "buy coffee"))
+		assert.Equal(t, `{"todos":["buy coffee"]}`, doc.Marshal())
+
+		assert.NoError(t, doc.Update(func(root *json.Object) error {
+			root.GetArray("todos").AddString("buy bread")
+			return nil
+		}, "buy bread"))
+		assert.Equal(t, `{"todos":["buy coffee","buy bread"]}`, doc.Marshal())
+		assert.NoError(t, cli.Sync(ctx))
+
+		changes, err := adminCli.ListChangeSummaries(ctx, "default", doc.Key(), 0, 0, true)
+		assert.NoError(t, err)
+		assert.Len(t, changes, 3)
+
+		assert.NoError(t, cli.Sync(ctx))
+
+		changes2, err := adminCli.ListChangeSummaries(ctx, "default", doc.Key(), 0, 0, true)
+		assert.NoError(t, err)
+		assert.Len(t, changes2, 0)
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The development cost is too high to allow multiple people to manage a project
or to develop `Team` concept. So, for now, only one user manages the project,
and let's do migration when implementing `team` in the future.

Perhaps the development steps would be something like this:

- Step 1: Make the `Project` owned by only a `User`
- Step 2: Create `Project`-`User` mapping table `Role`
- Step 3: Create `Team` own the `Project`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related to #377

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
