### PR TITLE
Lock watchDocuments depending on the client

### DIFF
--- a/pkg/document/key/key.go
+++ b/pkg/document/key/key.go
@@ -19,6 +19,7 @@ package key
 
 import (
 	errors "errors"
+	"strings"
 
 	"github.com/yorkie-team/yorkie/internal/validation"
 )
@@ -48,4 +49,16 @@ func (k Key) Validate() error {
 	}
 
 	return nil
+}
+
+// JoinKeys concatenates all the keys in slice into a single string.
+func JoinKeys(keys []Key) string {
+	var s strings.Builder
+	for i, key := range keys {
+		s.WriteString(key.String())
+		if i != len(keys)-1 {
+			s.WriteString(", ")
+		}
+	}
+	return s.String()
 }

--- a/pkg/document/key/key.go
+++ b/pkg/document/key/key.go
@@ -51,13 +51,13 @@ func (k Key) Validate() error {
 	return nil
 }
 
-// JoinKeys concatenates all the keys in slice into a single string.
-func JoinKeys(keys []Key) string {
+// Join concatenates all the keys in slice into a single string.
+func Join(keys []Key) string {
 	var s strings.Builder
 	for i, key := range keys {
 		s.WriteString(key.String())
 		if i != len(keys)-1 {
-			s.WriteString(", ")
+			s.WriteString(",")
 		}
 	}
 	return s.String()

--- a/pkg/document/key/key_test.go
+++ b/pkg/document/key/key_test.go
@@ -57,7 +57,7 @@ func TestKey(t *testing.T) {
 
 	t.Run("join key test", func(t *testing.T) {
 		keys := []Key{Key("key1"), Key("key2"), Key("key3")}
-		result := JoinKeys(keys)
-		assert.Equal(t, "key1, key2, key3", result)
+		result := Join(keys)
+		assert.Equal(t, "key1,key2,key3", result)
 	})
 }

--- a/pkg/document/key/key_test.go
+++ b/pkg/document/key/key_test.go
@@ -54,4 +54,10 @@ func TestKey(t *testing.T) {
 		err = Key("inv").Validate()
 		assert.Equal(t, err, ErrInvalidKey, "less than 4 characters is not allowed")
 	})
+
+	t.Run("join key test", func(t *testing.T) {
+		keys := []Key{Key("key1"), Key("key2"), Key("key3")}
+		result := JoinKeys(keys)
+		assert.Equal(t, "key1, key2, key3", result)
+	})
 }

