### PR TITLE
Fix wrong string escape in RichText's attrs

### DIFF
--- a/pkg/document/crdt/rht.go
+++ b/pkg/document/crdt/rht.go
@@ -177,7 +177,7 @@ func (rht *RHT) Marshal() string {
 			sb.WriteString(",")
 		}
 		value := members[k]
-		sb.WriteString(fmt.Sprintf(`"%s":"%s"`, k, value))
+		sb.WriteString(fmt.Sprintf(`"%s":"%s"`, EscapeString(k), EscapeString(value)))
 	}
 	sb.WriteString("}")
 

--- a/pkg/document/crdt/rht_pq_map.go
+++ b/pkg/document/crdt/rht_pq_map.go
@@ -226,7 +226,7 @@ func (rht *RHTPriorityQueueMap) Marshal() string {
 			sb.WriteString(",")
 		}
 		value := members[k]
-		sb.WriteString(fmt.Sprintf(`"%s":%s`, k, value.Marshal()))
+		sb.WriteString(fmt.Sprintf(`"%s":%s`, EscapeString(k), value.Marshal()))
 	}
 	sb.WriteString("}")
 

--- a/pkg/document/crdt/rht_test.go
+++ b/pkg/document/crdt/rht_test.go
@@ -8,10 +8,10 @@ import (
 
 func TestMarshal(t *testing.T) {
 	t.Run("marshal test", func(t *testing.T) {
-		key1 := "hello\\\t"
+		key1 := `hello\\\t`
 		value1 := "world\"\f\b"
 		key2 := "hi"
-		value2 := "test\r"
+		value2 := `test\r`
 		expected := `{"hello\\\\\\t":"world\\"\\f\\b","hi":"test\\r"}`
 
 		rht := NewRHT()

--- a/pkg/document/crdt/rht_test.go
+++ b/pkg/document/crdt/rht_test.go
@@ -1,0 +1,23 @@
+package crdt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMarshal(t *testing.T) {
+	t.Run("marshal test", func(t *testing.T) {
+		key1 := "hello\\\t"
+		value1 := "world\"\f\b"
+		key2 := "hi"
+		value2 := "test\r"
+		expected := `{"hello\\\\\\t":"world\\"\\f\\b","hi":"test\\r"}`
+
+		rht := NewRHT()
+		rht.Set(key1, value1, nil)
+		rht.Set(key2, value2, nil)
+		actual := rht.Marshal()
+		assert.Equal(t, expected, actual)
+	})
+}

--- a/pkg/document/crdt/strings.go
+++ b/pkg/document/crdt/strings.go
@@ -35,8 +35,6 @@ func EscapeString(s string) string {
 		case '\\':
 			buf.WriteByte('\\')
 			buf.WriteByte('\\')
-			buf.WriteByte('\\')
-			buf.WriteByte('\\')
 		case '"':
 			buf.WriteByte('\\')
 			buf.WriteByte('\\')

--- a/pkg/document/crdt/strings.go
+++ b/pkg/document/crdt/strings.go
@@ -32,26 +32,41 @@ func EscapeString(s string) string {
 			continue
 		}
 		switch c {
-		case '\\', '"':
+		case '\\':
 			buf.WriteByte('\\')
-			buf.WriteByte(c)
+			buf.WriteByte('\\')
+			buf.WriteByte('\\')
+			buf.WriteByte('\\')
+		case '"':
+			buf.WriteByte('\\')
+			buf.WriteByte('\\')
+			buf.WriteByte('"')
 		case '\n':
+			buf.WriteByte('\\')
 			buf.WriteByte('\\')
 			buf.WriteByte('n')
 		case '\f':
 			buf.WriteByte('\\')
+			buf.WriteByte('\\')
 			buf.WriteByte('f')
 		case '\b':
+			buf.WriteByte('\\')
 			buf.WriteByte('\\')
 			buf.WriteByte('b')
 		case '\r':
 			buf.WriteByte('\\')
+			buf.WriteByte('\\')
 			buf.WriteByte('r')
 		case '\t':
 			buf.WriteByte('\\')
+			buf.WriteByte('\\')
 			buf.WriteByte('t')
 		default:
-			buf.Write([]byte{'\\', 'u', '0', '0'})
+			buf.WriteByte('\\')
+			buf.WriteByte('\\')
+			buf.WriteByte('u')
+			buf.WriteByte('0')
+			buf.WriteByte('0')
 			buf.WriteByte(hex[c>>4])
 			buf.WriteByte(hex[c&0xF])
 		}

--- a/pkg/document/crdt/strings_test.go
+++ b/pkg/document/crdt/strings_test.go
@@ -37,28 +37,21 @@ func TestEscapeString(t *testing.T) {
 		assert.Equal(t, expected, actual)
 	})
 
-	t.Run("escape string with backslash", func(t *testing.T) {
-		str := `hello world\`
-		expected := `hello world\\\\`
-		actual := EscapeString(str)
-		assert.Equal(t, expected, actual)
-	})
-
-	t.Run("escape string with control character in switch case", func(t *testing.T) {
+	t.Run("escape string with raw control character", func(t *testing.T) {
 		str := "hello world\n"
 		expected := `hello world\\n`
 		actual := EscapeString(str)
 		assert.Equal(t, expected, actual)
 	})
 
-	t.Run("escape string with control character not in switch case", func(t *testing.T) {
-		str := "hello world\u0000"
-		expected := `hello world\\u0000`
+	t.Run("escape string with escaped control character", func(t *testing.T) {
+		str := `hello world\n`
+		expected := `hello world\\n`
 		actual := EscapeString(str)
 		assert.Equal(t, expected, actual)
 	})
 
-	t.Run("escape string with unicode character", func(t *testing.T) {
+	t.Run("escape string with raw unicode character", func(t *testing.T) {
 		str := "hello world\u1234"
 		expected := "hello world\u1234"
 		actual := EscapeString(str)

--- a/pkg/document/crdt/strings_test.go
+++ b/pkg/document/crdt/strings_test.go
@@ -23,11 +23,45 @@ import (
 )
 
 func TestEscapeString(t *testing.T) {
-	t.Run("escape string", func(t *testing.T) {
-		str := `"hello world"`
-		expected := `\"hello world\"`
+	t.Run("escape normal string", func(t *testing.T) {
+		str := `hello world`
+		expected := `hello world`
 		actual := EscapeString(str)
 		assert.Equal(t, expected, actual)
+	})
 
+	t.Run("escape string with doublequote", func(t *testing.T) {
+		str := `hello world"`
+		expected := `hello world\\"`
+		actual := EscapeString(str)
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("escape string with backslash", func(t *testing.T) {
+		str := `hello world\`
+		expected := `hello world\\\\`
+		actual := EscapeString(str)
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("escape string with control character in switch case", func(t *testing.T) {
+		str := "hello world\n"
+		expected := `hello world\\n`
+		actual := EscapeString(str)
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("escape string with control character not in switch case", func(t *testing.T) {
+		str := "hello world\u0000"
+		expected := `hello world\\u0000`
+		actual := EscapeString(str)
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("escape string with unicode character", func(t *testing.T) {
+		str := "hello world\u1234"
+		expected := "hello world\u1234"
+		actual := EscapeString(str)
+		assert.Equal(t, expected, actual)
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
In RichText's attrs, missing backslash before special characters caused JSON parse error. RHT.Marshal() now inserts escape characters when constructing JSON encoding.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #437

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [ ] Didn't break anything
