### PR TITLE
Resolve concurrent map issue

### DIFF
--- a/server/backend/sync/memory/coordinator.go
+++ b/server/backend/sync/memory/coordinator.go
@@ -65,10 +65,7 @@ func (c *Coordinator) Subscribe(
 		return nil, nil, err
 	}
 
-	var peers []types.Client
-	for _, sub := range c.pubSub.subscriptionsMapByDocID[documentID].Map() {
-		peers = append(peers, sub.Subscriber())
-	}
+	peers := c.pubSub.GetPeers(documentID)
 	return sub, peers, nil
 }
 

--- a/server/backend/sync/memory/pubsub.go
+++ b/server/backend/sync/memory/pubsub.go
@@ -201,6 +201,18 @@ func (m *PubSub) Publish(
 	}
 }
 
+// GetPeers returns the peers of the given document.
+func (m *PubSub) GetPeers(documentID types.ID) []types.Client {
+	m.subscriptionsMapMu.RLock()
+	defer m.subscriptionsMapMu.RUnlock()
+
+	var peers []types.Client
+	for _, sub := range m.subscriptionsMapByDocID[documentID].Map() {
+		peers = append(peers, sub.Subscriber())
+	}
+	return peers
+}
+
 // UpdatePresence updates the presence of the given client.
 func (m *PubSub) UpdatePresence(
 	publisher *types.Client,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The subscriptionMapByDocID was being accessed and utilized without proper mutex protection.
As a result, a fatal error occurred when simultaneous reads and writes were performed. 
To resolve this issue, I added the mutex lock when iterating the map.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes fatal error 

![image](https://github.com/yorkie-team/yorkie/assets/81357083/59fde2c0-6310-4c32-ab91-3c6a421a682e)


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
