### PR TITLE
Fix to valid authWebhookURL in benchmark test

### DIFF
--- a/test/bench/grpc_bench_test.go
+++ b/test/bench/grpc_bench_test.go
@@ -103,7 +103,7 @@ func benchmarkUpdateAndSync(
 func benchmarkUpdateProject(ctx context.Context, b *testing.B, cnt int, adminCli *admin.Client) error {
 	for i := 0; i < cnt; i++ {
 		name := fmt.Sprintf("name%d", i)
-		authWebhookURL := fmt.Sprintf("authWebhookURL%d", i)
+		authWebhookURL := fmt.Sprintf("http://authWebhookURL%d", i)
 		authWebhookMethods := []string{}
 		for _, m := range types.AuthMethods() {
 			authWebhookMethods = append(authWebhookMethods, string(m))


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The benchmark test fails with InvalidArgument errors, so I fix to valid authWebhookURL.

![image](https://user-images.githubusercontent.com/81357083/190327674-9db96c8f-8d87-4090-9aa6-3b78336eb450.png)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