--- a/server/backend/sync/memory/pubsub.go
+++ b/server/backend/sync/memory/pubsub.go
@@ -93,7 +93,7 @@ func (m *PubSub) Subscribe(
 	if logging.Enabled(zap.DebugLevel) {
 		logging.From(ctx).Debugf(
 			`Subscribe(%s,%s) Start`,
-			key.JoinKeys(keys),
+			key.Join(keys),
 			subscriber.ID.String(),
 		)
 	}
@@ -115,7 +115,7 @@ func (m *PubSub) Subscribe(
 	if logging.Enabled(zap.DebugLevel) {
 		logging.From(ctx).Debugf(
 			`Subscribe(%s,%s) End`,
-			key.JoinKeys(keys),
+			key.Join(keys),
 			subscriber.ID.String(),
 		)
 	}
@@ -148,7 +148,7 @@ func (m *PubSub) Unsubscribe(
 	if logging.Enabled(zap.DebugLevel) {
 		logging.From(ctx).Debugf(
 			`Unsubscribe(%s,%s) Start`,
-			key.JoinKeys(docKeys),
+			key.Join(docKeys),
 			sub.SubscriberID(),
 		)
 	}
@@ -170,7 +170,7 @@ func (m *PubSub) Unsubscribe(
 	if logging.Enabled(zap.DebugLevel) {
 		logging.From(ctx).Debugf(
 			`Unsubscribe(%s,%s) End`,
-			key.JoinKeys(docKeys),
+			key.Join(docKeys),
 			sub.SubscriberID(),
 		)
 	}

--- a/server/backend/sync/memory/pubsub.go
+++ b/server/backend/sync/memory/pubsub.go
@@ -93,7 +93,7 @@ func (m *PubSub) Subscribe(
 	if logging.Enabled(zap.DebugLevel) {
 		logging.From(ctx).Debugf(
 			`Subscribe(%s,%s) Start`,
-			keys[0],
+			key.JoinKeys(keys),
 			subscriber.ID.String(),
 		)
 	}
@@ -115,7 +115,7 @@ func (m *PubSub) Subscribe(
 	if logging.Enabled(zap.DebugLevel) {
 		logging.From(ctx).Debugf(
 			`Subscribe(%s,%s) End`,
-			keys[0],
+			key.JoinKeys(keys),
 			subscriber.ID.String(),
 		)
 	}
@@ -148,7 +148,7 @@ func (m *PubSub) Unsubscribe(
 	if logging.Enabled(zap.DebugLevel) {
 		logging.From(ctx).Debugf(
 			`Unsubscribe(%s,%s) Start`,
-			docKeys[0].String(),
+			key.JoinKeys(docKeys),
 			sub.SubscriberID(),
 		)
 	}
@@ -170,7 +170,7 @@ func (m *PubSub) Unsubscribe(
 	if logging.Enabled(zap.DebugLevel) {
 		logging.From(ctx).Debugf(
 			`Unsubscribe(%s,%s) End`,
-			docKeys[0].String(),
+			key.JoinKeys(docKeys),
 			sub.SubscriberID(),
 		)
 	}

--- a/server/backend/sync/memory/pubsub.go
+++ b/server/backend/sync/memory/pubsub.go
@@ -200,7 +200,8 @@ func (m *PubSub) Publish(
 
 				if logging.Enabled(zap.DebugLevel) {
 					logging.From(ctx).Debugf(
-						`Publish(%s,%s) to %s`,
+						`Publish %s(%s,%s) to %s`,
+						event.Type,
 						k,
 						publisherID.String(),
 						sub.SubscriberID(),

--- a/server/rpc/yorkie_server.go
+++ b/server/rpc/yorkie_server.go
@@ -18,6 +18,7 @@ package rpc
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/yorkie-team/yorkie/api/converter"
 	"github.com/yorkie-team/yorkie/api/types"
@@ -394,7 +395,7 @@ func (s *yorkieServer) WatchDocuments(
 
 	locker, err := s.backend.Coordinator.NewLocker(
 		stream.Context(),
-		sync.NewKey(cli.ID.String()),
+		sync.NewKey(fmt.Sprintf("watchdocs-%s", cli.ID.String())),
 	)
 	if err != nil {
 		return err
@@ -402,6 +403,11 @@ func (s *yorkieServer) WatchDocuments(
 	if err := locker.Lock(stream.Context()); err != nil {
 		return err
 	}
+	defer func() {
+		if err := locker.Unlock(context.Background()); err != nil {
+			logging.DefaultLogger().Error(err)
+		}
+	}()
 
 	subscription, peersMap, err := s.watchDocs(stream.Context(), *cli, docKeys)
 	if err != nil {
@@ -410,9 +416,6 @@ func (s *yorkieServer) WatchDocuments(
 	}
 	defer func() {
 		s.unwatchDocs(docKeys, subscription)
-		if err := locker.Unlock(stream.Context()); err != nil {
-			logging.DefaultLogger().Error(err)
-		}
 	}()
 
 	if err := stream.Send(&api.WatchDocumentsResponse{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

If a client requests to attach to multiple documents simultaneously, 
the existing connection will be disconnected and reconnected. 

Depending on the order of the published events, problems may occur on the client. 
If the `watched` event is published before the `unwatched` event, the test will fail 
since the final state is `watched`, but the `unwatched` event arrives later. 
(please refer to the [yorkie-js-sdk test](https://github.com/yorkie-team/yorkie-js-sdk/pull/464#issuecomment-1447547066)). 

<img width="600" alt="image" src="https://user-images.githubusercontent.com/81357083/222397680-8479c102-56c9-4af2-9601-255df4e87c4b.png">

This image shows the server log when the `watched` event is published first.

To resolve this, I added a lock for each client in the `watchDocument`.
This ensures that a lock is set when a client establishes a stream and released when the client unwatches.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/yorkie-team/yorkie-js-sdk/pull/464#issuecomment-1447547066

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
