### PR TITLE
Fix treePos calculating logic for text node

### DIFF
--- a/api/converter/from_pb.go
+++ b/api/converter/from_pb.go
@@ -642,12 +642,18 @@ func fromTreeNode(pbNode *api.TreeNode) (*crdt.TreeNode, error) {
 		attrs.Set(k, pbAttr.Value, updatedAt)
 	}
 
-	return crdt.NewTreeNode(
+	node := crdt.NewTreeNode(
 		id,
 		pbNode.Type,
 		attrs,
 		pbNode.Value,
-	), nil
+	)
+	node.RemovedAt, err = fromTimeTicket(pbNode.RemovedAt)
+	if err != nil {
+		return nil, err
+	}
+
+	return node, nil
 }
 
 func fromTreePos(pbPos *api.TreePos) (*crdt.TreePos, error) {

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -840,16 +840,14 @@ func (t *Tree) toTreePos(pos *TreePos) (*index.TreePos[*TreeNode], error) {
 			}
 
 			if !leftSiblingNode.IsRemoved() {
+				if leftSiblingNode.IsText() {
+					treePos = &index.TreePos[*TreeNode]{
+						Node:   leftSiblingNode.IndexTreeNode,
+						Offset: leftSiblingNode.IndexTreeNode.PaddedLength(),
+					}
+					return treePos, nil
+				}
 				offset++
-
-				// NOTE(sejongk): the below logic needed?
-				// if leftSiblingNode.IsText() {
-				// 	treePos = &index.TreePos[*TreeNode]{
-				// 		Node:   leftSiblingNode.IndexTreeNode,
-				// 		Offset: leftSiblingNode.IndexTreeNode.PaddedLength(),
-				// 	}
-				// 	return treePos
-				// }
 			}
 
 			treePos = &index.TreePos[*TreeNode]{
@@ -863,8 +861,8 @@ func (t *Tree) toTreePos(pos *TreePos) (*index.TreePos[*TreeNode], error) {
 	return treePos, nil
 }
 
-// toIndex converts the given CRDTTreePos to the index of the tree.
-func (t *Tree) toIndex(pos *TreePos) (int, error) {
+// ToIndex converts the given CRDTTreePos to the index of the tree.
+func (t *Tree) ToIndex(pos *TreePos) (int, error) {
 	treePos, err := t.toTreePos(pos)
 	if treePos == nil {
 		return -1, nil

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -831,24 +831,22 @@ func (t *Tree) toTreePos(pos *TreePos) *index.TreePos[*TreeNode] {
 			Offset: 0,
 		}
 	} else {
-		leftSiblingOffset, err := parentNode.IndexTreeNode.FindOffset(leftSiblingNode.IndexTreeNode)
-		if err != nil {
-			return nil
-		}
-
-		offset := leftSiblingOffset + 1
 		if leftSiblingNode.IsText() {
-			offset, err = t.IndexTree.LeftSiblingsSize(parentNode.IndexTreeNode, offset)
+			treePos = &index.TreePos[*TreeNode]{
+				Node:   leftSiblingNode.IndexTreeNode,
+				Offset: leftSiblingNode.IndexTreeNode.PaddedLength(),
+			}
+		} else {
+			leftSiblingOffset, err := parentNode.IndexTreeNode.FindOffset(leftSiblingNode.IndexTreeNode)
 			if err != nil {
-				return nil // NOTE(sejongk): should return error instead?
+				return nil
+			}
+
+			treePos = &index.TreePos[*TreeNode]{
+				Node:   parentNode.IndexTreeNode,
+				Offset: leftSiblingOffset + 1,
 			}
 		}
-
-		treePos = &index.TreePos[*TreeNode]{
-			Node:   parentNode.IndexTreeNode,
-			Offset: offset,
-		}
-
 	}
 
 	return treePos

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -537,7 +537,7 @@ func (t *Tree) FindPos(offset int) (*TreePos, error) {
 	var leftSibling *TreeNode
 
 	if node.IsText() {
-		if node.Parent.Children(true)[0] == node && offset == 0 {
+		if node.Parent.Children(false)[0] == node && offset == 0 {
 			leftSibling = node.Parent.Value
 		} else {
 			leftSibling = node.Value

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -640,7 +640,7 @@ func (t *Tree) Edit(from, to *TreePos,
 				index.TraverseNode(node.IndexTreeNode, func(node *index.Node[*TreeNode], depth int) {
 					if node.Value.remove(editedAt, time.MaxTicket) {
 						// TODO(sejongk): Refactor the repeated code.
-						latestCreatedAt = latestCreatedAtMapByActor[actorIDHex]
+						latestCreatedAt = createdAtMapByActor[actorIDHex]
 						createdAt := node.Value.ID.CreatedAt
 						if latestCreatedAt == nil || createdAt.After(latestCreatedAt) {
 							createdAtMapByActor[actorIDHex] = createdAt
@@ -680,7 +680,7 @@ func (t *Tree) Edit(from, to *TreePos,
 				if fromParent.Value.IsRemoved() {
 					actorIDHex := node.Value.ID.CreatedAt.ActorIDHex()
 					if node.Value.remove(editedAt, time.MaxTicket) {
-						latestCreatedAt := latestCreatedAtMapByActor[actorIDHex]
+						latestCreatedAt := createdAtMapByActor[actorIDHex]
 						createdAt := node.Value.ID.CreatedAt
 						if latestCreatedAt == nil || createdAt.After(latestCreatedAt) {
 							createdAtMapByActor[actorIDHex] = createdAt

--- a/pkg/index/tree.go
+++ b/pkg/index/tree.go
@@ -362,28 +362,17 @@ func (n *Node[V]) FindOffset(node *Node[V]) (int, error) {
 
 	// If nodes are removed, the offset of the removed node is the number of
 	// nodes before the node excluding the removed nodes.
-	if node.Value.IsRemoved() {
-		refined := 0
-		for _, child := range n.Children(true) {
-			if child == node {
-				if refined == 0 {
-					return 0, nil
-				}
-				return refined - 1, nil
-			}
-			if !node.Value.IsRemoved() {
-				refined++
-			}
-		}
-	}
-
-	for i, child := range n.Children() {
+	offset := 0
+	for _, child := range n.Children(true) {
 		if child == node {
-			return i, nil
+			return offset, nil
+		}
+		if !child.Value.IsRemoved() {
+			offset++
 		}
 	}
 
-	return -1, nil
+	return -1, ErrChildNotFound
 }
 
 // IsAncestorOf returns true if the node is an ancestor of the given node.

--- a/test/integration/tree_test.go
+++ b/test/integration/tree_test.go
@@ -1756,4 +1756,92 @@ func TestTree(t *testing.T) {
 		syncClientsThenAssertEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
 		assert.Equal(t, "<root><p>A</p></root>", d1.Root().GetTree("t").ToXML())
 	})
+
+	t.Run("Can delete very first text when there is tombstone in front of target text", func(t *testing.T) {
+		doc := document.New(helper.TestDocKey(t))
+		err := doc.Update(func(root *json.Object, p *presence.Presence) error {
+			// 01. Create a tree and insert a paragraph.
+			root.SetNewTree("t").Edit(0, 0, &json.TreeNode{
+				Type:     "p",
+				Children: []json.TreeNode{{Type: "text", Value: "abcdefghi"}}})
+			assert.Equal(t, "<root><p>abcdefghi</p></root>", root.GetTree("t").ToXML())
+
+			root.GetTree("t").Edit(1, 1, &json.TreeNode{
+				Type:  "text",
+				Value: "12345",
+			})
+			assert.Equal(t, "<root><p>12345abcdefghi</p></root>", root.GetTree("t").ToXML())
+
+			root.GetTree("t").Edit(2, 5)
+			assert.Equal(t, "<root><p>15abcdefghi</p></root>", root.GetTree("t").ToXML())
+
+			root.GetTree("t").Edit(3, 5)
+			assert.Equal(t, "<root><p>15cdefghi</p></root>", root.GetTree("t").ToXML())
+
+			root.GetTree("t").Edit(2, 4)
+			assert.Equal(t, "<root><p>1defghi</p></root>", root.GetTree("t").ToXML())
+
+			root.GetTree("t").Edit(1, 3)
+			assert.Equal(t, "<root><p>efghi</p></root>", root.GetTree("t").ToXML())
+
+			root.GetTree("t").Edit(1, 2)
+			assert.Equal(t, "<root><p>fghi</p></root>", root.GetTree("t").ToXML())
+
+			root.GetTree("t").Edit(2, 5)
+			assert.Equal(t, "<root><p>f</p></root>", root.GetTree("t").ToXML())
+
+			root.GetTree("t").Edit(1, 2)
+			assert.Equal(t, "<root><p></p></root>", root.GetTree("t").ToXML())
+
+			return nil
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("Can delete node when there is more than one text node in front which has size bigger than 1", func(t *testing.T) {
+		doc := document.New(helper.TestDocKey(t))
+		err := doc.Update(func(root *json.Object, p *presence.Presence) error {
+			// 01. Create a tree and insert a paragraph.
+			root.SetNewTree("t").Edit(0, 0, &json.TreeNode{
+				Type:     "p",
+				Children: []json.TreeNode{{Type: "text", Value: "abcde"}}})
+			assert.Equal(t, "<root><p>abcde</p></root>", root.GetTree("t").ToXML())
+
+			root.GetTree("t").Edit(6, 6, &json.TreeNode{
+				Type:  "text",
+				Value: "f",
+			})
+			assert.Equal(t, "<root><p>abcdef</p></root>", root.GetTree("t").ToXML())
+
+			root.GetTree("t").Edit(7, 7, &json.TreeNode{
+				Type:  "text",
+				Value: "g",
+			})
+			assert.Equal(t, "<root><p>abcdefg</p></root>", root.GetTree("t").ToXML())
+
+			root.GetTree("t").Edit(7, 8)
+			assert.Equal(t, "<root><p>abcdef</p></root>", root.GetTree("t").ToXML())
+
+			root.GetTree("t").Edit(6, 7)
+			assert.Equal(t, "<root><p>abcde</p></root>", root.GetTree("t").ToXML())
+
+			root.GetTree("t").Edit(5, 6)
+			assert.Equal(t, "<root><p>abcd</p></root>", root.GetTree("t").ToXML())
+
+			root.GetTree("t").Edit(4, 5)
+			assert.Equal(t, "<root><p>abc</p></root>", root.GetTree("t").ToXML())
+
+			root.GetTree("t").Edit(3, 4)
+			assert.Equal(t, "<root><p>ab</p></root>", root.GetTree("t").ToXML())
+
+			root.GetTree("t").Edit(2, 3)
+			assert.Equal(t, "<root><p>a</p></root>", root.GetTree("t").ToXML())
+
+			root.GetTree("t").Edit(1, 2)
+			assert.Equal(t, "<root><p></p></root>", root.GetTree("t").ToXML())
+
+			return nil
+		})
+		assert.NoError(t, err)
+	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix `toTreePos` to calculate treePos of text node correctly

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related to https://github.com/yorkie-team/yorkie-js-sdk/pull/611

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
