### PR TITLE
Move retention-related tests to retention_test.go

### DIFF
--- a/test/integration/retention_test.go
+++ b/test/integration/retention_test.go
@@ -31,10 +31,12 @@ import (
 	"github.com/yorkie-team/yorkie/api/types"
 	"github.com/yorkie-team/yorkie/client"
 	"github.com/yorkie-team/yorkie/pkg/document"
+	"github.com/yorkie-team/yorkie/pkg/document/change"
 	"github.com/yorkie-team/yorkie/pkg/document/json"
 	"github.com/yorkie-team/yorkie/pkg/document/key"
 	"github.com/yorkie-team/yorkie/server"
 	"github.com/yorkie-team/yorkie/server/backend/background"
+	"github.com/yorkie-team/yorkie/server/backend/database/mongo"
 	"github.com/yorkie-team/yorkie/server/logging"
 	"github.com/yorkie-team/yorkie/test/helper"
 )
@@ -114,5 +116,135 @@ func TestRetention(t *testing.T) {
 		changes2, err := adminCli.ListChangeSummaries(ctx, "default", doc.Key(), 0, 0, true)
 		assert.NoError(t, err)
 		assert.Len(t, changes2, 0)
+	})
+
+	t.Run("snapshot with purging chagnes test", func(t *testing.T) {
+		serverConfig := helper.TestConfig()
+		// Default SnapshotInterval is 0, SnashotThreshold must also be 0
+		serverConfig.Backend.SnapshotThreshold = 0
+		serverConfig.Backend.SnapshotWithPurgingChanges = true
+		testServer, err := server.New(serverConfig)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if err := testServer.Start(); err != nil {
+			logging.DefaultLogger().Fatal(err)
+		}
+
+		cli1, err := client.Dial(
+			testServer.RPCAddr(),
+			client.WithPresence(types.Presence{"name": fmt.Sprintf("name-%d", 0)}),
+		)
+		assert.NoError(t, err)
+
+		err = cli1.Activate(context.Background())
+		assert.NoError(t, err)
+		defer func() {
+			assert.NoError(t, cli1.Deactivate(context.Background()))
+			assert.NoError(t, cli1.Close())
+		}()
+
+		ctx := context.Background()
+
+		d1 := document.New(key.Key(t.Name()))
+		assert.NoError(t, cli1.Attach(ctx, d1))
+		defer func() { assert.NoError(t, cli1.Detach(ctx, d1)) }()
+
+		err = d1.Update(func(root *json.Object) error {
+			root.SetNewText("k1")
+			return nil
+		})
+		assert.NoError(t, err)
+
+		var edits = []struct {
+			from    int
+			to      int
+			content string
+		}{
+			{0, 0, "ㅎ"}, {0, 1, "하"},
+			{0, 1, "한"}, {0, 1, "하"},
+			{1, 1, "느"}, {1, 2, "늘"},
+		}
+
+		// Create 6 changes
+		for _, edit := range edits {
+			err = d1.Update(func(root *json.Object) error {
+				root.GetText("k1").Edit(edit.from, edit.to, edit.content)
+				return nil
+			})
+			assert.NoError(t, err)
+			err = cli1.Sync(ctx)
+			assert.NoError(t, err)
+		}
+
+		mongoConfig := &mongo.Config{
+			ConnectionTimeout: "5s",
+			ConnectionURI:     "mongodb://localhost:27017",
+			YorkieDatabase:    helper.TestDBName(),
+			PingTimeout:       "5s",
+		}
+		assert.NoError(t, mongoConfig.Validate())
+
+		mongoCli, err := mongo.Dial(mongoConfig)
+		assert.NoError(t, err)
+
+		docInfo, err := mongoCli.FindDocInfoByKey(
+			ctx,
+			"000000000000000000000000",
+			d1.Key(),
+		)
+		assert.NoError(t, err)
+
+		changes, err := mongoCli.FindChangesBetweenServerSeqs(
+			ctx,
+			docInfo.ID,
+			change.InitialServerSeq,
+			change.MaxServerSeq,
+		)
+		assert.NoError(t, err)
+
+		// When the snapshot is created, changes before minSyncedServerSeq are deleted, so two changes remain.
+		// Since minSyncedServerSeq is one older from the most recent ServerSeq,
+		// one is most recent ServerSeq and one is one older from the most recent ServerSeq
+		assert.Len(t, changes, 2)
+
+		cli2, err := client.Dial(
+			testServer.RPCAddr(),
+			client.WithPresence(types.Presence{"name": fmt.Sprintf("name-%d", 1)}),
+		)
+		assert.NoError(t, err)
+
+		err = cli2.Activate(context.Background())
+		assert.NoError(t, err)
+		defer func() {
+			assert.NoError(t, cli2.Deactivate(context.Background()))
+			assert.NoError(t, cli2.Close())
+		}()
+
+		d2 := document.New(key.Key(t.Name()))
+		assert.NoError(t, cli2.Attach(ctx, d2))
+		defer func() { assert.NoError(t, cli2.Detach(ctx, d2)) }()
+
+		// Create 6 changes
+		for _, edit := range edits {
+			err = d2.Update(func(root *json.Object) error {
+				root.GetText("k1").Edit(edit.from, edit.to, edit.content)
+				return nil
+			})
+			assert.NoError(t, err)
+			err = cli2.Sync(ctx)
+			assert.NoError(t, err)
+		}
+
+		changes, err = mongoCli.FindChangesBetweenServerSeqs(
+			ctx,
+			docInfo.ID,
+			change.InitialServerSeq,
+			change.MaxServerSeq,
+		)
+		assert.NoError(t, err)
+
+		assert.Len(t, changes, 8)
 	})
 }

