### PR TITLE
feat: cache project info

### DIFF
--- a/cmd/yorkie/server.go
+++ b/cmd/yorkie/server.go
@@ -50,6 +50,7 @@ var (
 	authWebhookMaxWaitInterval time.Duration
 	authWebhookCacheAuthTTL    time.Duration
 	authWebhookCacheUnauthTTL  time.Duration
+	projectInfoCacheTTL        time.Duration
 
 	etcdEndpoints     []string
 	etcdDialTimeout   time.Duration
@@ -72,6 +73,7 @@ func newServerCmd() *cobra.Command {
 			conf.Backend.AuthWebhookMaxWaitInterval = authWebhookMaxWaitInterval.String()
 			conf.Backend.AuthWebhookCacheAuthTTL = authWebhookCacheAuthTTL.String()
 			conf.Backend.AuthWebhookCacheUnauthTTL = authWebhookCacheUnauthTTL.String()
+			conf.Backend.ProjectInfoCacheTTL = projectInfoCacheTTL.String()
 
 			conf.Housekeeping.Interval = housekeepingInterval.String()
 
@@ -336,6 +338,18 @@ func init() {
 		"auth-webhook-cache-unauth-ttl",
 		server.DefaultAuthWebhookCacheUnauthTTL,
 		"TTL value to set when caching unauthorized webhook response.",
+	)
+	cmd.Flags().IntVar(
+		&conf.Backend.ProjectInfoCacheSize,
+		"project-info-cache-size",
+		server.DefaultProjectInfoCacheSize,
+		"The cache size of the project info.",
+	)
+	cmd.Flags().DurationVar(
+		&projectInfoCacheTTL,
+		"project-info-cache-ttl",
+		server.DefaultProjectInfoCacheTTL,
+		"TTL value to set when caching project info.",
 	)
 	cmd.Flags().StringVar(
 		&conf.Backend.Hostname,

--- a/server/backend/config.go
+++ b/server/backend/config.go
@@ -70,6 +70,12 @@ type Config struct {
 	// AuthWebhookCacheUnauthTTL is the TTL value to set when caching the unauthorized result.
 	AuthWebhookCacheUnauthTTL string `yaml:"AuthWebhookCacheUnauthTTL"`
 
+	// ProjectInfoCacheSize is the cache size of the project info.
+	ProjectInfoCacheSize int `yaml:"ProjectInfoCacheSize"`
+
+	// ProjectInfoCacheTTL is the TTL value to set when caching the project info.
+	ProjectInfoCacheTTL string `yaml:"ProjectInfoCacheTTL"`
+
 	// Hostname is yorkie server hostname. hostname is used by metrics.
 	Hostname string `yaml:"Hostname"`
 }
@@ -104,6 +110,14 @@ func (c *Config) Validate() error {
 		return fmt.Errorf(
 			`invalid argument "%s" for "--auth-webhook-cache-unauth-ttl" flag: %w`,
 			c.AuthWebhookCacheUnauthTTL,
+			err,
+		)
+	}
+
+	if _, err := time.ParseDuration(c.ProjectInfoCacheTTL); err != nil {
+		return fmt.Errorf(
+			`invalid argument "%s" for "--project-info-cache-ttl" flag: %w`,
+			c.ProjectInfoCacheTTL,
 			err,
 		)
 	}
@@ -149,6 +163,17 @@ func (c *Config) ParseAuthWebhookCacheUnauthTTL() time.Duration {
 	result, err := time.ParseDuration(c.AuthWebhookCacheUnauthTTL)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "parse auth webhook cache unauth ttl: %w", err)
+		os.Exit(1)
+	}
+
+	return result
+}
+
+// ParseProjectInfoCacheTTL returns TTL for project info cache.
+func (c *Config) ParseProjectInfoCacheTTL() time.Duration {
+	result, err := time.ParseDuration(c.ProjectInfoCacheTTL)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "parse project info cache ttl: %w", err)
 		os.Exit(1)
 	}
 

--- a/server/backend/config_test.go
+++ b/server/backend/config_test.go
@@ -31,6 +31,7 @@ func TestConfig(t *testing.T) {
 			AuthWebhookMaxWaitInterval: "0ms",
 			AuthWebhookCacheAuthTTL:    "10s",
 			AuthWebhookCacheUnauthTTL:  "10s",
+			ProjectInfoCacheTTL:        "1h",
 		}
 		assert.NoError(t, validConf.Validate())
 
@@ -49,5 +50,9 @@ func TestConfig(t *testing.T) {
 		conf4 := validConf
 		conf4.AuthWebhookCacheUnauthTTL = "s"
 		assert.Error(t, conf4.Validate())
+
+		conf5 := validConf
+		conf5.ProjectInfoCacheTTL = "1 hour"
+		assert.Error(t, conf5.Validate())
 	})
 }

--- a/server/config.go
+++ b/server/config.go
@@ -63,6 +63,8 @@ const (
 	DefaultAuthWebhookCacheSize       = 5000
 	DefaultAuthWebhookCacheAuthTTL    = 10 * time.Second
 	DefaultAuthWebhookCacheUnauthTTL  = 10 * time.Second
+	DefaultProjectInfoCacheSize       = 256
+	DefaultProjectInfoCacheTTL        = time.Hour
 
 	DefaultHostname = ""
 )
