### PR TITLE
Fix invalid index of SplayTree with single node

### DIFF
--- a/pkg/splay/splay.go
+++ b/pkg/splay/splay.go
@@ -165,7 +165,7 @@ func (t *Tree[V]) Splay(node *Node[V]) {
 
 // IndexOf Find the index of the given node.
 func (t *Tree[V]) IndexOf(node *Node[V]) int {
-	if node == nil || !node.hasLinks() {
+	if node == nil || node != t.root && !node.hasLinks() {
 		return -1
 	}
 

--- a/pkg/splay/splay_test.go
+++ b/pkg/splay/splay_test.go
@@ -143,6 +143,14 @@ func TestSplayTree(t *testing.T) {
 			tree.StructureAsString(),
 		)
 	})
+
+	t.Run("single node index test", func(t *testing.T) {
+		tree := splay.NewTree[*stringValue](nil)
+		node := tree.Insert(newSplayNode("A"))
+		assert.Equal(t, 0, tree.IndexOf(node))
+		tree.Delete(node)
+		assert.Equal(t, -1, tree.IndexOf(node))
+	})
 }
 
 func makeSampleTree() (*splay.Tree[*stringValue], []*splay.Node[*stringValue]) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix invalid index of SplayTree with a single node.

This PR addresses an issue with the `indexOf` in SplayTree, which was failing to calculate the correct index when there was only one node in the tree. The conditional statement has been updated to account for this scenario.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
