### PR TITLE
Set Default MaxConnectionAge & MaxConnectionAgeGrace to Infinity

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -36,8 +36,8 @@ import (
 const (
 	DefaultRPCPort                  = 11101
 	DefaultRPCMaxRequestsBytes      = 4 * 1024 * 1024 // 4MiB
-	DefaultRPCMaxConnectionAge      = 50 * time.Second
-	DefaultRPCMaxConnectionAgeGrace = 10 * time.Second
+	DefaultRPCMaxConnectionAge      = 0 * time.Second
+	DefaultRPCMaxConnectionAgeGrace = 0 * time.Second
 
 	DefaultProfilingPort = 11102
 

--- a/server/config.sample.yml
+++ b/server/config.sample.yml
@@ -8,11 +8,11 @@ RPC:
 
   # MaxConnectionAge is a duration for the maximum amount of time a connection may exist
   # before it will be closed by sending a GoAway.
-  MaxConnectionAge: "50s"
+  MaxConnectionAge: "0s"
 
   # MaxConnectionAgeGrace is a duration for the amount of time after receiving a GoAway
   # for pending RPCs to complete before forcibly closing connections.
-  MaxConnectionAgeGrace: "10s"
+  MaxConnectionAgeGrace: "0s"
 
   # CertFile is the file containing the TLS certificate.
   CertFile: ""


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Set default gRPC server keepalive options: `MaxConnectionAge` & `MaxConnectionAgeGrace` to Infinity.

Setting `MaxConnectionAge` & `MaxConnectionAgeGrace` to `0` will configure them to be infinite. [gRPC-go `http2_server.go` code](https://github.com/grpc/grpc-go/blob/master/internal/transport/http2_server.go#L223-L228)

This is to use envoy's `stream_idle_timeout` which is more suitable option to close stream connections. [Envoy timeouts: Stream timeouts](https://www.envoyproxy.io/docs/envoy/latest/faq/configuration/timeouts#stream-timeouts)

But it will be good to leave `MaxConnectionAge` & `MaxConnectionAgeGrace` options to let user determine connection close timeout when they needed, which is recommended in gRPC spec.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
