### PR TITLE
Fix the value type of Counter and remove double type from Counter

### DIFF
--- a/api/converter/converter_test.go
+++ b/api/converter/converter_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/yorkie-team/yorkie/api/types"
 	api "github.com/yorkie-team/yorkie/api/yorkie/v1"
 	"github.com/yorkie-team/yorkie/pkg/document"
+	"github.com/yorkie-team/yorkie/pkg/document/crdt"
 	"github.com/yorkie-team/yorkie/pkg/document/json"
 	"github.com/yorkie-team/yorkie/pkg/document/time"
 )
@@ -107,7 +108,7 @@ func TestConverter(t *testing.T) {
 				SetStyle(0, 5, map[string]string{"b": "1"})
 
 			// a counter
-			root.SetNewCounter("k5", 0).
+			root.SetNewCounter("k5", crdt.LongCnt, 0).
 				Increase(10).
 				Increase(math.MaxInt64)
 
@@ -169,7 +170,7 @@ func TestConverter(t *testing.T) {
 				SetStyle(0, 5, map[string]string{"b": "1"})
 
 			// counter
-			root.SetNewCounter("k4", 0).Increase(5)
+			root.SetNewCounter("k4", crdt.IntegerCnt, 0).Increase(5)
 
 			return nil
 		})

--- a/api/converter/from_bytes.go
+++ b/api/converter/from_bytes.go
@@ -273,6 +273,7 @@ func fromJSONCounter(pbCnt *api.JSONElement_Counter) (*crdt.Counter, error) {
 	}
 
 	counter := crdt.NewCounter(
+		counterType,
 		crdt.CounterValueFromBytes(counterType, pbCnt.Value),
 		createdAt,
 	)

--- a/api/converter/from_pb.go
+++ b/api/converter/from_pb.go
@@ -654,6 +654,7 @@ func fromElement(pbElement *api.JSONElementSimple) (crdt.Element, error) {
 			return nil, err
 		}
 		return crdt.NewCounter(
+			counterType,
 			crdt.CounterValueFromBytes(counterType, pbElement.Value),
 			createdAt,
 		), nil
@@ -691,8 +692,6 @@ func fromCounterType(valueType api.ValueType) (crdt.CounterType, error) {
 		return crdt.IntegerCnt, nil
 	case api.ValueType_VALUE_TYPE_LONG_CNT:
 		return crdt.LongCnt, nil
-	case api.ValueType_VALUE_TYPE_DOUBLE_CNT:
-		return crdt.DoubleCnt, nil
 	}
 
 	return 0, fmt.Errorf("%d, %w", valueType, ErrUnsupportedCounterType)

--- a/api/converter/to_pb.go
+++ b/api/converter/to_pb.go
@@ -513,8 +513,6 @@ func toCounterType(valueType crdt.CounterType) (api.ValueType, error) {
 		return api.ValueType_VALUE_TYPE_INTEGER_CNT, nil
 	case crdt.LongCnt:
 		return api.ValueType_VALUE_TYPE_LONG_CNT, nil
-	case crdt.DoubleCnt:
-		return api.ValueType_VALUE_TYPE_DOUBLE_CNT, nil
 	}
 
 	return 0, fmt.Errorf("%d, %w", valueType, ErrUnsupportedCounterType)

