### PR TITLE
Add flag options in document ls command

### DIFF
--- a/admin/client.go
+++ b/admin/client.go
@@ -233,7 +233,7 @@ func (c *Client) UpdateProject(
 func (c *Client) ListDocuments(
 	ctx context.Context,
 	projectName string,
-	previousId string,
+	previousID string,
 	pageSize int32,
 	isForward bool,
 ) ([]*types.DocumentSummary, error) {
@@ -241,7 +241,7 @@ func (c *Client) ListDocuments(
 		ctx,
 		&api.ListDocumentsRequest{
 			ProjectName: projectName,
-			PreviousId:  previousId,
+			PreviousId:  previousID,
 			PageSize:    pageSize,
 			IsForward:   isForward,
 		},

--- a/admin/client.go
+++ b/admin/client.go
@@ -230,11 +230,20 @@ func (c *Client) UpdateProject(
 }
 
 // ListDocuments lists documents.
-func (c *Client) ListDocuments(ctx context.Context, projectName string) ([]*types.DocumentSummary, error) {
+func (c *Client) ListDocuments(
+	ctx context.Context,
+	projectName string,
+	previousId string,
+	pageSize int32,
+	isForward bool,
+) ([]*types.DocumentSummary, error) {
 	response, err := c.client.ListDocuments(
 		ctx,
 		&api.ListDocumentsRequest{
 			ProjectName: projectName,
+			PreviousId:  previousId,
+			PageSize:    pageSize,
+			IsForward:   isForward,
 		},
 	)
 	if err != nil {

--- a/cmd/yorkie/document/list.go
+++ b/cmd/yorkie/document/list.go
@@ -30,7 +30,7 @@ import (
 )
 
 var (
-	previousId string
+	previousID string
 	pageSize   int32
 	isForward  bool
 )
@@ -58,7 +58,7 @@ func newListCommand() *cobra.Command {
 			}()
 
 			ctx := context.Background()
-			documents, err := cli.ListDocuments(ctx, projectName, previousId, pageSize, isForward)
+			documents, err := cli.ListDocuments(ctx, projectName, previousID, pageSize, isForward)
 			if err != nil {
 				return err
 			}
@@ -96,7 +96,7 @@ func newListCommand() *cobra.Command {
 func init() {
 	cmd := newListCommand()
 	cmd.Flags().StringVar(
-		&previousId,
+		&previousID,
 		"previous-id",
 		"",
 		"The previous document ID to start from",

--- a/cmd/yorkie/document/list.go
+++ b/cmd/yorkie/document/list.go
@@ -29,6 +29,12 @@ import (
 	"github.com/yorkie-team/yorkie/pkg/units"
 )
 
+var (
+	previousId string
+	pageSize   int32
+	isForward  bool
+)
+
 func newListCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "ls [project name]",
@@ -52,7 +58,7 @@ func newListCommand() *cobra.Command {
 			}()
 
 			ctx := context.Background()
-			documents, err := cli.ListDocuments(ctx, projectName)
+			documents, err := cli.ListDocuments(ctx, projectName, previousId, pageSize, isForward)
 			if err != nil {
 				return err
 			}
@@ -88,5 +94,24 @@ func newListCommand() *cobra.Command {
 }
 
 func init() {
-	SubCmd.AddCommand(newListCommand())
+	cmd := newListCommand()
+	cmd.Flags().StringVar(
+		&previousId,
+		"previous-id",
+		"",
+		"The previous document ID to start from",
+	)
+	cmd.Flags().Int32Var(
+		&pageSize,
+		"size",
+		0,
+		"The number of document to output per page",
+	)
+	cmd.Flags().BoolVar(
+		&isForward,
+		"forward",
+		false,
+		"Whether to search forward or backward",
+	)
+	SubCmd.AddCommand(cmd)
 }

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -90,14 +90,6 @@ func (c *Client) Close() error {
 	return nil
 }
 
-// DropDatabase drop mongodb table (only use in test cleanup)
-func (c *Client) DropDatabase(databaseName string) error {
-	if err := c.client.Database(databaseName).Drop(context.Background()); err != nil {
-		return fmt.Errorf("drop database(%s): %w", databaseName, err)
-	}
-	return nil
-}
-
 // EnsureDefaultUserAndProject creates the default user and project if they do not exist.
 func (c *Client) EnsureDefaultUserAndProject(
 	ctx context.Context,
@@ -1154,10 +1146,10 @@ func (c *Client) FindDocInfosByPaging(
 	}
 
 	opts := options.Find().SetLimit(int64(paging.PageSize))
-	if !paging.IsForward {
-		opts = opts.SetSort(map[string]int{"_id": -1})
-	} else {
+	if paging.IsForward {
 		opts = opts.SetSort(map[string]int{"_id": 1})
+	} else {
+		opts = opts.SetSort(map[string]int{"_id": -1})
 	}
 
 	cursor, err := c.collection(colDocuments).Find(ctx, filter, opts)

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -90,6 +90,14 @@ func (c *Client) Close() error {
 	return nil
 }
 
+// DropDatabase drop mongodb table (only use in test cleanup)
+func (c *Client) DropDatabase(databaseName string) error {
+	if err := c.client.Database(databaseName).Drop(context.Background()); err != nil {
+		return fmt.Errorf("drop database(%s): %w", databaseName, err)
+	}
+	return nil
+}
+
 // EnsureDefaultUserAndProject creates the default user and project if they do not exist.
 func (c *Client) EnsureDefaultUserAndProject(
 	ctx context.Context,
@@ -1148,6 +1156,8 @@ func (c *Client) FindDocInfosByPaging(
 	opts := options.Find().SetLimit(int64(paging.PageSize))
 	if !paging.IsForward {
 		opts = opts.SetSort(map[string]int{"_id": -1})
+	} else {
+		opts = opts.SetSort(map[string]int{"_id": 1})
 	}
 
 	cursor, err := c.collection(colDocuments).Find(ctx, filter, opts)

--- a/server/backend/database/mongo/client_test.go
+++ b/server/backend/database/mongo/client_test.go
@@ -72,11 +72,10 @@ func setupTestWithDummyData(t *testing.T) {
 	}
 }
 
-func cleanupTest(cli *mongo.Client, testDBName string) error {
+func cleanupTest(cli *mongo.Client, testDBName string) {
 	if err := cli.DropDatabase(testDBName); err != nil {
-		return fmt.Errorf("test cleanup fail: %w", err)
+		_ = fmt.Errorf("test cleanup fail: %w", err)
 	}
-	return nil
 }
 
 func TestClient(t *testing.T) {

--- a/server/documents/documents.go
+++ b/server/documents/documents.go
@@ -33,6 +33,9 @@ import (
 // document summary.
 const SnapshotMaxLen = 50
 
+// DocumentPageSizeLimit is the limit of the pagination size of documents.
+const documentPageSizeLimit = 100
+
 // ListDocumentSummaries returns a list of document summaries.
 func ListDocumentSummaries(
 	ctx context.Context,
@@ -40,6 +43,10 @@ func ListDocumentSummaries(
 	project *types.Project,
 	paging types.Paging[types.ID],
 ) ([]*types.DocumentSummary, error) {
+	if paging.PageSize > documentPageSizeLimit {
+		paging.PageSize = documentPageSizeLimit
+	}
+
 	docInfo, err := be.DB.FindDocInfosByPaging(ctx, project.ID, paging)
 	if err != nil {
 		return nil, err

--- a/server/rpc/yorkie_server.go
+++ b/server/rpc/yorkie_server.go
@@ -260,9 +260,6 @@ func (s *yorkieServer) DetachDocument(
 		return nil, err
 	}
 
-	if err := clientInfo.EnsureDocumentAttached(docInfo.ID); err != nil {
-		return nil, err
-	}
 	if err := clientInfo.DetachDocument(docInfo.ID); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Add flag options in document ls command
  - flag options(`--previous-id`, `--size`, `--forward`) in Admin ListDocument API and Document CLI
  - Add `document ls` flag options testcases
    - Fix creating duplicate dummy data to be create only once in test cases. (dummy project, dummy docs..) 
    - 
  - Bugfix `--forward` flags
    - before: ordering in `key` column
    - after: orderring in `_id` column
    ```
    # before
     ID           KEY           CREATED AT  ...
     6406...4d9a  codemirror0   19 minutes  ...
     6406...4e0c  codemirror1   19 minutes  ...
     6406...4e7e  codemirror11  18 minutes  ... 
     6406...4ecd  codemirror12  18 minutes  ... 
                  ...
     6406...4e27  codemirror2   19 minutes  ... 
     6406...4e65  codemirror3   19 minutes  ... 

     # after
     ID           KEY           CREATED AT  ...
     6406...4d9a  codemirror0   19 minutes  ...
     6406...4e0c  codemirror1   19 minutes  ...
     6406...4e27  codemirror2   19 minutes  ... 
     6406...4e65  codemirror3   19 minutes  ... 
                  ...
     6406...4e7e  codemirror11  18 minutes  ... 
     6406...4ecd  codemirror12  18 minutes  ... 
    ```


- Remove duplicate code
  - `clientInfo.DetachDocument()` already has `clientInfo.EnsureDocumentAttached()`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #478

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
# before: only no flag command works
yorkie document ls [projectName]

# after: --forward, --size, --previous-id flag works
yorkie document ls [projectName] --forward --size 10 --previous-id [docID]
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
