### PR TITLE
Remove panic from crdt counter

### DIFF
--- a/api/converter/from_bytes.go
+++ b/api/converter/from_bytes.go
@@ -267,12 +267,19 @@ func fromJSONCounter(pbCnt *api.JSONElement_Counter) (*crdt.Counter, error) {
 	if err != nil {
 		return nil, err
 	}
+	counterValue, err := crdt.CounterValueFromBytes(counterType, pbCnt.Value)
+	if err != nil {
+		return nil, err
+	}
 
-	counter := crdt.NewCounter(
+	counter, err := crdt.NewCounter(
 		counterType,
-		crdt.CounterValueFromBytes(counterType, pbCnt.Value),
+		counterValue,
 		createdAt,
 	)
+	if err != nil {
+		return nil, err
+	}
 	counter.SetMovedAt(movedAt)
 	counter.SetRemovedAt(removedAt)
 

--- a/api/converter/from_pb.go
+++ b/api/converter/from_pb.go
@@ -737,11 +737,20 @@ func fromElement(pbElement *api.JSONElementSimple) (crdt.Element, error) {
 		if err != nil {
 			return nil, err
 		}
-		return crdt.NewCounter(
+		counterValue, err := crdt.CounterValueFromBytes(counterType, pbElement.Value)
+		if err != nil {
+			return nil, err
+		}
+
+		counter, err := crdt.NewCounter(
 			counterType,
-			crdt.CounterValueFromBytes(counterType, pbElement.Value),
+			counterValue,
 			createdAt,
-		), nil
+		)
+		if err != nil {
+			return nil, err
+		}
+		return counter, nil
 	case api.ValueType_VALUE_TYPE_TREE:
 		return BytesToTree(pbElement.Value)
 	}

--- a/api/converter/to_bytes.go
+++ b/api/converter/to_bytes.go
@@ -158,11 +158,15 @@ func toCounter(counter *crdt.Counter) (*api.JSONElement, error) {
 	if err != nil {
 		return nil, err
 	}
+	counterValue, err := counter.Bytes()
+	if err != nil {
+		return nil, err
+	}
 
 	return &api.JSONElement{
 		Body: &api.JSONElement_Counter_{Counter: &api.JSONElement_Counter{
 			Type:      pbCounterType,
-			Value:     counter.Bytes(),
+			Value:     counterValue,
 			CreatedAt: ToTimeTicket(counter.CreatedAt()),
 			MovedAt:   ToTimeTicket(counter.MovedAt()),
 			RemovedAt: ToTimeTicket(counter.RemovedAt()),

--- a/api/converter/to_pb.go
+++ b/api/converter/to_pb.go
@@ -435,11 +435,15 @@ func toJSONElementSimple(elem crdt.Element) (*api.JSONElementSimple, error) {
 		if err != nil {
 			return nil, err
 		}
+		counterValue, err := elem.Bytes()
+		if err != nil {
+			return nil, err
+		}
 
 		return &api.JSONElementSimple{
 			Type:      pbCounterType,
 			CreatedAt: ToTimeTicket(elem.CreatedAt()),
-			Value:     elem.Bytes(),
+			Value:     counterValue,
 		}, nil
 	case *crdt.Tree:
 		bytes, err := TreeToBytes(elem)

--- a/pkg/document/crdt/counter.go
+++ b/pkg/document/crdt/counter.go
@@ -18,10 +18,14 @@ package crdt
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 
 	"github.com/yorkie-team/yorkie/pkg/document/time"
 )
+
+// ErrUnsupportedType returned when the given type is not supported.
+var ErrUnsupportedType = errors.New("unsupported type")
 
 // CounterType represents any type that can be used as a counter.
 type CounterType int
@@ -41,7 +45,7 @@ func CounterValueFromBytes(counterType CounterType, value []byte) (interface{}, 
 	case LongCnt:
 		return int64(binary.LittleEndian.Uint64(value)), nil
 	default:
-		return nil, fmt.Errorf("unsupported type")
+		return nil, ErrUnsupportedType
 	}
 }
 
@@ -78,7 +82,7 @@ func NewCounter(valueType CounterType, value interface{}, createdAt *time.Ticket
 			createdAt: createdAt,
 		}, nil
 	default:
-		return nil, fmt.Errorf("unsupported type")
+		return nil, ErrUnsupportedType
 	}
 }
 
@@ -94,7 +98,7 @@ func (p *Counter) Bytes() ([]byte, error) {
 		binary.LittleEndian.PutUint64(bytes[:], uint64(val))
 		return bytes[:], nil
 	default:
-		return nil, fmt.Errorf("unsupported type")
+		return nil, ErrUnsupportedType
 	}
 }
 
@@ -156,7 +160,7 @@ func (p *Counter) ValueType() CounterType {
 // So we need to assert int to int32.
 func (p *Counter) Increase(v *Primitive) (*Counter, error) {
 	if !p.IsNumericType() || !v.IsNumericType() {
-		return nil, fmt.Errorf("unsupported type")
+		return nil, ErrUnsupportedType
 	}
 	switch p.valueType {
 	case IntegerCnt:
@@ -172,7 +176,7 @@ func (p *Counter) Increase(v *Primitive) (*Counter, error) {
 		}
 		p.value = p.value.(int64) + longValue
 	default:
-		return nil, fmt.Errorf("unsupported type")
+		return nil, ErrUnsupportedType
 	}
 
 	return p, nil
@@ -198,7 +202,7 @@ func castToInt(value interface{}) (int32, error) {
 	case float64:
 		return int32(val), nil
 	default:
-		return 0, fmt.Errorf("unsupported type")
+		return 0, ErrUnsupportedType
 	}
 }
 
@@ -216,6 +220,6 @@ func castToLong(value interface{}) (int64, error) {
 	case float64:
 		return int64(val), nil
 	default:
-		return 0, fmt.Errorf("unsupported type")
+		return 0, ErrUnsupportedType
 	}
 }

--- a/pkg/document/crdt/counter_test.go
+++ b/pkg/document/crdt/counter_test.go
@@ -30,81 +30,94 @@ import (
 
 func TestCounter(t *testing.T) {
 	t.Run("new counter test", func(t *testing.T) {
-		intCntWithInt32Value := crdt.NewCounter(crdt.IntegerCnt, int32(math.MaxInt32), time.InitialTicket)
+		intCntWithInt32Value, err := crdt.NewCounter(crdt.IntegerCnt, int32(math.MaxInt32), time.InitialTicket)
+		assert.NoError(t, err)
 		assert.Equal(t, crdt.IntegerCnt, intCntWithInt32Value.ValueType())
 
-		intCntWithInt64Value := crdt.NewCounter(crdt.IntegerCnt, int64(math.MaxInt32+1), time.InitialTicket)
+		intCntWithInt64Value, err := crdt.NewCounter(crdt.IntegerCnt, int64(math.MaxInt32+1), time.InitialTicket)
+		assert.NoError(t, err)
 		assert.Equal(t, crdt.IntegerCnt, intCntWithInt64Value.ValueType())
 
-		intCntWithIntValue := crdt.NewCounter(crdt.IntegerCnt, math.MaxInt32, time.InitialTicket)
+		intCntWithIntValue, err := crdt.NewCounter(crdt.IntegerCnt, math.MaxInt32, time.InitialTicket)
+		assert.NoError(t, err)
 		assert.Equal(t, crdt.IntegerCnt, intCntWithIntValue.ValueType())
 
-		intCntWithDoubleValue := crdt.NewCounter(crdt.IntegerCnt, 0.5, time.InitialTicket)
+		intCntWithDoubleValue, err := crdt.NewCounter(crdt.IntegerCnt, 0.5, time.InitialTicket)
+		assert.NoError(t, err)
 		assert.Equal(t, crdt.IntegerCnt, intCntWithDoubleValue.ValueType())
 
-		intCntWithUnsupportedValue := func() { crdt.NewCounter(crdt.IntegerCnt, "", time.InitialTicket) }
-		assert.Panics(t, intCntWithUnsupportedValue)
+		_, err = crdt.NewCounter(crdt.IntegerCnt, "", time.InitialTicket)
+		assert.EqualError(t, err, "unsupported type")
 
-		longCntWithInt32Value := crdt.NewCounter(crdt.LongCnt, int32(math.MaxInt32), time.InitialTicket)
+		longCntWithInt32Value, err := crdt.NewCounter(crdt.LongCnt, int32(math.MaxInt32), time.InitialTicket)
+		assert.NoError(t, err)
 		assert.Equal(t, crdt.LongCnt, longCntWithInt32Value.ValueType())
 
-		longCntWithInt64Value := crdt.NewCounter(crdt.LongCnt, int64(math.MaxInt32+1), time.InitialTicket)
+		longCntWithInt64Value, err := crdt.NewCounter(crdt.LongCnt, int64(math.MaxInt32+1), time.InitialTicket)
+		assert.NoError(t, err)
 		assert.Equal(t, crdt.LongCnt, longCntWithInt64Value.ValueType())
 
-		longCntWithIntValue := crdt.NewCounter(crdt.LongCnt, math.MaxInt32+1, time.InitialTicket)
+		longCntWithIntValue, err := crdt.NewCounter(crdt.LongCnt, math.MaxInt32+1, time.InitialTicket)
+		assert.NoError(t, err)
 		assert.Equal(t, crdt.LongCnt, longCntWithIntValue.ValueType())
 
-		longCntWithDoubleValue := crdt.NewCounter(crdt.LongCnt, 0.5, time.InitialTicket)
+		longCntWithDoubleValue, err := crdt.NewCounter(crdt.LongCnt, 0.5, time.InitialTicket)
+		assert.NoError(t, err)
 		assert.Equal(t, crdt.LongCnt, longCntWithDoubleValue.ValueType())
 
-		longCntWithUnsupportedValue := func() { crdt.NewCounter(crdt.LongCnt, "", time.InitialTicket) }
-		assert.Panics(t, longCntWithUnsupportedValue)
+		_, err = crdt.NewCounter(crdt.LongCnt, "", time.InitialTicket)
+		assert.EqualError(t, err, "unsupported type")
 	})
 
 	t.Run("increase test", func(t *testing.T) {
 		var x = 5
 		var y int64 = 10
 		var z = 3.14
-		integer := crdt.NewCounter(crdt.IntegerCnt, x, time.InitialTicket)
-		long := crdt.NewCounter(crdt.LongCnt, y, time.InitialTicket)
-		double := crdt.NewCounter(crdt.IntegerCnt, z, time.InitialTicket)
+		integer, err := crdt.NewCounter(crdt.IntegerCnt, x, time.InitialTicket)
+		assert.NoError(t, err)
+		long, err := crdt.NewCounter(crdt.LongCnt, y, time.InitialTicket)
+		assert.NoError(t, err)
+		double, err := crdt.NewCounter(crdt.IntegerCnt, z, time.InitialTicket)
+		assert.NoError(t, err)
 
 		integerOperand := crdt.NewPrimitive(x, time.InitialTicket)
 		longOperand := crdt.NewPrimitive(y, time.InitialTicket)
 		doubleOperand := crdt.NewPrimitive(z, time.InitialTicket)
 
 		// normal process test
-		integer.Increase(integerOperand)
-		integer.Increase(longOperand)
-		integer.Increase(doubleOperand)
+		_, err = integer.Increase(integerOperand)
+		assert.NoError(t, err)
+		_, err = integer.Increase(longOperand)
+		assert.NoError(t, err)
+		_, err = integer.Increase(doubleOperand)
+		assert.NoError(t, err)
 		assert.Equal(t, integer.Marshal(), "23")
 
-		long.Increase(integerOperand)
-		long.Increase(longOperand)
-		long.Increase(doubleOperand)
+		_, err = long.Increase(integerOperand)
+		assert.NoError(t, err)
+		_, err = long.Increase(longOperand)
+		assert.NoError(t, err)
+		_, err = long.Increase(doubleOperand)
+		assert.NoError(t, err)
 		assert.Equal(t, long.Marshal(), "28")
 
-		double.Increase(integerOperand)
-		double.Increase(longOperand)
-		double.Increase(doubleOperand)
+		_, err = double.Increase(integerOperand)
+		assert.NoError(t, err)
+		_, err = double.Increase(longOperand)
+		assert.NoError(t, err)
+		_, err = double.Increase(doubleOperand)
+		assert.NoError(t, err)
 		assert.Equal(t, double.Marshal(), "21")
 
 		// error process test
-		// TODO: it should be modified to error check
-		// when 'Remove panic from server code (#50)' is completed.
-		unsupportedTypePanicTest := func() {
-			r := recover()
-			assert.NotNil(t, r)
-			assert.Equal(t, r, "unsupported type")
+		unsupportedTypeErrorTest := func(v interface{}) {
+			_, err = crdt.NewCounter(crdt.IntegerCnt, v, time.InitialTicket)
+			assert.EqualError(t, err, "unsupported type")
 		}
-		unsupportedTest := func(v interface{}) {
-			defer unsupportedTypePanicTest()
-			crdt.NewCounter(crdt.IntegerCnt, v, time.InitialTicket)
-		}
-		unsupportedTest("str")
-		unsupportedTest(true)
-		unsupportedTest([]byte{2})
-		unsupportedTest(gotime.Now())
+		unsupportedTypeErrorTest("str")
+		unsupportedTypeErrorTest(true)
+		unsupportedTypeErrorTest([]byte{2})
+		unsupportedTypeErrorTest(gotime.Now())
 
 		assert.Equal(t, integer.Marshal(), "23")
 		assert.Equal(t, long.Marshal(), "28")
@@ -112,11 +125,13 @@ func TestCounter(t *testing.T) {
 	})
 
 	t.Run("Counter value overflow test", func(t *testing.T) {
-		integer := crdt.NewCounter(crdt.IntegerCnt, math.MaxInt32, time.InitialTicket)
+		integer, err := crdt.NewCounter(crdt.IntegerCnt, math.MaxInt32, time.InitialTicket)
+		assert.NoError(t, err)
 		assert.Equal(t, integer.ValueType(), crdt.IntegerCnt)
 
 		operand := crdt.NewPrimitive(1, time.InitialTicket)
-		integer.Increase(operand)
+		_, err = integer.Increase(operand)
+		assert.NoError(t, err)
 		assert.Equal(t, integer.ValueType(), crdt.IntegerCnt)
 		assert.Equal(t, integer.Marshal(), strconv.FormatInt(math.MinInt32, 10))
 	})

--- a/pkg/document/crdt/counter_test.go
+++ b/pkg/document/crdt/counter_test.go
@@ -47,7 +47,7 @@ func TestCounter(t *testing.T) {
 		assert.Equal(t, crdt.IntegerCnt, intCntWithDoubleValue.ValueType())
 
 		_, err = crdt.NewCounter(crdt.IntegerCnt, "", time.InitialTicket)
-		assert.EqualError(t, err, "unsupported type")
+		assert.ErrorIs(t, err, crdt.ErrUnsupportedType)
 
 		longCntWithInt32Value, err := crdt.NewCounter(crdt.LongCnt, int32(math.MaxInt32), time.InitialTicket)
 		assert.NoError(t, err)
@@ -66,7 +66,7 @@ func TestCounter(t *testing.T) {
 		assert.Equal(t, crdt.LongCnt, longCntWithDoubleValue.ValueType())
 
 		_, err = crdt.NewCounter(crdt.LongCnt, "", time.InitialTicket)
-		assert.EqualError(t, err, "unsupported type")
+		assert.ErrorIs(t, err, crdt.ErrUnsupportedType)
 	})
 
 	t.Run("increase test", func(t *testing.T) {
@@ -112,7 +112,7 @@ func TestCounter(t *testing.T) {
 		// error process test
 		unsupportedTypeErrorTest := func(v interface{}) {
 			_, err = crdt.NewCounter(crdt.IntegerCnt, v, time.InitialTicket)
-			assert.EqualError(t, err, "unsupported type")
+			assert.ErrorIs(t, err, crdt.ErrUnsupportedType)
 		}
 		unsupportedTypeErrorTest("str")
 		unsupportedTypeErrorTest(true)

--- a/pkg/document/json/counter.go
+++ b/pkg/document/json/counter.go
@@ -71,7 +71,9 @@ func (p *Counter) Increase(v interface{}) *Counter {
 		panic("unsupported type")
 	}
 
-	p.Counter.Increase(primitive)
+	if _, err := p.Counter.Increase(primitive); err != nil {
+		panic(err)
+	}
 
 	p.context.Push(operations.NewIncrease(
 		p.CreatedAt(),

--- a/pkg/document/json/object.go
+++ b/pkg/document/json/object.go
@@ -75,14 +75,22 @@ func (p *Object) SetNewCounter(k string, t crdt.CounterType, n interface{}) *Cou
 	v := p.setInternal(k, func(ticket *time.Ticket) crdt.Element {
 		switch t {
 		case crdt.IntegerCnt:
+			counter, err := crdt.NewCounter(crdt.IntegerCnt, n, ticket)
+			if err != nil {
+				panic(err)
+			}
 			return NewCounter(
 				p.context,
-				crdt.NewCounter(crdt.IntegerCnt, n, ticket),
+				counter,
 			)
 		case crdt.LongCnt:
+			counter, err := crdt.NewCounter(crdt.LongCnt, n, ticket)
+			if err != nil {
+				panic(err)
+			}
 			return NewCounter(
 				p.context,
-				crdt.NewCounter(crdt.LongCnt, n, ticket),
+				counter,
 			)
 		default:
 			panic("unsupported type")

--- a/pkg/document/operations/increase.go
+++ b/pkg/document/operations/increase.go
@@ -51,7 +51,9 @@ func (o *Increase) Execute(root *crdt.Root) error {
 	}
 
 	value := o.value.(*crdt.Primitive)
-	cnt.Increase(value)
+	if _, err := cnt.Increase(value); err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Remove the panic methods in `crdt/counter.go`
- Before, there were panic methods to reveal errors in development environment, but because it risks stopping the server in production, so those panics were replaced with error methods.
- As the panic methods in counter were replaced, the related test codes also were modified.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related to [#497](https://github.com/yorkie-team/yorkie/issues/497#issuecomment-1617477643) (`crdt/counter`)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
