### PR TITLE
Remove use of bou.ke/monkey library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/yorkie-team/yorkie
 go 1.19
 
 require (
-	bou.ke/monkey v1.0.2
 	github.com/go-playground/locales v0.14.0
 	github.com/go-playground/universal-translator v0.18.0
 	github.com/go-playground/validator/v10 v10.11.1
@@ -18,6 +17,7 @@ require (
 	github.com/rs/xid v1.4.0
 	github.com/spf13/cobra v1.5.0
 	github.com/stretchr/testify v1.8.0
+	github.com/undefinedlabs/go-mpatch v1.0.6
 	go.etcd.io/etcd/api/v3 v3.5.5
 	go.etcd.io/etcd/client/v3 v3.5.5
 	go.mongodb.org/mongo-driver v1.10.3

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
-bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -293,6 +291,8 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/undefinedlabs/go-mpatch v1.0.6 h1:h8q5ORH/GaOE1Se1DMhrOyljXZEhRcROO7agMqWXCOY=
+github.com/undefinedlabs/go-mpatch v1.0.6/go.mod h1:TyJZDQ/5AgyN7FSLiBJ8RO9u2c6wbtRvK827b6AVqY4=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.1.1 h1:VOMT+81stJgXW3CpHyqHN3AXDYIMsx56mEFrB37Mb/E=

--- a/server/backend/database/memory/housekeeping_test.go
+++ b/server/backend/database/memory/housekeeping_test.go
@@ -21,11 +21,12 @@ package memory_test
 import (
 	"context"
 	"fmt"
+	"log"
 	"testing"
 	gotime "time"
 
-	"bou.ke/monkey"
 	"github.com/stretchr/testify/assert"
+	monkey "github.com/undefinedlabs/go-mpatch"
 
 	"github.com/yorkie-team/yorkie/server/backend/database"
 	"github.com/yorkie-team/yorkie/server/backend/database/memory"
@@ -40,12 +41,15 @@ func TestHousekeeping(t *testing.T) {
 		ctx := context.Background()
 
 		yesterday := gotime.Now().Add(-24 * gotime.Hour)
-		guard := monkey.Patch(gotime.Now, func() gotime.Time { return yesterday })
+		patch, err := monkey.PatchMethod(gotime.Now, func() gotime.Time { return yesterday })
+		if err != nil {
+			log.Fatal(err)
+		}
 		clientA, err := memdb.ActivateClient(ctx, projectID, fmt.Sprintf("%s-A", t.Name()))
 		assert.NoError(t, err)
 		clientB, err := memdb.ActivateClient(ctx, projectID, fmt.Sprintf("%s-B", t.Name()))
 		assert.NoError(t, err)
-		guard.Unpatch()
+		patch.Unpatch()
 
 		clientC, err := memdb.ActivateClient(ctx, projectID, fmt.Sprintf("%s-C", t.Name()))
 		assert.NoError(t, err)

--- a/server/backend/database/memory/housekeeping_test.go
+++ b/server/backend/database/memory/housekeeping_test.go
@@ -49,7 +49,10 @@ func TestHousekeeping(t *testing.T) {
 		assert.NoError(t, err)
 		clientB, err := memdb.ActivateClient(ctx, projectID, fmt.Sprintf("%s-B", t.Name()))
 		assert.NoError(t, err)
-		patch.Unpatch()
+		err = patch.Unpatch()
+		if err != nil {
+			log.Fatal(err)
+		}
 
 		clientC, err := memdb.ActivateClient(ctx, projectID, fmt.Sprintf("%s-C", t.Name()))
 		assert.NoError(t, err)

--- a/test/integration/retention_test.go
+++ b/test/integration/retention_test.go
@@ -25,8 +25,8 @@ import (
 	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/stretchr/testify/assert"
+	monkey "github.com/undefinedlabs/go-mpatch"
 
 	"github.com/yorkie-team/yorkie/api/types"
 	"github.com/yorkie-team/yorkie/client"
@@ -43,17 +43,17 @@ import (
 
 func TestRetention(t *testing.T) {
 	var b *background.Background
-	monkey.PatchInstanceMethod(
+	patch, err := monkey.PatchInstanceMethodByName(
 		reflect.TypeOf(b),
 		"AttachGoroutine",
 		func(_ *background.Background, f func(c context.Context)) {
 			f(context.Background())
 		},
 	)
-	defer monkey.UnpatchInstanceMethod(
-		reflect.TypeOf(b),
-		"AttachGoroutine",
-	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer patch.Unpatch()
 
 	t.Run("history test with purging changes", func(t *testing.T) {
 		conf := helper.TestConfig()

--- a/test/integration/snapshot_test.go
+++ b/test/integration/snapshot_test.go
@@ -21,11 +21,12 @@ package integration
 import (
 	"context"
 	"fmt"
+	"log"
 	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/stretchr/testify/assert"
+	monkey "github.com/undefinedlabs/go-mpatch"
 
 	"github.com/yorkie-team/yorkie/pkg/document"
 	"github.com/yorkie-team/yorkie/pkg/document/json"
@@ -36,17 +37,17 @@ import (
 
 func TestSnapshot(t *testing.T) {
 	var b *background.Background
-	monkey.PatchInstanceMethod(
+	patch, err := monkey.PatchInstanceMethodByName(
 		reflect.TypeOf(b),
 		"AttachGoroutine",
 		func(_ *background.Background, f func(c context.Context)) {
 			f(context.Background())
 		},
 	)
-	defer monkey.UnpatchInstanceMethod(
-		reflect.TypeOf(b),
-		"AttachGoroutine",
-	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer patch.Unpatch()
 
 	clients := activeClients(t, 2)
 	c1, c2 := clients[0], clients[1]


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Remove use of bou.ke/monkey library.

Recently there was an issue pointing to the license of the monkey patch library.
I looked for several ways to replace it, but other monkey patch libraries have the same problem that there are too few users and can not used in the arm architecture.

So, I thought about changing it in a way that avoids the need for a monkey patch, and I tried it. 
But, this method may be considered unclean.
I'd appreciate it if you could comment on what I've been working on

<b>Edit: </b>
I changed it to use the undefinedlabs/go-mpatch library instead of the above method.
Same problem not working on ARM architecture, but I was able to completely replace the bou.ke/monkey library.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #416 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
