### PR TITLE
Revise Prometheus PVC Spec Syntax Error

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -7,8 +7,9 @@
 - Update `YORKIE_VERSION` in [Makefile](https://github.com/yorkie-team/yorkie/blob/main/Makefile#L1).
 - Update `version` and `appVersion` in [yorkie-cluster Helm Chart](https://github.com/yorkie-team/yorkie/blob/main/build/charts/yorkie-cluster/Chart.yaml#L16-L17).
 - If `yorkie-monitoring` or `yorkie-argocd` Helm Chart have changes, you also need to update `version` and `appVersion` for each chart.
-  - [yorkie-monitoring Helm Chart](https://github.com/yorkie-team/yorkie/blob/main/build/charts/yorkie-monitoring/Chart.yaml#L16-L17) 
-  - [yorkie-argocd Helm Chart](https://github.com/yorkie-team/yorkie/blob/main/build/charts/yorkie-argocd/Chart.yaml#L16-L17) 
+  - [yorkie-monitoring Helm Chart](https://github.com/yorkie-team/yorkie/blob/main/build/charts/yorkie-monitoring/Chart.yaml#L16-L17)
+  - [yorkie-argocd Helm Chart](https://github.com/yorkie-team/yorkie/blob/main/build/charts/yorkie-argocd/Chart.yaml#L16-L17)
+- Also, you need to update `helmChartTargetRevision` in `yorkie-argocd` Helm Chart's [values.yaml](https://github.com/yorkie-team/yorkie/blob/main/build/charts/yorkie-argocd/values.yaml#L13) 
 
 ### 2. Write changelog of this version in [CHANGELOG.md](https://github.com/yorkie-team/yorkie/blob/main/CHANGELOG.md).
 

--- a/build/charts/yorkie-monitoring/Chart.yaml
+++ b/build/charts/yorkie-monitoring/Chart.yaml
@@ -13,8 +13,8 @@ maintainers:
 
 sources:
   - https://github.com/yorkie-team/yorkie
-version: 0.4.1
-appVersion: "0.4.1"
+version: 0.4.7
+appVersion: "0.4.7"
 kubeVersion: ">=1.24.0-0"
 
 keywords:

--- a/build/charts/yorkie-monitoring/Chart.yaml
+++ b/build/charts/yorkie-monitoring/Chart.yaml
@@ -13,8 +13,8 @@ maintainers:
 
 sources:
   - https://github.com/yorkie-team/yorkie
-version: 0.4.0
-appVersion: "0.4.0"
+version: 0.4.1
+appVersion: "0.4.1"
 kubeVersion: ">=1.24.0-0"
 
 keywords:

--- a/build/charts/yorkie-monitoring/values.yaml
+++ b/build/charts/yorkie-monitoring/values.yaml
@@ -164,18 +164,15 @@ kube-prometheus-stack:
 
       # Prometheus StorageSpec for persistent data
       # ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/storage.md
-      #
-      storageSpec: {}
-      # Using PersistentVolumeClaim
-      #
-      volumeClaimTemplate:
-        spec:
-          # storageClassName: gluster
-          accessModes: ["ReadWriteOnce"]
-          resources:
-            requests:
-              storage: 1Gi
-        selector: {}
+      storageSpec:
+        # Using PersistentVolumeClaim
+        volumeClaimTemplate:
+          spec:
+            # storageClassName: gluster
+            accessModes: ["ReadWriteOnce"]
+            resources:
+              requests:
+                storage: 1Gi
   
   prometheus-node-exporter:
     # fullnameOverride should be {{monitoring.name}} + "prometheus-node-exporter"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Revise Prometheus PVC spec syntax error.

I found out that the `yorkie-monitoring` helm chart was not storing prometheus metrics, which leads to data loss of metrics every time a node goes down (e.g., EC2 spot instance goes down).

This was because the helm chart syntax of `volumeClaimTemplate` was wrong (it was not linked to `storageSpec`). Therefore, I corrected the syntax to make Prometheus successfully claim PVC.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
