### PR TITLE
Fix invalid JSON returned when marshaling dates

### DIFF
--- a/pkg/document/crdt/primitive.go
+++ b/pkg/document/crdt/primitive.go
@@ -200,7 +200,7 @@ func (p *Primitive) Marshal() string {
 		// {"a":{"0":1,"1":2},"b":2}
 		return fmt.Sprintf(`"%s"`, p.value)
 	case Date:
-		return p.value.(gotime.Time).Format(gotime.RFC3339)
+		return fmt.Sprintf(`"%s"`, p.value.(gotime.Time).Format(gotime.RFC3339))
 	}
 
 	panic("unsupported type")

--- a/pkg/document/crdt/primitive_test.go
+++ b/pkg/document/crdt/primitive_test.go
@@ -17,6 +17,7 @@
 package crdt_test
 
 import (
+	"fmt"
 	"math"
 	"testing"
 	gotime "time"
@@ -41,7 +42,7 @@ func TestPrimitive(t *testing.T) {
 		{float64(0), crdt.Double, "0.000000"},
 		{"0", crdt.String, `"0"`},
 		{[]byte{}, crdt.Bytes, `""`},
-		{gotime.Unix(0, 0), crdt.Date, gotime.Unix(0, 0).Format(gotime.RFC3339)},
+		{gotime.Unix(0, 0), crdt.Date, fmt.Sprintf(`"%s"`, gotime.Unix(0, 0).Format(gotime.RFC3339))},
 	}
 
 	t.Run("creation and deep copy test", func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix invalid JSON returned when marshaling dates.

AS-IS
```js
{
  "date": 2022-11-25T01:15:41+09:00
}
```

TO-BE
```js
{
  "date": "2022-11-25T01:15:41+09:00"
}
```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
