### PR TITLE
Add removed_at exist false option in FindDocInfosByPaging

### DIFF
--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -1200,6 +1200,9 @@ func (c *Client) FindDocInfosByPaging(
 		"project_id": bson.M{
 			"$eq": encodedProjectID,
 		},
+		"removed_at": bson.M{
+			"$exists": false,
+		},
 	}
 	if paging.Offset != "" {
 		encodedOffset, err := encodeID(paging.Offset)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

In yorkie dashboard, documents are showing that were already deleted.
<img width="882" alt="스크린샷 2023-06-27 오후 5 28 07" src="https://github.com/yorkie-team/yorkie/assets/60080670/b39a8543-af8a-4b37-9cfc-751fc857633d">


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
