### PR TITLE
feat: add logout command to cli

### DIFF
--- a/cmd/yorkie/config/config.go
+++ b/cmd/yorkie/config/config.go
@@ -122,3 +122,17 @@ func Save(config *Config) error {
 
 	return nil
 }
+
+func Delete() error {
+	configPathValue, err := configPath()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "get config path: %w", err)
+		os.Exit(1)
+	}
+
+	if err := os.Remove(filepath.Clean(configPathValue)); err != nil {
+		return fmt.Errorf("remove config file: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/yorkie/config/config.go
+++ b/cmd/yorkie/config/config.go
@@ -123,6 +123,7 @@ func Save(config *Config) error {
 	return nil
 }
 
+// Delete deletes the configuration file.
 func Delete() error {
 	configPathValue, err := configPath()
 	if err != nil {

--- a/cmd/yorkie/logout.go
+++ b/cmd/yorkie/logout.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/yorkie-team/yorkie/cmd/yorkie/config"
+)
+
+var (
+	flagForce bool
+)
+
+func newLogoutCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "logout",
+		Short: "Log out from the Yorkie server",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			conf, err := config.Load()
+			if err != nil {
+				return err
+			}
+			if flagForce {
+				return config.Delete()
+			}
+			if config.RPCAddr == "" {
+				return errors.New("you must specify the server address to log out")
+			}
+			if _, ok := conf.Auths[config.RPCAddr]; !ok {
+				return fmt.Errorf("you are not logged in to %s", config.RPCAddr)
+			}
+			if len(conf.Auths) <= 1 {
+				return config.Delete()
+			}
+			delete(conf.Auths, config.RPCAddr)
+			return config.Save(conf)
+		},
+	}
+}
+
+func init() {
+	cmd := newLogoutCmd()
+	cmd.Flags().BoolVar(
+		&flagForce,
+		"force",
+		false,
+		"force log out from all servers",
+	)
+	rootCmd.AddCommand(cmd)
+}

--- a/cmd/yorkie/logout.go
+++ b/cmd/yorkie/logout.go
@@ -3,7 +3,9 @@ package main
 import (
 	"errors"
 	"fmt"
+
 	"github.com/spf13/cobra"
+
 	"github.com/yorkie-team/yorkie/cmd/yorkie/config"
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**: Add `logout` command to yorkie cli

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #488 

**Special notes for your reviewer**:

Since `yorkie login` allows login to multiple servers, logout should also allow logout on a per-server basis. thus `yorkie logout` command would work as follows:

- If the user is logged in to only one server
  - can log out with `yorkie logout`.
- If the user is logged in to multiple servers
  - can log out from a specific server with `yorkie logout --rpc-addr "<SERVER_ADDRESS>"`.
- or log out from all servers with `yorkie logout --force`. (is `--all` is better name than `--force`?)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
