### PR TITLE
Increase CRDT Counter in local change

### DIFF
--- a/pkg/document/document_test.go
+++ b/pkg/document/document_test.go
@@ -373,6 +373,7 @@ func TestDocument(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, `{"age":128}`, doc.Marshal())
+		assert.Equal(t, "128", doc.Root().GetCounter("age").Counter.Marshal())
 
 		// long type test
 		err = doc.Update(func(root *json.Object) error {

--- a/pkg/document/json/counter.go
+++ b/pkg/document/json/counter.go
@@ -71,6 +71,8 @@ func (p *Counter) Increase(v interface{}) *Counter {
 		panic("unsupported type")
 	}
 
+	p.Counter.Increase(primitive)
+
 	p.context.Push(operations.NewIncrease(
 		p.CreatedAt(),
 		primitive,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
When changing value of Counter through calling `increase()`, local value in `Document.doc` is not updated. The problem was hidden because `Document.clone` and remote value has been updated normally.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Address [yorkie-team/yorkie-js-sdk#438](https://github.com/yorkie-team/yorkie-js-sdk/issues/438)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
