### PR TITLE
Revise Helm Charts for Production Installations

### DIFF
--- a/build/charts/yorkie-argocd/templates/ingress.yaml
+++ b/build/charts/yorkie-argocd/templates/ingress.yaml
@@ -15,10 +15,13 @@ metadata:
 spec:
   ingressClassName: {{ .Values.ingress.ingressClassName }}
   rules:
+    {{ if .Values.ingress.hosts.enabled }}
+    - host: {{ .Values.ingress.hosts.apiHost }}
+      http:
+    {{ end }}
+    {{ if not .Values.ingress.hosts.enabled }}
     - http:
-      {{ if .Values.ingress.hosts.enabled }}
-      host: {{ .Values.ingress.hosts.apiHost }}
-      {{ end }}
+    {{ end }}
         paths:
           - path: {{ .Values.ingress.hosts.argoCDPath }}/
             pathType: Prefix

--- a/build/charts/yorkie-argocd/templates/install.yaml
+++ b/build/charts/yorkie-argocd/templates/install.yaml
@@ -1035,9 +1035,6 @@ spec:
         - ""
         - --appendonly
         - "no"
-        env:
-        - name: ARGOCD_REDIS_SERVICE
-          value: argocd-redis
         image: redis:7.0.9-alpine
         imagePullPolicy: Always
         name: redis
@@ -1092,7 +1089,7 @@ spec:
       - args:
         - /usr/local/bin/argocd-repo-server
         - --redis
-        - $(ARGOCD_REDIS_SERVICE):6379
+        - argocd-redis:6379
         env:
         - name: ARGOCD_RECONCILIATION_TIMEOUT
           valueFrom:

--- a/build/charts/yorkie-cluster/templates/ingress.yaml
+++ b/build/charts/yorkie-cluster/templates/ingress.yaml
@@ -17,10 +17,13 @@ metadata:
 spec:
   ingressClassName: {{ .Values.ingress.ingressClassName }}
   rules:
+    {{ if .Values.ingress.hosts.enabled }}
+    - host: {{ .Values.ingress.hosts.apiHost }}
+      http:
+    {{ end }}
+    {{ if not .Values.ingress.hosts.enabled }}
     - http:
-      {{ if .Values.ingress.hosts.enabled }}
-      host: {{ .Values.ingress.hosts.apiHost }}
-      {{ end }}
+    {{ end }}
         paths:
           - path: /
             pathType: Prefix

--- a/build/charts/yorkie-cluster/values.yaml
+++ b/build/charts/yorkie-cluster/values.yaml
@@ -63,7 +63,6 @@ ingress:
   hosts:
     enabled: false
     apiHost: api.yorkie.dev
-    adminHost: admin.yorkie.dev
     
   alb:
     enabled: false

--- a/build/charts/yorkie-monitoring/templates/ingress.yaml
+++ b/build/charts/yorkie-monitoring/templates/ingress.yaml
@@ -16,10 +16,13 @@ metadata:
 spec:
   ingressClassName: {{ .Values.ingress.ingressClassName }}
   rules:
+    {{ if .Values.ingress.hosts.enabled }}
+    - host: {{ .Values.ingress.hosts.apiHost }}
+      http:
+    {{ end }}
+    {{ if not .Values.ingress.hosts.enabled }}
     - http:
-      {{ if .Values.ingress.hosts.enabled }}
-      host: {{ .Values.ingress.hosts.apiHost }}
-      {{ end }}
+    {{ end }}
         paths:
           - path: {{ .Values.ingress.hosts.grafanaPath }}/
             pathType: Prefix


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Revise Helm charts to fix various issues when installing Helm charts on production environments.

- Fix ingress syntax error (fixes installation failure when `ingress.hosts.enabled = true`).
- Fix ArgoCD's misuse of `ARGOCD_REDIS_SERVICE` env when connecting to other server pods (ref: https://github.com/argoproj/argo-cd/issues/13214)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
