### PR TITLE
Filter out removed documents from ListDocuments API

### DIFF
--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -1181,7 +1181,7 @@ func (d *DB) FindDocInfosByPaging(
 			break
 		}
 
-		if info.ID != paging.Offset {
+		if info.ID != paging.Offset && info.RemovedAt.IsZero() {
 			docInfos = append(docInfos, info)
 		}
 	}

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -1200,6 +1200,9 @@ func (c *Client) FindDocInfosByPaging(
 		"project_id": bson.M{
 			"$eq": encodedProjectID,
 		},
+		"removed_at": bson.M{
+			"$exists": false,
+		},
 	}
 	if paging.Offset != "" {
 		encodedOffset, err := encodeID(paging.Offset)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Filter out removed documents from ListDocuments API

Previously, removed documents were exposed in the document list of CLI or Dashboard.
This commit ensures that removed documents are removed from the list, making it appears as if they are properly removed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related to #464

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