@@ -199,6 +201,14 @@ func (c *Config) ensureDefaultValue() {
 
 	if c.Backend.AuthWebhookCacheUnauthTTL == "" {
 		c.Backend.AuthWebhookCacheUnauthTTL = DefaultAuthWebhookCacheUnauthTTL.String()
+	}
+
+	if c.Backend.ProjectInfoCacheSize == 0 {
+		c.Backend.ProjectInfoCacheSize = DefaultProjectInfoCacheSize
+	}
+
+	if c.Backend.ProjectInfoCacheTTL == "" {
+		c.Backend.ProjectInfoCacheTTL = DefaultProjectInfoCacheTTL.String()
 	}
 
 	if c.Mongo != nil {

--- a/server/config.sample.yml
+++ b/server/config.sample.yml
@@ -74,6 +74,12 @@ Backend:
   # AuthWebhookCacheUnauthTTL is the TTL value to set when caching the unauthorized result.
   AuthWebhookCacheUnauthTTL: "10s"
 
+  # ProjectInfoCacheSize is the size of the project info cache.
+  ProjectInfoCacheSize: 256
+
+  # ProjectInfoCacheTTL is the TTL value to set when caching the project info.
+  ProjectInfoCacheTTL: "1h"
+
   # Hostname is the hostname of the server. If not provided, the hostname will be
   # determined automatically by the OS (Optional, default: os.Hostname()).
   Hostname: ""

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -77,5 +77,9 @@ func TestNewConfigFromFile(t *testing.T) {
 		authWebhookCacheUnauthTTL, err := time.ParseDuration(conf.Backend.AuthWebhookCacheUnauthTTL)
 		assert.NoError(t, err)
 		assert.Equal(t, authWebhookCacheUnauthTTL, server.DefaultAuthWebhookCacheUnauthTTL)
+
+		projectInfoCacheTTL, err := time.ParseDuration(conf.Backend.ProjectInfoCacheTTL)
+		assert.NoError(t, err)
+		assert.Equal(t, projectInfoCacheTTL, server.DefaultProjectInfoCacheTTL)
 	})
 }

--- a/server/rpc/interceptors/context.go
+++ b/server/rpc/interceptors/context.go
@@ -19,7 +19,6 @@ package interceptors
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	grpcmiddleware "github.com/grpc-ecosystem/go-grpc-middleware"
@@ -155,7 +154,7 @@ func (i *ContextInterceptor) buildContext(ctx context.Context) (context.Context,
 		md.Authorization = authorization[0]
 	}
 	ctx = metadata.With(ctx, md)
-	cacheKey := fmt.Sprintf("%s:%s", md.APIKey, md.Authorization)
+	cacheKey := md.APIKey
 
 	// 02. building project
 	if cachedProjectInfo, ok := i.projectInfoCache.Get(cacheKey); ok {

--- a/server/rpc/interceptors/context.go
+++ b/server/rpc/interceptors/context.go
@@ -39,7 +39,7 @@ import (
 	"github.com/yorkie-team/yorkie/server/rpc/metadata"
 )
 
-const projectInfoCacheSize = 1
+const projectInfoCacheSize = 256
 const projectInfoCacheTTL = time.Hour
 
 // ContextInterceptor is an interceptor for building additional context.

--- a/server/rpc/server_test.go
+++ b/server/rpc/server_test.go
@@ -76,6 +76,8 @@ func TestMain(m *testing.M) {
 		ClientDeactivateThreshold: helper.ClientDeactivateThreshold,
 		SnapshotThreshold:         helper.SnapshotThreshold,
 		AuthWebhookCacheSize:      helper.AuthWebhookSize,
+		ProjectInfoCacheSize:      helper.ProjectInfoCacheSize,
+		ProjectInfoCacheTTL:       helper.ProjectInfoCacheTTL.String(),
 		AdminTokenDuration:        helper.AdminTokenDuration,
 	}, &mongo.Config{
 		ConnectionURI:     helper.MongoConnectionURI,

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -69,6 +69,8 @@ var (
 	AuthWebhookSize            = 100
 	AuthWebhookCacheAuthTTL    = 10 * gotime.Second
 	AuthWebhookCacheUnauthTTL  = 10 * gotime.Second
+	ProjectInfoCacheSize       = 256
+	ProjectInfoCacheTTL        = 5 * gotime.Second
 
 	MongoConnectionURI     = "mongodb://localhost:27017"
 	MongoConnectionTimeout = "5s"
@@ -238,6 +240,8 @@ func TestConfig() *server.Config {
 			AuthWebhookCacheSize:       AuthWebhookSize,
 			AuthWebhookCacheAuthTTL:    AuthWebhookCacheAuthTTL.String(),
 			AuthWebhookCacheUnauthTTL:  AuthWebhookCacheUnauthTTL.String(),
+			ProjectInfoCacheSize:       ProjectInfoCacheSize,
+			ProjectInfoCacheTTL:        ProjectInfoCacheTTL.String(),
 		},
 		Mongo: &mongo.Config{
 			ConnectionURI:     MongoConnectionURI,

--- a/test/integration/auth_webhook_test.go
+++ b/test/integration/auth_webhook_test.go
@@ -161,6 +161,8 @@ func TestProjectAuthWebhook(t *testing.T) {
 		)
 		assert.NoError(t, err)
 
+		projectInfoCacheTTL := 5 * time.Second
+		time.Sleep(projectInfoCacheTTL)
 		cli, err := client.Dial(
 			svr.RPCAddr(),
 			client.WithAPIKey(project.PublicKey),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Cache ProjectInfo to improve response time.

For caching I used the existing LRU cache implementation because it seems there is no external cache layer like redis.

In cluster mode, each node has its own cache, so there is still a possibility of query requests for same project info.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #568

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
