### PR TITLE
Resolve Helm Chart Installation Fail on Custom Release Name

### DIFF
--- a/build/charts/yorkie-argocd/values.yaml
+++ b/build/charts/yorkie-argocd/values.yaml
@@ -10,7 +10,7 @@ argocd:
   source:
     # Set helm chart repository url
     helmChartRepoURL: https://yorkie-team.github.io/yorkie/helm-charts
-    helmChartTargetRevision: 0.3.3
+    helmChartTargetRevision: 0.3.4
 
     # Set to GitOps repostiroy to reference helm chart custom values 
     gitOpsRepoURL: https://github.com/yorkie-team/devops.git

--- a/build/charts/yorkie-monitoring/README.md
+++ b/build/charts/yorkie-monitoring/README.md
@@ -32,8 +32,7 @@ _See [`helm install`](https://helm.sh/docs/helm/helm_install/) for command docum
 By default this chart installs additional, dependent charts:
 
 - [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
-
-To disable dependencies during installation, see [multiple releases](#multiple-releases) below.
+- [loki-stack](https://github.com/grafana/helm-charts/tree/main/charts/loki-stack)
 
 _See [`helm dependency`](https://helm.sh/docs/helm/helm_dependency/) for command documentation._
 
@@ -51,6 +50,12 @@ CRDs created by this chart are not removed by default and should be manually cle
 
 ```bash
 kubectl get crd -oname | grep --color=never 'monitoring.coreos.com' | xargs kubectl delete
+```
+
+Also, ServiceAccounts are not removed by default and shold be manually cleaned up:
+
+```bash
+kubectl delete serviceaccounts --all -n monitoring
 ```
 
 ## Upgrading Chart

--- a/build/charts/yorkie-monitoring/templates/yorkie-servicemonitor.yaml
+++ b/build/charts/yorkie-monitoring/templates/yorkie-servicemonitor.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/part-of: {{ .Values.monitoring.name }}
     app.kubernetes.io/managed-by: Helm
     prometheus: monitoring
-  name: {{ .Values.monitoring.name }}
+  name: {{ .Values.monitoring.yorkieName }}-monitor
   namespace: {{ .Values.monitoring.namespace }}
 spec:
   endpoints:

--- a/build/charts/yorkie-monitoring/values.yaml
+++ b/build/charts/yorkie-monitoring/values.yaml
@@ -3,7 +3,7 @@ monitoring:
   name: &monitoringName yorkie-monitoring
   namespace: &monitoringNamespace monitoring
 
-  # Name of yorkie used for yorkie cluster
+  # Configured name used for yorkie cluster
   yorkieName: yorkie
   yorkieNamespace: yorkie
 
@@ -28,7 +28,9 @@ ingress:
 
 # Configuration for manual prometheus monitoring stack
 kube-prometheus-stack:
-  fullnameOverride: *monitoringName
+  # fullnameOverride should be {{monitoring.name}} + "prometheus-stack"
+  # TODO(krapie) refactor these values to helper.tpl file
+  fullnameOverride: yorkie-monitoring-prometheus-stack
   namespaceOverride: *monitoringNamespace
 
   # Configuration for alertmanager
@@ -40,6 +42,10 @@ kube-prometheus-stack:
   # ref: https://github.com/grafana/helm-charts/blob/main/charts/grafana/values.yaml
   grafana:
     enabled: true
+
+    # fullnameOverride should be {{monitoring.name}} + "grafana"
+    # TODO(krapie) refactor these values to helper.tpl file
+    fullnameOverride: yorkie-monitoring-grafana
 
     defaultDashboardsTimezone: utc
     defaultDashboardsEnabled: false
@@ -170,11 +176,23 @@ kube-prometheus-stack:
             requests:
               storage: 1Gi
         selector: {}
+  
+  prometheus-node-exporter:
+    # fullnameOverride should be {{monitoring.name}} + "prometheus-node-exporter"
+    # TODO(krapie) refactor these values to helper.tpl file
+    fullnameOverride: yorkie-monitoring-prometheus-node-exporter
+
+  kube-state-metrics:
+    # fullnameOverride should be {{monitoring.name}} + "prometheus-state-metrics"
+    # TODO(krapie) refactor these values to helper.tpl file
+    fullnameOverride: yorkie-monitoring-state-metrics
 
 # Configuration for loki monitoring stack
 loki-stack:
   loki:
     isDefault: false
+    # fullnameOverride should be {{monitoring.name}} + "loki"
+    # TODO(krapie) refactor these values to helper.tpl file    
     fullnameOverride: yorkie-monitoring-loki
 
     persistence:
@@ -182,6 +200,8 @@ loki-stack:
       size: 1Gi
 
   promtail:
+    # fullnameOverride should be {{monitoring.name}} + "promtail"
+    # TODO(krapie) refactor these values to helper.tpl file  
     fullnameOverride: yorkie-monitoring-promtail
     
     config:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Resolve Helm chart installation fail on custom release name.

This was due to resource name conflict between Helm subcharts (`prometheus-community/kube-prometheus-stack` & `grafana/grafana`).

Therefore, `fullnameOverride` field has been manually configured to resolve resource name conflict. This will soon be refactored by Helm's `_helper.tpl` for dynamically setting Helm template values.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #528 

**Special notes for your reviewer**:

Since Helm chart version is not changed, Helm chart releaser action will not create new Helm chart which contains new revisions including this PR.

So I will manually rebuild Helm charts in packages (by deleting 0.3.4 version Helm charts and re-run Helm chart releaser action).

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
