### PR TITLE
Fix invalid document finding query in CreateChangeInfos

### DIFF
--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -749,16 +749,15 @@ func (d *DB) CreateChangeInfos(
 
 	raw, err := txn.First(
 		tblDocuments,
-		"project_id_key_removed_at",
+		"project_id_id",
 		projectID.String(),
-		docInfo.Key.String(),
-		gotime.Time{},
+		docInfo.ID.String(),
 	)
 	if err != nil {
-		return fmt.Errorf("find document by key: %w", err)
+		return fmt.Errorf("find document: %w", err)
 	}
 	if raw == nil {
-		return fmt.Errorf("%s: %w", docInfo.Key, database.ErrDocumentNotFound)
+		return fmt.Errorf("%s: %w", docInfo.ID, database.ErrDocumentNotFound)
 	}
 	loadedDocInfo := raw.(*database.DocInfo).DeepCopy()
 	if loadedDocInfo.ServerSeq != initialServerSeq {


### PR DESCRIPTION
We need to find the document based on ID.

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix invalid document finding query in CreateChangeInfos

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
