### PR TITLE
Added listEqual function to compare Tree and TreeNode for tree test

### DIFF
--- a/pkg/document/json/tree.go
+++ b/pkg/document/json/tree.go
@@ -317,3 +317,25 @@ func buildDescendants(ctx *change.Context, n TreeNode, parent *crdt.TreeNode) er
 
 	return nil
 }
+
+// PostorderTraversalTreeNode Added listEqual function to compare Tree and TreeNode for tree test
+func PostorderTraversalTreeNode(node crdt.TreeNodeForTest) []TreeNode {
+	var result []TreeNode
+
+	for _, child := range node.Children {
+		result = append(result, PostorderTraversalTreeNode(child)...)
+	}
+
+	childrenField := []TreeNode(nil)
+	if node.Children != nil {
+		childrenField = []TreeNode{}
+	}
+
+	current := TreeNode{
+		Type:     node.Type,
+		Value:    node.Value,
+		Children: childrenField,
+	}
+
+	return append(result, current)
+}

--- a/test/integration/tree_test.go
+++ b/test/integration/tree_test.go
@@ -30,6 +30,16 @@ import (
 	"github.com/yorkie-team/yorkie/test/helper"
 )
 
+/**
+* `listEqual` is a helper function that the given tree is equal to the
+* expected list of nodes.
+ */
+func listEqual(t assert.TestingT, tree *json.Tree, expected []json.TreeNode) {
+	var nodes []json.TreeNode
+	nodes = json.PostorderTraversalTreeNode(tree.Structure())
+	assert.Equal(t, expected, nodes)
+}
+
 func TestTree(t *testing.T) {
 	clients := activeClients(t, 2)
 	c1, c2 := clients[0], clients[1]
@@ -112,7 +122,19 @@ func TestTree(t *testing.T) {
 			})
 			assert.Equal(t, "<doc><p>ab</p><ng><note>cd</note><note>ef</note></ng><bp>gh</bp></doc>", root.GetTree("t").ToXML())
 			assert.Equal(t, 18, root.GetTree("t").Len())
-			// TODO(krapie): add listEqual test later
+			listEqual(t, root.GetTree("t"),
+				[]json.TreeNode{
+					{Type: "text", Value: "ab"},
+					{Type: "p", Children: []json.TreeNode{}},
+					{Type: "text", Value: "cd"},
+					{Type: "note", Children: []json.TreeNode{}},
+					{Type: "text", Value: "ef"},
+					{Type: "note", Children: []json.TreeNode{}},
+					{Type: "ng", Children: []json.TreeNode{}},
+					{Type: "text", Value: "gh"},
+					{Type: "bp", Children: []json.TreeNode{}},
+					{Type: "doc", Children: []json.TreeNode{}},
+				})
 			return nil
 		})
 		assert.NoError(t, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
- can test the Tree as an array without converting it to xml.
- Porting work to suit the test code of yorkie-js-sdk

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

- yorkie-js-sdk uses the for statement, but here we use the postorder Traversal

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
