### PR TITLE
feat: replace etcd image source from bitnami to quay

### DIFF
--- a/docker/docker-compose-full.yml
+++ b/docker/docker-compose-full.yml
@@ -18,11 +18,18 @@ services:
     depends_on:
       - prometheus
   etcd:
-    image: bitnami/etcd:latest
+    image: quay.io/coreos/etcd:latest
     container_name: etcd
-    environment:
-      - ALLOW_NONE_AUTHENTICATION=yes
-      - ETCD_ADVERTISE_CLIENT_URLS=http://etcd:2379
+    entrypoint: /usr/local/bin/etcd
+    command:
+      - '--name=etcd'
+      - '--initial-advertise-peer-urls=http://etcd:2379,http://etcd:2380'
+      - '--advertise-client-urls=http://etcd:2379,http://etcd:2380'
+      - '--listen-client-urls=http://0.0.0.0:2379'
+      - '--listen-peer-urls=http://0.0.0.0:2380'
+      - '--initial-cluster=etcd=http://etcd:2379,etcd=http://etcd:2380'
+      - '--initial-cluster-token=etcd'
+      - '--initial-cluster-state=new'
     ports:
       - '2379:2379'
       - '2380:2380'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,11 +2,18 @@ version: '3.3'
 
 services:
   etcd:
-    image: bitnami/etcd:latest
+    image: quay.io/coreos/etcd:latest
     container_name: etcd
-    environment:
-      - ALLOW_NONE_AUTHENTICATION=yes
-      - ETCD_ADVERTISE_CLIENT_URLS=http://etcd:2379
+    entrypoint: /usr/local/bin/etcd
+    command:
+      - '--name=etcd'
+      - '--initial-advertise-peer-urls=http://etcd:2379,http://etcd:2380'
+      - '--advertise-client-urls=http://etcd:2379,http://etcd:2380'
+      - '--listen-client-urls=http://0.0.0.0:2379'
+      - '--listen-peer-urls=http://0.0.0.0:2380'
+      - '--initial-cluster=etcd=http://etcd:2379,etcd=http://etcd:2380'
+      - '--initial-cluster-token=etcd'
+      - '--initial-cluster-state=new'
     ports:
       - '2379:2379'
       - '2380:2380'


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
To resolve the issue of etcd not running properly in the arm64 architecture.

@dc7303 discovered and raised this issue before(etcd-io/etcd#14321), but the problem remains unresolved. For now, When we run `bitnami/etcd` image on arm64 environment, the first time the image run always fails and then we must restart image ourselves.

There was a [comment](https://github.com/etcd-io/etcd/issues/14321#issuecomment-1277240307) on the issue that said using the `quay.io/coreos/etcd` image would solve the problem, and it really works on my arm64 environment without any problems. So I made this pr because I thought it would be better to use the `quay.io/coreos/etcd` image rather than `bitnami/etcd`.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
no issues related.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
