### PR TITLE
Add Leader Election for Housekeeping in Sharded Cluster using MongoDB

### DIFF
--- a/build/charts/yorkie-cluster/templates/deployment.yaml
+++ b/build/charts/yorkie-cluster/templates/deployment.yaml
@@ -41,10 +41,8 @@ spec:
           "--mongo-connection-uri",
           "mongodb://{{ .Values.yorkie.args.dbUrl }}:{{ .Values.yorkie.args.dbPort }}/yorkie-meta",
           "--enable-pprof",
-          "--leader-election",
+          "--housekeeping-leader-election",
           "true",
-          "--client-deactivate-threshold",
-          "30s",
         ]
         ports:
           - containerPort: {{ .Values.yorkie.ports.rpcPort }}

--- a/build/charts/yorkie-cluster/templates/deployment.yaml
+++ b/build/charts/yorkie-cluster/templates/deployment.yaml
@@ -41,6 +41,10 @@ spec:
           "--mongo-connection-uri",
           "mongodb://{{ .Values.yorkie.args.dbUrl }}:{{ .Values.yorkie.args.dbPort }}/yorkie-meta",
           "--enable-pprof",
+          "--leader-election",
+          "true",
+          "--client-deactivate-threshold",
+          "30s",
         ]
         ports:
           - containerPort: {{ .Values.yorkie.ports.rpcPort }}

--- a/cmd/yorkie/server.go
+++ b/cmd/yorkie/server.go
@@ -229,6 +229,12 @@ func init() {
 		server.DefaultHousekeepingCandidatesLimitPerProject,
 		"candidates limit per project for a single housekeeping run",
 	)
