### PR TITLE
Set cobra default output to stdout

### DIFF
--- a/cmd/yorkie/commands.go
+++ b/cmd/yorkie/commands.go
@@ -18,6 +18,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/yorkie-team/yorkie/cmd/yorkie/config"
@@ -40,6 +42,8 @@ func Run() int {
 }
 
 func init() {
+	rootCmd.SetOut(os.Stdout)
+	rootCmd.SetErr(os.Stderr)
 	rootCmd.AddCommand(project.SubCmd)
 	rootCmd.AddCommand(document.SubCmd)
 	// TODO(chacha912): set rpcAddr from env using viper.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fixes an issue that could not pipe output from the Yorkie CLI

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #490 

**Special notes for your reviewer**:

cobra prints output to `os.Stderr` by default when calling the Print function internally. See https://github.com/spf13/cobra/blob/v1.7.0/command.go#L1349-L1351

So we can pipe the results if we explicitly tell it to output to Stdout like:
```
$ ./yorkie project ls --rpc-addr "api.yorkie.dev:443" | wc -l
2

$ ./yorkie project ls --rpc-addr "api.yorkie.dev:443" | awk 'NR>1 {print $1}'
myProject
```


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
