### PR TITLE
Resolve CI failure with longer MaxConnectionAge

### DIFF
--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -50,8 +50,8 @@ var testStartedAt int64
 var (
 	RPCPort                  = 21101
 	RPCMaxRequestBytes       = uint64(4 * 1024 * 1024)
-	RPCMaxConnectionAge      = 4 * gotime.Second
-	RPCMaxConnectionAgeGrace = 1 * gotime.Second
+	RPCMaxConnectionAge      = 8 * gotime.Second
+	RPCMaxConnectionAgeGrace = 2 * gotime.Second
 
 	ProfilingPort = 21102
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Resolve CI failure with longer `MaxConnectionAge`.

This is to resolve intermittent CI failure, with the assumption that the RPC server's short `MaxConnectionAge` on testing is causing CI failure.

Because this solution is based on an assumption, we need to see whether this change will resolve CI failure or not.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #546

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
