### PR TITLE
Clean up codes

### DIFF
--- a/api/types/auth_webhook.go
+++ b/api/types/auth_webhook.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+
+	"github.com/yorkie-team/yorkie/pkg/document/key"
 )
 
 // VerbType represents an action taken on the document.
@@ -82,6 +84,18 @@ func AuthMethods() []Method {
 type AccessAttribute struct {
 	Key  string   `json:"key"`
 	Verb VerbType `json:"verb"`
+}
+
+// NewAccessAttributes creates a new instance of AccessAttributes.
+func NewAccessAttributes(docKeys []key.Key, verb VerbType) []AccessAttribute {
+	attrs := make([]AccessAttribute, len(docKeys))
+	for i, docKey := range docKeys {
+		attrs[i] = AccessAttribute{
+			Key:  docKey.String(),
+			Verb: verb,
+		}
+	}
+	return attrs
 }
 
 // AccessInfo represents an access information.

--- a/server/documents/documents.go
+++ b/server/documents/documents.go
@@ -29,6 +29,10 @@ import (
 	"github.com/yorkie-team/yorkie/server/packs"
 )
 
+// SnapshotMaxLen is the maximum length of the document snapshot in the
+// document summary.
+const SnapshotMaxLen = 50
+
 // ListDocumentSummaries returns a list of document summaries.
 func ListDocumentSummaries(
 	ctx context.Context,
@@ -48,14 +52,9 @@ func ListDocumentSummaries(
 			return nil, err
 		}
 
-		var snapshot string
-		fullSnapshot := doc.Marshal()
-		snapshotCutline := 50
-
-		if len(fullSnapshot) < snapshotCutline {
-			snapshot = fullSnapshot
-		} else {
-			snapshot = fullSnapshot[:snapshotCutline] + " ..."
+		snapshot := doc.Marshal()
+		if len(snapshot) > SnapshotMaxLen {
+			snapshot = snapshot[:SnapshotMaxLen] + "..."
 		}
 
 		summaries = append(summaries, &types.DocumentSummary{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Add the missing `unwatchDocs` function in `WatchDocuments` API
- Extract `types.NewAccessAttributes`
- Clean up code that uses magic number

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
