### PR TITLE
Update Helm Chart Releaser Action

### DIFF
--- a/.cr.yaml
+++ b/.cr.yaml
@@ -1,1 +1,2 @@
 pages-index-path: helm-charts/index.yaml
+make-release-latest: false

--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -1,8 +1,9 @@
 name: Release Charts
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - main
 
 jobs:
   release:
@@ -11,7 +12,6 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -29,16 +29,12 @@ jobs:
 
       - name: Add dependency chart repos
         run: |
-          helm repo add base https://istio-release.storage.googleapis.com/charts
-          helm repo add istiod https://istio-release.storage.googleapis.com/charts
-          helm repo add gateway https://istio-release.storage.googleapis.com/charts
-          helm repo add kube-prometheus-stack https://prometheus-community.github.io/helm-charts
-
+          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+          helm repo add grafana https://grafana.github.io/helm-charts
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
         with:
           charts_dir: build/charts
-          mark_as_latest: false
           config: ${{ github.workspace }}/.cr.yaml
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Update Helm Chart Releaser Action.

Three changes:
- `mark-release-latest` option is also deprecated in chart-releaser-action. Therefore moved to `.cr.yaml` since option is still available in helm-releaser.
- Reverted action trigger to main branch push. This is because chart-releaser-action detects chart diff by tag, therefore it will not work for publish trigger(publish involves tagging, so helm-releaser-action will see diff from published tag)
- Updated chart dependencies

Follow https://github.com/helm/chart-releaser-action/pull/137 for more information about chart-releaser-action.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
