### PR TITLE
Rename Presences to Users

### DIFF
--- a/design/presence.md
+++ b/design/presence.md
@@ -55,7 +55,7 @@ doc.getMyPresence(); // { color: 'blue', cursor: { x: 1, y: 1 } }
 doc.getPresence(clientID);
 
 // Get all users currently participating in the document
-const users = doc.getPresences();
+const users = doc.getUsers();
 for (const { clientID, presence } of users) {
   // Do something...
 }

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -303,16 +303,15 @@ func (d *Document) PresenceForTest(clientID string) innerpresence.Presence {
 	return d.doc.PresenceForTest(clientID)
 }
 
-// Presences returns the presence map of online clients.
-func (d *Document) Presences() map[string]innerpresence.Presence {
+// Users returns online users who are watching the document.
+func (d *Document) Users() map[string]innerpresence.Presence {
 	// TODO(hackerwins): We need to use client key instead of actor ID for exposing presence.
-	return d.doc.Presences()
+	return d.doc.Users()
 }
 
-// AllPresences returns the presence map of all clients
-// regardless of whether the client is online or not.
-func (d *Document) AllPresences() map[string]innerpresence.Presence {
-	return d.doc.AllPresences()
+// AllUsers returns the all users regardless of whether the user is online or not.
+func (d *Document) AllUsers() map[string]innerpresence.Presence {
+	return d.doc.AllUsers()
 }
 
 // SetOnlineClients sets the online clients.

--- a/pkg/document/internal_document.go
+++ b/pkg/document/internal_document.go
@@ -326,8 +326,8 @@ func (d *InternalDocument) PresenceForTest(clientID string) innerpresence.Presen
 	return d.presences.Load(clientID).DeepCopy()
 }
 
-// Presences returns the presence map of online clients.
-func (d *InternalDocument) Presences() map[string]innerpresence.Presence {
+// Users returns online users who are watching the document.
+func (d *InternalDocument) Users() map[string]innerpresence.Presence {
 	presences := make(map[string]innerpresence.Presence)
 	d.onlineClients.Range(func(key, value interface{}) bool {
 		p := d.presences.Load(key.(string))
@@ -340,9 +340,8 @@ func (d *InternalDocument) Presences() map[string]innerpresence.Presence {
 	return presences
 }
 
-// AllPresences returns the presence map of all clients
-// regardless of whether the client is online or not.
-func (d *InternalDocument) AllPresences() map[string]innerpresence.Presence {
+// AllUsers returns the all users regardless of whether the user is online or not.
+func (d *InternalDocument) AllUsers() map[string]innerpresence.Presence {
 	presences := make(map[string]innerpresence.Presence)
 	d.presences.Range(func(key string, value innerpresence.Presence) bool {
 		presences[key] = value.DeepCopy()

--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -967,7 +967,7 @@ func (d *DB) CreateSnapshotInfo(
 	docID types.ID,
 	doc *document.InternalDocument,
 ) error {
-	snapshot, err := converter.SnapshotToBytes(doc.RootObject(), doc.AllPresences())
+	snapshot, err := converter.SnapshotToBytes(doc.RootObject(), doc.AllUsers())
 	if err != nil {
 		return err
 	}

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -1050,7 +1050,7 @@ func (c *Client) CreateSnapshotInfo(
 	if err != nil {
 		return err
 	}
-	snapshot, err := converter.SnapshotToBytes(doc.RootObject(), doc.AllPresences())
+	snapshot, err := converter.SnapshotToBytes(doc.RootObject(), doc.AllUsers())
 	if err != nil {
 		return err
 	}

--- a/server/packs/pushpull.go
+++ b/server/packs/pushpull.go
@@ -157,7 +157,7 @@ func pullSnapshot(
 	}
 	cpAfterPull := cpAfterPush.NextServerSeq(docInfo.ServerSeq)
 
-	snapshot, err := converter.SnapshotToBytes(doc.RootObject(), doc.AllPresences())
+	snapshot, err := converter.SnapshotToBytes(doc.RootObject(), doc.AllUsers())
 	if err != nil {
 		return nil, err
 	}

--- a/server/rpc/admin_server.go
+++ b/server/rpc/admin_server.go
@@ -254,7 +254,7 @@ func (s *adminServer) GetSnapshotMeta(
 		return nil, err
 	}
 
-	snapshot, err := converter.SnapshotToBytes(doc.RootObject(), doc.AllPresences())
+	snapshot, err := converter.SnapshotToBytes(doc.RootObject(), doc.AllUsers())
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration/presence_test.go
+++ b/test/integration/presence_test.go
@@ -58,14 +58,14 @@ func TestPresence(t *testing.T) {
 			p.Set("updated", "true")
 			return nil
 		}))
-		encoded, err := gojson.Marshal(d1.AllPresences())
+		encoded, err := gojson.Marshal(d1.AllUsers())
 		assert.NoError(t, err)
 		assert.Equal(t, fmt.Sprintf(`{"%s":{"updated":"true"}}`, c1.ID()), string(encoded))
 
 		// 03 Sync documents and check that the presence is updated on the other client
 		assert.NoError(t, c1.Sync(ctx))
 		assert.NoError(t, c2.Sync(ctx))
-		encoded, err = gojson.Marshal(d2.AllPresences())
+		encoded, err = gojson.Marshal(d2.AllUsers())
 		assert.NoError(t, err)
 		assert.Equal(t, fmt.Sprintf(`{"%s":{"updated":"true"},"%s":{}}`, c1.ID(), c2.ID()), string(encoded))
 	})
@@ -88,14 +88,14 @@ func TestPresence(t *testing.T) {
 				return nil
 			}))
 		}
-		encoded, err := gojson.Marshal(d1.AllPresences())
+		encoded, err := gojson.Marshal(d1.AllUsers())
 		assert.NoError(t, err)
 		assert.Equal(t, fmt.Sprintf(`{"%s":{"updated":"9"}}`, c1.ID()), string(encoded))
 
 		// 03 Sync documents and check that the presence is updated on the other client
 		assert.NoError(t, c1.Sync(ctx))
 		assert.NoError(t, c2.Sync(ctx))
-		encoded, err = gojson.Marshal(d2.AllPresences())
+		encoded, err = gojson.Marshal(d2.AllUsers())
 		assert.NoError(t, err)
 		assert.Equal(t, fmt.Sprintf(`{"%s":{"updated":"9"},"%s":{}}`, c1.ID(), c2.ID()), string(encoded))
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Rename `doc.getPresences()` to `doc.getUsers()` as the returned value aligns more closely with user information, making this name easier to comprehend.

The reason `users` is used in `getUsers` is that using `clients` (as yorkie Client) might imply that it should hold all information about the yorkie client. However, users only contain clientID and presence information, so I used the term `users` instead of `clients.`


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related https://github.com/yorkie-team/yorkie/pull/609
https://github.com/yorkie-team/yorkie-js-sdk/pull/618

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
