### PR TITLE
Add XML dummy objects: DocumentFragment, Node, Element, Text

### DIFF
--- a/pkg/document/xml/element.go
+++ b/pkg/document/xml/element.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xml
+
+import "strings"
+
+// Element is an element of XML.
+type Element struct {
+	name     string
+	children []Node
+}
+
+// NewElement creates a new instance of Element.
+func NewElement(name string) *Element {
+	return &Element{
+		name: name,
+	}
+}
+
+// Append appends the given node to the children of this Element.
+func (e *Element) Append(n Node) {
+	e.children = append(e.children, n)
+}
+
+// String returns the string representation of this Element.
+func (e *Element) String() string {
+	sb := strings.Builder{}
+
+	sb.WriteString("<")
+	sb.WriteString(e.name)
+	sb.WriteString(">")
+
+	for _, child := range e.children {
+		sb.WriteString(child.String())
+	}
+
+	sb.WriteString("</")
+	sb.WriteString(e.name)
+	sb.WriteString(">")
+
+	return sb.String()
+}

--- a/pkg/document/xml/fragment.go
+++ b/pkg/document/xml/fragment.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package xml provides XML-like document to the CRDT version.
+package xml
+
+import "strings"
+
+// DocumentFragment is a fragment of XML.
+type DocumentFragment struct {
+	children []Node
+}
+
+// NewDocumentFragment creates a new instance of DocumentFragment.
+func NewDocumentFragment() *DocumentFragment {
+	return &DocumentFragment{}
+}
+
+// Append appends the given node to the children of this DocumentFragment.
+func (f *DocumentFragment) Append(n Node) {
+	f.children = append(f.children, n)
+}
+
+// String returns the string representation of this DocumentFragment.
+func (f *DocumentFragment) String() string {
+	sb := strings.Builder{}
+
+	sb.WriteString("<document>")
+	for _, child := range f.children {
+		sb.WriteString(child.String())
+	}
+	sb.WriteString("</document>")
+
+	return sb.String()
+}
+
+// ChildNodes returns the children of this DocumentFragment.
+func (f *DocumentFragment) ChildNodes() []Node {
+	return f.children
+}
+
+// Delete deletes the given range of children of this DocumentFragment.
+func (f *DocumentFragment) Delete(from int, to int) {
+	// TODO: implement this
+}

--- a/pkg/document/xml/fragment_test.go
+++ b/pkg/document/xml/fragment_test.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xml_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/pkg/document/xml"
+)
+
+func TestFragment(t *testing.T) {
+	t.Run("basic xml test", func(t *testing.T) {
+		fragment := xml.NewDocumentFragment()
+		assert.Equal(t, "<document></document>", fragment.String())
+
+		fragment.Append(xml.NewText("abcd"))
+		assert.Len(t, fragment.ChildNodes(), 1)
+		assert.Equal(t, "<document>abcd</document>", fragment.String())
+
+		noteElem := xml.NewElement("note")
+		fragment.Append(noteElem)
+		assert.Len(t, fragment.ChildNodes(), 2)
+		assert.Equal(t, "<document>abcd<note></note></document>", fragment.String())
+
+		noteElem.Append(xml.NewText("1234"))
+		assert.Equal(t, "<document>abcd<note>1234</note></document>", fragment.String())
+
+		fragment.Delete(2, 6)
+		// TODO(hackerwins): uncomment this after implementing Delete.
+		// assert.Equal(t, "<document>ab<note>34</note></document>", fragment.String())
+	})
+}

--- a/pkg/document/xml/node.go
+++ b/pkg/document/xml/node.go
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xml
+
+// Node is an interface that represents a node in the XML document.
+type Node interface {
+	// String returns the string representation of the node.
+	String() string
+}

--- a/pkg/document/xml/text.go
+++ b/pkg/document/xml/text.go
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xml
+
+// Text is a text node in XML. It is a leaf node.
+type Text struct {
+	value string
+}
+
+// NewText creates a new instance of Text.
+func NewText(value string) *Text {
+	return &Text{
+		value: value,
+	}
+}
+
+// String returns the string representation of this Text.
+func (t *Text) String() string {
+	return t.value
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add XML dummy objects: DocumentFragment, Node, Element, Text

Dummy objects have been added to specify the user interface.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Address https://github.com/yorkie-team/yorkie-js-sdk/issues/257

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
