### PR TITLE
Add gRPC MaxConnectionAge & MaxConnectionAgeGrace options

### DIFF
--- a/cmd/yorkie/server.go
+++ b/cmd/yorkie/server.go
@@ -191,6 +191,12 @@ func init() {
 		server.DefaultRPCMaxRequestsBytes,
 		"Maximum client request size in bytes the server will accept.",
 	)
+	cmd.Flags().StringVar(
+		&conf.RPC.MaxConnectionAge,
+		"rpc-max-connection-age",
+		server.DefaultRPCMaxConnectionAge.String(),
+		"Maximum duration of connection may exist before it will be closed by sending a GoAway.",
+	)
 	cmd.Flags().IntVar(
 		&conf.Profiling.Port,
 		"profiling-port",

--- a/cmd/yorkie/server.go
+++ b/cmd/yorkie/server.go
@@ -197,6 +197,12 @@ func init() {
 		server.DefaultRPCMaxConnectionAge.String(),
 		"Maximum duration of connection may exist before it will be closed by sending a GoAway.",
 	)
+	cmd.Flags().StringVar(
+		&conf.RPC.MaxConnectionAgeGrace,
+		"rpc-max-connection-age-grace",
+		server.DefaultRPCMaxConnectionAgeGrace.String(),
+		"Additional grace period after MaxConnectionAge after which connections will be forcibly closed.",
+	)
 	cmd.Flags().IntVar(
 		&conf.Profiling.Port,
 		"profiling-port",

--- a/server/config.go
+++ b/server/config.go
@@ -36,6 +36,7 @@ import (
 const (
 	DefaultRPCPort             = 11101
 	DefaultRPCMaxRequestsBytes = 4 * 1024 * 1024 // 4MiB
+	DefaultRPCMaxConnectionAge = 1 * time.Minute
 
 	DefaultProfilingPort = 11102
 
@@ -150,6 +151,10 @@ func (c *Config) ensureDefaultValue() {
 
 	if c.RPC.MaxRequestBytes == 0 {
 		c.RPC.MaxRequestBytes = DefaultRPCMaxRequestsBytes
+	}
+
+	if c.RPC.MaxConnectionAge == "" {
+		c.RPC.MaxConnectionAge = DefaultRPCMaxConnectionAge.String()
 	}
 
 	if c.Profiling.Port == 0 {

--- a/server/config.go
+++ b/server/config.go
@@ -34,9 +34,10 @@ import (
 
 // Below are the values of the default values of Yorkie config.
 const (
-	DefaultRPCPort             = 11101
-	DefaultRPCMaxRequestsBytes = 4 * 1024 * 1024 // 4MiB
-	DefaultRPCMaxConnectionAge = 1 * time.Minute
+	DefaultRPCPort                  = 11101
+	DefaultRPCMaxRequestsBytes      = 4 * 1024 * 1024 // 4MiB
+	DefaultRPCMaxConnectionAge      = 50 * time.Second
+	DefaultRPCMaxConnectionAgeGrace = 10 * time.Second
 
 	DefaultProfilingPort = 11102
 
@@ -155,6 +156,10 @@ func (c *Config) ensureDefaultValue() {
 
 	if c.RPC.MaxConnectionAge == "" {
 		c.RPC.MaxConnectionAge = DefaultRPCMaxConnectionAge.String()
+	}
+
+	if c.RPC.MaxConnectionAgeGrace == "" {
+		c.RPC.MaxConnectionAgeGrace = DefaultRPCMaxConnectionAgeGrace.String()
 	}
 
 	if c.Profiling.Port == 0 {

--- a/server/config.sample.yml
+++ b/server/config.sample.yml
@@ -6,6 +6,10 @@ RPC:
   # MaxRequestBytes is the maximum client request size in bytes the server will accept (default: 4194304, 4MiB).
   MaxRequestBytes: 4194304
 
+  # MaxConnectionAge is a duration for the maximum amount of time a connection may exist
+  # before it will be closed by sending a GoAway.
+  MaxConnectionAge: "60s"
+
   # CertFile is the file containing the TLS certificate.
   CertFile: ""
 

--- a/server/config.sample.yml
+++ b/server/config.sample.yml
@@ -8,7 +8,11 @@ RPC:
 
   # MaxConnectionAge is a duration for the maximum amount of time a connection may exist
   # before it will be closed by sending a GoAway.
-  MaxConnectionAge: "60s"
+  MaxConnectionAge: "50s"
+
+  # MaxConnectionAgeGrace is a duration for the amount of time after receiving a GoAway
+  # for pending RPCs to complete before forcibly closing connections.
+  MaxConnectionAgeGrace: "10s"
 
   # CertFile is the file containing the TLS certificate.
   CertFile: ""

--- a/server/rpc/config.go
+++ b/server/rpc/config.go
@@ -32,6 +32,8 @@ var (
 	ErrInvalidKeyFile = errors.New("invalid key file for RPC server")
 	// ErrInvalidMaxConnectionAge occurs when the max connection age is invalid.
 	ErrInvalidMaxConnectionAge = errors.New("invalid max connection age for RPC server")
+	// ErrInvalidMaxConnectionAgeGrace occurs when the max connection age grace is invalid.
+	ErrInvalidMaxConnectionAgeGrace = errors.New("invalid max connection age grace for RPC server")
 )
 
 // Config is the configuration for creating a Server instance.
@@ -51,6 +53,10 @@ type Config struct {
 	// MaxConnectionAge is a duration for the maximum amount of time a connection may exist
 	// before it will be closed by sending a GoAway.
 	MaxConnectionAge string `yaml:"MaxConnectionAge"`
+
+	// MaxConnectionAgeGrace is a duration for the amount of time after receiving a GoAway
+	// for pending RPCs to complete before forcibly closing connections.
+	MaxConnectionAgeGrace string `yaml:"MaxConnectionAgeGrace"`
 }
 
 // Validate validates the port number and the files for certification.
@@ -74,9 +80,17 @@ func (c *Config) Validate() error {
 
 	if _, err := time.ParseDuration(c.MaxConnectionAge); err != nil {
 		return fmt.Errorf(
-			"must be a valid time duration string format %d: %w",
+			"%s: %w",
 			c.MaxConnectionAge,
 			ErrInvalidMaxConnectionAge,
+		)
+	}
+
+	if _, err := time.ParseDuration(c.MaxConnectionAgeGrace); err != nil {
+		return fmt.Errorf(
+			"%s: %w",
+			c.MaxConnectionAgeGrace,
+			ErrInvalidMaxConnectionAgeGrace,
 		)
 	}
 

--- a/server/rpc/config.go
+++ b/server/rpc/config.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 )
 
 var (
@@ -29,6 +30,8 @@ var (
 	ErrInvalidCertFile = errors.New("invalid cert file for RPC server")
 	// ErrInvalidKeyFile occurs when the key file is invalid.
 	ErrInvalidKeyFile = errors.New("invalid key file for RPC server")
+	// ErrInvalidMaxConnectionAge occurs when the max connection age is invalid.
+	ErrInvalidMaxConnectionAge = errors.New("invalid max connection age for RPC server")
 )
 
 // Config is the configuration for creating a Server instance.
@@ -44,6 +47,10 @@ type Config struct {
 
 	// MaxRequestBytes is the maximum client request size in bytes the server will accept.
 	MaxRequestBytes uint64 `yaml:"MaxRequestBytes"`
+
+	// MaxConnectionAge is a duration for the maximum amount of time a connection may exist
+	// before it will be closed by sending a GoAway.
+	MaxConnectionAge string `yaml:"MaxConnectionAge"`
 }
 
 // Validate validates the port number and the files for certification.
@@ -63,6 +70,14 @@ func (c *Config) Validate() error {
 		if _, err := os.Stat(c.KeyFile); err != nil {
 			return fmt.Errorf("%s: %w", c.KeyFile, ErrInvalidKeyFile)
 		}
+	}
+
+	if _, err := time.ParseDuration(c.MaxConnectionAge); err != nil {
+		return fmt.Errorf(
+			"must be a valid time duration string format %d: %w",
+			c.MaxConnectionAge,
+			ErrInvalidMaxConnectionAge,
+		)
 	}
 
 	return nil

--- a/server/rpc/server.go
+++ b/server/rpc/server.go
@@ -21,20 +21,21 @@ package rpc
 import (
 	"context"
 	"fmt"
+	"google.golang.org/grpc/keepalive"
 	"math"
 	"net"
+	"time"
 
 	grpcmiddleware "github.com/grpc-ecosystem/go-grpc-middleware"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/health"
-	healthpb "google.golang.org/grpc/health/grpc_health_v1"
-
 	api "github.com/yorkie-team/yorkie/api/yorkie/v1"
 	"github.com/yorkie-team/yorkie/server/backend"
 	"github.com/yorkie-team/yorkie/server/grpchelper"
 	"github.com/yorkie-team/yorkie/server/logging"
 	"github.com/yorkie-team/yorkie/server/rpc/interceptors"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 // Server is a normal server that processes the logic requested by the client.
@@ -73,9 +74,17 @@ func NewServer(conf *Config, be *backend.Backend) (*Server, error) {
 		opts = append(opts, grpc.Creds(creds))
 	}
 
+	maxConnectionAge, err := time.ParseDuration(conf.MaxConnectionAge)
+	if err != nil {
+		return nil, fmt.Errorf("parse max connection age: %w", err)
+	}
+
 	opts = append(opts, grpc.MaxRecvMsgSize(int(conf.MaxRequestBytes)))
 	opts = append(opts, grpc.MaxSendMsgSize(math.MaxInt32))
 	opts = append(opts, grpc.MaxConcurrentStreams(math.MaxUint32))
+	opts = append(opts, grpc.KeepaliveParams(keepalive.ServerParameters{
+		MaxConnectionAge: maxConnectionAge,
+	}))
 
 	yorkieServiceCtx, yorkieServiceCancel := context.WithCancel(context.Background())
 

--- a/server/rpc/server.go
+++ b/server/rpc/server.go
@@ -21,21 +21,22 @@ package rpc
 import (
 	"context"
 	"fmt"
-	"google.golang.org/grpc/keepalive"
 	"math"
 	"net"
 	"time"
 
 	grpcmiddleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/keepalive"
+
 	api "github.com/yorkie-team/yorkie/api/yorkie/v1"
 	"github.com/yorkie-team/yorkie/server/backend"
 	"github.com/yorkie-team/yorkie/server/grpchelper"
 	"github.com/yorkie-team/yorkie/server/logging"
 	"github.com/yorkie-team/yorkie/server/rpc/interceptors"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/health"
-	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 // Server is a normal server that processes the logic requested by the client.
@@ -79,11 +80,17 @@ func NewServer(conf *Config, be *backend.Backend) (*Server, error) {
 		return nil, fmt.Errorf("parse max connection age: %w", err)
 	}
 
+	maxConnectionAgeGrace, err := time.ParseDuration(conf.MaxConnectionAgeGrace)
+	if err != nil {
+		return nil, fmt.Errorf("parse max connection age grace: %w", err)
+	}
+
 	opts = append(opts, grpc.MaxRecvMsgSize(int(conf.MaxRequestBytes)))
 	opts = append(opts, grpc.MaxSendMsgSize(math.MaxInt32))
 	opts = append(opts, grpc.MaxConcurrentStreams(math.MaxUint32))
 	opts = append(opts, grpc.KeepaliveParams(keepalive.ServerParameters{
-		MaxConnectionAge: maxConnectionAge,
+		MaxConnectionAge:      maxConnectionAge,
+		MaxConnectionAgeGrace: maxConnectionAgeGrace,
 	}))
 
 	yorkieServiceCtx, yorkieServiceCancel := context.WithCancel(context.Background())

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -45,8 +45,9 @@ var testStartedAt int64
 
 // Below are the values of the Yorkie config used in the test.
 var (
-	RPCPort            = 21101
-	RPCMaxRequestBytes = uint64(4 * 1024 * 1024)
+	RPCPort             = 21101
+	RPCMaxRequestBytes  = uint64(4 * 1024 * 1024)
+	RPCMaxConnectionAge = 10 * gotime.Second
 
 	ProfilingPort = 21102
 
@@ -113,8 +114,9 @@ func TestConfig() *server.Config {
 	portOffset += 100
 	return &server.Config{
 		RPC: &rpc.Config{
-			Port:            RPCPort + portOffset,
-			MaxRequestBytes: RPCMaxRequestBytes,
+			Port:             RPCPort + portOffset,
+			MaxRequestBytes:  RPCMaxRequestBytes,
+			MaxConnectionAge: RPCMaxConnectionAge.String(),
 		},
 		Profiling: &profiling.Config{
 			Port: ProfilingPort + portOffset,

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -45,9 +45,10 @@ var testStartedAt int64
 
 // Below are the values of the Yorkie config used in the test.
 var (
-	RPCPort             = 21101
-	RPCMaxRequestBytes  = uint64(4 * 1024 * 1024)
-	RPCMaxConnectionAge = 10 * gotime.Second
+	RPCPort                  = 21101
+	RPCMaxRequestBytes       = uint64(4 * 1024 * 1024)
+	RPCMaxConnectionAge      = 4 * gotime.Second
+	RPCMaxConnectionAgeGrace = 1 * gotime.Second
 
 	ProfilingPort = 21102
 
@@ -55,7 +56,7 @@ var (
 
 	AdminUser                             = server.DefaultAdminUser
 	AdminPassword                         = server.DefaultAdminPassword
-	HousekeepingInterval                  = 1 * gotime.Second
+	HousekeepingInterval                  = 10 * gotime.Second
 	HousekeepingCandidatesLimitPerProject = 10
 
 	ClientDeactivateThreshold  = "10s"
@@ -114,9 +115,10 @@ func TestConfig() *server.Config {
 	portOffset += 100
 	return &server.Config{
 		RPC: &rpc.Config{
-			Port:             RPCPort + portOffset,
-			MaxRequestBytes:  RPCMaxRequestBytes,
-			MaxConnectionAge: RPCMaxConnectionAge.String(),
+			Port:                  RPCPort + portOffset,
+			MaxRequestBytes:       RPCMaxRequestBytes,
+			MaxConnectionAge:      RPCMaxConnectionAge.String(),
+			MaxConnectionAgeGrace: RPCMaxConnectionAgeGrace.String(),
 		},
 		Profiling: &profiling.Config{
 			Port: ProfilingPort + portOffset,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add gRPC `MaxConnectionAge` & `MaxConnectionAgeGrace` options.

This is to avoid "split-brain" of long-lived gRPC stream connection when performing hash-based load balancing in Yorkie cluster.

For more information, follow: https://github.com/envoyproxy/envoy/issues/26459

gRPC suggest to use `MAX_CONNECTION_AGE` to avoid long-lived RPC issue on load balancing(https://youtu.be/Naonb2XD_2Q?t=136), but stream is not actually closed even `MAX_CONNECTION_AGE` is configured.

This is because after `MAX_CONNECTION_AGE`, server sends GoAway to client, but GoAway is not a signal to close connection instantly. It's just a signal to tell client not to send additional request to server(https://github.com/grpc/grpc-java/issues/8770)

Therefore, `MAX_CONNECTION_AGE_GRACE` is also introduced to forcibly close stream.

So this is how it works:
1. After stream is established, stream is available for `maxConnectionAge`.
2. After `maxConnectionAge`, GoAway frame is sent to client to gracefully close the stream. But stream is not closed at this point.
3. After `MaxConnectionAgeGrace`, stream is forcibly closed.

Reference: https://pkg.go.dev/google.golang.org/grpc/keepalive

Hence, `maxConnectionAge` and `maxConnectionAgeGrace` options are added as gRPC server's keepalive option parameters.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

As I researched some information about long-lived connection, graceful close, etc, I now have good explanation about why `close_connections_on_host_set_change`(gracefully draining connections) are not working for long-lived gRPC connections.

It is because envoy sends HTTP2 GoAway frame on draining sequence, but GoAway is not for instant connection close. Therefore, no connection close are made after draining, and `close_connections_on_host_set_change` option will not work as well.

References: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/operations/draining

Also, I found some interesting issue related to our issue on long-lived connection close: https://github.com/grpc/grpc/issues/26703.

Maybe it will be useful to introduce `force_close_connections_on_host_set_change` on envoy:: https://github.com/envoyproxy/envoy/issues/26459

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