--- a/pkg/document/crdt/counter.go
+++ b/pkg/document/crdt/counter.go
@@ -58,74 +58,16 @@ type Counter struct {
 func NewCounter(valueType CounterType, value interface{}, createdAt *time.Ticket) *Counter {
 	switch valueType {
 	case IntegerCnt:
-		switch val := value.(type) {
-		case int32:
-			return &Counter{
-				valueType: IntegerCnt,
-				value:     val,
-				createdAt: createdAt,
-			}
-		case int64:
-			return &Counter{
-				valueType: IntegerCnt,
-				value:     int32(val),
-				createdAt: createdAt,
-			}
-		case int:
-			return &Counter{
-				valueType: IntegerCnt,
-				value:     int32(val),
-				createdAt: createdAt,
-			}
-		case float32:
-			return &Counter{
-				valueType: IntegerCnt,
-				value:     int32(val),
-				createdAt: createdAt,
-			}
-		case float64:
-			return &Counter{
-				valueType: IntegerCnt,
-				value:     int32(val),
-				createdAt: createdAt,
-			}
-		default:
-			panic("unsupported type")
+		return &Counter{
+			valueType: IntegerCnt,
+			value:     castToInt(value),
+			createdAt: createdAt,
 		}
 	case LongCnt:
-		switch val := value.(type) {
-		case int64:
-			return &Counter{
-				valueType: LongCnt,
-				value:     val,
-				createdAt: createdAt,
-			}
-		case int32:
-			return &Counter{
-				valueType: LongCnt,
-				value:     int64(val),
-				createdAt: createdAt,
-			}
-		case int:
-			return &Counter{
-				valueType: LongCnt,
-				value:     int64(val),
-				createdAt: createdAt,
-			}
-		case float32:
-			return &Counter{
-				valueType: LongCnt,
-				value:     int64(val),
-				createdAt: createdAt,
-			}
-		case float64:
-			return &Counter{
-				valueType: LongCnt,
-				value:     int64(val),
-				createdAt: createdAt,
-			}
-		default:
-			panic("unsupported type")
+		return &Counter{
+			valueType: LongCnt,
+			value:     castToLong(value),
+			createdAt: createdAt,
 		}
 	}
 
@@ -210,23 +152,11 @@ func (p *Counter) Increase(v *Primitive) *Counter {
 	}
 	switch p.valueType {
 	case IntegerCnt:
-		switch v.valueType {
-		case Long:
-			p.value = p.value.(int32) + int32(v.value.(int64))
-		case Double:
-			p.value = p.value.(int32) + int32(v.value.(float64))
-		default:
-			p.value = p.value.(int32) + v.value.(int32)
-		}
+		p.value = p.value.(int32) + castToInt(v.value)
 	case LongCnt:
-		switch v.valueType {
-		case Integer:
-			p.value = p.value.(int64) + int64(v.value.(int32))
-		case Double:
-			p.value = p.value.(int64) + int64(v.value.(float64))
-		default:
-			p.value = p.value.(int64) + v.value.(int64)
-		}
+		p.value = p.value.(int64) + castToLong(v.value)
+	default:
+		panic("unsupported type")
 	}
 
 	return p
@@ -236,4 +166,40 @@ func (p *Counter) Increase(v *Primitive) *Counter {
 func (p *Counter) IsNumericType() bool {
 	t := p.valueType
 	return t == IntegerCnt || t == LongCnt
+}
+
+// castToInt casts numeric type to int32.
+func castToInt(value interface{}) int32 {
+	switch val := value.(type) {
+	case int32:
+		return val
+	case int64:
+		return int32(val)
+	case int:
+		return int32(val)
+	case float32:
+		return int32(val)
+	case float64:
+		return int32(val)
+	default:
+		panic("unsupported type")
+	}
+}
+
+// castToLong casts numeric type to int64.
+func castToLong(value interface{}) int64 {
+	switch val := value.(type) {
+	case int64:
+		return val
+	case int32:
+		return int64(val)
+	case int:
+		return int64(val)
+	case float32:
+		return int64(val)
+	case float64:
+		return int64(val)
+	default:
+		panic("unsupported type")
+	}
 }

--- a/pkg/document/crdt/primitive.go
+++ b/pkg/document/crdt/primitive.go
@@ -52,7 +52,7 @@ func ValueFromBytes(valueType ValueType, value []byte) interface{} {
 		return false
 	case Integer:
 		val := int32(binary.LittleEndian.Uint32(value))
-		return int(val)
+		return int32(val)
 	case Long:
 		return int64(binary.LittleEndian.Uint64(value))
 	case Double:
@@ -95,6 +95,18 @@ func NewPrimitive(value interface{}, createdAt *time.Ticket) *Primitive {
 			value:     val,
 			createdAt: createdAt,
 		}
+	case int32:
+		return &Primitive{
+			valueType: Integer,
+			value:     val,
+			createdAt: createdAt,
+		}
+	case int64:
+		return &Primitive{
+			valueType: Long,
+			value:     val,
+			createdAt: createdAt,
+		}
 	case int:
 		if val > math.MaxInt32 || val < math.MinInt32 {
 			return &Primitive{
@@ -105,13 +117,13 @@ func NewPrimitive(value interface{}, createdAt *time.Ticket) *Primitive {
 		}
 		return &Primitive{
 			valueType: Integer,
-			value:     val,
+			value:     int32(val),
 			createdAt: createdAt,
 		}
-	case int64:
+	case float32:
 		return &Primitive{
-			valueType: Long,
-			value:     val,
+			valueType: Double,
+			value:     float64(val),
 			createdAt: createdAt,
 		}
 	case float64:
@@ -155,7 +167,7 @@ func (p *Primitive) Bytes() []byte {
 			return []byte{1}
 		}
 		return []byte{0}
-	case int:
+	case int32:
 		bytes := [4]byte{}
 		binary.LittleEndian.PutUint32(bytes[:], uint32(val))
 		return bytes[:]

--- a/pkg/document/crdt/primitive_test.go
+++ b/pkg/document/crdt/primitive_test.go
@@ -38,6 +38,7 @@ func TestPrimitive(t *testing.T) {
 		{false, crdt.Boolean, "false"},
 		{true, crdt.Boolean, "true"},
 		{0, crdt.Integer, "0"},
+		{int32(0), crdt.Integer, "0"},
 		{int64(0), crdt.Long, "0"},
 		{float64(0), crdt.Double, "0.000000"},
 		{"0", crdt.String, `"0"`},

--- a/pkg/document/document_test.go
+++ b/pkg/document/document_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/yorkie-team/yorkie/pkg/document"
 	"github.com/yorkie-team/yorkie/pkg/document/change"
+	"github.com/yorkie-team/yorkie/pkg/document/crdt"
 	"github.com/yorkie-team/yorkie/pkg/document/json"
 	"github.com/yorkie-team/yorkie/pkg/document/time"
 )
@@ -360,7 +361,7 @@ func TestDocument(t *testing.T) {
 
 		// integer type test
 		err := doc.Update(func(root *json.Object) error {
-			root.SetNewCounter("age", 5)
+			root.SetNewCounter("age", crdt.IntegerCnt, 5)
 
 			age := root.GetCounter("age")
 			age.Increase(long)
@@ -376,8 +377,9 @@ func TestDocument(t *testing.T) {
 
 		// long type test
 		err = doc.Update(func(root *json.Object) error {
-			root.SetNewCounter("price", 9000000000000000000)
+			root.SetNewCounter("price", crdt.LongCnt, 9000000000000000000)
 			price := root.GetCounter("price")
+			println(price.ValueType())
 			price.Increase(long)
 			price.Increase(double)
 			price.Increase(float)
@@ -389,21 +391,6 @@ func TestDocument(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, `{"age":128,"price":9000000000000000123}`, doc.Marshal())
 
-		// double type test
-		err = doc.Update(func(root *json.Object) error {
-			root.SetNewCounter("width", 10.5)
-			width := root.GetCounter("width")
-			width.Increase(long)
-			width.Increase(double)
-			width.Increase(float)
-			width.Increase(uinteger)
-			width.Increase(integer)
-
-			return nil
-		})
-		assert.NoError(t, err)
-		assert.Equal(t, `{"age":128,"price":9000000000000000123,"width":134.300000}`, doc.Marshal())
-
 		// negative operator test
 		err = doc.Update(func(root *json.Object) error {
 			age := root.GetCounter("age")
@@ -414,14 +401,10 @@ func TestDocument(t *testing.T) {
 			price.Increase(-100)
 			price.Increase(-20.5)
 
-			width := root.GetCounter("width")
-			width.Increase(-4)
-			width.Increase(-0.3)
-
 			return nil
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, `{"age":120,"price":9000000000000000003,"width":130.000000}`, doc.Marshal())
+		assert.Equal(t, `{"age":120,"price":9000000000000000003}`, doc.Marshal())
 
 		// TODO: it should be modified to error check
 		// when 'Remove panic from server code (#50)' is completed.
@@ -439,7 +422,7 @@ func TestDocument(t *testing.T) {
 			return nil
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, `{"age":120,"price":9000000000000000003,"width":130.000000}`, doc.Marshal())
+		assert.Equal(t, `{"age":120,"price":9000000000000000003}`, doc.Marshal())
 	})
 
 	t.Run("rollback test", func(t *testing.T) {

--- a/pkg/document/json/counter.go
+++ b/pkg/document/json/counter.go
@@ -63,15 +63,9 @@ func (p *Counter) Increase(v interface{}) *Counter {
 		}
 	case crdt.IntegerCnt:
 		if isInt {
-			primitive = crdt.NewPrimitive(value, ticket)
+			primitive = crdt.NewPrimitive(int32(value.(int)), ticket)
 		} else {
-			primitive = crdt.NewPrimitive(int(value.(float64)), ticket)
-		}
-	case crdt.DoubleCnt:
-		if isInt {
-			primitive = crdt.NewPrimitive(float64(value.(int)), ticket)
-		} else {
-			primitive = crdt.NewPrimitive(value, ticket)
+			primitive = crdt.NewPrimitive(int32(value.(float64)), ticket)
 		}
 	default:
 		panic("unsupported type")

--- a/pkg/document/json/object.go
+++ b/pkg/document/json/object.go
@@ -83,12 +83,22 @@ func (p *Object) SetNewRichText(k string) *RichText {
 }
 
 // SetNewCounter sets a new NewCounter for the given key.
-func (p *Object) SetNewCounter(k string, n interface{}) *Counter {
+func (p *Object) SetNewCounter(k string, t crdt.CounterType, n interface{}) *Counter {
 	v := p.setInternal(k, func(ticket *time.Ticket) crdt.Element {
-		return NewCounter(
-			p.context,
-			crdt.NewCounter(n, ticket),
-		)
+		switch t {
+		case crdt.IntegerCnt:
+			return NewCounter(
+				p.context,
+				crdt.NewCounter(crdt.IntegerCnt, n, ticket),
+			)
+		case crdt.LongCnt:
+			return NewCounter(
+				p.context,
+				crdt.NewCounter(crdt.LongCnt, n, ticket),
+			)
+		default:
+			panic("unsupported type")
+		}
 	})
 
 	return v.(*Counter)

--- a/test/bench/document_bench_test.go
+++ b/test/bench/document_bench_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/yorkie-team/yorkie/pkg/document"
 	"github.com/yorkie-team/yorkie/pkg/document/change"
+	"github.com/yorkie-team/yorkie/pkg/document/crdt"
 	"github.com/yorkie-team/yorkie/pkg/document/json"
 	"github.com/yorkie-team/yorkie/pkg/document/time"
 )
@@ -341,7 +342,7 @@ func BenchmarkDocument(b *testing.B) {
 
 			// integer type test
 			err := doc.Update(func(root *json.Object) error {
-				root.SetNewCounter("age", 5)
+				root.SetNewCounter("age", crdt.IntegerCnt, 5)
 
 				age := root.GetCounter("age")
 				age.Increase(long)
@@ -357,7 +358,7 @@ func BenchmarkDocument(b *testing.B) {
 
 			// long type test
 			err = doc.Update(func(root *json.Object) error {
-				root.SetNewCounter("price", 9000000000000000000)
+				root.SetNewCounter("price", crdt.LongCnt, 9000000000000000000)
 				price := root.GetCounter("price")
 				price.Increase(long)
 				price.Increase(double)
@@ -370,21 +371,6 @@ func BenchmarkDocument(b *testing.B) {
 			assert.NoError(b, err)
 			assert.Equal(b, `{"age":128,"price":9000000000000000123}`, doc.Marshal())
 
-			// double type test
-			err = doc.Update(func(root *json.Object) error {
-				root.SetNewCounter("width", 10.5)
-				width := root.GetCounter("width")
-				width.Increase(long)
-				width.Increase(double)
-				width.Increase(float)
-				width.Increase(uinteger)
-				width.Increase(integer)
-
-				return nil
-			})
-			assert.NoError(b, err)
-			assert.Equal(b, `{"age":128,"price":9000000000000000123,"width":134.300000}`, doc.Marshal())
-
 			// negative operator test
 			err = doc.Update(func(root *json.Object) error {
 				age := root.GetCounter("age")
@@ -395,14 +381,10 @@ func BenchmarkDocument(b *testing.B) {
 				price.Increase(-100)
 				price.Increase(-20.5)
 
-				width := root.GetCounter("width")
-				width.Increase(-4)
-				width.Increase(-0.3)
-
 				return nil
 			})
 			assert.NoError(b, err)
-			assert.Equal(b, `{"age":120,"price":9000000000000000003,"width":130.000000}`, doc.Marshal())
+			assert.Equal(b, `{"age":120,"price":9000000000000000003}`, doc.Marshal())
 
 			// TODO: it should be modified to error check
 			// when 'Remove panic from server code (#50)' is completed.
@@ -420,7 +402,7 @@ func BenchmarkDocument(b *testing.B) {
 				return nil
 			})
 			assert.NoError(b, err)
-			assert.Equal(b, `{"age":120,"price":9000000000000000003,"width":130.000000}`, doc.Marshal())
+			assert.Equal(b, `{"age":120,"price":9000000000000000003}`, doc.Marshal())
 		}
 	})
 
@@ -642,7 +624,7 @@ func benchmarkCounter(cnt int, b *testing.B) {
 		doc := document.New("d1")
 
 		err := doc.Update(func(root *json.Object) error {
-			counter := root.SetNewCounter("k1", 0)
+			counter := root.SetNewCounter("k1", crdt.IntegerCnt, 0)
 			for c := 0; c < cnt; c++ {
 				counter.Increase(c)
 			}

--- a/test/integration/counter_test.go
+++ b/test/integration/counter_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/yorkie-team/yorkie/pkg/document"
+	"github.com/yorkie-team/yorkie/pkg/document/crdt"
 	"github.com/yorkie-team/yorkie/pkg/document/json"
 	"github.com/yorkie-team/yorkie/pkg/document/key"
 )
@@ -42,7 +43,7 @@ func TestCounter(t *testing.T) {
 		assert.NoError(t, err)
 
 		err = d1.Update(func(root *json.Object) error {
-			root.SetNewCounter("age", 1).
+			root.SetNewCounter("age", crdt.LongCnt, 1).
 				Increase(2).
 				Increase(2.5).
 				Increase(-100000000).
@@ -67,9 +68,9 @@ func TestCounter(t *testing.T) {
 		assert.NoError(t, err)
 
 		err = d1.Update(func(root *json.Object) error {
-			root.SetNewCounter("age", 0)
-			root.SetNewCounter("width", 0)
-			root.SetNewCounter("height", 0)
+			root.SetNewCounter("age", crdt.IntegerCnt, 0)
+			root.SetNewCounter("width", crdt.LongCnt, 0)
+			root.SetNewCounter("height", crdt.LongCnt, 0)
 			return nil
 		})
 		assert.NoError(t, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
To prevent dynamic type change of Counter, explicit type specification is required in Counter constructor. Moreover, double type is removed in Counter to mitigate confusion.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #436

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Users should specify the type of Counter when calling the constructor.
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
