### PR TITLE
Rename StructureAsString to toTestString

### DIFF
--- a/api/converter/converter_test.go
+++ b/api/converter/converter_test.go
@@ -221,7 +221,7 @@ func TestConverter(t *testing.T) {
 		pbNodes := converter.ToTreeNodes(root)
 		clone, err := converter.FromTreeNodes(pbNodes)
 		assert.NoError(t, err)
-		assert.Equal(t, crdt.ToStructure(root), crdt.ToStructure(clone))
+		assert.Equal(t, crdt.ToTreeNodeForTest(root), crdt.ToTreeNodeForTest(clone))
 		assert.Equal(t, crdt.ToXML(root), crdt.ToXML(clone))
 	})
 

--- a/pkg/document/crdt/array.go
+++ b/pkg/document/crdt/array.go
@@ -95,10 +95,10 @@ func (a *Array) Marshal() string {
 	return a.elements.Marshal()
 }
 
-// StructureAsString returns a String containing the metadata of the elements
+// ToTestString returns a String containing the metadata of the elements
 // for debugging purpose.
-func (a *Array) StructureAsString() string {
-	return a.elements.StructureAsString()
+func (a *Array) ToTestString() string {
+	return a.elements.ToTestString()
 }
 
 // DeepCopy copies itself deeply.

--- a/pkg/document/crdt/rga_tree_list.go
+++ b/pkg/document/crdt/rga_tree_list.go
@@ -227,10 +227,10 @@ func (a *RGATreeList) Len() int {
 	return a.nodeMapByIndex.Len()
 }
 
-// StructureAsString returns a String containing the metadata of the node id
+// ToTestString returns a String containing the metadata of the node id
 // for debugging purpose.
-func (a *RGATreeList) StructureAsString() string {
-	return a.nodeMapByIndex.StructureAsString()
+func (a *RGATreeList) ToTestString() string {
+	return a.nodeMapByIndex.ToTestString()
 }
 
 // Delete deletes the node of the given index.

--- a/pkg/document/crdt/rga_tree_split.go
+++ b/pkg/document/crdt/rga_tree_split.go
@@ -21,7 +21,7 @@ type RGATreeSplitValue interface {
 	DeepCopy() RGATreeSplitValue
 	String() string
 	Marshal() string
-	structureAsString() string
+	toTestString() string
 }
 
 // RGATreeSplitNodeID is an ID of RGATreeSplitNode.
@@ -85,10 +85,10 @@ func (id *RGATreeSplitNodeID) Split(offset int) *RGATreeSplitNodeID {
 	return NewRGATreeSplitNodeID(id.createdAt, id.offset+offset)
 }
 
-// StructureAsString returns a String containing the metadata of the node id
+// ToTestString returns a String containing the metadata of the node id
 // for debugging purpose.
-func (id *RGATreeSplitNodeID) StructureAsString() string {
-	return fmt.Sprintf("%s:%d", id.createdAt.StructureAsString(), id.offset)
+func (id *RGATreeSplitNodeID) ToTestString() string {
+	return fmt.Sprintf("%s:%d", id.createdAt.ToTestString(), id.offset)
 }
 
 func (id *RGATreeSplitNodeID) hasSameCreatedAt(other *RGATreeSplitNodeID) bool {
@@ -120,10 +120,10 @@ func (pos *RGATreeSplitNodePos) getAbsoluteID() *RGATreeSplitNodeID {
 	return NewRGATreeSplitNodeID(pos.id.createdAt, pos.id.offset+pos.relativeOffset)
 }
 
-// StructureAsString returns a String containing the metadata of the position
+// ToTestString returns a String containing the metadata of the position
 // for debugging purpose.
-func (pos *RGATreeSplitNodePos) StructureAsString() string {
-	return fmt.Sprintf("%s:%d", pos.id.StructureAsString(), pos.relativeOffset)
+func (pos *RGATreeSplitNodePos) ToTestString() string {
+	return fmt.Sprintf("%s:%d", pos.id.ToTestString(), pos.relativeOffset)
 }
 
 // ID returns the ID of this RGATreeSplitNodePos.
@@ -245,10 +245,10 @@ func (s *RGATreeSplitNode[V]) createdAt() *time.Ticket {
 	return s.id.createdAt
 }
 
-// structureAsString returns a String containing the metadata of the node
+// toTestString returns a String containing the metadata of the node
 // for debugging purpose.
-func (s *RGATreeSplitNode[V]) structureAsString() string {
-	return fmt.Sprintf("%s %s", s.id.StructureAsString(), s.value.structureAsString())
+func (s *RGATreeSplitNode[V]) toTestString() string {
+	return fmt.Sprintf("%s %s", s.id.ToTestString(), s.value.toTestString())
 }
 
 // Remove removes this node if it created before the time of deletion are
@@ -357,7 +357,7 @@ func (s *RGATreeSplit[V]) findNodeWithSplit(
 func (s *RGATreeSplit[V]) findFloorNodePreferToLeft(id *RGATreeSplitNodeID) (*RGATreeSplitNode[V], error) {
 	node := s.findFloorNode(id)
 	if node == nil {
-		return nil, fmt.Errorf("the node of the given id should be found: " + s.StructureAsString())
+		return nil, fmt.Errorf("the node of the given id should be found: " + s.ToTestString())
 	}
 
 	if id.offset > 0 && node.id.offset == id.offset {
@@ -373,7 +373,7 @@ func (s *RGATreeSplit[V]) findFloorNodePreferToLeft(id *RGATreeSplitNodeID) (*RG
 
 func (s *RGATreeSplit[V]) splitNode(node *RGATreeSplitNode[V], offset int) (*RGATreeSplitNode[V], error) {
 	if offset > node.contentLen() {
-		return nil, fmt.Errorf("offset should be less than or equal to length: " + s.StructureAsString())
+		return nil, fmt.Errorf("offset should be less than or equal to length: " + s.ToTestString())
 	}
 
 	if offset == 0 {
@@ -599,17 +599,17 @@ func (s *RGATreeSplit[V]) nodes() []*RGATreeSplitNode[V] {
 	return nodes
 }
 
-// StructureAsString returns a String containing the metadata of the nodes
+// ToTestString returns a String containing the metadata of the nodes
 // for debugging purpose.
-func (s *RGATreeSplit[V]) StructureAsString() string {
+func (s *RGATreeSplit[V]) ToTestString() string {
 	builder := strings.Builder{}
 
 	node := s.initialHead
 	for node != nil {
 		if node.removedAt != nil {
-			builder.WriteString(fmt.Sprintf("{%s}", node.structureAsString()))
+			builder.WriteString(fmt.Sprintf("{%s}", node.toTestString()))
 		} else {
-			builder.WriteString(fmt.Sprintf("[%s]", node.structureAsString()))
+			builder.WriteString(fmt.Sprintf("[%s]", node.toTestString()))
 		}
 		node = node.next
 	}

--- a/pkg/document/crdt/text.go
+++ b/pkg/document/crdt/text.go
@@ -74,9 +74,9 @@ func (t *TextValue) Marshal() string {
 	)
 }
 
-// structureAsString returns a String containing the metadata of this value
+// toTestString returns a String containing the metadata of this value
 // for debugging purpose.
-func (t *TextValue) structureAsString() string {
+func (t *TextValue) toTestString() string {
 	return fmt.Sprintf(
 		`%s "%s"`,
 		t.attrs.Marshal(),
@@ -309,10 +309,10 @@ func (t *Text) Nodes() []*RGATreeSplitNode[*TextValue] {
 	return t.rgaTreeSplit.nodes()
 }
 
-// StructureAsString returns a String containing the metadata of the text
+// ToTestString returns a String containing the metadata of the text
 // for debugging purpose.
-func (t *Text) StructureAsString() string {
-	return t.rgaTreeSplit.StructureAsString()
+func (t *Text) ToTestString() string {
+	return t.rgaTreeSplit.ToTestString()
 }
 
 // CheckWeight returns false when there is an incorrect weight node.

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -124,7 +124,7 @@ func NewTreeNode(id *TreeNodeID, nodeType string, attributes *RHT, value ...stri
 
 // toIDString returns a string that can be used as an ID for this TreeNodeID.
 func (t *TreeNodeID) toIDString() string {
-	return t.CreatedAt.StructureAsString() + ":" + strconv.Itoa(t.Offset)
+	return t.CreatedAt.ToTestString() + ":" + strconv.Itoa(t.Offset)
 }
 
 // Compare compares the given two CRDTTreePos.
@@ -895,9 +895,9 @@ func (t *Tree) toTreeNodes(pos *TreePos) (*TreeNode, *TreeNode) {
 	return parentNode, leftSiblingNode
 }
 
-// Structure returns the structure of this tree.
-func (t *Tree) Structure() TreeNodeForTest {
-	return ToStructure(t.Root())
+// ToTreeNodeForTest returns the JSON of this tree for debugging.
+func (t *Tree) ToTreeNodeForTest() TreeNodeForTest {
+	return ToTreeNodeForTest(t.Root())
 }
 
 // PathToPos returns the position of the given path
@@ -915,8 +915,8 @@ func (t *Tree) PathToPos(path []int) (*TreePos, error) {
 	return pos, nil
 }
 
-// ToStructure returns the JSON of this tree for debugging.
-func ToStructure(node *TreeNode) TreeNodeForTest {
+// ToTreeNodeForTest returns the JSON of this tree for debugging.
+func ToTreeNodeForTest(node *TreeNode) TreeNodeForTest {
 	if node.IsText() {
 		currentNode := node
 		return TreeNodeForTest{
@@ -929,7 +929,7 @@ func ToStructure(node *TreeNode) TreeNodeForTest {
 
 	var children []TreeNodeForTest
 	for _, child := range node.IndexTreeNode.Children() {
-		children = append(children, ToStructure(child.Value))
+		children = append(children, ToTreeNodeForTest(child.Value))
 	}
 
 	return TreeNodeForTest{

--- a/pkg/document/crdt/tree_test.go
+++ b/pkg/document/crdt/tree_test.go
@@ -170,7 +170,7 @@ func TestTree(t *testing.T) {
 			},
 			Size:      15,
 			IsRemoved: false,
-		}, tree.Structure())
+		}, tree.ToTreeNodeForTest())
 
 		//       0   1 2 3 4 5 6 7 8    9   10 11 12 13 14 15    16
 		// <root> <p> h e l l o ~ ! </p> <p>  w  o  r  l  d  </p>  </root>
@@ -205,10 +205,10 @@ func TestTree(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "<root><p>ab</p><p>cd</p></root>", tree.ToXML())
 
-		structure := tree.Structure()
-		assert.Equal(t, 8, structure.Size)
-		assert.Equal(t, 2, structure.Children[0].Size)
-		assert.Equal(t, 2, structure.Children[0].Children[0].Size)
+		node := tree.ToTreeNodeForTest()
+		assert.Equal(t, 8, node.Size)
+		assert.Equal(t, 2, node.Children[0].Size)
+		assert.Equal(t, 2, node.Children[0].Children[0].Size)
 
 		// 02. Delete b from the first paragraph.
 		// 	     0   1 2    3   4 5 6    7
@@ -217,10 +217,10 @@ func TestTree(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "<root><p>a</p><p>cd</p></root>", tree.ToXML())
 
-		structure = tree.Structure()
-		assert.Equal(t, 7, structure.Size)
-		assert.Equal(t, 1, structure.Children[0].Size)
-		assert.Equal(t, 1, structure.Children[0].Children[0].Size)
+		node = tree.ToTreeNodeForTest()
+		assert.Equal(t, 7, node.Size)
+		assert.Equal(t, 1, node.Children[0].Size)
+		assert.Equal(t, 1, node.Children[0].Children[0].Size)
 	})
 
 	t.Run("delete nodes between element nodes test", func(t *testing.T) {
@@ -254,11 +254,11 @@ func TestTree(t *testing.T) {
 		// TODO(sejongk): Use the below assertions after implementing Tree.Move.
 		// assert.Equal(t, "<root><p>ad</p></root>", tree.ToXML())
 
-		// structure := tree.Structure()
-		// assert.Equal(t, 4, structure.Size)
-		// assert.Equal(t, 2, structure.Children[0].Size)
-		// assert.Equal(t, 1, structure.Children[0].Children[0].Size)
-		// assert.Equal(t, 1, structure.Children[0].Children[1].Size)
+		// node := tree.ToTreeNodeForTest()
+		// assert.Equal(t, 4, node.Size)
+		// assert.Equal(t, 2, node.Children[0].Size)
+		// assert.Equal(t, 1, node.Children[0].Children[0].Size)
+		// assert.Equal(t, 1, node.Children[0].Children[1].Size)
 
 		// // 03. insert a new text node at the start of the first paragraph.
 		// _, err = tree.EditByIndex(1, 1, nil, []*crdt.TreeNode{crdt.NewTreeNode(helper.IssuePos(ctx),

--- a/pkg/document/document_test.go
+++ b/pkg/document/document_test.go
@@ -130,22 +130,22 @@ func TestDocument(t *testing.T) {
 			root.SetNewArray("k1").AddInteger(1).AddInteger(2).AddInteger(3)
 			assert.Equal(t, 3, root.GetArray("k1").Len())
 			assert.Equal(t, `{"k1":[1,2,3]}`, root.Marshal())
-			assert.Equal(t, "[0,0]0[1,1]1[2,1]2[3,1]3", root.GetArray("k1").StructureAsString())
+			assert.Equal(t, "[0,0]0[1,1]1[2,1]2[3,1]3", root.GetArray("k1").ToTestString())
 
 			root.GetArray("k1").Delete(1)
 			assert.Equal(t, `{"k1":[1,3]}`, root.Marshal())
 			assert.Equal(t, 2, root.GetArray("k1").Len())
-			assert.Equal(t, "[0,0]0[1,1]1[2,0]2[1,1]3", root.GetArray("k1").StructureAsString())
+			assert.Equal(t, "[0,0]0[1,1]1[2,0]2[1,1]3", root.GetArray("k1").ToTestString())
 
 			root.GetArray("k1").InsertIntegerAfter(0, 2)
 			assert.Equal(t, `{"k1":[1,2,3]}`, root.Marshal())
 			assert.Equal(t, 3, root.GetArray("k1").Len())
-			assert.Equal(t, "[0,0]0[1,1]1[3,1]2[1,0]2[1,1]3", root.GetArray("k1").StructureAsString())
+			assert.Equal(t, "[0,0]0[1,1]1[3,1]2[1,0]2[1,1]3", root.GetArray("k1").ToTestString())
 
 			root.GetArray("k1").InsertIntegerAfter(2, 4)
 			assert.Equal(t, `{"k1":[1,2,3,4]}`, root.Marshal())
 			assert.Equal(t, 4, root.GetArray("k1").Len())
-			assert.Equal(t, "[0,0]0[1,1]1[2,1]2[2,0]2[3,1]3[4,1]4", root.GetArray("k1").StructureAsString())
+			assert.Equal(t, "[0,0]0[1,1]1[2,1]2[2,0]2[3,1]3[4,1]4", root.GetArray("k1").ToTestString())
 
 			for i := 0; i < root.GetArray("k1").Len(); i++ {
 				assert.Equal(
@@ -216,23 +216,23 @@ func TestDocument(t *testing.T) {
 			text := root.GetText("k1")
 			assert.Equal(t,
 				`[0:0:00:0 {} ""][1:2:00:0 {} "A"][1:3:00:0 {} "12"]{1:2:00:1 {} "BC"}[1:2:00:3 {} "D"]`,
-				text.StructureAsString(),
+				text.ToTestString(),
 			)
 
 			from, _ := text.CreateRange(0, 0)
-			assert.Equal(t, "0:0:00:0:0", from.StructureAsString())
+			assert.Equal(t, "0:0:00:0:0", from.ToTestString())
 
 			from, _ = text.CreateRange(1, 1)
-			assert.Equal(t, "1:2:00:0:1", from.StructureAsString())
+			assert.Equal(t, "1:2:00:0:1", from.ToTestString())
 
 			from, _ = text.CreateRange(2, 2)
-			assert.Equal(t, "1:3:00:0:1", from.StructureAsString())
+			assert.Equal(t, "1:3:00:0:1", from.ToTestString())
 
 			from, _ = text.CreateRange(3, 3)
-			assert.Equal(t, "1:3:00:0:2", from.StructureAsString())
+			assert.Equal(t, "1:3:00:0:2", from.ToTestString())
 
 			from, _ = text.CreateRange(4, 4)
-			assert.Equal(t, "1:2:00:3:1", from.StructureAsString())
+			assert.Equal(t, "1:2:00:3:1", from.ToTestString())
 			return nil
 		})
 		assert.NoError(t, err)
@@ -265,7 +265,7 @@ func TestDocument(t *testing.T) {
 			assert.Equal(
 				t,
 				`[0:0:00:0 {} ""][1:2:00:0 {} "Hello world"]`,
-				text.StructureAsString(),
+				text.ToTestString(),
 			)
 			return nil
 		})
@@ -277,7 +277,7 @@ func TestDocument(t *testing.T) {
 			text.Style(0, 5, map[string]string{"b": "1"})
 			assert.Equal(t,
 				`[0:0:00:0 {} ""][1:2:00:0 {"b":"1"} "Hello"][1:2:00:5 {} " world"]`,
-				text.StructureAsString(),
+				text.ToTestString(),
 			)
 			return nil
 		})
@@ -294,14 +294,14 @@ func TestDocument(t *testing.T) {
 			assert.Equal(
 				t,
 				`[0:0:00:0 {} ""][1:2:00:0 {"b":"1"} "Hello"][1:2:00:5 {} " world"]`,
-				text.StructureAsString(),
+				text.ToTestString(),
 			)
 
 			text.Style(3, 5, map[string]string{"i": "1"})
 			assert.Equal(
 				t,
 				`[0:0:00:0 {} ""][1:2:00:0 {"b":"1"} "Hel"][1:2:00:3 {"b":"1","i":"1"} "lo"][1:2:00:5 {} " world"]`,
-				text.StructureAsString(),
+				text.ToTestString(),
 			)
 			return nil
 		})
@@ -319,7 +319,7 @@ func TestDocument(t *testing.T) {
 				t,
 				`[0:0:00:0 {} ""][1:2:00:0 {"b":"1"} "Hel"][1:2:00:3 {"b":"1","i":"1"} "lo"]`+
 					`[4:1:00:0 {} " Yorkie"]{1:2:00:5 {} " world"}`,
-				text.StructureAsString(),
+				text.ToTestString(),
 			)
 			return nil
 		})
@@ -337,7 +337,7 @@ func TestDocument(t *testing.T) {
 				t,
 				`[0:0:00:0 {} ""][1:2:00:0 {"b":"1"} "Hel"][1:2:00:3 {"b":"1","i":"1"} "lo"]`+
 					`[5:1:00:0 {"list":"true"} "\n"][4:1:00:0 {} " Yorkie"]{1:2:00:5 {} " world"}`,
-				text.StructureAsString(),
+				text.ToTestString(),
 			)
 			return nil
 		})
@@ -483,7 +483,7 @@ func TestDocument(t *testing.T) {
 		assert.Equal(
 			t,
 			`[0:0:00:0 {} ""][1:3:00:0 {} "12"]{1:2:00:0 {} "AB"}[1:2:00:2 {} "CD"]`,
-			doc.Root().GetText("text").StructureAsString(),
+			doc.Root().GetText("text").ToTestString(),
 		)
 
 		assert.Equal(t, 1, doc.GarbageLen())
@@ -492,7 +492,7 @@ func TestDocument(t *testing.T) {
 		assert.Equal(
 			t,
 			`[0:0:00:0 {} ""][1:3:00:0 {} "12"][1:2:00:2 {} "CD"]`,
-			doc.Root().GetText("text").StructureAsString(),
+			doc.Root().GetText("text").ToTestString(),
 		)
 
 		err = doc.Update(func(root *json.Object, p *presence.Presence) error {
@@ -503,7 +503,7 @@ func TestDocument(t *testing.T) {
 		assert.Equal(
 			t,
 			`[0:0:00:0 {} ""][1:3:00:0 {} "12"]{1:2:00:2 {} "CD"}`,
-			doc.Root().GetText("text").StructureAsString(),
+			doc.Root().GetText("text").ToTestString(),
 		)
 	})
 

--- a/pkg/document/time/ticket.go
+++ b/pkg/document/time/ticket.go
@@ -71,9 +71,9 @@ func NewTicket(
 	}
 }
 
-// StructureAsString returns a string containing the metadata of the ticket
+// ToTestString returns a string containing the metadata of the ticket
 // for debugging purpose.
-func (t *Ticket) StructureAsString() string {
+func (t *Ticket) ToTestString() string {
 	return fmt.Sprintf(
 		"%d:%d:%s", t.lamport, t.delimiter, t.actorID.String()[22:24],
 	)

--- a/pkg/document/time/ticket_test.go
+++ b/pkg/document/time/ticket_test.go
@@ -31,7 +31,7 @@ func TestTicket(t *testing.T) {
 
 		assert.Equal(t, "0:1:"+ticket.ActorIDHex(), ticket.Key())
 		assert.Equal(t, "0:1:"+ticket.ActorIDHex()[22:24],
-			ticket.StructureAsString())
+			ticket.ToTestString())
 	})
 
 	t.Run("ticket comparing test", func(t *testing.T) {

--- a/pkg/splay/splay.go
+++ b/pkg/splay/splay.go
@@ -221,9 +221,9 @@ func (t *Tree[V]) String() string {
 	return builder.String()
 }
 
-// StructureAsString returns a string containing the metadata of the Node
+// ToTestString returns a string containing the metadata of the Node
 // for debugging purpose.
-func (t *Tree[V]) StructureAsString() string {
+func (t *Tree[V]) ToTestString() string {
 	var builder strings.Builder
 
 	traverseInOrder(t.root, func(node *Node[V]) {

--- a/pkg/splay/splay_test.go
+++ b/pkg/splay/splay_test.go
@@ -56,16 +56,16 @@ func TestSplayTree(t *testing.T) {
 		assert.Equal(t, 0, idx)
 
 		nodeA := tree.Insert(newSplayNode("A2"))
-		assert.Equal(t, "[2,2]A2", tree.StructureAsString())
+		assert.Equal(t, "[2,2]A2", tree.ToTestString())
 		nodeB := tree.Insert(newSplayNode("B23"))
-		assert.Equal(t, "[2,2]A2[5,3]B23", tree.StructureAsString())
+		assert.Equal(t, "[2,2]A2[5,3]B23", tree.ToTestString())
 		nodeC := tree.Insert(newSplayNode("C234"))
-		assert.Equal(t, "[2,2]A2[5,3]B23[9,4]C234", tree.StructureAsString())
+		assert.Equal(t, "[2,2]A2[5,3]B23[9,4]C234", tree.ToTestString())
 		nodeD := tree.Insert(newSplayNode("D2345"))
-		assert.Equal(t, "[2,2]A2[5,3]B23[9,4]C234[14,5]D2345", tree.StructureAsString())
+		assert.Equal(t, "[2,2]A2[5,3]B23[9,4]C234[14,5]D2345", tree.ToTestString())
 
 		tree.Splay(nodeB)
-		assert.Equal(t, "[2,2]A2[14,3]B23[9,4]C234[5,5]D2345", tree.StructureAsString())
+		assert.Equal(t, "[2,2]A2[14,3]B23[9,4]C234[5,5]D2345", tree.ToTestString())
 
 		assert.Equal(t, 0, tree.IndexOf(nodeA))
 		assert.Equal(t, 2, tree.IndexOf(nodeB))
@@ -92,20 +92,20 @@ func TestSplayTree(t *testing.T) {
 		tree := splay.NewTree[*stringValue](nil)
 
 		nodeH := tree.Insert(newSplayNode("H"))
-		assert.Equal(t, "[1,1]H", tree.StructureAsString())
+		assert.Equal(t, "[1,1]H", tree.ToTestString())
 		assert.Equal(t, 1, tree.Len())
 		nodeE := tree.Insert(newSplayNode("E"))
-		assert.Equal(t, "[1,1]H[2,1]E", tree.StructureAsString())
+		assert.Equal(t, "[1,1]H[2,1]E", tree.ToTestString())
 		assert.Equal(t, 2, tree.Len())
 		nodeL := tree.Insert(newSplayNode("LL"))
-		assert.Equal(t, "[1,1]H[2,1]E[4,2]LL", tree.StructureAsString())
+		assert.Equal(t, "[1,1]H[2,1]E[4,2]LL", tree.ToTestString())
 		assert.Equal(t, 4, tree.Len())
 		nodeO := tree.Insert(newSplayNode("O"))
-		assert.Equal(t, "[1,1]H[2,1]E[4,2]LL[5,1]O", tree.StructureAsString())
+		assert.Equal(t, "[1,1]H[2,1]E[4,2]LL[5,1]O", tree.ToTestString())
 		assert.Equal(t, 5, tree.Len())
 
 		tree.Delete(nodeE)
-		assert.Equal(t, "[4,1]H[3,2]LL[1,1]O", tree.StructureAsString())
+		assert.Equal(t, "[4,1]H[3,2]LL[1,1]O", tree.ToTestString())
 		assert.Equal(t, 4, tree.Len())
 
 		assert.Equal(t, tree.IndexOf(nodeH), 0)
@@ -122,7 +122,7 @@ func TestSplayTree(t *testing.T) {
 		assert.Equal(
 			t,
 			"[1,1]A[3,2]BB[6,3]CCC[10,4]DDDD[15,5]EEEEE[19,4]FFFF[22,3]GGG[0,0]HH[0,0]I",
-			tree.StructureAsString(),
+			tree.ToTestString(),
 		)
 
 		tree, nodes = makeSampleTree()
@@ -132,7 +132,7 @@ func TestSplayTree(t *testing.T) {
 		assert.Equal(
 			t,
 			"[1,1]A[3,2]BB[6,3]CCC[0,0]DDDD[0,0]EEEEE[0,0]FFFF[0,0]GGG[9,2]HH[1,1]I",
-			tree.StructureAsString(),
+			tree.ToTestString(),
 		)
 
 		tree, nodes = makeSampleTree()
@@ -144,7 +144,7 @@ func TestSplayTree(t *testing.T) {
 		assert.Equal(
 			t,
 			"[1,1]A[3,2]BB[6,3]CCC[0,0]DDDD[0,0]EEEEE[0,0]FFFF[0,0]GGG[0,0]HH[7,1]I",
-			tree.StructureAsString(),
+			tree.ToTestString(),
 		)
 	})
 

--- a/server/packs/packs.go
+++ b/server/packs/packs.go
@@ -131,7 +131,7 @@ func PushPull(
 		clientInfo.Key,
 		len(pushedChanges),
 		pullLog,
-		minSyncedTicket.StructureAsString(),
+		minSyncedTicket.ToTestString(),
 	)
 
 	// 05. publish document change event then store snapshot asynchronously.

--- a/server/rpc/interceptors/default.go
+++ b/server/rpc/interceptors/default.go
@@ -18,6 +18,7 @@ package interceptors
 
 import (
 	"context"
+	"errors"
 	gotime "time"
 
 	"google.golang.org/grpc"
@@ -75,6 +76,11 @@ func (i *DefaultInterceptor) Stream() grpc.StreamServerInterceptor {
 		start := gotime.Now()
 		err := handler(srv, ss)
 		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				reqLogger.Debugf("RPC : stream %q %s => %q", info.FullMethod, gotime.Since(start), err.Error())
+				return grpchelper.ToStatusError(err)
+			}
+
 			reqLogger.Warnf("RPC : stream %q %s => %q", info.FullMethod, gotime.Since(start), err.Error())
 			return grpchelper.ToStatusError(err)
 		}

--- a/test/bench/document_bench_test.go
+++ b/test/bench/document_bench_test.go
@@ -142,22 +142,22 @@ func BenchmarkDocument(b *testing.B) {
 				root.SetNewArray("k1").AddInteger(1).AddInteger(2).AddInteger(3)
 				assert.Equal(b, 3, root.GetArray("k1").Len())
 				assert.Equal(b, `{"k1":[1,2,3]}`, root.Marshal())
-				assert.Equal(b, "[0,0]0[1,1]1[2,1]2[3,1]3", root.GetArray("k1").StructureAsString())
+				assert.Equal(b, "[0,0]0[1,1]1[2,1]2[3,1]3", root.GetArray("k1").ToTestString())
 
 				root.GetArray("k1").Delete(1)
 				assert.Equal(b, `{"k1":[1,3]}`, root.Marshal())
 				assert.Equal(b, 2, root.GetArray("k1").Len())
-				assert.Equal(b, "[0,0]0[1,1]1[2,0]2[1,1]3", root.GetArray("k1").StructureAsString())
+				assert.Equal(b, "[0,0]0[1,1]1[2,0]2[1,1]3", root.GetArray("k1").ToTestString())
 
 				root.GetArray("k1").InsertIntegerAfter(0, 2)
 				assert.Equal(b, `{"k1":[1,2,3]}`, root.Marshal())
 				assert.Equal(b, 3, root.GetArray("k1").Len())
-				assert.Equal(b, "[0,0]0[1,1]1[3,1]2[1,0]2[1,1]3", root.GetArray("k1").StructureAsString())
+				assert.Equal(b, "[0,0]0[1,1]1[3,1]2[1,0]2[1,1]3", root.GetArray("k1").ToTestString())
 
 				root.GetArray("k1").InsertIntegerAfter(2, 4)
 				assert.Equal(b, `{"k1":[1,2,3,4]}`, root.Marshal())
 				assert.Equal(b, 4, root.GetArray("k1").Len())
-				assert.Equal(b, "[0,0]0[1,1]1[2,1]2[2,0]2[3,1]3[4,1]4", root.GetArray("k1").StructureAsString())
+				assert.Equal(b, "[0,0]0[1,1]1[2,1]2[2,0]2[3,1]3[4,1]4", root.GetArray("k1").ToTestString())
 
 				for i := 0; i < root.GetArray("k1").Len(); i++ {
 					assert.Equal(
@@ -195,23 +195,23 @@ func BenchmarkDocument(b *testing.B) {
 				text := root.GetText("k1")
 				assert.Equal(b,
 					`[0:0:00:0 {} ""][1:2:00:0 {} "A"][1:3:00:0 {} "12"]{1:2:00:1 {} "BC"}[1:2:00:3 {} "D"]`,
-					text.StructureAsString(),
+					text.ToTestString(),
 				)
 
 				from, _ := text.CreateRange(0, 0)
-				assert.Equal(b, "0:0:00:0:0", from.StructureAsString())
+				assert.Equal(b, "0:0:00:0:0", from.ToTestString())
 
 				from, _ = text.CreateRange(1, 1)
-				assert.Equal(b, "1:2:00:0:1", from.StructureAsString())
+				assert.Equal(b, "1:2:00:0:1", from.ToTestString())
 
 				from, _ = text.CreateRange(2, 2)
-				assert.Equal(b, "1:3:00:0:1", from.StructureAsString())
+				assert.Equal(b, "1:3:00:0:1", from.ToTestString())
 
 				from, _ = text.CreateRange(3, 3)
-				assert.Equal(b, "1:3:00:0:2", from.StructureAsString())
+				assert.Equal(b, "1:3:00:0:2", from.ToTestString())
 
 				from, _ = text.CreateRange(4, 4)
-				assert.Equal(b, "1:2:00:3:1", from.StructureAsString())
+				assert.Equal(b, "1:2:00:3:1", from.ToTestString())
 				return nil
 			})
 			assert.NoError(b, err)
@@ -248,7 +248,7 @@ func BenchmarkDocument(b *testing.B) {
 				assert.Equal(
 					b,
 					`[0:0:00:0 {} ""][1:2:00:0 {} "Hello world"]`,
-					text.StructureAsString(),
+					text.ToTestString(),
 				)
 				return nil
 			})
@@ -260,7 +260,7 @@ func BenchmarkDocument(b *testing.B) {
 				text.Style(0, 5, map[string]string{"b": "1"})
 				assert.Equal(b,
 					`[0:0:00:0 {} ""][1:2:00:0 {"b":"1"} "Hello"][1:2:00:5 {} " world"]`,
-					text.StructureAsString(),
+					text.ToTestString(),
 				)
 				return nil
 			})
@@ -277,14 +277,14 @@ func BenchmarkDocument(b *testing.B) {
 				assert.Equal(
 					b,
 					`[0:0:00:0 {} ""][1:2:00:0 {"b":"1"} "Hello"][1:2:00:5 {} " world"]`,
-					text.StructureAsString(),
+					text.ToTestString(),
 				)
 
 				text.Style(3, 5, map[string]string{"i": "1"})
 				assert.Equal(
 					b,
 					`[0:0:00:0 {} ""][1:2:00:0 {"b":"1"} "Hel"][1:2:00:3 {"b":"1","i":"1"} "lo"][1:2:00:5 {} " world"]`,
-					text.StructureAsString(),
+					text.ToTestString(),
 				)
 				return nil
 			})
@@ -302,7 +302,7 @@ func BenchmarkDocument(b *testing.B) {
 					b,
 					`[0:0:00:0 {} ""][1:2:00:0 {"b":"1"} "Hel"][1:2:00:3 {"b":"1","i":"1"} "lo"]`+
 						`[4:1:00:0 {} " Yorkie"]{1:2:00:5 {} " world"}`,
-					text.StructureAsString(),
+					text.ToTestString(),
 				)
 				return nil
 			})
@@ -319,7 +319,7 @@ func BenchmarkDocument(b *testing.B) {
 				assert.Equal(
 					b,
 					`[0:0:00:0 {} ""][1:2:00:0 {"b":"1"} "Hel"][1:2:00:3 {"b":"1","i":"1"} "lo"][5:1:00:0 {"list":"true"} "\n"][4:1:00:0 {} " Yorkie"]{1:2:00:5 {} " world"}`,
-					text.StructureAsString(),
+					text.ToTestString(),
 				)
 				return nil
 			})


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Rename StructureAsString to toTestString.

We originally used StructureAsString to represent a method for generating a string representation, primarily for debugging purposes. However, we've now decided to use `struct` to represent the structure for serialization. As a result, this commit updates the method name to align with our new naming convention, which is toTestString.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related to https://github.com/yorkie-team/yorkie-js-sdk/pull/561

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
