### PR TITLE
Add TLS Option & Insecure Flag in Admin CLI

### DIFF
--- a/admin/client.go
+++ b/admin/client.go
@@ -19,10 +19,9 @@ package admin
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"strings"
-
-	"crypto/tls"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"

--- a/cmd/yorkie/commands.go
+++ b/cmd/yorkie/commands.go
@@ -45,4 +45,5 @@ func init() {
 	// TODO(chacha912): set rpcAddr from env using viper.
 	// https://github.com/spf13/cobra/blob/main/user_guide.md#bind-flags-with-config
 	rootCmd.PersistentFlags().StringVar(&config.RPCAddr, "rpc-addr", "localhost:11101", "Address of the rpc server")
+	rootCmd.PersistentFlags().BoolVar(&config.IsInsecure, "insecure", false, "Skip the TLS connection of the client")
 }

--- a/cmd/yorkie/config/config.go
+++ b/cmd/yorkie/config/config.go
@@ -25,8 +25,12 @@ import (
 	"path/filepath"
 )
 
-// RPCAddr is the address of the rpc server.
-var RPCAddr string
+var (
+	// RPCAddr is the address of the rpc server.
+	RPCAddr string
+	// IsInsecure is whether to disable the TLS connection of the client.
+	IsInsecure bool
+)
 
 // ensureYorkieDir ensures that the directory of Yorkie exists.
 func ensureYorkieDir() (string, error) {

--- a/cmd/yorkie/document/list.go
+++ b/cmd/yorkie/document/list.go
@@ -49,7 +49,7 @@ func newListCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			cli, err := admin.Dial(config.RPCAddr, admin.WithToken(token))
+			cli, err := admin.Dial(config.RPCAddr, admin.WithToken(token), admin.WithInsecure(config.IsInsecure))
 			if err != nil {
 				return err
 			}

--- a/cmd/yorkie/document/remove.go
+++ b/cmd/yorkie/document/remove.go
@@ -41,7 +41,7 @@ func newRemoveCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			cli, err := admin.Dial(config.RPCAddr, admin.WithToken(token))
+			cli, err := admin.Dial(config.RPCAddr, admin.WithToken(token), admin.WithInsecure(config.IsInsecure))
 			if err != nil {
 				return err
 			}

--- a/cmd/yorkie/history.go
+++ b/cmd/yorkie/history.go
@@ -48,7 +48,7 @@ func newHistoryCmd() *cobra.Command {
 				return err
 			}
 
-			cli, err := admin.Dial(config.RPCAddr, admin.WithToken(token))
+			cli, err := admin.Dial(config.RPCAddr, admin.WithToken(token), admin.WithInsecure(config.IsInsecure))
 			if err != nil {
 				return err
 			}

--- a/cmd/yorkie/login.go
+++ b/cmd/yorkie/login.go
@@ -35,7 +35,7 @@ func newLoginCmd() *cobra.Command {
 		Use:   "login",
 		Short: "Log in to the Yorkie server",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cli, err := admin.Dial(config.RPCAddr)
+			cli, err := admin.Dial(config.RPCAddr, admin.WithInsecure(config.IsInsecure))
 			if err != nil {
 				return err
 			}

--- a/cmd/yorkie/project/create.go
+++ b/cmd/yorkie/project/create.go
@@ -45,7 +45,7 @@ func newCreateCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			cli, err := admin.Dial(config.RPCAddr, admin.WithToken(token))
+			cli, err := admin.Dial(config.RPCAddr, admin.WithToken(token), admin.WithInsecure(config.IsInsecure))
 			if err != nil {
 				return err
 			}

--- a/cmd/yorkie/project/list.go
+++ b/cmd/yorkie/project/list.go
@@ -38,7 +38,7 @@ func newListCommand() *cobra.Command {
 				return err
 			}
 
-			cli, err := admin.Dial(config.RPCAddr, admin.WithToken(token))
+			cli, err := admin.Dial(config.RPCAddr, admin.WithToken(token), admin.WithInsecure(config.IsInsecure))
 			if err != nil {
 				return err
 			}

--- a/cmd/yorkie/project/update.go
+++ b/cmd/yorkie/project/update.go
@@ -54,7 +54,7 @@ func newUpdateCommand() *cobra.Command {
 				return err
 			}
 
-			cli, err := admin.Dial(config.RPCAddr, admin.WithToken(token))
+			cli, err := admin.Dial(config.RPCAddr, admin.WithToken(token), admin.WithInsecure(config.IsInsecure))
 			if err != nil {
 				return err
 			}

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -87,7 +87,7 @@ func TestDBName() string {
 
 // CreateAdminCli returns a new instance of admin cli for testing.
 func CreateAdminCli(t assert.TestingT, rpcAddr string) *adminClient.Client {
-	adminCli, err := adminClient.Dial(rpcAddr)
+	adminCli, err := adminClient.Dial(rpcAddr, adminClient.WithInsecure(true))
 	assert.NoError(t, err)
 
 	_, err = adminCli.LogIn(context.Background(), server.DefaultAdminUser, server.DefaultAdminPassword)

--- a/test/integration/admin_test.go
+++ b/test/integration/admin_test.go
@@ -38,7 +38,7 @@ import (
 func TestAdmin(t *testing.T) {
 	ctx := context.Background()
 
-	adminCli, err := admin.Dial(defaultServer.RPCAddr())
+	adminCli, err := admin.Dial(defaultServer.RPCAddr(), admin.WithInsecure(true))
 	assert.NoError(t, err)
 	_, err = adminCli.LogIn(ctx, "admin", "admin")
 	assert.NoError(t, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add TLS option & insecure flag in admin CLI.

This is to set TLS connectivity between hosted server (`api.yorkie.dev`) and admin CLI.
Also, `--insecure` global flag is added to disable the TLS connection of the client when needed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/yorkie-team/devops/issues/43

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
