### PR TITLE
Add a workaround to prevent retrieving removed documents from MemDB

### DIFF
--- a/server/backend/backend.go
+++ b/server/backend/backend.go
@@ -118,7 +118,7 @@ func New(
 	}
 
 	logging.DefaultLogger().Infof(
-		"backend created: id: %s, rpc: %s: db: %s",
+		"backend created: id: %s, rpc: %s",
 		serverInfo.ID,
 		dbInfo,
 	)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a workaround to prevent retrieving removed documents from MemDB

Removed documents should be filtered out by the query, but somehow it does not work. This is a workaround.

```go
val, err := txn.First(tblDocuments, "project_id_key_removed_at", projectID.String(), key.String(), gotime.Time{})
```

So this commit adds a workaround to prevent retrieving removed documents from MemDB.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related to #464

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
