### PR TITLE
Support multi-level and partial element selection

### DIFF
--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -591,10 +591,10 @@ func (t *Tree) Edit(from, to *TreePos,
 	var toBeRemoved []*TreeNode
 
 	err = t.traverseInPosRange(fromParent.Value, fromLeft.Value, toParent.Value, toLeft.Value,
-		func(node *TreeNode, contain index.TagContain) {
+		func(node *TreeNode, contain index.TagContained) {
 			// If node is a element node and half-contained in the range,
 			// it should not be removed.
-			if !node.IsText() && contain != index.ContainsAll {
+			if !node.IsText() && contain != index.AllContained {
 				return
 			}
 
@@ -676,7 +676,7 @@ func (t *Tree) Edit(from, to *TreePos,
 }
 
 func (t *Tree) traverseInPosRange(fromParent, fromLeft, toParent, toLeft *TreeNode,
-	callback func(node *TreeNode, contain index.TagContain),
+	callback func(node *TreeNode, contain index.TagContained),
 ) error {
 	fromIdx, err := t.ToIndex(fromParent, fromLeft)
 	if err != nil {
@@ -719,7 +719,7 @@ func (t *Tree) Style(from, to *TreePos, attributes map[string]string, editedAt *
 	}
 
 	err = t.traverseInPosRange(fromParent.Value, fromLeft.Value, toParent.Value, toLeft.Value,
-		func(node *TreeNode, contain index.TagContain) {
+		func(node *TreeNode, contain index.TagContained) {
 			if !node.IsRemoved() {
 				if node.Attrs == nil {
 					node.Attrs = NewRHT()
@@ -741,7 +741,6 @@ func (t *Tree) Style(from, to *TreePos, attributes map[string]string, editedAt *
 // splits the text node if necessary.
 // crdt.TreePos is a position in the CRDT perspective. This is different
 // from indexTree.TreePos which is a position of the tree in the local perspective.
-// TODO(sejongk): clarify the comments
 func (t *Tree) FindTreeNodesWithSplitText(pos *TreePos, editedAt *time.Ticket) (
 	*index.Node[*TreeNode], *index.Node[*TreeNode], error,
 ) {

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -737,14 +737,11 @@ func (t *Tree) Style(from, to *TreePos, attributes map[string]string, editedAt *
 	return nil
 }
 
-/**
- * FindTreeNodesWithSplitText finds TreeNode of the given crdt.TreePos and
- * splits the text node if necessary.
- *
- * crdt.TreePos is a position in the CRDT perspective. This is different
- * from indexTree.TreePos which is a position of the tree in the local perspective.
- * TODO(sejongk): clarify the comments
-**/
+// FindTreeNodesWithSplitText finds TreeNode of the given crdt.TreePos and
+// splits the text node if necessary.
+// crdt.TreePos is a position in the CRDT perspective. This is different
+// from indexTree.TreePos which is a position of the tree in the local perspective.
+// TODO(sejongk): clarify the comments
 func (t *Tree) FindTreeNodesWithSplitText(pos *TreePos, editedAt *time.Ticket) (
 	*index.Node[*TreeNode], *index.Node[*TreeNode], error,
 ) {

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -674,7 +674,9 @@ func (t *Tree) Edit(from, to *TreePos,
 	return createdAtMapByActor, nil
 }
 
-func (t *Tree) traverseInPosRange(fromPos, toPos *TreePos, callback func(node *TreeNode, contain index.TagContain)) error {
+func (t *Tree) traverseInPosRange(fromPos, toPos *TreePos,
+	callback func(node *TreeNode, contain index.TagContain),
+) error {
 	fromIdx, err := t.ToIndex(fromPos)
 	if err != nil {
 		return err

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -720,7 +720,7 @@ func (t *Tree) Style(from, to *TreePos, attributes map[string]string, editedAt *
 
 	err = t.traverseInPosRange(fromParent.Value, fromLeft.Value, toParent.Value, toLeft.Value,
 		func(node *TreeNode, contain index.TagContained) {
-			if !node.IsRemoved() {
+			if !node.IsRemoved() && !node.IsText() {
 				if node.Attrs == nil {
 					node.Attrs = NewRHT()
 				}

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -720,7 +720,7 @@ func (t *Tree) Style(from, to *TreePos, attributes map[string]string, editedAt *
 
 	err = t.traverseInPosRange(fromParent.Value, fromLeft.Value, toParent.Value, toLeft.Value,
 		func(node *TreeNode, contain index.TagContained) {
-			if !node.IsRemoved() && !node.IsText() {
+			if !node.IsRemoved() && !node.IsText() && len(attributes) > 0 {
 				if node.Attrs == nil {
 					node.Attrs = NewRHT()
 				}

--- a/pkg/document/crdt/tree_test.go
+++ b/pkg/document/crdt/tree_test.go
@@ -224,8 +224,6 @@ func TestTree(t *testing.T) {
 	})
 
 	t.Run("delete nodes between element nodes test", func(t *testing.T) {
-		t.Skip("TODO(hackerwins): We need to fix this test.")
-
 		// 01. Create a tree with 2 paragraphs.
 		//       0   1 2 3    4   5 6 7    8
 		// <root> <p> a b </p> <p> c d </p> </root>
@@ -251,19 +249,22 @@ func TestTree(t *testing.T) {
 		// <root> <p> a d </p> </root>
 		_, err = tree.EditByIndex(2, 6, nil, nil, helper.IssueTime(ctx))
 		assert.NoError(t, err)
-		assert.Equal(t, "<root><p>ad</p></root>", tree.ToXML())
+		assert.Equal(t, "<root><p>a</p><p>d</p></root>", tree.ToXML())
 
-		structure := tree.Structure()
-		assert.Equal(t, 4, structure.Size)
-		assert.Equal(t, 2, structure.Children[0].Size)
-		assert.Equal(t, 1, structure.Children[0].Children[0].Size)
-		assert.Equal(t, 1, structure.Children[0].Children[1].Size)
+		// TODO(sejongk): Use the below assertions after implementing Tree.Move.
+		// assert.Equal(t, "<root><p>ad</p></root>", tree.ToXML())
 
-		// 03. insert a new text node at the start of the first paragraph.
-		_, err = tree.EditByIndex(1, 1, nil, []*crdt.TreeNode{crdt.NewTreeNode(helper.IssuePos(ctx),
-			"text", nil, "@")}, helper.IssueTime(ctx))
-		assert.NoError(t, err)
-		assert.Equal(t, "<root><p>@ad</p></root>", tree.ToXML())
+		// structure := tree.Structure()
+		// assert.Equal(t, 4, structure.Size)
+		// assert.Equal(t, 2, structure.Children[0].Size)
+		// assert.Equal(t, 1, structure.Children[0].Children[0].Size)
+		// assert.Equal(t, 1, structure.Children[0].Children[1].Size)
+
+		// // 03. insert a new text node at the start of the first paragraph.
+		// _, err = tree.EditByIndex(1, 1, nil, []*crdt.TreeNode{crdt.NewTreeNode(helper.IssuePos(ctx),
+		// 	"text", nil, "@")}, helper.IssueTime(ctx))
+		// assert.NoError(t, err)
+		// assert.Equal(t, "<root><p>@ad</p></root>", tree.ToXML())
 	})
 
 	t.Run("style node with element attributes test", func(t *testing.T) {
@@ -284,21 +285,25 @@ func TestTree(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "<root><p>ab</p><p>cd</p></root>", tree.ToXML())
 
-		// Currently styling attributes to opening tag is only possible.
-		// TODO(sejongk): We have to let it possible to style attributes to closing tag.
+		// style attributes with opening tag
 		err = tree.StyleByIndex(0, 1, map[string]string{"weight": "bold"}, helper.IssueTime(ctx))
 		assert.NoError(t, err)
 		assert.Equal(t, `<root><p weight="bold">ab</p><p>cd</p></root>`, tree.ToXML())
 
+		// style attributes with closing tag
+		err = tree.StyleByIndex(3, 4, map[string]string{"color": "red"}, helper.IssueTime(ctx))
+		assert.NoError(t, err)
+		assert.Equal(t, `<root><p color="red" weight="bold">ab</p><p>cd</p></root>`, tree.ToXML())
+
 		// 02. style attributes to elements.
 		err = tree.StyleByIndex(0, 5, map[string]string{"style": "italic"}, helper.IssueTime(ctx))
 		assert.NoError(t, err)
-		assert.Equal(t, `<root><p style="italic" weight="bold">ab</p><p style="italic">cd</p></root>`, tree.ToXML())
+		assert.Equal(t, `<root><p color="red" style="italic" weight="bold">ab</p><p style="italic">cd</p></root>`, tree.ToXML())
 
 		// 03. Ignore styling attributes to text nodes.
 		err = tree.StyleByIndex(1, 3, map[string]string{"bold": "true"}, helper.IssueTime(ctx))
 		assert.NoError(t, err)
-		assert.Equal(t, `<root><p style="italic" weight="bold">ab</p><p style="italic">cd</p></root>`, tree.ToXML())
+		assert.Equal(t, `<root><p color="red" style="italic" weight="bold">ab</p><p style="italic">cd</p></root>`, tree.ToXML())
 	})
 
 	t.Run("can find the closest TreePos when parentNode or leftSiblingNode does not exist", func(t *testing.T) {

--- a/pkg/document/crdt/tree_test.go
+++ b/pkg/document/crdt/tree_test.go
@@ -298,12 +298,14 @@ func TestTree(t *testing.T) {
 		// 02. style attributes to elements.
 		err = tree.StyleByIndex(0, 5, map[string]string{"style": "italic"}, helper.IssueTime(ctx))
 		assert.NoError(t, err)
-		assert.Equal(t, `<root><p color="red" style="italic" weight="bold">ab</p><p style="italic">cd</p></root>`, tree.ToXML())
+		assert.Equal(t, `<root><p color="red" style="italic" weight="bold">ab</p>`+
+			`<p style="italic">cd</p></root>`, tree.ToXML())
 
 		// 03. Ignore styling attributes to text nodes.
 		err = tree.StyleByIndex(1, 3, map[string]string{"bold": "true"}, helper.IssueTime(ctx))
 		assert.NoError(t, err)
-		assert.Equal(t, `<root><p color="red" style="italic" weight="bold">ab</p><p style="italic">cd</p></root>`, tree.ToXML())
+		assert.Equal(t, `<root><p color="red" style="italic" weight="bold">ab</p>`+
+			`<p style="italic">cd</p></root>`, tree.ToXML())
 	})
 
 	t.Run("can find the closest TreePos when parentNode or leftSiblingNode does not exist", func(t *testing.T) {

--- a/pkg/document/crdt/tree_test.go
+++ b/pkg/document/crdt/tree_test.go
@@ -341,7 +341,10 @@ func TestTree(t *testing.T) {
 		assert.Equal(t, "<r><p></p></r>", tree.ToXML())
 
 		treePos := crdt.NewTreePos(pNode.ID, textNode.ID)
-		idx, err := tree.ToIndex(treePos)
+
+		parent, leftSibling, err := tree.FindTreeNodesWithSplitText(treePos, helper.IssueTime(ctx))
+		assert.NoError(t, err)
+		idx, err := tree.ToIndex(parent.Value, leftSibling.Value)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, idx)
 
@@ -353,7 +356,9 @@ func TestTree(t *testing.T) {
 		assert.Equal(t, "<r></r>", tree.ToXML())
 
 		treePos = crdt.NewTreePos(pNode.ID, textNode.ID)
-		idx, err = tree.ToIndex(treePos)
+		parent, leftSibling, err = tree.FindTreeNodesWithSplitText(treePos, helper.IssueTime(ctx))
+		assert.NoError(t, err)
+		idx, err = tree.ToIndex(parent.Value, leftSibling.Value)
 		assert.NoError(t, err)
 		assert.Equal(t, 0, idx)
 	})

--- a/pkg/document/crdt/tree_test.go
+++ b/pkg/document/crdt/tree_test.go
@@ -372,24 +372,36 @@ func TestTree(t *testing.T) {
 		_, err = tree.EditByIndex(1, 1, nil, []*crdt.TreeNode{crdt.NewTreeNode(helper.IssuePos(ctx),
 			"text", nil, "ab")}, helper.IssueTime(ctx))
 		assert.NoError(t, err)
+		_, err = tree.EditByIndex(3, 3, nil, []*crdt.TreeNode{crdt.NewTreeNode(helper.IssuePos(ctx),
+			"p", nil)}, helper.IssueTime(ctx))
+		assert.NoError(t, err)
 		_, err = tree.EditByIndex(4, 4, nil, []*crdt.TreeNode{crdt.NewTreeNode(helper.IssuePos(ctx),
+			"text", nil, "x")}, helper.IssueTime(ctx))
+		assert.NoError(t, err)
+		_, err = tree.EditByIndex(7, 7, nil, []*crdt.TreeNode{crdt.NewTreeNode(helper.IssuePos(ctx),
 			"p", nil)}, helper.IssueTime(ctx))
 		assert.NoError(t, err)
-		_, err = tree.EditByIndex(5, 5, nil, []*crdt.TreeNode{crdt.NewTreeNode(helper.IssuePos(ctx),
+		_, err = tree.EditByIndex(8, 8, nil, []*crdt.TreeNode{crdt.NewTreeNode(helper.IssuePos(ctx),
 			"p", nil)}, helper.IssueTime(ctx))
 		assert.NoError(t, err)
-		_, err = tree.EditByIndex(6, 6, nil, []*crdt.TreeNode{crdt.NewTreeNode(helper.IssuePos(ctx),
+		_, err = tree.EditByIndex(9, 9, nil, []*crdt.TreeNode{crdt.NewTreeNode(helper.IssuePos(ctx),
 			"text", nil, "cd")}, helper.IssueTime(ctx))
 		assert.NoError(t, err)
-		_, err = tree.EditByIndex(10, 10, nil, []*crdt.TreeNode{crdt.NewTreeNode(helper.IssuePos(ctx),
+		_, err = tree.EditByIndex(13, 13, nil, []*crdt.TreeNode{crdt.NewTreeNode(helper.IssuePos(ctx),
 			"p", nil)}, helper.IssueTime(ctx))
 		assert.NoError(t, err)
-		_, err = tree.EditByIndex(11, 11, nil, []*crdt.TreeNode{crdt.NewTreeNode(helper.IssuePos(ctx),
+		_, err = tree.EditByIndex(14, 14, nil, []*crdt.TreeNode{crdt.NewTreeNode(helper.IssuePos(ctx),
+			"p", nil)}, helper.IssueTime(ctx))
+		assert.NoError(t, err)
+		_, err = tree.EditByIndex(15, 15, nil, []*crdt.TreeNode{crdt.NewTreeNode(helper.IssuePos(ctx),
+			"text", nil, "y")}, helper.IssueTime(ctx))
+		assert.NoError(t, err)
+		_, err = tree.EditByIndex(17, 17, nil, []*crdt.TreeNode{crdt.NewTreeNode(helper.IssuePos(ctx),
 			"text", nil, "ef")}, helper.IssueTime(ctx))
 		assert.NoError(t, err)
-		assert.Equal(t, "<root><p>ab</p><p><p>cd</p></p><p>ef</p></root>", tree.ToXML())
+		assert.Equal(t, "<root><p>ab<p>x</p></p><p><p>cd</p></p><p><p>y</p>ef</p></root>", tree.ToXML())
 
-		_, err = tree.EditByIndex(2, 12, nil, nil, helper.IssueTime(ctx))
+		_, err = tree.EditByIndex(2, 18, nil, nil, helper.IssueTime(ctx))
 		assert.NoError(t, err)
 		assert.Equal(t, "<root><p>a</p><p>f</p></root>", tree.ToXML())
 

--- a/pkg/index/tree.go
+++ b/pkg/index/tree.go
@@ -119,27 +119,27 @@ func postorderTraversal[V Value](node *Node[V], callback func(node *Node[V], dep
 	callback(node, depth)
 }
 
-// TagContain represents whether the opening or closing tag of a element is selected.
-type TagContain int
+// TagContained represents whether the opening or closing tag of a element is selected.
+type TagContained int
 
 const (
-	// ContainsAll represents that both opening and closing tag of a element are selected.
-	ContainsAll TagContain = 1 + iota
-	// ContainsOpening represents that only the opening tag is selected.
-	ContainsOpening
-	// ContainsClosing represents that only the closing tag is selected.
-	ContainsClosing
+	// AllContained represents that both opening and closing tag of a element are selected.
+	AllContained TagContained = 1 + iota
+	// OpeningContained represents that only the opening tag is selected.
+	OpeningContained
+	// ClosingContained represents that only the closing tag is selected.
+	ClosingContained
 )
 
 // ToString returns the string of TagContain.
-func (c TagContain) ToString() string {
+func (c TagContained) ToString() string {
 	var str string
 	switch c {
-	case ContainsAll:
+	case AllContained:
 		str = "All"
-	case ContainsOpening:
+	case OpeningContained:
 		str = "Opening"
-	case ContainsClosing:
+	case ClosingContained:
 		str = "Closing"
 	}
 	return str
@@ -148,7 +148,7 @@ func (c TagContain) ToString() string {
 // nodesBetween iterates the nodes between the given range.
 // If the given range is collapsed, the callback is not called.
 // It traverses the tree with postorder traversal.
-func nodesBetween[V Value](root *Node[V], from, to int, callback func(node V, contain TagContain)) error {
+func nodesBetween[V Value](root *Node[V], from, to int, callback func(node V, contain TagContained)) error {
 	if from > to {
 		return fmt.Errorf("from cannot be greater than to %d > %d", from, to)
 	}
@@ -190,13 +190,13 @@ func nodesBetween[V Value](root *Node[V], from, to int, callback func(node V, co
 			}
 
 			if fromChild < 0 || toChild > child.Length || child.IsText() {
-				var contain TagContain
+				var contain TagContained
 				if (fromChild < 0 && toChild > child.Length) || child.IsText() {
-					contain = ContainsAll
+					contain = AllContained
 				} else if fromChild < 0 {
-					contain = ContainsOpening
+					contain = OpeningContained
 				} else {
-					contain = ContainsClosing
+					contain = ClosingContained
 				}
 				callback(child.Value, contain)
 			}
@@ -595,7 +595,7 @@ func (n *Node[V]) OffsetOfChild(node *Node[V]) int {
 }
 
 // NodesBetween returns the nodes between the given range.
-func (t *Tree[V]) NodesBetween(from int, to int, callback func(node V, contain TagContain)) error {
+func (t *Tree[V]) NodesBetween(from int, to int, callback func(node V, contain TagContained)) error {
 	return nodesBetween(t.root, from, to, callback)
 }
 

--- a/pkg/index/tree.go
+++ b/pkg/index/tree.go
@@ -148,6 +148,7 @@ func (c TagContained) ToString() string {
 // nodesBetween iterates the nodes between the given range.
 // If the given range is collapsed, the callback is not called.
 // It traverses the tree with postorder traversal.
+// NOTE(sejongk): Nodes should not be removed in callback, because it leads wrong behaviors.
 func nodesBetween[V Value](root *Node[V], from, to int, callback func(node V, contain TagContained)) error {
 	if from > to {
 		return fmt.Errorf("from cannot be greater than to %d > %d", from, to)
@@ -176,9 +177,6 @@ func nodesBetween[V Value](root *Node[V], from, to int, callback func(node V, co
 			if child.IsText() {
 				toChild = to - pos
 			}
-			// pos can be affected by children traversal and callback call.
-			// so, update pos before these to keep it safe.
-			pos += child.PaddedLength()
 
 			if err := nodesBetween(
 				child,
@@ -200,9 +198,8 @@ func nodesBetween[V Value](root *Node[V], from, to int, callback func(node V, co
 				}
 				callback(child.Value, contain)
 			}
-		} else {
-			pos += child.PaddedLength()
 		}
+		pos += child.PaddedLength()
 	}
 
 	return nil

--- a/pkg/index/tree.go
+++ b/pkg/index/tree.go
@@ -119,14 +119,19 @@ func postorderTraversal[V Value](node *Node[V], callback func(node *Node[V], dep
 	callback(node, depth)
 }
 
+// TagContain represents whether the opening or closing tag of a element is selected.
 type TagContain int
 
 const (
+	// ContainsAll represents that both opening and closing tag of a element are selected.
 	ContainsAll TagContain = 1 + iota
+	// ContainsOpening represents that only the opening tag is selected.
 	ContainsOpening
+	// ContainsClosing represents that only the closing tag is selected.
 	ContainsClosing
 )
 
+// ToString returns the string of TagContain.
 func (c TagContain) ToString() string {
 	var str string
 	switch c {

--- a/pkg/index/tree_test.go
+++ b/pkg/index/tree_test.go
@@ -169,7 +169,8 @@ func TestIndexTree(t *testing.T) {
 		//        0   1 2 3    4   5 6 7 8    9   10 11 12    13
 		// `<root> <p> a b </p> <p> c d e </p> <p>  f  g  </p> </root>`
 
-		helper.NodesBetweenEqual(t, tree, 2, 11, []string{"text.b:All", "p:Closing", "text.cde:All", "p:All", "text.fg:All", "p:Opening"})
+		helper.NodesBetweenEqual(t, tree, 2, 11, []string{"text.b:All", "p:Closing",
+			"text.cde:All", "p:All", "text.fg:All", "p:Opening"})
 		helper.NodesBetweenEqual(t, tree, 2, 6, []string{"text.b:All", "p:Closing", "text.cde:All", "p:Opening"})
 		helper.NodesBetweenEqual(t, tree, 0, 1, []string{"p:Opening"})
 		helper.NodesBetweenEqual(t, tree, 3, 4, []string{"p:Closing"})

--- a/pkg/index/tree_test.go
+++ b/pkg/index/tree_test.go
@@ -166,12 +166,14 @@ func TestIndexTree(t *testing.T) {
 				{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "fg"}}},
 			},
 		})
+		//        0   1 2 3    4   5 6 7 8    9   10 11 12    13
+		// `<root> <p> a b </p> <p> c d e </p> <p>  f  g  </p> </root>`
 
-		helper.NodesBetweenEqual(t, tree, 2, 11, []string{"text.b", "p", "text.cde", "p", "text.fg", "p"})
-		helper.NodesBetweenEqual(t, tree, 2, 6, []string{"text.b", "p", "text.cde", "p"})
-		helper.NodesBetweenEqual(t, tree, 0, 1, []string{"p"})
-		helper.NodesBetweenEqual(t, tree, 3, 4, []string{"p"})
-		helper.NodesBetweenEqual(t, tree, 3, 5, []string{"p", "p"})
+		helper.NodesBetweenEqual(t, tree, 2, 11, []string{"text.b:All", "p:Closing", "text.cde:All", "p:All", "text.fg:All", "p:Opening"})
+		helper.NodesBetweenEqual(t, tree, 2, 6, []string{"text.b:All", "p:Closing", "text.cde:All", "p:Opening"})
+		helper.NodesBetweenEqual(t, tree, 0, 1, []string{"p:Opening"})
+		helper.NodesBetweenEqual(t, tree, 3, 4, []string{"p:Closing"})
+		helper.NodesBetweenEqual(t, tree, 3, 5, []string{"p:Closing", "p:Opening"})
 	})
 
 	t.Run("find index of the given node test", func(t *testing.T) {
@@ -232,8 +234,6 @@ func TestIndexTree(t *testing.T) {
 	})
 
 	t.Run("find treePos from given path test", func(t *testing.T) {
-		t.Skip("TODO(hackerwins): We need to fix this test")
-
 		//       0   1 2 3    4   5 6 7 8    9   10 11 12   13
 		// <root> <p> a b </p> <p> c d e </p> <p>  f  g  </p>  </root>
 		tree := helper.BuildIndexTree(&json.TreeNode{
@@ -256,83 +256,68 @@ func TestIndexTree(t *testing.T) {
 
 		pos, err = tree.PathToTreePos([]int{0, 0})
 		assert.NoError(t, err)
-		assert.Equal(t, "p", helper.ToDiagnostic(pos.Node.Value))
-		assert.Equal(t, 0, pos.Offset)
-
-		pos, err = tree.PathToTreePos([]int{0, 0, 0})
-		assert.NoError(t, err)
 		assert.Equal(t, "text.a", helper.ToDiagnostic(pos.Node.Value))
 		assert.Equal(t, 0, pos.Offset)
 
-		pos, err = tree.PathToTreePos([]int{0, 0, 1})
+		pos, err = tree.PathToTreePos([]int{0, 1})
 		assert.NoError(t, err)
 		assert.Equal(t, "text.a", helper.ToDiagnostic(pos.Node.Value))
 		assert.Equal(t, 1, pos.Offset)
 
-		pos, err = tree.PathToTreePos([]int{0, 1, 0})
-		assert.NoError(t, err)
-		assert.Equal(t, "text.b", helper.ToDiagnostic(pos.Node.Value))
-		assert.Equal(t, 0, pos.Offset)
-
-		pos, err = tree.PathToTreePos([]int{0, 1, 1})
+		pos, err = tree.PathToTreePos([]int{0, 2})
 		assert.NoError(t, err)
 		assert.Equal(t, "text.b", helper.ToDiagnostic(pos.Node.Value))
 		assert.Equal(t, 1, pos.Offset)
 
 		pos, err = tree.PathToTreePos([]int{1})
 		assert.NoError(t, err)
-		assert.Equal(t, "p", helper.ToDiagnostic(pos.Node.Value))
-		assert.Equal(t, 0, pos.Offset)
+		assert.Equal(t, "root", helper.ToDiagnostic(pos.Node.Value))
+		assert.Equal(t, 1, pos.Offset)
 
 		pos, err = tree.PathToTreePos([]int{1, 0})
-		assert.NoError(t, err)
-		assert.Equal(t, "p", helper.ToDiagnostic(pos.Node.Value))
-		assert.Equal(t, 0, pos.Offset)
-
-		pos, err = tree.PathToTreePos([]int{1, 0, 0})
 		assert.NoError(t, err)
 		assert.Equal(t, "text.cde", helper.ToDiagnostic(pos.Node.Value))
 		assert.Equal(t, 0, pos.Offset)
 
-		pos, err = tree.PathToTreePos([]int{1, 0, 1})
+		pos, err = tree.PathToTreePos([]int{1, 1})
 		assert.NoError(t, err)
 		assert.Equal(t, "text.cde", helper.ToDiagnostic(pos.Node.Value))
 		assert.Equal(t, 1, pos.Offset)
 
-		pos, err = tree.PathToTreePos([]int{1, 0, 2})
+		pos, err = tree.PathToTreePos([]int{1, 2})
 		assert.NoError(t, err)
 		assert.Equal(t, "text.cde", helper.ToDiagnostic(pos.Node.Value))
 		assert.Equal(t, 2, pos.Offset)
 
-		pos, err = tree.PathToTreePos([]int{1, 0, 3})
+		pos, err = tree.PathToTreePos([]int{1, 3})
 		assert.NoError(t, err)
 		assert.Equal(t, "text.cde", helper.ToDiagnostic(pos.Node.Value))
 		assert.Equal(t, 3, pos.Offset)
 
 		pos, err = tree.PathToTreePos([]int{2})
 		assert.NoError(t, err)
-		assert.Equal(t, "p", helper.ToDiagnostic(pos.Node.Value))
-		assert.Equal(t, 1, pos.Offset)
+		assert.Equal(t, "root", helper.ToDiagnostic(pos.Node.Value))
+		assert.Equal(t, 2, pos.Offset)
 
-		pos, err = tree.PathToTreePos([]int{2, 0, 0})
+		pos, err = tree.PathToTreePos([]int{2, 0})
 		assert.NoError(t, err)
 		assert.Equal(t, "text.fg", helper.ToDiagnostic(pos.Node.Value))
 		assert.Equal(t, 0, pos.Offset)
 
-		pos, err = tree.PathToTreePos([]int{2, 0, 1})
+		pos, err = tree.PathToTreePos([]int{2, 1})
 		assert.NoError(t, err)
 		assert.Equal(t, "text.fg", helper.ToDiagnostic(pos.Node.Value))
 		assert.Equal(t, 1, pos.Offset)
 
-		pos, err = tree.PathToTreePos([]int{2, 0, 2})
+		pos, err = tree.PathToTreePos([]int{2, 2})
 		assert.NoError(t, err)
 		assert.Equal(t, "text.fg", helper.ToDiagnostic(pos.Node.Value))
 		assert.Equal(t, 2, pos.Offset)
 
 		pos, err = tree.PathToTreePos([]int{3})
 		assert.NoError(t, err)
-		assert.Equal(t, "p", helper.ToDiagnostic(pos.Node.Value))
-		assert.Equal(t, 2, pos.Offset)
+		assert.Equal(t, "root", helper.ToDiagnostic(pos.Node.Value))
+		assert.Equal(t, 3, pos.Offset)
 	})
 
 	t.Run("find path from given treePos test", func(t *testing.T) {

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -137,14 +137,16 @@ func IssueTime(change *change.Context) *time.Ticket {
 // indexes.
 func NodesBetweenEqual(t assert.TestingT, tree *index.Tree[*crdt.TreeNode], from, to int, expected []string) bool {
 	var nodes []*crdt.TreeNode
-	err := tree.NodesBetween(from, to, func(node *crdt.TreeNode) {
+	var contains []index.TagContain
+	err := tree.NodesBetween(from, to, func(node *crdt.TreeNode, contain index.TagContain) {
 		nodes = append(nodes, node)
+		contains = append(contains, contain)
 	})
 	assert.NoError(t, err)
 
 	var actual []string
-	for _, node := range nodes {
-		actual = append(actual, ToDiagnostic(node))
+	for i := 0; i < len(nodes); i++ {
+		actual = append(actual, fmt.Sprintf("%s:%s", ToDiagnostic(nodes[i]), contains[i].ToString()))
 	}
 	assert.Equal(t, expected, actual)
 

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -137,8 +137,8 @@ func IssueTime(change *change.Context) *time.Ticket {
 // indexes.
 func NodesBetweenEqual(t assert.TestingT, tree *index.Tree[*crdt.TreeNode], from, to int, expected []string) bool {
 	var nodes []*crdt.TreeNode
-	var contains []index.TagContain
-	err := tree.NodesBetween(from, to, func(node *crdt.TreeNode, contain index.TagContain) {
+	var contains []index.TagContained
+	err := tree.NodesBetween(from, to, func(node *crdt.TreeNode, contain index.TagContained) {
 		nodes = append(nodes, node)
 		contains = append(contains, contain)
 	})

--- a/test/integration/tree_test.go
+++ b/test/integration/tree_test.go
@@ -416,8 +416,6 @@ func TestTree(t *testing.T) {
 	})
 
 	t.Run("edit its content with attributes test", func(t *testing.T) {
-		t.Skip("TODO(hackerwins): We need to fix this test.")
-
 		doc := document.New(helper.TestDocKey(t))
 		err := doc.Update(func(root *json.Object, p *presence.Presence) error {
 			root.SetNewTree("t", &json.TreeNode{Type: "doc"})
@@ -438,12 +436,16 @@ func TestTree(t *testing.T) {
 			assert.Equal(t, `<doc><p bold="true">ab</p><p italic="true">cd</p></doc>`, root.GetTree("t").ToXML())
 
 			root.GetTree("t").Edit(2, 6, nil)
-			assert.Equal(t, `<doc><p italic="true">ad</p></doc>`, root.GetTree("t").ToXML())
+			assert.Equal(t, `<doc><p bold="true">a</p><p italic="true">d</p></doc>`, root.GetTree("t").ToXML())
+			// TODO(sejongk): Use the below assertion after implementing Tree.Move.
+			// assert.Equal(t, `<doc><p italic="true">ad</p></doc>`, root.GetTree("t").ToXML())
 
 			return nil
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, `<doc><p italic="true">ad</p></doc>`, doc.Root().GetTree("t").ToXML())
+		assert.Equal(t, `<doc><p bold="true">a</p><p italic="true">d</p></doc>`, doc.Root().GetTree("t").ToXML())
+		// TODO(sejongk): Use the below assertion after implementing Tree.Move.
+		// assert.Equal(t, `<doc><p italic="true">ad</p></doc>`, doc.Root().GetTree("t").ToXML())
 	})
 
 	t.Run("sync with other clients test", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Support the below features by introducing tree traversal to Tree.Edit.
- Select multiple nodes in a multi-level range.
- Select a part of nodes (ex. selecting only the closing tag of the node).

It also removes every skip in test cases for Tree.
However, after introducing the later features like Tree.Move, those test cases should be changed to apply new features.

**Which issue(s) this PR fixes**:
Fixes #610 

**Special notes for your reviewer**:
I used the index-based tree traversal, because the implementation is more concise and clear than the node-based traversal.
This method requires converting a crdt.TreePos into a index in a user's tree for tree traversal.
If there is any room for performance degradation because of this conversion, we can replace this with the node-based traversal.

**Does this PR introduce a user-facing change?**:

```release-note

```

**Additional documentation**:
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
