### PR TITLE
Update ClientInfo with ID and extract `testcases` package 

### DIFF
--- a/server/backend/database/database.go
+++ b/server/backend/database/database.go
@@ -47,6 +47,9 @@ var (
 	// ErrDocumentNotFound is returned when the document could not be found.
 	ErrDocumentNotFound = errors.New("document not found")
 
+	// ErrClientDocNotFound is returned when mapping between client and document could not be found.
+	ErrClientDocNotFound = errors.New("client document not found")
+
 	// ErrConflictOnUpdate is returned when a conflict occurs during update.
 	ErrConflictOnUpdate = errors.New("conflict on update")
 

--- a/server/backend/database/memory/database_test.go
+++ b/server/backend/database/memory/database_test.go
@@ -19,10 +19,10 @@ package memory_test
 import (
 	"context"
 	"fmt"
-	mongodb "go.mongodb.org/mongo-driver/mongo"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	mongodb "go.mongodb.org/mongo-driver/mongo"
 
 	"github.com/yorkie-team/yorkie/api/types"
 	"github.com/yorkie-team/yorkie/pkg/document"
@@ -301,7 +301,6 @@ func TestDB(t *testing.T) {
 			assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(3))
 			assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(5))
 			assert.NoError(t, err)
-
 		})
 
 		t.Run("detach document test", func(t *testing.T) {

--- a/server/backend/database/memory/database_test.go
+++ b/server/backend/database/memory/database_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	mongodb "go.mongodb.org/mongo-driver/mongo"
 
 	"github.com/yorkie-team/yorkie/api/types"
 	"github.com/yorkie-team/yorkie/pkg/document"
@@ -32,6 +31,7 @@ import (
 	"github.com/yorkie-team/yorkie/pkg/document/time"
 	"github.com/yorkie-team/yorkie/server/backend/database"
 	"github.com/yorkie-team/yorkie/server/backend/database/memory"
+	"github.com/yorkie-team/yorkie/server/backend/database/testcases"
 )
 
 func TestDB(t *testing.T) {
@@ -40,7 +40,6 @@ func TestDB(t *testing.T) {
 	assert.NoError(t, err)
 
 	projectID := database.DefaultProjectID
-	dummyClientID := types.ID("000000000000000000000000")
 	dummyOwnerID := types.ID("000000000000000000000000")
 	otherOwnerID := types.ID("000000000000000000000001")
 	notExistsID := types.ID("000000000000000000000000")
@@ -226,158 +225,9 @@ func TestDB(t *testing.T) {
 		assert.Equal(t, docInfo1.Key, docInfo2.Key)
 		assert.NotEqual(t, docInfo1.ID, docInfo2.ID)
 	})
+
 	t.Run("UpdateClientInfoAfterPushPull test", func(t *testing.T) {
-		ctx := context.Background()
-
-		t.Run("document is not attached in clientInfo test", func(t *testing.T) {
-			clientInfo, err := db.ActivateClient(ctx, projectID, t.Name())
-			assert.NoError(t, err)
-
-			docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
-			docInfo, err := db.FindDocInfoByKeyAndOwner(ctx, projectID, clientInfo.ID, docKey, true)
-			assert.NoError(t, err)
-
-			err = db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo)
-			assert.ErrorIs(t, err, database.ErrDocumentNeverAttached)
-			assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
-			assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
-		})
-
-		t.Run("document attach test", func(t *testing.T) {
-			clientInfo, err := db.ActivateClient(ctx, projectID, t.Name())
-			assert.NoError(t, err)
-
-			docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
-			docInfo, err := db.FindDocInfoByKeyAndOwner(ctx, projectID, clientInfo.ID, docKey, true)
-			assert.NoError(t, err)
-
-			assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
-			assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
-
-			result, err := db.FindClientInfoByID(ctx, projectID, clientInfo.ID)
-			assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentAttached)
-			assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(0))
-			assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(0))
-			assert.NoError(t, err)
-		})
-
-		t.Run("update server_seq and client_seq in clientInfo test", func(t *testing.T) {
-			clientInfo, err := db.ActivateClient(ctx, projectID, t.Name())
-			assert.NoError(t, err)
-
-			docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
-			docInfo, err := db.FindDocInfoByKeyAndOwner(ctx, projectID, clientInfo.ID, docKey, true)
-			assert.NoError(t, err)
-
-			assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
-			clientInfo.Documents[docInfo.ID].ServerSeq = 1
-			clientInfo.Documents[docInfo.ID].ClientSeq = 1
-			assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
-
-			result, err := db.FindClientInfoByID(ctx, projectID, clientInfo.ID)
-			assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentAttached)
-			assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(1))
-			assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(1))
-			assert.NoError(t, err)
-
-			// update with larger seq
-			clientInfo.Documents[docInfo.ID].ServerSeq = 3
-			clientInfo.Documents[docInfo.ID].ClientSeq = 5
-			assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
-
-			result, err = db.FindClientInfoByID(ctx, projectID, clientInfo.ID)
-			assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentAttached)
-			assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(3))
-			assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(5))
-			assert.NoError(t, err)
-
-			// update with smaller seq(should be ignored)
-			clientInfo.Documents[docInfo.ID].ServerSeq = 2
-			clientInfo.Documents[docInfo.ID].ClientSeq = 3
-			assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
-
-			result, err = db.FindClientInfoByID(ctx, projectID, clientInfo.ID)
-			assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentAttached)
-			assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(3))
-			assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(5))
-			assert.NoError(t, err)
-		})
-
-		t.Run("detach document test", func(t *testing.T) {
-			clientInfo, err := db.ActivateClient(ctx, projectID, t.Name())
-			assert.NoError(t, err)
-
-			docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
-			docInfo, err := db.FindDocInfoByKeyAndOwner(ctx, projectID, clientInfo.ID, docKey, true)
-			assert.NoError(t, err)
-
-			assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
-			clientInfo.Documents[docInfo.ID].ServerSeq = 1
-			clientInfo.Documents[docInfo.ID].ClientSeq = 1
-			assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
-
-			result, err := db.FindClientInfoByID(ctx, projectID, clientInfo.ID)
-			assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentAttached)
-			assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(1))
-			assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(1))
-			assert.NoError(t, err)
-
-			assert.NoError(t, clientInfo.DetachDocument(docInfo.ID))
-			assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
-
-			result, err = db.FindClientInfoByID(ctx, projectID, clientInfo.ID)
-			assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentDetached)
-			assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(0))
-			assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(0))
-			assert.NoError(t, err)
-		})
-
-		t.Run("remove document test", func(t *testing.T) {
-			clientInfo, err := db.ActivateClient(ctx, projectID, t.Name())
-			assert.NoError(t, err)
-
-			docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
-			docInfo, err := db.FindDocInfoByKeyAndOwner(ctx, projectID, clientInfo.ID, docKey, true)
-			assert.NoError(t, err)
-
-			assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
-			clientInfo.Documents[docInfo.ID].ServerSeq = 1
-			clientInfo.Documents[docInfo.ID].ClientSeq = 1
-			assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
-
-			result, err := db.FindClientInfoByID(ctx, projectID, clientInfo.ID)
-			assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentAttached)
-			assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(1))
-			assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(1))
-			assert.NoError(t, err)
-
-			assert.NoError(t, clientInfo.RemoveDocument(docInfo.ID))
-			assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
-
-			result, err = db.FindClientInfoByID(ctx, projectID, clientInfo.ID)
-			assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentRemoved)
-			assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(0))
-			assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(0))
-			assert.NoError(t, err)
-		})
-
-		t.Run("invalid clientInfo test", func(t *testing.T) {
-			clientInfo, err := db.ActivateClient(ctx, projectID, t.Name())
-			assert.NoError(t, err)
-
-			docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
-			docInfo, err := db.FindDocInfoByKeyAndOwner(ctx, projectID, clientInfo.ID, docKey, true)
-			assert.NoError(t, err)
-
-			assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
-			assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
-
-			clientInfo.ID = "invalid clientInfo id"
-			assert.Error(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
-
-			clientInfo.ID = dummyClientID
-			assert.Error(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo), mongodb.ErrNoDocuments)
-		})
+		testcases.RunUpdateClientInfoAfterPushPullTest(t, db, projectID)
 	})
 
 	t.Run("insert and find changes test", func(t *testing.T) {

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -577,8 +577,8 @@ func (c *Client) UpdateClientInfoAfterPushPull(
 	}
 
 	clientDocInfoKey := "documents." + docInfo.ID.String() + "."
-	clientDocInfo, has := clientInfo.Documents[docInfo.ID]
-	if !has {
+	clientDocInfo, ok := clientInfo.Documents[docInfo.ID]
+	if !ok {
 		return fmt.Errorf("client doc info: %w", database.ErrDocumentNeverAttached)
 	}
 

--- a/server/backend/database/mongo/client_test.go
+++ b/server/backend/database/mongo/client_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	mongodb "go.mongodb.org/mongo-driver/mongo"
 
 	"github.com/yorkie-team/yorkie/api/types"
 	"github.com/yorkie-team/yorkie/pkg/document"
@@ -192,6 +193,161 @@ func TestClient(t *testing.T) {
 		// Check they have same key but different id
 		assert.Equal(t, docInfo1.Key, docInfo2.Key)
 		assert.NotEqual(t, docInfo1.ID, docInfo2.ID)
+	})
+
+	t.Run("UpdateClientInfoAfterPushPull test", func(t *testing.T) {
+		ctx := context.Background()
+
+		t.Run("document is not attached in clientInfo test", func(t *testing.T) {
+			clientInfo, err := cli.ActivateClient(ctx, dummyProjectID, t.Name())
+			assert.NoError(t, err)
+
+			docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
+			docInfo, err := cli.FindDocInfoByKeyAndOwner(ctx, dummyProjectID, clientInfo.ID, docKey, true)
+			assert.NoError(t, err)
+
+			err = cli.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo)
+			assert.ErrorIs(t, err, database.ErrDocumentNeverAttached)
+			assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
+			assert.NoError(t, cli.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+		})
+
+		t.Run("document attach test", func(t *testing.T) {
+			clientInfo, err := cli.ActivateClient(ctx, dummyProjectID, t.Name())
+			assert.NoError(t, err)
+
+			docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
+			docInfo, err := cli.FindDocInfoByKeyAndOwner(ctx, dummyProjectID, clientInfo.ID, docKey, true)
+			assert.NoError(t, err)
+
+			assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
+			assert.NoError(t, cli.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+
+			result, err := cli.FindClientInfoByID(ctx, dummyProjectID, clientInfo.ID)
+			assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentAttached)
+			assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(0))
+			assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(0))
+			assert.NoError(t, err)
+		})
+
+		t.Run("update server_seq and client_seq in clientInfo test", func(t *testing.T) {
+			clientInfo, err := cli.ActivateClient(ctx, dummyProjectID, t.Name())
+			assert.NoError(t, err)
+
+			docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
+			docInfo, err := cli.FindDocInfoByKeyAndOwner(ctx, dummyProjectID, clientInfo.ID, docKey, true)
+			assert.NoError(t, err)
+
+			assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
+			clientInfo.Documents[docInfo.ID].ServerSeq = 1
+			clientInfo.Documents[docInfo.ID].ClientSeq = 1
+			assert.NoError(t, cli.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+
+			result, err := cli.FindClientInfoByID(ctx, dummyProjectID, clientInfo.ID)
+			assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentAttached)
+			assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(1))
+			assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(1))
+			assert.NoError(t, err)
+
+			// update with larger seq
+			clientInfo.Documents[docInfo.ID].ServerSeq = 3
+			clientInfo.Documents[docInfo.ID].ClientSeq = 5
+			assert.NoError(t, cli.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+
+			result, err = cli.FindClientInfoByID(ctx, dummyProjectID, clientInfo.ID)
+			assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentAttached)
+			assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(3))
+			assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(5))
+			assert.NoError(t, err)
+
+			// update with smaller seq(should be ignored)
+			clientInfo.Documents[docInfo.ID].ServerSeq = 2
+			clientInfo.Documents[docInfo.ID].ClientSeq = 3
+			assert.NoError(t, cli.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+
+			result, err = cli.FindClientInfoByID(ctx, dummyProjectID, clientInfo.ID)
+			assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentAttached)
+			assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(3))
+			assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(5))
+			assert.NoError(t, err)
+
+		})
+
+		t.Run("detach document test", func(t *testing.T) {
+			clientInfo, err := cli.ActivateClient(ctx, dummyProjectID, t.Name())
+			assert.NoError(t, err)
+
+			docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
+			docInfo, err := cli.FindDocInfoByKeyAndOwner(ctx, dummyProjectID, clientInfo.ID, docKey, true)
+			assert.NoError(t, err)
+
+			assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
+			clientInfo.Documents[docInfo.ID].ServerSeq = 1
+			clientInfo.Documents[docInfo.ID].ClientSeq = 1
+			assert.NoError(t, cli.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+
+			result, err := cli.FindClientInfoByID(ctx, dummyProjectID, clientInfo.ID)
+			assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentAttached)
+			assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(1))
+			assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(1))
+			assert.NoError(t, err)
+
+			assert.NoError(t, clientInfo.DetachDocument(docInfo.ID))
+			assert.NoError(t, cli.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+
+			result, err = cli.FindClientInfoByID(ctx, dummyProjectID, clientInfo.ID)
+			assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentDetached)
+			assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(0))
+			assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(0))
+			assert.NoError(t, err)
+		})
+
+		t.Run("remove document test", func(t *testing.T) {
+			clientInfo, err := cli.ActivateClient(ctx, dummyProjectID, t.Name())
+			assert.NoError(t, err)
+
+			docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
+			docInfo, err := cli.FindDocInfoByKeyAndOwner(ctx, dummyProjectID, clientInfo.ID, docKey, true)
+			assert.NoError(t, err)
+
+			assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
+			clientInfo.Documents[docInfo.ID].ServerSeq = 1
+			clientInfo.Documents[docInfo.ID].ClientSeq = 1
+			assert.NoError(t, cli.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+
+			result, err := cli.FindClientInfoByID(ctx, dummyProjectID, clientInfo.ID)
+			assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentAttached)
+			assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(1))
+			assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(1))
+			assert.NoError(t, err)
+
+			assert.NoError(t, clientInfo.RemoveDocument(docInfo.ID))
+			assert.NoError(t, cli.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+
+			result, err = cli.FindClientInfoByID(ctx, dummyProjectID, clientInfo.ID)
+			assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentRemoved)
+			assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(0))
+			assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(0))
+			assert.NoError(t, err)
+		})
+
+		t.Run("invalid clientInfo test", func(t *testing.T) {
+			clientInfo, err := cli.ActivateClient(ctx, dummyProjectID, t.Name())
+			assert.NoError(t, err)
+
+			docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
+			docInfo, err := cli.FindDocInfoByKeyAndOwner(ctx, dummyProjectID, clientInfo.ID, docKey, true)
+			assert.NoError(t, err)
+
+			assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
+			assert.NoError(t, cli.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+
+			clientInfo.ID = "invalid clientInfo id"
+			assert.Error(t, cli.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+
+			clientInfo.ID = dummyClientID
+			assert.Error(t, cli.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo), mongodb.ErrNoDocuments)
+		})
 	})
 
 	t.Run("FindDocInfosByPaging test", func(t *testing.T) {

--- a/server/backend/database/mongo/client_test.go
+++ b/server/backend/database/mongo/client_test.go
@@ -24,13 +24,13 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	mongodb "go.mongodb.org/mongo-driver/mongo"
 
 	"github.com/yorkie-team/yorkie/api/types"
 	"github.com/yorkie-team/yorkie/pkg/document"
 	"github.com/yorkie-team/yorkie/pkg/document/key"
 	"github.com/yorkie-team/yorkie/server/backend/database"
 	"github.com/yorkie-team/yorkie/server/backend/database/mongo"
+	"github.com/yorkie-team/yorkie/server/backend/database/testcases"
 	"github.com/yorkie-team/yorkie/test/helper"
 )
 
@@ -196,158 +196,7 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("UpdateClientInfoAfterPushPull test", func(t *testing.T) {
-		ctx := context.Background()
-
-		t.Run("document is not attached in clientInfo test", func(t *testing.T) {
-			clientInfo, err := cli.ActivateClient(ctx, dummyProjectID, t.Name())
-			assert.NoError(t, err)
-
-			docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
-			docInfo, err := cli.FindDocInfoByKeyAndOwner(ctx, dummyProjectID, clientInfo.ID, docKey, true)
-			assert.NoError(t, err)
-
-			err = cli.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo)
-			assert.ErrorIs(t, err, database.ErrDocumentNeverAttached)
-			assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
-			assert.NoError(t, cli.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
-		})
-
-		t.Run("document attach test", func(t *testing.T) {
-			clientInfo, err := cli.ActivateClient(ctx, dummyProjectID, t.Name())
-			assert.NoError(t, err)
-
-			docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
-			docInfo, err := cli.FindDocInfoByKeyAndOwner(ctx, dummyProjectID, clientInfo.ID, docKey, true)
-			assert.NoError(t, err)
-
-			assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
-			assert.NoError(t, cli.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
-
-			result, err := cli.FindClientInfoByID(ctx, dummyProjectID, clientInfo.ID)
-			assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentAttached)
-			assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(0))
-			assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(0))
-			assert.NoError(t, err)
-		})
-
-		t.Run("update server_seq and client_seq in clientInfo test", func(t *testing.T) {
-			clientInfo, err := cli.ActivateClient(ctx, dummyProjectID, t.Name())
-			assert.NoError(t, err)
-
-			docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
-			docInfo, err := cli.FindDocInfoByKeyAndOwner(ctx, dummyProjectID, clientInfo.ID, docKey, true)
-			assert.NoError(t, err)
-
-			assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
-			clientInfo.Documents[docInfo.ID].ServerSeq = 1
-			clientInfo.Documents[docInfo.ID].ClientSeq = 1
-			assert.NoError(t, cli.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
-
-			result, err := cli.FindClientInfoByID(ctx, dummyProjectID, clientInfo.ID)
-			assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentAttached)
-			assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(1))
-			assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(1))
-			assert.NoError(t, err)
-
-			// update with larger seq
-			clientInfo.Documents[docInfo.ID].ServerSeq = 3
-			clientInfo.Documents[docInfo.ID].ClientSeq = 5
-			assert.NoError(t, cli.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
-
-			result, err = cli.FindClientInfoByID(ctx, dummyProjectID, clientInfo.ID)
-			assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentAttached)
-			assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(3))
-			assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(5))
-			assert.NoError(t, err)
-
-			// update with smaller seq(should be ignored)
-			clientInfo.Documents[docInfo.ID].ServerSeq = 2
-			clientInfo.Documents[docInfo.ID].ClientSeq = 3
-			assert.NoError(t, cli.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
-
-			result, err = cli.FindClientInfoByID(ctx, dummyProjectID, clientInfo.ID)
-			assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentAttached)
-			assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(3))
-			assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(5))
-			assert.NoError(t, err)
-
-		})
-
-		t.Run("detach document test", func(t *testing.T) {
-			clientInfo, err := cli.ActivateClient(ctx, dummyProjectID, t.Name())
-			assert.NoError(t, err)
-
-			docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
-			docInfo, err := cli.FindDocInfoByKeyAndOwner(ctx, dummyProjectID, clientInfo.ID, docKey, true)
-			assert.NoError(t, err)
-
-			assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
-			clientInfo.Documents[docInfo.ID].ServerSeq = 1
-			clientInfo.Documents[docInfo.ID].ClientSeq = 1
-			assert.NoError(t, cli.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
-
-			result, err := cli.FindClientInfoByID(ctx, dummyProjectID, clientInfo.ID)
-			assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentAttached)
-			assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(1))
-			assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(1))
-			assert.NoError(t, err)
-
-			assert.NoError(t, clientInfo.DetachDocument(docInfo.ID))
-			assert.NoError(t, cli.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
-
-			result, err = cli.FindClientInfoByID(ctx, dummyProjectID, clientInfo.ID)
-			assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentDetached)
-			assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(0))
-			assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(0))
-			assert.NoError(t, err)
-		})
-
-		t.Run("remove document test", func(t *testing.T) {
-			clientInfo, err := cli.ActivateClient(ctx, dummyProjectID, t.Name())
-			assert.NoError(t, err)
-
-			docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
-			docInfo, err := cli.FindDocInfoByKeyAndOwner(ctx, dummyProjectID, clientInfo.ID, docKey, true)
-			assert.NoError(t, err)
-
-			assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
-			clientInfo.Documents[docInfo.ID].ServerSeq = 1
-			clientInfo.Documents[docInfo.ID].ClientSeq = 1
-			assert.NoError(t, cli.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
-
-			result, err := cli.FindClientInfoByID(ctx, dummyProjectID, clientInfo.ID)
-			assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentAttached)
-			assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(1))
-			assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(1))
-			assert.NoError(t, err)
-
-			assert.NoError(t, clientInfo.RemoveDocument(docInfo.ID))
-			assert.NoError(t, cli.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
-
-			result, err = cli.FindClientInfoByID(ctx, dummyProjectID, clientInfo.ID)
-			assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentRemoved)
-			assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(0))
-			assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(0))
-			assert.NoError(t, err)
-		})
-
-		t.Run("invalid clientInfo test", func(t *testing.T) {
-			clientInfo, err := cli.ActivateClient(ctx, dummyProjectID, t.Name())
-			assert.NoError(t, err)
-
-			docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
-			docInfo, err := cli.FindDocInfoByKeyAndOwner(ctx, dummyProjectID, clientInfo.ID, docKey, true)
-			assert.NoError(t, err)
-
-			assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
-			assert.NoError(t, cli.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
-
-			clientInfo.ID = "invalid clientInfo id"
-			assert.Error(t, cli.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
-
-			clientInfo.ID = dummyClientID
-			assert.Error(t, cli.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo), mongodb.ErrNoDocuments)
-		})
+		testcases.RunUpdateClientInfoAfterPushPullTest(t, cli, dummyProjectID)
 	})
 
 	t.Run("FindDocInfosByPaging test", func(t *testing.T) {

--- a/server/backend/database/testcases/testcase.go
+++ b/server/backend/database/testcases/testcase.go
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2023 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package testcases contains testcases for database. It is used by database
+// implementations to test their own implementations with the same testcases.
+package testcases
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	mongodb "go.mongodb.org/mongo-driver/mongo"
+
+	"github.com/yorkie-team/yorkie/api/types"
+	"github.com/yorkie-team/yorkie/pkg/document/key"
+	"github.com/yorkie-team/yorkie/server/backend/database"
+)
+
+// RunUpdateClientInfoAfterPushPullTest executes the testcases for the given database.
+func RunUpdateClientInfoAfterPushPullTest(t *testing.T, db database.Database, projectID types.ID) {
+	dummyClientID := types.ID("000000000000000000000000")
+	ctx := context.Background()
+
+	t.Run("document is not attached in clientInfo test", func(t *testing.T) {
+		clientInfo, err := db.ActivateClient(ctx, projectID, t.Name())
+		assert.NoError(t, err)
+
+		docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
+		docInfo, err := db.FindDocInfoByKeyAndOwner(ctx, projectID, clientInfo.ID, docKey, true)
+		assert.NoError(t, err)
+
+		err = db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo)
+		assert.ErrorIs(t, err, database.ErrDocumentNeverAttached)
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
+		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+	})
+
+	t.Run("document attach test", func(t *testing.T) {
+		clientInfo, err := db.ActivateClient(ctx, projectID, t.Name())
+		assert.NoError(t, err)
+
+		docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
+		docInfo, err := db.FindDocInfoByKeyAndOwner(ctx, projectID, clientInfo.ID, docKey, true)
+		assert.NoError(t, err)
+
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
+		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+
+		result, err := db.FindClientInfoByID(ctx, projectID, clientInfo.ID)
+		assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentAttached)
+		assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(0))
+		assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(0))
+		assert.NoError(t, err)
+	})
+
+	t.Run("update server_seq and client_seq in clientInfo test", func(t *testing.T) {
+		clientInfo, err := db.ActivateClient(ctx, projectID, t.Name())
+		assert.NoError(t, err)
+
+		docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
+		docInfo, err := db.FindDocInfoByKeyAndOwner(ctx, projectID, clientInfo.ID, docKey, true)
+		assert.NoError(t, err)
+
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
+		clientInfo.Documents[docInfo.ID].ServerSeq = 1
+		clientInfo.Documents[docInfo.ID].ClientSeq = 1
+		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+
+		result, err := db.FindClientInfoByID(ctx, projectID, clientInfo.ID)
+		assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentAttached)
+		assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(1))
+		assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(1))
+		assert.NoError(t, err)
+
+		// update with larger seq
+		clientInfo.Documents[docInfo.ID].ServerSeq = 3
+		clientInfo.Documents[docInfo.ID].ClientSeq = 5
+		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+
+		result, err = db.FindClientInfoByID(ctx, projectID, clientInfo.ID)
+		assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentAttached)
+		assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(3))
+		assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(5))
+		assert.NoError(t, err)
+
+		// update with smaller seq(should be ignored)
+		clientInfo.Documents[docInfo.ID].ServerSeq = 2
+		clientInfo.Documents[docInfo.ID].ClientSeq = 3
+		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+
+		result, err = db.FindClientInfoByID(ctx, projectID, clientInfo.ID)
+		assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentAttached)
+		assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(3))
+		assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(5))
+		assert.NoError(t, err)
+	})
+
+	t.Run("detach document test", func(t *testing.T) {
+		clientInfo, err := db.ActivateClient(ctx, projectID, t.Name())
+		assert.NoError(t, err)
+
+		docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
+		docInfo, err := db.FindDocInfoByKeyAndOwner(ctx, projectID, clientInfo.ID, docKey, true)
+		assert.NoError(t, err)
+
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
+		clientInfo.Documents[docInfo.ID].ServerSeq = 1
+		clientInfo.Documents[docInfo.ID].ClientSeq = 1
+		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+
+		result, err := db.FindClientInfoByID(ctx, projectID, clientInfo.ID)
+		assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentAttached)
+		assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(1))
+		assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(1))
+		assert.NoError(t, err)
+
+		assert.NoError(t, clientInfo.DetachDocument(docInfo.ID))
+		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+
+		result, err = db.FindClientInfoByID(ctx, projectID, clientInfo.ID)
+		assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentDetached)
+		assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(0))
+		assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(0))
+		assert.NoError(t, err)
+	})
+
+	t.Run("remove document test", func(t *testing.T) {
+		clientInfo, err := db.ActivateClient(ctx, projectID, t.Name())
+		assert.NoError(t, err)
+
+		docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
+		docInfo, err := db.FindDocInfoByKeyAndOwner(ctx, projectID, clientInfo.ID, docKey, true)
+		assert.NoError(t, err)
+
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
+		clientInfo.Documents[docInfo.ID].ServerSeq = 1
+		clientInfo.Documents[docInfo.ID].ClientSeq = 1
+		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+
+		result, err := db.FindClientInfoByID(ctx, projectID, clientInfo.ID)
+		assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentAttached)
+		assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(1))
+		assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(1))
+		assert.NoError(t, err)
+
+		assert.NoError(t, clientInfo.RemoveDocument(docInfo.ID))
+		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+
+		result, err = db.FindClientInfoByID(ctx, projectID, clientInfo.ID)
+		assert.Equal(t, result.Documents[docInfo.ID].Status, database.DocumentRemoved)
+		assert.Equal(t, result.Documents[docInfo.ID].ServerSeq, int64(0))
+		assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(0))
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid clientInfo test", func(t *testing.T) {
+		clientInfo, err := db.ActivateClient(ctx, projectID, t.Name())
+		assert.NoError(t, err)
+
+		docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
+		docInfo, err := db.FindDocInfoByKeyAndOwner(ctx, projectID, clientInfo.ID, docKey, true)
+		assert.NoError(t, err)
+
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
+		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+
+		clientInfo.ID = "invalid clientInfo id"
+		assert.Error(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+
+		clientInfo.ID = dummyClientID
+		assert.Error(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo), mongodb.ErrNoDocuments)
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

* Update ClientInfo with ID, not key

Previously, when updating ClientInfo, it was updated with key. After
introducing multi-tenancy, it is dangerous to use the same key for
each project.

* Extract `testcases` package

To test the same test cases for each database implementation.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
