### PR TITLE
Add ClientDeactivateThreshold field in admin CLI project list

### DIFF
--- a/cmd/yorkie/project/list.go
+++ b/cmd/yorkie/project/list.go
@@ -64,6 +64,7 @@ func newListCommand() *cobra.Command {
 				"SECRET KEY",
 				"AUTH WEBHOOK URL",
 				"AUTH WEBHOOK METHODS",
+				"CLIENT DEACTIVATE THRESHOLD",
 				"CREATED AT",
 			})
 			for _, project := range projects {
@@ -73,6 +74,7 @@ func newListCommand() *cobra.Command {
 					project.SecretKey,
 					project.AuthWebhookURL,
 					project.AuthWebhookMethods,
+					project.ClientDeactivateThreshold,
 					units.HumanDuration(time.Now().UTC().Sub(project.CreatedAt)),
 				})
 			}

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -35,6 +35,12 @@ func TestValidation(t *testing.T) {
 
 		err = ValidateValue("invalid-key-$-wrong-string-value", "required,slug,min=4,max=30")
 		assert.Equal(t, err.(Violation).Tag, "slug")
+
+		err = ValidateValue("1h30m20s", "duration,min=2")
+		assert.Nil(t, err, "valid time duration string format")
+
+		err = ValidateValue("one hour", "duration,min=2")
+		assert.Equal(t, err.(Violation).Tag, "duration")
 	})
 
 	t.Run("ValidateStruct test", func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Add `ClientDeactivateThreshold` field in project list admin CLI.

`ClientDeactivateThreshold` field was omitted in project list in admin CLI.

~~2. Set minimum value limit on `ClientDeactivateThreshold` by restricting string value to must contain hour prefix(`h` prefix). This will ensure `ClientDeactivateThreshold` value to have minimum value limit of `1 hour`.~~
~~Furthermore, there was no minimum value limit on `ClientDeactivateThreshold`, which may result in excessive client deactivation.
For example, if `ClientDeactivateThreshold` is set to `01s`(or any other smaller value than `housekeepingInterval`), client may deactivate every time housekeeping occurs.~~

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
