### PR TITLE
Check client Sequence while pushpulled

### DIFF
--- a/server/backend/database/client_info.go
+++ b/server/backend/database/client_info.go
@@ -131,8 +131,6 @@ func (i *ClientInfo) DetachDocument(docID types.ID) error {
 	}
 
 	i.Documents[docID].Status = DocumentDetached
-	i.Documents[docID].ClientSeq = 0
-	i.Documents[docID].ServerSeq = 0
 	i.UpdatedAt = time.Now()
 
 	return nil
@@ -145,8 +143,6 @@ func (i *ClientInfo) RemoveDocument(docID types.ID) error {
 	}
 
 	i.Documents[docID].Status = DocumentRemoved
-	i.Documents[docID].ClientSeq = 0
-	i.Documents[docID].ServerSeq = 0
 	i.UpdatedAt = time.Now()
 
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Add sequence validation logic.
  - When process push changes, the client sequence has to be prevClientSeq + 1 
  - If the client sends an invalid ServerSeq, Send a snapshot so that the client can try to fix it.
- Preserve sequence numbers for the push-pull response of detach and remove API. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
