### PR TITLE
Remove panic method in json text

### DIFF
--- a/api/converter/converter_test.go
+++ b/api/converter/converter_test.go
@@ -41,14 +41,14 @@ func TestConverter(t *testing.T) {
 		doc := document.New("d1")
 
 		err = doc.Update(func(root *json.Object) error {
-			root.SetNewText("k1").Edit(0, 0, "A")
+			_, _ = root.SetNewText("k1").Edit(0, 0, "A")
 			return nil
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, `{"k1":[{"val":"A"}]}`, doc.Marshal())
 
 		err = doc.Update(func(root *json.Object) error {
-			root.SetNewText("k1").Edit(0, 0, "B")
+			_, _ = root.SetNewText("k1").Edit(0, 0, "B")
 			return nil
 		})
 		assert.NoError(t, err)
@@ -91,21 +91,21 @@ func TestConverter(t *testing.T) {
 				Delete(4)
 
 			// plain text
-			root.SetNewText("k3").
-				Edit(0, 0, "ㅎ").
-				Edit(0, 1, "하").
-				Edit(0, 1, "한").
-				Edit(0, 1, "하").
-				Edit(1, 1, "느").
-				Edit(1, 2, "늘").
-				Edit(2, 2, "구름").
-				Edit(2, 3, "뭉게구")
+			plainText := root.SetNewText("k3")
+			_, _ = plainText.Edit(0, 0, "ㅎ")
+			_, _ = plainText.Edit(0, 1, "하")
+			_, _ = plainText.Edit(0, 1, "한")
+			_, _ = plainText.Edit(0, 1, "하")
+			_, _ = plainText.Edit(1, 1, "느")
+			_, _ = plainText.Edit(1, 2, "늘")
+			_, _ = plainText.Edit(2, 2, "구름")
+			_, _ = plainText.Edit(2, 3, "뭉게구")
 
 			// rich text
-			root.SetNewText("k4").
-				Edit(0, 0, "Hello world", nil).
-				Edit(6, 11, "sky", nil).
-				Style(0, 5, map[string]string{"b": "1"})
+			richText := root.SetNewText("k4")
+			_, _ = richText.Edit(0, 0, "Hello world", nil)
+			_, _ = richText.Edit(6, 11, "sky", nil)
+			_, _ = richText.Style(0, 5, map[string]string{"b": "1"})
 
 			// a counter
 			root.SetNewCounter("k5", crdt.LongCnt, 0).
@@ -155,19 +155,19 @@ func TestConverter(t *testing.T) {
 			root.GetArray("k2").MoveBefore(nextCreatedAt, targetCreatedAt)
 
 			// plain text
-			root.SetNewText("k3").
-				Edit(0, 0, "ㅎ").
-				Edit(0, 1, "하").
-				Edit(0, 1, "한").
-				Edit(0, 1, "하").
-				Edit(1, 1, "느").
-				Edit(1, 2, "늘").
-				Select(1, 2)
+			plainText := root.SetNewText("k3")
+			_, _ = plainText.Edit(0, 0, "ㅎ")
+			_, _ = plainText.Edit(0, 1, "하")
+			_, _ = plainText.Edit(0, 1, "한")
+			_, _ = plainText.Edit(0, 1, "하")
+			_, _ = plainText.Edit(1, 1, "느")
+			_, _ = plainText.Edit(1, 2, "늘")
+			_, _ = plainText.Select(1, 2)
 
 			// rich text
-			root.SetNewText("k3").
-				Edit(0, 0, "Hello World", nil).
-				Style(0, 5, map[string]string{"b": "1"})
+			richText := root.SetNewText("k3")
+			_, _ = richText.Edit(0, 0, "Hello World", nil)
+			_, _ = richText.Style(0, 5, map[string]string{"b": "1"})
 
 			// counter
 			root.SetNewCounter("k4", crdt.IntegerCnt, 0).Increase(5)

--- a/pkg/document/document_test.go
+++ b/pkg/document/document_test.go
@@ -202,9 +202,9 @@ func TestDocument(t *testing.T) {
 		//           |                |          |
 		// [init] - [A] - [12] - [BC deleted] - [D]
 		err := doc.Update(func(root *json.Object) error {
-			root.SetNewText("k1").
-				Edit(0, 0, "ABCD").
-				Edit(1, 3, "12")
+			text := root.SetNewText("k1")
+			_, _ = text.Edit(0, 0, "ABCD")
+			_, _ = text.Edit(1, 3, "12")
 			assert.Equal(t, `{"k1":[{"val":"A"},{"val":"12"},{"val":"D"}]}`, root.Marshal())
 			return nil
 		})
@@ -241,13 +241,13 @@ func TestDocument(t *testing.T) {
 		doc := document.New("d1")
 
 		err := doc.Update(func(root *json.Object) error {
-			root.SetNewText("k1").
-				Edit(0, 0, "ㅎ").
-				Edit(0, 1, "하").
-				Edit(0, 1, "한").
-				Edit(0, 1, "하").
-				Edit(1, 1, "느").
-				Edit(1, 2, "늘")
+			text := root.SetNewText("k1")
+			_, _ = text.Edit(0, 0, "ㅎ")
+			_, _ = text.Edit(0, 1, "하")
+			_, _ = text.Edit(0, 1, "한")
+			_, _ = text.Edit(0, 1, "하")
+			_, _ = text.Edit(1, 1, "느")
+			_, _ = text.Edit(1, 2, "늘")
 			assert.Equal(t, `{"k1":[{"val":"하"},{"val":"늘"}]}`, root.Marshal())
 			return nil
 		})
@@ -260,7 +260,7 @@ func TestDocument(t *testing.T) {
 
 		err := doc.Update(func(root *json.Object) error {
 			text := root.SetNewText("k1")
-			text.Edit(0, 0, "Hello world", nil)
+			_, _ = text.Edit(0, 0, "Hello world", nil)
 			assert.Equal(
 				t,
 				`[0:0:00:0 {} ""][1:2:00:0 {} "Hello world"]`,
@@ -273,7 +273,7 @@ func TestDocument(t *testing.T) {
 
 		err = doc.Update(func(root *json.Object) error {
 			text := root.GetText("k1")
-			text.Style(0, 5, map[string]string{"b": "1"})
+			_, _ = text.Style(0, 5, map[string]string{"b": "1"})
 			assert.Equal(t,
 				`[0:0:00:0 {} ""][1:2:00:0 {"b":"1"} "Hello"][1:2:00:5 {} " world"]`,
 				text.StructureAsString(),
@@ -289,14 +289,14 @@ func TestDocument(t *testing.T) {
 
 		err = doc.Update(func(root *json.Object) error {
 			text := root.GetText("k1")
-			text.Style(0, 5, map[string]string{"b": "1"})
+			_, _ = text.Style(0, 5, map[string]string{"b": "1"})
 			assert.Equal(
 				t,
 				`[0:0:00:0 {} ""][1:2:00:0 {"b":"1"} "Hello"][1:2:00:5 {} " world"]`,
 				text.StructureAsString(),
 			)
 
-			text.Style(3, 5, map[string]string{"i": "1"})
+			_, _ = text.Style(3, 5, map[string]string{"i": "1"})
 			assert.Equal(
 				t,
 				`[0:0:00:0 {} ""][1:2:00:0 {"b":"1"} "Hel"][1:2:00:3 {"b":"1","i":"1"} "lo"][1:2:00:5 {} " world"]`,
@@ -313,7 +313,7 @@ func TestDocument(t *testing.T) {
 
 		err = doc.Update(func(root *json.Object) error {
 			text := root.GetText("k1")
-			text.Edit(5, 11, " Yorkie", nil)
+			_, _ = text.Edit(5, 11, " Yorkie", nil)
 			assert.Equal(
 				t,
 				`[0:0:00:0 {} ""][1:2:00:0 {"b":"1"} "Hel"][1:2:00:3 {"b":"1","i":"1"} "lo"]`+
@@ -331,7 +331,7 @@ func TestDocument(t *testing.T) {
 
 		err = doc.Update(func(root *json.Object) error {
 			text := root.GetText("k1")
-			text.Edit(5, 5, "\n", map[string]string{"list": "true"})
+			_, _ = text.Edit(5, 5, "\n", map[string]string{"list": "true"})
 			assert.Equal(
 				t,
 				`[0:0:00:0 {} ""][1:2:00:0 {"b":"1"} "Hel"][1:2:00:3 {"b":"1","i":"1"} "lo"]`+
@@ -474,8 +474,8 @@ func TestDocument(t *testing.T) {
 
 		err := doc.Update(func(root *json.Object) error {
 			root.SetNewText("text")
-			root.GetText("text").Edit(0, 0, "ABCD")
-			root.GetText("text").Edit(0, 2, "12")
+			_, _ = root.GetText("text").Edit(0, 0, "ABCD")
+			_, _ = root.GetText("text").Edit(0, 2, "12")
 			return nil
 		})
 		assert.NoError(t, err)
@@ -495,7 +495,7 @@ func TestDocument(t *testing.T) {
 		)
 
 		err = doc.Update(func(root *json.Object) error {
-			root.GetText("text").Edit(2, 4, "")
+			_, _ = root.GetText("text").Edit(2, 4, "")
 			return nil
 		})
 		assert.NoError(t, err)

--- a/pkg/document/json/text.go
+++ b/pkg/document/json/text.go
@@ -17,6 +17,7 @@
 package json
 
 import (
+	"fmt"
 	"github.com/yorkie-team/yorkie/pkg/document/change"
 	"github.com/yorkie-team/yorkie/pkg/document/crdt"
 	"github.com/yorkie-team/yorkie/pkg/document/operations"
@@ -38,9 +39,9 @@ func NewText(ctx *change.Context, text *crdt.Text) *Text {
 }
 
 // Edit edits the given range with the given content and attributes.
-func (p *Text) Edit(from, to int, content string, attributes ...map[string]string) *Text {
+func (p *Text) Edit(from, to int, content string, attributes ...map[string]string) (*Text, error) {
 	if from > to {
-		panic("from should be less than or equal to to")
+		return nil, fmt.Errorf("json text edit: from should be less than or equal to to(from: %d, to: %d)", from, to)
 	}
 	fromPos, toPos := p.Text.CreateRange(from, to)
 
@@ -74,13 +75,13 @@ func (p *Text) Edit(from, to int, content string, attributes ...map[string]strin
 		p.context.RegisterTextElementWithGarbage(p)
 	}
 
-	return p
+	return p, nil
 }
 
 // Style applies the style of the given range.
-func (p *Text) Style(from, to int, attributes map[string]string) *Text {
+func (p *Text) Style(from, to int, attributes map[string]string) (*Text, error) {
 	if from > to {
-		panic("from should be less than or equal to to")
+		return nil, fmt.Errorf("json text style: from should be less than or equal to to(from: %d, to: %d)", from, to)
 	}
 	fromPos, toPos := p.Text.CreateRange(from, to)
 
@@ -100,13 +101,13 @@ func (p *Text) Style(from, to int, attributes map[string]string) *Text {
 		ticket,
 	))
 
-	return p
+	return p, nil
 }
 
 // Select stores that the given range has been selected.
-func (p *Text) Select(from, to int) *Text {
+func (p *Text) Select(from, to int) (*Text, error) {
 	if from > to {
-		panic("from should be less than or equal to to")
+		return nil, fmt.Errorf("json text select: from should be less than or equal to to(from: %d, to: %d)", from, to)
 	}
 	fromPos, toPos := p.Text.CreateRange(from, to)
 
@@ -123,5 +124,5 @@ func (p *Text) Select(from, to int) *Text {
 		toPos,
 		ticket,
 	))
-	return p
+	return p, nil
 }

--- a/test/bench/document_bench_test.go
+++ b/test/bench/document_bench_test.go
@@ -181,9 +181,9 @@ func BenchmarkDocument(b *testing.B) {
 			//           |                |          |
 			// [init] - [A] - [12] - [BC deleted] - [D]
 			err := doc.Update(func(root *json.Object) error {
-				root.SetNewText("k1").
-					Edit(0, 0, "ABCD").
-					Edit(1, 3, "12")
+				text := root.SetNewText("k1")
+				_, _ = text.Edit(0, 0, "ABCD")
+				_, _ = text.Edit(1, 3, "12")
 				assert.Equal(b, `{"k1":[{"val":"A"},{"val":"12"},{"val":"D"}]}`, root.Marshal())
 				return nil
 			})
@@ -222,13 +222,13 @@ func BenchmarkDocument(b *testing.B) {
 			doc := document.New("d1")
 
 			err := doc.Update(func(root *json.Object) error {
-				root.SetNewText("k1").
-					Edit(0, 0, "ㅎ").
-					Edit(0, 1, "하").
-					Edit(0, 1, "한").
-					Edit(0, 1, "하").
-					Edit(1, 1, "느").
-					Edit(1, 2, "늘")
+				text := root.SetNewText("k1")
+				_, _ = text.Edit(0, 0, "ㅎ")
+				_, _ = text.Edit(0, 1, "하")
+				_, _ = text.Edit(0, 1, "한")
+				_, _ = text.Edit(0, 1, "하")
+				_, _ = text.Edit(1, 1, "느")
+				_, _ = text.Edit(1, 2, "늘")
 				assert.Equal(b, `{"k1":[{"val":"하"},{"val":"늘"}]}`, root.Marshal())
 				return nil
 			})
@@ -243,7 +243,7 @@ func BenchmarkDocument(b *testing.B) {
 
 			err := doc.Update(func(root *json.Object) error {
 				text := root.SetNewText("k1")
-				text.Edit(0, 0, "Hello world", nil)
+				_, _ = text.Edit(0, 0, "Hello world", nil)
 				assert.Equal(
 					b,
 					`[0:0:00:0 {} ""][1:2:00:0 {} "Hello world"]`,
@@ -256,7 +256,7 @@ func BenchmarkDocument(b *testing.B) {
 
 			err = doc.Update(func(root *json.Object) error {
 				text := root.GetText("k1")
-				text.Style(0, 5, map[string]string{"b": "1"})
+				_, _ = text.Style(0, 5, map[string]string{"b": "1"})
 				assert.Equal(b,
 					`[0:0:00:0 {} ""][1:2:00:0 {"b":"1"} "Hello"][1:2:00:5 {} " world"]`,
 					text.StructureAsString(),
@@ -272,14 +272,14 @@ func BenchmarkDocument(b *testing.B) {
 
 			err = doc.Update(func(root *json.Object) error {
 				text := root.GetText("k1")
-				text.Style(0, 5, map[string]string{"b": "1"})
+				_, _ = text.Style(0, 5, map[string]string{"b": "1"})
 				assert.Equal(
 					b,
 					`[0:0:00:0 {} ""][1:2:00:0 {"b":"1"} "Hello"][1:2:00:5 {} " world"]`,
 					text.StructureAsString(),
 				)
 
-				text.Style(3, 5, map[string]string{"i": "1"})
+				_, _ = text.Style(3, 5, map[string]string{"i": "1"})
 				assert.Equal(
 					b,
 					`[0:0:00:0 {} ""][1:2:00:0 {"b":"1"} "Hel"][1:2:00:3 {"b":"1","i":"1"} "lo"][1:2:00:5 {} " world"]`,
@@ -296,7 +296,7 @@ func BenchmarkDocument(b *testing.B) {
 
 			err = doc.Update(func(root *json.Object) error {
 				text := root.GetText("k1")
-				text.Edit(5, 11, " Yorkie", nil)
+				_, _ = text.Edit(5, 11, " Yorkie", nil)
 				assert.Equal(
 					b,
 					`[0:0:00:0 {} ""][1:2:00:0 {"b":"1"} "Hel"][1:2:00:3 {"b":"1","i":"1"} "lo"]`+
@@ -314,7 +314,7 @@ func BenchmarkDocument(b *testing.B) {
 
 			err = doc.Update(func(root *json.Object) error {
 				text := root.GetText("k1")
-				text.Edit(5, 5, "\n", map[string]string{"list": "true"})
+				_, _ = text.Edit(5, 5, "\n", map[string]string{"list": "true"})
 				assert.Equal(
 					b,
 					`[0:0:00:0 {} ""][1:2:00:0 {"b":"1"} "Hel"][1:2:00:3 {"b":"1","i":"1"} "lo"][5:1:00:0 {"list":"true"} "\n"][4:1:00:0 {} " Yorkie"]{1:2:00:5 {} " world"}`,
@@ -478,7 +478,7 @@ func benchmarkText(cnt int, b *testing.B) {
 		err := doc.Update(func(root *json.Object) error {
 			text := root.SetNewText("k1")
 			for c := 0; c < cnt; c++ {
-				text.Edit(c, c, "a")
+				_, _ = text.Edit(c, c, "a")
 			}
 			return nil
 		})
@@ -494,7 +494,7 @@ func benchmarkTextDeleteAll(cnt int, b *testing.B) {
 		err := doc.Update(func(root *json.Object) error {
 			text := root.SetNewText("k1")
 			for c := 0; c < cnt; c++ {
-				text.Edit(c, c, "a")
+				_, _ = text.Edit(c, c, "a")
 			}
 			return nil
 		}, "Create cnt-length text to test")
@@ -503,7 +503,7 @@ func benchmarkTextDeleteAll(cnt int, b *testing.B) {
 		b.StartTimer()
 		err = doc.Update(func(root *json.Object) error {
 			text := root.GetText("k1")
-			text.Edit(0, cnt, "")
+			_, _ = text.Edit(0, cnt, "")
 			return nil
 		}, "Delete all at a time")
 		assert.NoError(b, err)
@@ -521,7 +521,7 @@ func benchmarkTextEditGC(cnt int, b *testing.B) {
 		err := doc.Update(func(root *json.Object) error {
 			text := root.SetNewText("k1")
 			for i := 0; i < cnt; i++ {
-				text.Edit(i, i, "a")
+				_, _ = text.Edit(i, i, "a")
 			}
 			return nil
 		}, "creates a text then appends a")
@@ -530,7 +530,7 @@ func benchmarkTextEditGC(cnt int, b *testing.B) {
 		err = doc.Update(func(root *json.Object) error {
 			text := root.GetText("k1")
 			for i := 0; i < cnt; i++ {
-				text.Edit(i, i+1, "b")
+				_, _ = text.Edit(i, i+1, "b")
 			}
 			return nil
 		}, "replace contents with b")
@@ -551,7 +551,7 @@ func benchmarkTextSplitGC(cnt int, b *testing.B) {
 		}
 		err := doc.Update(func(root *json.Object) error {
 			text := root.SetNewText("k2")
-			text.Edit(0, 0, builder.String())
+			_, _ = text.Edit(0, 0, builder.String())
 			return nil
 		}, "initial")
 		assert.NoError(b, err)
@@ -560,7 +560,7 @@ func benchmarkTextSplitGC(cnt int, b *testing.B) {
 			text := root.GetText("k2")
 			for i := 0; i < cnt; i++ {
 				if i != cnt {
-					text.Edit(i, i+1, "b")
+					_, _ = text.Edit(i, i+1, "b")
 				}
 			}
 			return nil

--- a/test/bench/grpc_bench_test.go
+++ b/test/bench/grpc_bench_test.go
@@ -91,7 +91,7 @@ func benchmarkUpdateAndSync(
 	for i := 0; i < cnt; i++ {
 		err := d.Update(func(root *json.Object) error {
 			text := root.GetText(key)
-			text.Edit(0, 0, "c")
+			_, _ = text.Edit(0, 0, "c")
 			return nil
 		})
 		assert.NoError(b, err)
@@ -272,13 +272,13 @@ func BenchmarkRPC(b *testing.B) {
 
 				err := doc1.Update(func(root *json.Object) error {
 					text := root.SetNewText("k1")
-					text.Edit(0, 0, builder.String())
+					_, _ = text.Edit(0, 0, builder.String())
 					return nil
 				})
 				assert.NoError(b, err)
 				err = doc2.Update(func(root *json.Object) error {
 					text := root.SetNewText("k1")
-					text.Edit(0, 0, builder.String())
+					_, _ = text.Edit(0, 0, builder.String())
 					return nil
 				})
 				assert.NoError(b, err)

--- a/test/bench/text_editing_bench_test.go
+++ b/test/bench/text_editing_bench_test.go
@@ -54,10 +54,10 @@ func BenchmarkTextEditing(b *testing.B) {
 			text := root.GetText("text")
 			if mode == 0 {
 				value := edit[2].(string)
-				text.Edit(cursor, cursor, value)
+				_, _ = text.Edit(cursor, cursor, value)
 			} else if mode == 1 {
 				// deletion
-				text.Edit(cursor, cursor+1, "")
+				_, _ = text.Edit(cursor, cursor+1, "")
 			}
 			return nil
 		})

--- a/test/integration/gc_test.go
+++ b/test/integration/gc_test.go
@@ -112,10 +112,8 @@ func TestGarbageCollection(t *testing.T) {
 		assert.NoError(t, err)
 
 		err = d1.Update(func(root *json.Object) error {
-			root.SetNewText("text").
-				Edit(0, 0, "Hello world")
-			root.SetNewText("richText").
-				Edit(0, 0, "Hello world", nil)
+			_, _ = root.SetNewText("text").Edit(0, 0, "Hello world")
+			_, _ = root.SetNewText("richText").Edit(0, 0, "Hello world", nil)
 			return nil
 		}, "sets test and richText")
 		assert.NoError(t, err)
@@ -131,11 +129,10 @@ func TestGarbageCollection(t *testing.T) {
 		assert.NoError(t, err)
 
 		err = d2.Update(func(root *json.Object) error {
-			root.GetText("text").
-				Edit(0, 1, "a").
-				Edit(1, 2, "b")
-			root.GetText("richText").
-				Edit(0, 1, "a", map[string]string{"b": "1"})
+			text := root.GetText("text")
+			_, _ = text.Edit(0, 1, "a")
+			_, _ = text.Edit(1, 2, "b")
+			_, _ = root.GetText("richText").Edit(0, 1, "a", map[string]string{"b": "1"})
 			return nil
 		}, "edit text type elements")
 		assert.NoError(t, err)
@@ -187,8 +184,8 @@ func TestGarbageCollection(t *testing.T) {
 			root.SetInteger("1", 1)
 			root.SetNewArray("2").AddInteger(1, 2, 3)
 			root.SetInteger("3", 3)
-			root.SetNewText("4").Edit(0, 0, "Hi")
-			root.SetNewText("5").Edit(0, 0, "Hi", nil)
+			_, _ = root.SetNewText("4").Edit(0, 0, "Hi")
+			_, _ = root.SetNewText("5").Edit(0, 0, "Hi", nil)
 			return nil
 		}, "sets 1,2,3,4,5")
 		assert.NoError(t, err)
@@ -205,8 +202,8 @@ func TestGarbageCollection(t *testing.T) {
 
 		err = d1.Update(func(root *json.Object) error {
 			root.Delete("2")
-			root.GetText("4").Edit(0, 1, "h")
-			root.GetText("5").Edit(0, 1, "h", map[string]string{"b": "1"})
+			_, _ = root.GetText("4").Edit(0, 1, "h")
+			_, _ = root.GetText("5").Edit(0, 1, "h", map[string]string{"b": "1"})
 			return nil
 		}, "removes 2 and edit text type elements")
 		assert.NoError(t, err)

--- a/test/integration/retention_test.go
+++ b/test/integration/retention_test.go
@@ -168,7 +168,7 @@ func TestRetention(t *testing.T) {
 		// Create 6 changes
 		for _, edit := range edits {
 			err = d1.Update(func(root *json.Object) error {
-				root.GetText("k1").Edit(edit.from, edit.to, edit.content)
+				_, _ = root.GetText("k1").Edit(edit.from, edit.to, edit.content)
 				return nil
 			})
 			assert.NoError(t, err)
@@ -227,7 +227,7 @@ func TestRetention(t *testing.T) {
 		// Create 6 changes
 		for _, edit := range edits {
 			err = d2.Update(func(root *json.Object) error {
-				root.GetText("k1").Edit(edit.from, edit.to, edit.content)
+				_, _ = root.GetText("k1").Edit(edit.from, edit.to, edit.content)
 				return nil
 			})
 			assert.NoError(t, err)

--- a/test/integration/snapshot_test.go
+++ b/test/integration/snapshot_test.go
@@ -117,7 +117,7 @@ func TestSnapshot(t *testing.T) {
 
 		for _, edit := range edits {
 			err = d1.Update(func(root *json.Object) error {
-				root.GetText("k1").Edit(edit.from, edit.to, edit.content)
+				_, _ = root.GetText("k1").Edit(edit.from, edit.to, edit.content)
 				return nil
 			})
 			assert.NoError(t, err)
@@ -154,14 +154,14 @@ func TestSnapshot(t *testing.T) {
 
 		for i := 0; i <= int(helper.SnapshotThreshold); i++ {
 			err = d1.Update(func(root *json.Object) error {
-				root.GetText("k1").Edit(i, i, "x")
+				_, _ = root.GetText("k1").Edit(i, i, "x")
 				return nil
 			})
 			assert.NoError(t, err)
 		}
 
 		err = d2.Update(func(root *json.Object) error {
-			root.GetText("k1").Edit(0, 0, "o")
+			_, _ = root.GetText("k1").Edit(0, 0, "o")
 			return nil
 		})
 		assert.NoError(t, err)

--- a/test/integration/text_test.go
+++ b/test/integration/text_test.go
@@ -53,13 +53,13 @@ func TestText(t *testing.T) {
 		assert.NoError(t, err)
 
 		err = d1.Update(func(root *json.Object) error {
-			root.GetText("k1").Edit(0, 0, "ABCD")
+			_, _ = root.GetText("k1").Edit(0, 0, "ABCD")
 			return nil
 		}, "edit 0,0 ABCD by c1")
 		assert.NoError(t, err)
 
 		err = d2.Update(func(root *json.Object) error {
-			root.GetText("k1").Edit(0, 0, "1234")
+			_, _ = root.GetText("k1").Edit(0, 0, "1234")
 			return nil
 		}, "edit 0,0 1234 by c2")
 		assert.NoError(t, err)
@@ -67,13 +67,13 @@ func TestText(t *testing.T) {
 		syncClientsThenAssertEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
 
 		err = d1.Update(func(root *json.Object) error {
-			root.GetText("k1").Edit(2, 3, "XX")
+			_, _ = root.GetText("k1").Edit(2, 3, "XX")
 			return nil
 		}, "edit 2,3 XX by c1")
 		assert.NoError(t, err)
 
 		err = d2.Update(func(root *json.Object) error {
-			root.GetText("k1").Edit(2, 3, "YY")
+			_, _ = root.GetText("k1").Edit(2, 3, "YY")
 			return nil
 		}, "edit 2,3 YY by c2")
 		assert.NoError(t, err)
@@ -81,13 +81,13 @@ func TestText(t *testing.T) {
 		syncClientsThenAssertEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
 
 		err = d1.Update(func(root *json.Object) error {
-			root.GetText("k1").Edit(4, 5, "ZZ")
+			_, _ = root.GetText("k1").Edit(4, 5, "ZZ")
 			return nil
 		}, "edit 4,5 ZZ by c1")
 		assert.NoError(t, err)
 
 		err = d2.Update(func(root *json.Object) error {
-			root.GetText("k1").Edit(2, 3, "TT")
+			_, _ = root.GetText("k1").Edit(2, 3, "TT")
 			return nil
 		}, "edit 2,3 TT by c2")
 		assert.NoError(t, err)
@@ -102,7 +102,7 @@ func TestText(t *testing.T) {
 		assert.NoError(t, err)
 
 		err = d1.Update(func(root *json.Object) error {
-			root.SetNewText("k1").Edit(0, 0, "Hello world", nil)
+			_, _ = root.SetNewText("k1").Edit(0, 0, "Hello world", nil)
 			return nil
 		}, `set a new text with "Hello world" by c1`)
 		assert.NoError(t, err)
@@ -115,14 +115,14 @@ func TestText(t *testing.T) {
 
 		err = d1.Update(func(root *json.Object) error {
 			text := root.GetText("k1")
-			text.Style(0, 1, map[string]string{"b": "1"})
+			_, _ = text.Style(0, 1, map[string]string{"b": "1"})
 			return nil
 		}, `set style b to "H" by c1`)
 		assert.NoError(t, err)
 
 		err = d2.Update(func(root *json.Object) error {
 			text := root.GetText("k1")
-			text.Style(0, 5, map[string]string{"i": "1"})
+			_, _ = text.Style(0, 5, map[string]string{"i": "1"})
 			return nil
 		}, `set style i to "Hello" by c2`)
 		assert.NoError(t, err)
@@ -149,9 +149,9 @@ func TestText(t *testing.T) {
 		assert.NoError(t, err)
 
 		err = d1.Update(func(root *json.Object) error {
-			root.GetText("k1").Edit(0, 0, "123")
-			root.GetText("k1").Edit(3, 3, "456")
-			root.GetText("k1").Edit(6, 6, "789")
+			_, _ = root.GetText("k1").Edit(0, 0, "123")
+			_, _ = root.GetText("k1").Edit(3, 3, "456")
+			_, _ = root.GetText("k1").Edit(6, 6, "789")
 			return nil
 		}, "set new text by c1")
 		assert.NoError(t, err)
@@ -160,14 +160,14 @@ func TestText(t *testing.T) {
 		assert.Equal(t, `{"k1":[{"val":"123"},{"val":"456"},{"val":"789"}]}`, d2.Marshal())
 
 		err = d1.Update(func(root *json.Object) error {
-			root.GetText("k1").Edit(1, 7, "")
+			_, _ = root.GetText("k1").Edit(1, 7, "")
 			return nil
 		}, "delete block by c1")
 		assert.NoError(t, err)
 		assert.Equal(t, `{"k1":[{"val":"1"},{"val":"89"}]}`, d1.Marshal())
 
 		err = d2.Update(func(root *json.Object) error {
-			root.GetText("k1").Edit(2, 5, "")
+			_, _ = root.GetText("k1").Edit(2, 5, "")
 			return nil
 		}, "delete block by c2")
 		assert.NoError(t, err)
@@ -195,9 +195,9 @@ func TestText(t *testing.T) {
 		assert.NoError(t, err)
 
 		err = d1.Update(func(root *json.Object) error {
-			root.GetText("k1").Edit(0, 0, "0")
-			root.GetText("k1").Edit(1, 1, "0")
-			root.GetText("k1").Edit(2, 2, "0")
+			_, _ = root.GetText("k1").Edit(0, 0, "0")
+			_, _ = root.GetText("k1").Edit(1, 1, "0")
+			_, _ = root.GetText("k1").Edit(2, 2, "0")
 			return nil
 		}, "set new text by c1")
 		assert.NoError(t, err)
@@ -206,16 +206,16 @@ func TestText(t *testing.T) {
 		assert.Equal(t, `{"k1":[{"val":"0"},{"val":"0"},{"val":"0"}]}`, d2.Marshal())
 
 		err = d1.Update(func(root *json.Object) error {
-			root.GetText("k1").Edit(1, 2, "1")
-			root.GetText("k1").Edit(1, 2, "1")
-			root.GetText("k1").Edit(1, 2, "")
+			_, _ = root.GetText("k1").Edit(1, 2, "1")
+			_, _ = root.GetText("k1").Edit(1, 2, "1")
+			_, _ = root.GetText("k1").Edit(1, 2, "")
 			return nil
 		}, "newly create then delete by c1")
 		assert.NoError(t, err)
 		assert.Equal(t, `{"k1":[{"val":"0"},{"val":"0"}]}`, d1.Marshal())
 
 		err = d2.Update(func(root *json.Object) error {
-			root.GetText("k1").Edit(0, 3, "")
+			_, _ = root.GetText("k1").Edit(0, 3, "")
 			return nil
 		}, "delete the range includes above new nodes")
 		assert.NoError(t, err)


### PR DESCRIPTION
Remove panic method in json text
- go sdk json text interface has the condition that cause panic
- `from should be less than or equal to to` condition

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #501 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