--- a/test/integration/snapshot_test.go
+++ b/test/integration/snapshot_test.go
@@ -21,23 +21,16 @@ package integration
 import (
 	"context"
 	"fmt"
-	"log"
 	"reflect"
 	"testing"
 
 	"bou.ke/monkey"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/yorkie-team/yorkie/api/types"
-	"github.com/yorkie-team/yorkie/client"
 	"github.com/yorkie-team/yorkie/pkg/document"
-	"github.com/yorkie-team/yorkie/pkg/document/change"
 	"github.com/yorkie-team/yorkie/pkg/document/json"
 	"github.com/yorkie-team/yorkie/pkg/document/key"
-	"github.com/yorkie-team/yorkie/server"
 	"github.com/yorkie-team/yorkie/server/backend/background"
-	"github.com/yorkie-team/yorkie/server/backend/database/mongo"
-	"github.com/yorkie-team/yorkie/server/logging"
 	"github.com/yorkie-team/yorkie/test/helper"
 )
 
@@ -174,135 +167,5 @@ func TestSnapshot(t *testing.T) {
 		assert.NoError(t, err)
 
 		syncClientsThenAssertEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
-	})
-
-	t.Run("snapshot with purging chagnes test", func(t *testing.T) {
-		serverConfig := helper.TestConfig()
-		// Default SnapshotInterval is 0, SnashotThreshold must also be 0
-		serverConfig.Backend.SnapshotThreshold = 0
-		serverConfig.Backend.SnapshotWithPurgingChanges = true
-		testServer, err := server.New(serverConfig)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		if err := testServer.Start(); err != nil {
-			logging.DefaultLogger().Fatal(err)
-		}
-
-		cli1, err := client.Dial(
-			testServer.RPCAddr(),
-			client.WithPresence(types.Presence{"name": fmt.Sprintf("name-%d", 0)}),
-		)
-		assert.NoError(t, err)
-
-		err = cli1.Activate(context.Background())
-		assert.NoError(t, err)
-		defer func() {
-			assert.NoError(t, cli1.Deactivate(context.Background()))
-			assert.NoError(t, cli1.Close())
-		}()
-
-		ctx := context.Background()
-
-		d1 := document.New(key.Key(t.Name()))
-		assert.NoError(t, cli1.Attach(ctx, d1))
-		defer func() { assert.NoError(t, cli1.Detach(ctx, d1)) }()
-
-		err = d1.Update(func(root *json.Object) error {
-			root.SetNewText("k1")
-			return nil
-		})
-		assert.NoError(t, err)
-
-		var edits = []struct {
-			from    int
-			to      int
-			content string
-		}{
-			{0, 0, "ㅎ"}, {0, 1, "하"},
-			{0, 1, "한"}, {0, 1, "하"},
-			{1, 1, "느"}, {1, 2, "늘"},
-		}
-
-		// Create 6 changes
-		for _, edit := range edits {
-			err = d1.Update(func(root *json.Object) error {
-				root.GetText("k1").Edit(edit.from, edit.to, edit.content)
-				return nil
-			})
-			assert.NoError(t, err)
-			err = cli1.Sync(ctx)
-			assert.NoError(t, err)
-		}
-
-		mongoConfig := &mongo.Config{
-			ConnectionTimeout: "5s",
-			ConnectionURI:     "mongodb://localhost:27017",
-			YorkieDatabase:    helper.TestDBName(),
-			PingTimeout:       "5s",
-		}
-		assert.NoError(t, mongoConfig.Validate())
-
-		mongoCli, err := mongo.Dial(mongoConfig)
-		assert.NoError(t, err)
-
-		docInfo, err := mongoCli.FindDocInfoByKey(
-			ctx,
-			"000000000000000000000000",
-			d1.Key(),
-		)
-		assert.NoError(t, err)
-
-		changes, err := mongoCli.FindChangesBetweenServerSeqs(
-			ctx,
-			docInfo.ID,
-			change.InitialServerSeq,
-			change.MaxServerSeq,
-		)
-		assert.NoError(t, err)
-
-		// When the snapshot is created, changes before minSyncedServerSeq are deleted, so two changes remain.
-		// Since minSyncedServerSeq is one older from the most recent ServerSeq,
-		// one is most recent ServerSeq and one is one older from the most recent ServerSeq
-		assert.Len(t, changes, 2)
-
-		cli2, err := client.Dial(
-			testServer.RPCAddr(),
-			client.WithPresence(types.Presence{"name": fmt.Sprintf("name-%d", 1)}),
-		)
-		assert.NoError(t, err)
-
-		err = cli2.Activate(context.Background())
-		assert.NoError(t, err)
-		defer func() {
-			assert.NoError(t, cli2.Deactivate(context.Background()))
-			assert.NoError(t, cli2.Close())
-		}()
-
-		d2 := document.New(key.Key(t.Name()))
-		assert.NoError(t, cli2.Attach(ctx, d2))
-		defer func() { assert.NoError(t, cli2.Detach(ctx, d2)) }()
-
-		// Create 6 changes
-		for _, edit := range edits {
-			err = d2.Update(func(root *json.Object) error {
-				root.GetText("k1").Edit(edit.from, edit.to, edit.content)
-				return nil
-			})
-			assert.NoError(t, err)
-			err = cli2.Sync(ctx)
-			assert.NoError(t, err)
-		}
-
-		changes, err = mongoCli.FindChangesBetweenServerSeqs(
-			ctx,
-			docInfo.ID,
-			change.InitialServerSeq,
-			change.MaxServerSeq,
-		)
-		assert.NoError(t, err)
-
-		assert.Len(t, changes, 8)
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Move retention-related tests to retention_test.go.
Recently, retention-related tests have been moved to retention_test.go.  #398
This part of the code also tests whether snapshots and changes are stored in the DB as intended when using the retention feature(`--backend-snapshot-with-purging-changes` flag), so I suggest moving to retention_test.go.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