+	cmd.Flags().BoolVar(
+		&conf.Housekeeping.LeaderElection,
+		"housekeeping-leader-election",
+		server.DefaultHousekeepingLeaderElection,
+		"Enable leader election to run housekeeping only on the leader.",
+	)
 	cmd.Flags().DurationVar(
 		&housekeepingLeaseDuration,
 		"housekeeping-lease-duration",
@@ -350,12 +356,6 @@ func init() {
 		"hostname",
 		server.DefaultHostname,
 		"Yorkie Server Hostname",
-	)
-	cmd.Flags().BoolVar(
-		&conf.Backend.LeaderElection,
-		"leader-election",
-		server.DefaultLeaderElection,
-		"Enable leader election to run tasks only on the leader.",
 	)
 
 	rootCmd.AddCommand(cmd)

--- a/cmd/yorkie/server.go
+++ b/cmd/yorkie/server.go
@@ -40,6 +40,7 @@ var (
 
 	adminTokenDuration        time.Duration
 	housekeepingInterval      time.Duration
+	housekeepingLeaseDuration time.Duration
 	clientDeactivateThreshold string
 
 	mongoConnectionURI     string
@@ -74,6 +75,7 @@ func newServerCmd() *cobra.Command {
 			conf.Backend.AuthWebhookCacheUnauthTTL = authWebhookCacheUnauthTTL.String()
 
 			conf.Housekeeping.Interval = housekeepingInterval.String()
+			conf.Housekeeping.LeaseDuration = housekeepingLeaseDuration.String()
 
 			if mongoConnectionURI != "" {
 				conf.Mongo = &mongo.Config{
@@ -227,6 +229,12 @@ func init() {
 		server.DefaultHousekeepingCandidatesLimitPerProject,
 		"candidates limit per project for a single housekeeping run",
 	)
+	cmd.Flags().DurationVar(
+		&housekeepingLeaseDuration,
+		"housekeeping-lease-duration",
+		server.DefaultHousekeepingLeaseDuration,
+		"lease duration for a leader election in housekeeping",
+	)
 	cmd.Flags().StringVar(
 		&mongoConnectionURI,
 		"mongo-connection-uri",
@@ -342,6 +350,12 @@ func init() {
 		"hostname",
 		server.DefaultHostname,
 		"Yorkie Server Hostname",
+	)
+	cmd.Flags().BoolVar(
+		&conf.Backend.LeaderElection,
+		"leader-election",
+		server.DefaultLeaderElection,
+		"Enable leader election to run tasks only on the leader.",
 	)
 
 	rootCmd.AddCommand(cmd)

--- a/server/backend/backend.go
+++ b/server/backend/backend.go
@@ -34,7 +34,7 @@ import (
 	memdb "github.com/yorkie-team/yorkie/server/backend/database/memory"
 	"github.com/yorkie-team/yorkie/server/backend/database/mongo"
 	"github.com/yorkie-team/yorkie/server/backend/election"
-	dbelection "github.com/yorkie-team/yorkie/server/backend/election/database"
+	mongoelection "github.com/yorkie-team/yorkie/server/backend/election/mongo"
 	"github.com/yorkie-team/yorkie/server/backend/housekeeping"
 	"github.com/yorkie-team/yorkie/server/backend/sync"
 	memsync "github.com/yorkie-team/yorkie/server/backend/sync/memory"
@@ -107,7 +107,7 @@ func New(
 		return nil, err
 	}
 
-	elector := dbelection.NewElector(hostname, db)
+	elector := mongoelection.NewElector(hostname, db)
 
 	keeping, err := housekeeping.Start(
 		housekeepingConf,

--- a/server/backend/backend.go
+++ b/server/backend/backend.go
@@ -33,6 +33,7 @@ import (
 	"github.com/yorkie-team/yorkie/server/backend/database"
 	memdb "github.com/yorkie-team/yorkie/server/backend/database/memory"
 	"github.com/yorkie-team/yorkie/server/backend/database/mongo"
+	"github.com/yorkie-team/yorkie/server/backend/election"
 	"github.com/yorkie-team/yorkie/server/backend/housekeeping"
 	"github.com/yorkie-team/yorkie/server/backend/sync"
 	memsync "github.com/yorkie-team/yorkie/server/backend/sync/memory"
@@ -48,6 +49,7 @@ type Backend struct {
 
 	DB           database.Database
 	Coordinator  sync.Coordinator
+	Elector      *election.Elector
 	Metrics      *prometheus.Metrics
 	Background   *background.Background
 	Housekeeping *housekeeping.Housekeeping
@@ -64,11 +66,12 @@ func New(
 ) (*Backend, error) {
 	hostname := conf.Hostname
 	if hostname == "" {
-		hostname, err := os.Hostname()
+		osHostname, err := os.Hostname()
 		if err != nil {
 			return nil, fmt.Errorf("os.Hostname: %w", err)
 		}
-		conf.Hostname = hostname
+		conf.Hostname = osHostname
+		hostname = osHostname
 	}
 
 	serverInfo := &sync.ServerInfo{
@@ -98,6 +101,14 @@ func New(
 	//  will need to distribute workloads of a document.
 	coordinator := memsync.NewCoordinator(serverInfo)
 
+	var elector *election.Elector
+	if conf.LeaderElection {
+		elector, err = election.New(hostname, db)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	authWebhookCache, err := cache.NewLRUExpireCache[string, *types.AuthWebhookResponse](conf.AuthWebhookCacheSize)
 	if err != nil {
 		return nil, err
@@ -107,6 +118,7 @@ func New(
 		housekeepingConf,
 		db,
 		coordinator,
+		elector,
 	)
 	if err != nil {
 		return nil, err
@@ -118,8 +130,9 @@ func New(
 	}
 
 	logging.DefaultLogger().Infof(
-		"backend created: id: %s, rpc: %s",
+		"backend created: id: %s, rpc: %s, db: %s",
 		serverInfo.ID,
+		serverInfo.Hostname,
 		dbInfo,
 	)
 
@@ -141,6 +154,7 @@ func New(
 		Metrics:      metrics,
 		DB:           db,
 		Coordinator:  coordinator,
+		Elector:      elector,
 		Housekeeping: keeping,
 
 		AuthWebhookCache: authWebhookCache,
@@ -153,6 +167,12 @@ func (b *Backend) Shutdown() error {
 
 	if err := b.Housekeeping.Stop(); err != nil {
 		return err
+	}
+
+	if b.Config.LeaderElection {
+		if err := b.Elector.Stop(); err != nil {
+			return err
+		}
 	}
 
 	if err := b.Coordinator.Close(); err != nil {

--- a/server/backend/config.go
+++ b/server/backend/config.go
@@ -72,10 +72,6 @@ type Config struct {
 
 	// Hostname is yorkie server hostname. hostname is used by metrics.
 	Hostname string `yaml:"Hostname"`
-
-	// LeaderElection is the flag to enable leader election for performing housekeeping only on leader node.
-	// Server should be deployed in Kubernetes platform to enable this flag.
-	LeaderElection bool `yaml:"LeaderElection"`
 }
 
 // Validate validates this config.

--- a/server/backend/config.go
+++ b/server/backend/config.go
@@ -42,7 +42,7 @@ type Config struct {
 	// we are using server as single-tenant mode, this should be set to true.
 	UseDefaultProject bool `yaml:"UseDefaultProject"`
 
-	// ClientDeactivateThreshold is deactivate threshold of clients in specific project for housekeeping.
+	// ClientDeactivateThreshold is deactivation threshold of clients in specific project for housekeeping.
 	ClientDeactivateThreshold string `yaml:"ClientDeactivateThreshold"`
 
 	// SnapshotThreshold is the threshold that determines if changes should be
@@ -72,6 +72,10 @@ type Config struct {
 
 	// Hostname is yorkie server hostname. hostname is used by metrics.
 	Hostname string `yaml:"Hostname"`
+
+	// LeaderElection is the flag to enable leader election for performing housekeeping only on leader node.
+	// Server should be deployed in Kubernetes platform to enable this flag.
+	LeaderElection bool `yaml:"LeaderElection"`
 }
 
 // Validate validates this config.

--- a/server/backend/database/database.go
+++ b/server/backend/database/database.go
@@ -276,4 +276,10 @@ type Database interface {
 		leaseLockName string,
 		leaseDuration gotime.Duration,
 	) error
+
+	// FindLeader returns the leader hostname for the given leaseLockName.
+	FindLeader(
+		ctx context.Context,
+		leaseLockName string,
+	) (*string, error)
 }

--- a/server/backend/database/database.go
+++ b/server/backend/database/database.go
@@ -20,6 +20,7 @@ package database
 import (
 	"context"
 	"errors"
+	gotime "time"
 
 	"github.com/yorkie-team/yorkie/api/types"
 	"github.com/yorkie-team/yorkie/pkg/document"
@@ -253,4 +254,26 @@ type Database interface {
 		docID types.ID,
 		excludeClientID types.ID,
 	) (bool, error)
+
+	// CreateTTLIndex creates a TTL index.
+	CreateTTLIndex(
+		ctx context.Context,
+		leaseDuration gotime.Duration,
+	) error
+
+	// TryToAcquireLeaderLease tries to acquire the leader lease.
+	TryToAcquireLeaderLease(
+		ctx context.Context,
+		hostname string,
+		leaseLockName string,
+		leaseDuration gotime.Duration,
+	) (bool, error)
+
+	// RenewLeaderLease renews the leader lease.
+	RenewLeaderLease(
+		ctx context.Context,
+		hostname string,
+		leaseLockName string,
+		leaseDuration gotime.Duration,
+	) error
 }

--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -1308,6 +1308,37 @@ func (d *DB) findTicketByServerSeq(
 	), nil
 }
 
+// CreateTTLIndex creates a TTL index.
+func (d *DB) CreateTTLIndex(
+	ctx context.Context,
+	leaseDuration gotime.Duration,
+) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+// TryToAcquireLeaderLease tries to acquire the leader lease.
+func (d *DB) TryToAcquireLeaderLease(
+	ctx context.Context,
+	hostname string,
+	leaseLockName string,
+	leaseDuration gotime.Duration,
+) (bool, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+// RenewLeaderLease renews the leader lease.
+func (d *DB) RenewLeaderLease(
+	ctx context.Context,
+	hostname string,
+	leaseLockName string,
+	leaseDuration gotime.Duration,
+) error {
+	//TODO implement me
+	panic("implement me")
+}
+
 func newID() types.ID {
 	return types.ID(primitive.NewObjectID().Hex())
 }

--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -1337,6 +1337,11 @@ func (d *DB) RenewLeaderLease(
 	return nil
 }
 
+// FindLeader returns the leader hostname for the given leaseLockName.
+func (d *DB) FindLeader(ctx context.Context, leaseLockName string) (*string, error) {
+	return nil, nil
+}
+
 func newID() types.ID {
 	return types.ID(primitive.NewObjectID().Hex())
 }

--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -1313,8 +1313,7 @@ func (d *DB) CreateTTLIndex(
 	ctx context.Context,
 	leaseDuration gotime.Duration,
 ) error {
-	//TODO implement me
-	panic("implement me")
+	return nil
 }
 
 // TryToAcquireLeaderLease tries to acquire the leader lease.
@@ -1324,8 +1323,8 @@ func (d *DB) TryToAcquireLeaderLease(
 	leaseLockName string,
 	leaseDuration gotime.Duration,
 ) (bool, error) {
-	//TODO implement me
-	panic("implement me")
+	// In memory database, leader is always myself.
+	return true, nil
 }
 
 // RenewLeaderLease renews the leader lease.
@@ -1335,8 +1334,7 @@ func (d *DB) RenewLeaderLease(
 	leaseLockName string,
 	leaseDuration gotime.Duration,
 ) error {
-	//TODO implement me
-	panic("implement me")
+	return nil
 }
 
 func newID() types.ID {

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -1467,7 +1467,7 @@ func (c *Client) RenewLeaderLease(
 // FindLeader returns the leader hostname for the given leaseLockName.
 func (c *Client) FindLeader(ctx context.Context, leaseLockName string) (*string, error) {
 	electionInfo := &struct {
-		ElectionId    string      `bson:"election_id"`
+		ElectionID    string      `bson:"election_id"`
 		LeaderID      string      `bson:"leader_id"`
 		LeaseExpireAt gotime.Time `bson:"lease_expire_at"`
 	}{}

--- a/server/backend/database/mongo/client_test.go
+++ b/server/backend/database/mongo/client_test.go
@@ -17,7 +17,9 @@
 package mongo_test
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 

--- a/server/backend/database/mongo/indexes.go
+++ b/server/backend/database/mongo/indexes.go
@@ -33,6 +33,7 @@ const (
 	colChanges    = "changes"
 	colSnapshots  = "snapshots"
 	colSyncedSeqs = "syncedseqs"
+	colElections  = "elections"
 )
 
 type collectionInfo struct {
@@ -129,6 +130,20 @@ var collectionInfos = []collectionInfo{
 				{Key: "doc_id", Value: bsonx.Int32(1)},
 				{Key: "lamport", Value: bsonx.Int32(1)},
 				{Key: "actor_id", Value: bsonx.Int32(1)},
+			},
+		}},
+	}, {
+		name: colElections,
+		indexes: []mongo.IndexModel{{
+			Keys: bsonx.Doc{
+				{Key: "election_id", Value: bsonx.Int32(1)},
+			},
+			Options: options.Index().SetUnique(true),
+		}, {
+			Keys: bsonx.Doc{
+				{Key: "election_id", Value: bsonx.Int32(1)},
+				{Key: "leader_id", Value: bsonx.Int32(1)},
+				{Key: "lease_expire_at", Value: bsonx.Int32(1)},
 			},
 		}},
 	},

--- a/server/backend/election/database/election.go
+++ b/server/backend/election/database/election.go
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2023 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package database is a database implementation of election package.
+package database
+
+import (
+	"context"
+	"time"
+
+	"github.com/yorkie-team/yorkie/server/backend/database"
+	"github.com/yorkie-team/yorkie/server/logging"
+)
+
+// Elector is a database-based implementation of election.Elector.
+type Elector struct {
+	database database.Database
+
+	hostname string
+
+	ctx        context.Context
+	cancelFunc context.CancelFunc
+}
+
+// NewElector creates a new elector instance.
+func NewElector(
+	hostname string,
+	database database.Database,
+) *Elector {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+
+	return &Elector{
+		database: database,
+
+		hostname: hostname,
+
+		ctx:        ctx,
+		cancelFunc: cancelFunc,
+	}
+}
+
+// StartElection starts leader election.
+func (e *Elector) StartElection(
+	leaseLockName string,
+	leaseDuration time.Duration,
+	onStartLeading func(ctx context.Context),
+	onStoppedLeading func(),
+) error {
+	if err := e.database.CreateTTLIndex(context.Background(), leaseDuration); err != nil {
+		return err
+	}
+
+	go e.run(leaseLockName, leaseDuration, onStartLeading, onStoppedLeading)
+	return nil
+}
+
+// Stop stops all leader elections.
+func (e *Elector) Stop() error {
+	e.cancelFunc()
+
+	return nil
+}
+
+// run starts leader election loop.
+// run will not return before leader election loop is stopped by ctx,
+// or it has stopped holding the leader lease
+func (e *Elector) run(
+	leaseLockName string,
+	leaseDuration time.Duration,
+	onStartLeading func(ctx context.Context),
+	onStoppedLeading func(),
+) {
+	for {
+		ctx := context.Background()
+		acquired, err := e.database.TryToAcquireLeaderLease(ctx, e.hostname, leaseLockName, leaseDuration)
+		if err != nil {
+			continue
+		}
+
+		if acquired {
+			go onStartLeading(ctx)
+			logging.From(ctx).Infof(
+				"leader elected: %s", e.hostname,
+			)
+
+			for {
+				err = e.database.RenewLeaderLease(ctx, e.hostname, leaseLockName, leaseDuration)
+				if err != nil {
+					break
+				}
+
+				select {
+				case <-time.After(leaseDuration / 2):
+				case <-e.ctx.Done():
+					return
+				}
+			}
+		} else {
+			onStoppedLeading()
+			logging.From(ctx).Infof(
+				"leader lost: %s", e.hostname,
+			)
+		}
+
+		select {
+		case <-time.After(leaseDuration):
+		case <-e.ctx.Done():
+			return
+		}
+	}
+}

--- a/server/backend/election/election.go
+++ b/server/backend/election/election.go
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2023 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package election provides leader election between server cluster. It is used to
+// elect leader among server cluster and run tasks only on the leader.
+package election
+
+import (
+	"context"
+	"time"
+
+	"github.com/yorkie-team/yorkie/server/backend/database"
+	"github.com/yorkie-team/yorkie/server/logging"
+)
+
+// Elector is responsible for leader election between server cluster.
+type Elector struct {
+	database database.Database
+	hostname string
+
+	ctx        context.Context
+	cancelFunc context.CancelFunc
+}
+
+// New creates a new elector instance.
+func New(
+	hostname string,
+	database database.Database,
+) (*Elector, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+
+	return &Elector{
+		database: database,
+		hostname: hostname,
+
+		ctx:        ctx,
+		cancelFunc: cancelFunc,
+	}, nil
+}
+
+// Start starts leader election.
+func (e *Elector) Start(
+	leaseLockName string,
+	leaseDuration time.Duration,
+	onStartLeading func(ctx context.Context),
+	onStoppedLeading func(),
+) error {
+	if err := e.database.CreateTTLIndex(context.Background(), leaseDuration); err != nil {
+		return err
+	}
+
+	go e.Run(leaseLockName, leaseDuration, onStartLeading, onStoppedLeading)
+	return nil
+}
+
+// Stop stops leader election.
+func (e *Elector) Stop() error {
+	e.cancelFunc()
+
+	return nil
+}
+
+// Run starts leader election loop.
+// Run will not return before leader election loop is stopped by ctx,
+// or it has stopped holding the leader lease
+func (e *Elector) Run(
+	leaseLockName string,
+	leaseDuration time.Duration,
+	onStartLeading func(ctx context.Context),
+	onStoppedLeading func(),
+) {
+	for {
+		ctx := context.Background()
+		acquired, err := e.database.TryToAcquireLeaderLease(ctx, e.hostname, leaseLockName, leaseDuration)
+		if err != nil {
+			continue
+		}
+
+		if acquired {
+			go onStartLeading(ctx)
+			logging.From(ctx).Infof(
+				"leader elected: %s", e.hostname,
+			)
+
+			for {
+				err = e.database.RenewLeaderLease(ctx, e.hostname, leaseLockName, leaseDuration)
+				if err != nil {
+					break
+				}
+
+				select {
+				case <-time.After(leaseDuration / 2):
+				case <-e.ctx.Done():
+					return
+				}
+			}
+		} else {
+			onStoppedLeading()
+			logging.From(ctx).Infof(
+				"leader lost: %s", e.hostname,
+			)
+		}
+
+		select {
+		case <-time.After(leaseDuration):
+		case <-e.ctx.Done():
+			return
+		}
+	}
+}

--- a/server/backend/election/mongo/election_test.go
+++ b/server/backend/election/mongo/election_test.go
@@ -1,0 +1,98 @@
+package mongo_test
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"github.com/yorkie-team/yorkie/server/backend/database/mongo"
+	mongoelection "github.com/yorkie-team/yorkie/server/backend/election/mongo"
+	"github.com/yorkie-team/yorkie/test/helper"
+	"testing"
+	"time"
+)
+
+var (
+	normalTask = func(ctx context.Context) {}
+	stopTask   = func() {}
+)
+
+func setupTestWithDummyData(t *testing.T) *mongo.Client {
+	config := &mongo.Config{
+		ConnectionTimeout: "5s",
+		ConnectionURI:     "mongodb://localhost:27017",
+		YorkieDatabase:    helper.TestDBName(),
+		PingTimeout:       "5s",
+	}
+	assert.NoError(t, config.Validate())
+
+	db, err := mongo.Dial(config)
+	assert.NoError(t, err)
+
+	return db
+}
+
+func TestElection(t *testing.T) {
+	db := setupTestWithDummyData(t)
+
+	t.Run("leader election with multiple electors test", func(t *testing.T) {
+		leaseLockName := t.Name()
+
+		electorA := mongoelection.NewElector("A", db)
+		electorB := mongoelection.NewElector("B", db)
+		electorC := mongoelection.NewElector("C", db)
+
+		assert.NoError(t, electorA.StartElection(leaseLockName, helper.LeaseDuration, normalTask, stopTask))
+		assert.NoError(t, electorB.StartElection(leaseLockName, helper.LeaseDuration, normalTask, stopTask))
+		assert.NoError(t, electorC.StartElection(leaseLockName, helper.LeaseDuration, normalTask, stopTask))
+
+		// elector A will be the leader because it is the first to start the election.
+		leader, err := db.FindLeader(context.Background(), leaseLockName)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "A", *leader)
+
+		// wait for lease expiration and check the leader again
+		// elector A is still the leader because it has renewed the lease.
+		time.Sleep(helper.LeaseDuration)
+		assert.Equal(t, "A", *leader)
+
+		// stop electorA and electorB, then wait for the next leader election
+		// elector C will be the leader because other electors are stopped.
+		assert.NoError(t, electorA.Stop())
+		assert.NoError(t, electorB.Stop())
+
+		time.Sleep(helper.LeaseDuration)
+
+		leader, err = db.FindLeader(context.Background(), leaseLockName)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "C", *leader)
+	})
+
+	t.Run("lease renewal while handling a a long task test", func(t *testing.T) {
+		leaseLockName := t.Name()
+		longTask := func(ctx context.Context) {
+			time.Sleep(helper.LeaseDuration * 2)
+		}
+
+		electorA := mongoelection.NewElector("A", db)
+		electorB := mongoelection.NewElector("B", db)
+		electorC := mongoelection.NewElector("C", db)
+
+		assert.NoError(t, electorA.StartElection(leaseLockName, helper.LeaseDuration, longTask, stopTask))
+		assert.NoError(t, electorB.StartElection(leaseLockName, helper.LeaseDuration, normalTask, stopTask))
+		assert.NoError(t, electorC.StartElection(leaseLockName, helper.LeaseDuration, normalTask, stopTask))
+
+		// check if elector A is still the leader
+		time.Sleep(helper.LeaseDuration)
+
+		leader, err := db.FindLeader(context.Background(), leaseLockName)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "A", *leader)
+	})
+
+	t.Run("handle background routines when shutting down the server test", func(t *testing.T) {
+		// TODO(krapie): find the way to gradually close election routines
+		t.Skip()
+	})
+}

--- a/server/backend/housekeeping/housekeeping.go
+++ b/server/backend/housekeeping/housekeeping.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/yorkie-team/yorkie/server/backend/database"
+	"github.com/yorkie-team/yorkie/server/backend/election"
 	"github.com/yorkie-team/yorkie/server/backend/sync"
 	"github.com/yorkie-team/yorkie/server/clients"
 	"github.com/yorkie-team/yorkie/server/logging"
@@ -32,6 +33,7 @@ import (
 
 const (
 	deactivateCandidatesKey = "housekeeping/deactivateCandidates"
+	lockLeaseName           = "housekeeping"
 )
 
 // Config is the configuration for the housekeeping service.
@@ -41,6 +43,9 @@ type Config struct {
 
 	// CandidatesLimitPerProject is the maximum number of candidates to be returned per project.
 	CandidatesLimitPerProject int `yaml:"CandidatesLimitPerProject"`
+
+	// LeaseDuration is the duration that non-leader candidates will wait to force acquire leadership.
+	LeaseDuration string `yaml:"LeaseDuration"`
 }
 
 // Validate validates the configuration.
@@ -49,6 +54,14 @@ func (c *Config) Validate() error {
 		return fmt.Errorf(
 			`invalid argument %s for "--housekeeping-interval" flag: %w`,
 			c.Interval,
+			err,
+		)
+	}
+
+	if _, err := time.ParseDuration(c.LeaseDuration); err != nil {
+		return fmt.Errorf(
+			`invalid argument %s for "--housekeeping-lease-duration" flag: %w`,
+			c.LeaseDuration,
 			err,
 		)
 	}
@@ -62,9 +75,11 @@ func (c *Config) Validate() error {
 type Housekeeping struct {
 	database    database.Database
 	coordinator sync.Coordinator
+	elector     *election.Elector
 
 	interval                  time.Duration
 	candidatesLimitPerProject int
+	leaseDuration             time.Duration
 
 	ctx        context.Context
 	cancelFunc context.CancelFunc
@@ -75,8 +90,9 @@ func Start(
 	conf *Config,
 	database database.Database,
 	coordinator sync.Coordinator,
+	elector *election.Elector,
 ) (*Housekeeping, error) {
-	h, err := New(conf, database, coordinator)
+	h, err := New(conf, database, coordinator, elector)
 	if err != nil {
 		return nil, err
 	}
@@ -92,10 +108,15 @@ func New(
 	conf *Config,
 	database database.Database,
 	coordinator sync.Coordinator,
+	elector *election.Elector,
 ) (*Housekeeping, error) {
 	interval, err := time.ParseDuration(conf.Interval)
 	if err != nil {
 		return nil, fmt.Errorf("parse interval %s: %w", conf.Interval, err)
+	}
+	leaseDuration, err := time.ParseDuration(conf.LeaseDuration)
+	if err != nil {
+		return nil, fmt.Errorf("parse lease duration %s: %w", conf.LeaseDuration, err)
 	}
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
@@ -103,9 +124,11 @@ func New(
 	return &Housekeeping{
 		database:    database,
 		coordinator: coordinator,
+		elector:     elector,
 
 		interval:                  interval,
 		candidatesLimitPerProject: conf.CandidatesLimitPerProject,
+		leaseDuration:             leaseDuration,
 
 		ctx:        ctx,
 		cancelFunc: cancelFunc,
@@ -114,7 +137,20 @@ func New(
 
 // Start starts the housekeeping service.
 func (h *Housekeeping) Start() error {
-	go h.run()
+	if h.elector != nil {
+		err := h.elector.Start(
+			lockLeaseName,
+			h.leaseDuration,
+			func(ctx context.Context) { h.run() },
+			func() { h.cancelFunc() },
+		)
+		if err != nil {
+			return err
+		}
+	} else {
+		go h.run()
+	}
+
 	return nil
 }
 

--- a/server/config.go
+++ b/server/config.go
@@ -42,6 +42,7 @@ const (
 
 	DefaultHousekeepingInterval                  = 30 * time.Second
 	DefaultHousekeepingCandidatesLimitPerProject = 500
+	DefaultHousekeepingLeaderElection            = false
 	DefaultHousekeepingLeaseDuration             = 60 * time.Second
 
 	DefaultMongoConnectionURI     = "mongodb://localhost:27017"
@@ -65,8 +66,7 @@ const (
 	DefaultAuthWebhookCacheAuthTTL    = 10 * time.Second
 	DefaultAuthWebhookCacheUnauthTTL  = 10 * time.Second
 
-	DefaultHostname       = ""
-	DefaultLeaderElection = false
+	DefaultHostname = ""
 )
 
 // Config is the configuration for creating a Yorkie instance.
@@ -233,6 +233,7 @@ func newConfig(port int, profilingPort int) *Config {
 		Housekeeping: &housekeeping.Config{
 			Interval:                  DefaultHousekeepingInterval.String(),
 			CandidatesLimitPerProject: DefaultHousekeepingCandidatesLimitPerProject,
+			LeaderElection:            DefaultHousekeepingLeaderElection,
 			LeaseDuration:             DefaultHousekeepingLeaseDuration.String(),
 		},
 		Backend: &backend.Config{

--- a/server/config.go
+++ b/server/config.go
@@ -42,6 +42,7 @@ const (
 
 	DefaultHousekeepingInterval                  = 30 * time.Second
 	DefaultHousekeepingCandidatesLimitPerProject = 500
+	DefaultHousekeepingLeaseDuration             = 60 * time.Second
 
 	DefaultMongoConnectionURI     = "mongodb://localhost:27017"
 	DefaultMongoConnectionTimeout = 5 * time.Second
@@ -64,7 +65,8 @@ const (
 	DefaultAuthWebhookCacheAuthTTL    = 10 * time.Second
 	DefaultAuthWebhookCacheUnauthTTL  = 10 * time.Second
 
-	DefaultHostname = ""
+	DefaultHostname       = ""
+	DefaultLeaderElection = false
 )
 
 // Config is the configuration for creating a Yorkie instance.
@@ -231,6 +233,7 @@ func newConfig(port int, profilingPort int) *Config {
 		Housekeeping: &housekeeping.Config{
 			Interval:                  DefaultHousekeepingInterval.String(),
 			CandidatesLimitPerProject: DefaultHousekeepingCandidatesLimitPerProject,
+			LeaseDuration:             DefaultHousekeepingLeaseDuration.String(),
 		},
 		Backend: &backend.Config{
 			ClientDeactivateThreshold:  DefaultClientDeactivateThreshold,

--- a/server/config.sample.yml
+++ b/server/config.sample.yml
@@ -36,6 +36,12 @@ Housekeeping:
   # CandidatesLimitPerProject is the maximum number of candidates to be returned per project (default: 100).
   CandidatesLimitPerProject: 100
 
+  # LeaderElection is the flag to enable leader election for performing housekeeping only on leader node.
+  LeaderElection: false
+
+  # LeaseDuration is the duration that non-leader candidates will wait to force acquire leadership.
+  LeaseDuration: "15s"
+
 # Backend is the configuration for the backend of Yorkie.
 Backend:
   # UseDefaultProject is whether to use the default project (default: true).
@@ -77,10 +83,6 @@ Backend:
   # Hostname is the hostname of the server. If not provided, the hostname will be
   # determined automatically by the OS (Optional, default: os.Hostname()).
   Hostname: ""
-
-  # LeaderElection is the flag to enable leader election for performing housekeeping only on leader node.
-  # Server should be deployed in Kubernetes platform to enable this flag.
-  LeaderElection: false
 
 # Mongo is the MongoDB configuration (Optional).
 Mongo:

--- a/server/config.sample.yml
+++ b/server/config.sample.yml
@@ -43,7 +43,7 @@ Backend:
   # used. If we are using server as single-tenant mode, this should be set to true.
   UseDefaultProject: true
   
-  # ClientDeactivateThreshold is deactivate threshold of clients in specific project for housekeeping.
+  # ClientDeactivateThreshold is deactivation threshold of clients in specific project for housekeeping.
   ClientDeactivateThreshold: "24h"
 
   # SnapshotThreshold is the threshold that determines if changes should be
@@ -77,6 +77,10 @@ Backend:
   # Hostname is the hostname of the server. If not provided, the hostname will be
   # determined automatically by the OS (Optional, default: os.Hostname()).
   Hostname: ""
+
+  # LeaderElection is the flag to enable leader election for performing housekeeping only on leader node.
+  # Server should be deployed in Kubernetes platform to enable this flag.
+  LeaderElection: false
 
 # Mongo is the MongoDB configuration (Optional).
 Mongo:

--- a/server/rpc/server_test.go
+++ b/server/rpc/server_test.go
@@ -85,6 +85,7 @@ func TestMain(m *testing.M) {
 	}, &housekeeping.Config{
 		Interval:                  helper.HousekeepingInterval.String(),
 		CandidatesLimitPerProject: helper.HousekeepingCandidatesLimitPerProject,
+		LeaseDuration:             helper.HousekeepingLeaseDuration.String(),
 	}, met)
 	if err != nil {
 		log.Fatal(err)

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -59,6 +59,7 @@ var (
 	AdminPassword                         = server.DefaultAdminPassword
 	HousekeepingInterval                  = 10 * gotime.Second
 	HousekeepingCandidatesLimitPerProject = 10
+	HousekeepingLeaseDuration             = 10 * gotime.Second
 
 	AdminTokenDuration         = "10s"
 	ClientDeactivateThreshold  = "10s"
@@ -222,6 +223,7 @@ func TestConfig() *server.Config {
 		Housekeeping: &housekeeping.Config{
 			Interval:                  HousekeepingInterval.String(),
 			CandidatesLimitPerProject: HousekeepingCandidatesLimitPerProject,
+			LeaseDuration:             HousekeepingLeaseDuration.String(),
 		},
 		Backend: &backend.Config{
 			AdminUser:                  server.DefaultAdminUser,

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -74,6 +74,8 @@ var (
 	MongoConnectionURI     = "mongodb://localhost:27017"
 	MongoConnectionTimeout = "5s"
 	MongoPingTimeout       = "5s"
+
+	LeaseDuration = 2 * gotime.Second
 )
 
 func init() {

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -59,6 +59,7 @@ var (
 	AdminPassword                         = server.DefaultAdminPassword
 	HousekeepingInterval                  = 10 * gotime.Second
 	HousekeepingCandidatesLimitPerProject = 10
+	HousekeepingLeaderElection            = false
 	HousekeepingLeaseDuration             = 10 * gotime.Second
 
 	AdminTokenDuration         = "10s"
@@ -223,6 +224,7 @@ func TestConfig() *server.Config {
 		Housekeeping: &housekeeping.Config{
 			Interval:                  HousekeepingInterval.String(),
 			CandidatesLimitPerProject: HousekeepingCandidatesLimitPerProject,
+			LeaderElection:            HousekeepingLeaderElection,
 			LeaseDuration:             HousekeepingLeaseDuration.String(),
 		},
 		Backend: &backend.Config{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add leader election for housekeeping in sharded cluster using mongodb.

- `server/backend/election` package is added for leader election, with `database` implementation.
- `database` implementation uses mongoDB and [TTL indexes](https://www.mongodb.com/docs/manual/core/index-ttl/) to ensure that only one node can acquire housekeeping leader lease by preventing other nodes try to update the same document simultaneously on document expiry.
- `yorkie-cluster` Helm Chart is configured to enable `--housekeeping-leader-election` to perform leader-only housekeeping in sharded cluster.
- Also, small error in `hostname` value in `server/backend/backend.go` is fixed. For more information, follow: [Add user agent metrics PR](https://github.com/yorkie-team/yorkie/pull/492/files#r1175507046)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #505

**Special notes for your reviewer**:

I have tested on K8s environment with `yorkie-cluster` Helm chart with minikube, and it worked as expected.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
