### PR TITLE
improve commit and buildDate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,12 @@ YORKIE_VERSION := 0.2.17
 
 GO_PROJECT = github.com/yorkie-team/yorkie
 
+ifeq ($(OS),Windows_NT)
+    EXECUTABLE = ./bin/yorkie.exe
+else
+    EXECUTABLE = ./bin/yorkie
+endif
+
 # inject the version number into the golang version package using the -X linker flag
 GO_LDFLAGS ?=
 GO_LDFLAGS += -X ${GO_PROJECT}/internal/version.Version=${YORKIE_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,10 @@
 YORKIE_VERSION := 0.2.17
 
-GIT_COMMIT := $(shell /usr/bin/git rev-parse --short HEAD)
 GO_PROJECT = github.com/yorkie-team/yorkie
-
-ifeq ($(OS),Windows_NT)
-    BUILD_DATE := $(shell echo %date:~6,4%-%date:~0,2%-%date:~3,2%)
-    GO_SRC := $(shell dir /s /b *.go | findstr /v "vendor")
-    EXECUTABLE = ./bin/yorkie.exe
-else
-    BUILD_DATE := $(shell date "+%Y-%m-%d")
-    GO_SRC := $(shell find . -path ./vendor -prune -o -type f -name '*.go' -print)
-    EXECUTABLE = ./bin/yorkie
-endif
 
 # inject the version number into the golang version package using the -X linker flag
 GO_LDFLAGS ?=
-GO_LDFLAGS += -X ${GO_PROJECT}/internal/version.GitCommit=${GIT_COMMIT}
 GO_LDFLAGS += -X ${GO_PROJECT}/internal/version.Version=${YORKIE_VERSION}
-GO_LDFLAGS += -X ${GO_PROJECT}/internal/version.BuildDate=${BUILD_DATE}
 
 default: help
 

--- a/cmd/yorkie/version.go
+++ b/cmd/yorkie/version.go
@@ -26,15 +26,18 @@ import (
 	"github.com/yorkie-team/yorkie/internal/version"
 )
 
+const commitRevisionKey = "vcs.revision"
+const buildTimeKey = "vcs.time"
+
 func newVersionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Print the version number of Yorkie",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Printf("Yorkie: %s\n", version.Version)
-			fmt.Printf("Commit: %s\n", getBuildInfoByKey("vcs.revision"))
+			fmt.Printf("Commit: %s\n", getBuildInfoByKey(commitRevisionKey))
 			fmt.Printf("Go: %s\n", runtime.Version())
-			fmt.Printf("Build date: %s\n", getBuildInfoByKey("vcs.time"))
+			fmt.Printf("Build date: %s\n", getBuildInfoByKey(buildTimeKey))
 			return nil
 		},
 	}

--- a/cmd/yorkie/version.go
+++ b/cmd/yorkie/version.go
@@ -19,6 +19,7 @@ package main
 import (
 	"fmt"
 	"runtime"
+	"runtime/debug"
 
 	"github.com/spf13/cobra"
 
@@ -31,12 +32,25 @@ func newVersionCmd() *cobra.Command {
 		Short: "Print the version number of Yorkie",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Printf("Yorkie: %s\n", version.Version)
-			fmt.Printf("Commit: %s\n", version.GitCommit)
+			fmt.Printf("Commit: %s\n", getBuildInfoByKey("vcs.revision"))
 			fmt.Printf("Go: %s\n", runtime.Version())
-			fmt.Printf("Build date: %s\n", version.BuildDate)
+			fmt.Printf("Build date: %s\n", getBuildInfoByKey("vcs.time"))
 			return nil
 		},
 	}
+}
+
+func getBuildInfoByKey(key string) string {
+	return func() string {
+		if info, ok := debug.ReadBuildInfo(); ok {
+			for _, setting := range info.Settings {
+				if setting.Key == key {
+					return setting.Value
+				}
+			}
+		}
+		return ""
+	}()
 }
 
 func init() {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,12 +2,6 @@ package version
 
 // At build time, the versions is replaced with the current version using the -X linker flag
 var (
-	// GitCommit is the git commit that was compiled.
-	GitCommit string
-
 	// Version is the main version number that is being run at the moment.
 	Version = "0.0.0"
-
-	// BuildDate is the date the executable was built.
-	BuildDate string
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- improve version cmd's commitVersion and buildTime (use debug/buildInfo (add [this feature](https://tip.golang.org/doc/go1.18#debug/buildinfo) in go 1.18)).
- rm make script depending on os.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
