### PR TITLE
Remove unused nodeMapByCreatedAt in RHT

### DIFF
--- a/pkg/document/crdt/rht.go
+++ b/pkg/document/crdt/rht.go
@@ -74,15 +74,13 @@ func (n *RHTNode) RemovedAt() *time.Ticket {
 // RHT is a hashtable with logical clock(Replicated hashtable).
 // For more details about RHT: http://csl.skku.edu/papers/jpdc11.pdf
 type RHT struct {
-	nodeMapByKey       map[string]*RHTNode
-	nodeMapByCreatedAt map[string]*RHTNode
+	nodeMapByKey map[string]*RHTNode
 }
 
 // NewRHT creates a new instance of RHT.
 func NewRHT() *RHT {
 	return &RHT{
-		nodeMapByKey:       make(map[string]*RHTNode),
-		nodeMapByCreatedAt: make(map[string]*RHTNode),
+		nodeMapByKey: make(map[string]*RHTNode),
 	}
 }
 
@@ -112,7 +110,6 @@ func (rht *RHT) Set(k, v string, executedAt *time.Ticket) {
 	if node, ok := rht.nodeMapByKey[k]; !ok || executedAt.After(node.updatedAt) {
 		newNode := newRHTNode(k, v, executedAt)
 		rht.nodeMapByKey[k] = newNode
-		rht.nodeMapByCreatedAt[executedAt.Key()] = newNode
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Remove unused nodeMapByCreatedAt in RHT

In `RHT`, `nodeMapByCreatedAt` is required for remote deletion. However, `RHT` for representing attributes in `RichText`, doesn't currently need delete method, so this commit removes `nodeMapByCreatedAt`.

CC) @skhugh 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related to https://github.com/yorkie-team/yorkie-js-sdk/pull/386

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
