### PR TITLE
Add additional unwrap code in ToStatusError gRPC error handler

### DIFF
--- a/server/grpchelper/status.go
+++ b/server/grpchelper/status.go
@@ -100,9 +100,9 @@ func detailsFromError(err error) (protoiface.MessageV1, bool) {
 // occurs while executing logic in API handler, gRPC status.error should be
 // returned so that the client can know more about the status of the request.
 func ToStatusError(err error) error {
-	cause := errors.Unwrap(err)
-	if cause == nil {
-		cause = err
+	cause := err
+	for errors.Unwrap(cause) != nil {
+		cause = errors.Unwrap(cause)
 	}
 	if code, ok := errorToCode[cause]; ok {
 		return status.Error(code, err.Error())


### PR DESCRIPTION
**What this PR does / why we need it**:

Add additional unwrap code in `TostatusError()` in `grpchelper/status.go` which unwrap’s error until cause is set to base inner error.

This additional code is needed to avoid `errorToCode` map’s `hash of unhashable type` runtime error which leads to server panic.

This will prevent Yorkie server(Yorkie SaaS API) to panic(service unavailable) on unexpected error triggered by user. 

Below is `ToStatusError()`’s parameter, `err`’s inner stacks(errors)

```go
error(*fmt.wrapError) *{
    	msg: "decode project info: connection(localhost:27017[-12]) incomplete read of message header: context canceled",
	err: error(go.mongodb.org/mongo-driver/mongo.CommandError) {
		Code: 0,
		Message: "connection(localhost:27017[-12]) incomplete read of message header: context canceled",
		Labels: []string len: 1, cap: 1, ["NetworkError"],
		Name: "",
		Wrapped: error(go.mongodb.org/mongo-driver/x/mongo/driver/topology.ConnectionError) *{
			ConnectionID: "localhost:27017[-12]",
			Wrapped: error(*errors.errorString) *{
				s: "context canceled"
			},
			init: false,
			message: "incomplete read of message header"
		},
		Raw: go.mongodb.org/mongo-driver/bson.Raw len: 0, cap: 0, nil
	}
}
```

Parameter `err` needs to be unwrapped to base inner error. If not, `errorToCode[cause]` map (maps error to gRPC status code) will get invalid key for map like `errorToCode[mongo.CommandError]` which will lead to server `panic: runtime error: hash of unhashable type mongo.CommandError`.

This runtime error will occur when parameter `err` has nested errors (ex: `mongo.CommandError`)

**Which issue(s) this PR fixes**:

No issue is related.

**Special notes for your reviewer**:

This PR started with server log provided by @hackerwins on discord thread on unexpected server down issue.

<img width="1279" alt="panic" src="https://user-images.githubusercontent.com/70474071/209976502-a79a381f-1650-49a1-859f-45b3dfdba014.png">

Also, I'm not sure about the initial cause of this error, which makes `connection(localhost:27017[-12]) incomplete read of message header: context canceled` error. I'll keep trying to reproduce this issue in code ASAP.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation**:

```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
