### PR TITLE
Modify converter to allow setting values for object and array

### DIFF
--- a/api/converter/converter_test.go
+++ b/api/converter/converter_test.go
@@ -36,13 +36,8 @@ import (
 
 func TestConverter(t *testing.T) {
 	t.Run("snapshot simple test", func(t *testing.T) {
-		obj, err := converter.BytesToObject(nil)
-		assert.NoError(t, err)
-		assert.Equal(t, "{}", obj.Marshal())
-
 		doc := document.New("d1")
-
-		err = doc.Update(func(root *json.Object, p *presence.Presence) error {
+		err := doc.Update(func(root *json.Object, p *presence.Presence) error {
 			root.SetNewText("k1").Edit(0, 0, "A")
 			return nil
 		})
@@ -59,7 +54,7 @@ func TestConverter(t *testing.T) {
 		bytes, err := converter.ObjectToBytes(doc.RootObject())
 		assert.NoError(t, err)
 
-		obj, err = converter.BytesToObject(bytes)
+		obj, err := converter.BytesToObject(bytes)
 		assert.NoError(t, err)
 		assert.Equal(t, `{"k1":[{"val":"B"}]}`, obj.Marshal())
 	})

--- a/api/converter/converter_test.go
+++ b/api/converter/converter_test.go
@@ -243,6 +243,28 @@ func TestConverter(t *testing.T) {
 		assert.Equal(t, tree.ToXML(), clone.ToXML())
 	})
 
+	t.Run("array converting to bytes test", func(t *testing.T) {
+		root := helper.TestRoot()
+		ctx := helper.TextChangeContext(root)
+
+		treeList := crdt.NewRGATreeList()
+		arr := crdt.NewArray(treeList, ctx.IssueTimeTicket())
+		primitive, _ := crdt.NewPrimitive("1", ctx.IssueTimeTicket())
+		_ = arr.Add(primitive)
+		primitive, _ = crdt.NewPrimitive("2", ctx.IssueTimeTicket())
+		_ = arr.Add(primitive)
+		primitive, _ = crdt.NewPrimitive("3", ctx.IssueTimeTicket())
+		_ = arr.Add(primitive)
+
+		bytes, err := converter.ArrayToBytes(arr)
+		assert.NoError(t, err)
+		clone, err := converter.BytesToArray(bytes)
+		assert.NoError(t, err)
+
+		assert.Equal(t, `["1","2","3"]`, arr.Marshal())
+		assert.Equal(t, `["1","2","3"]`, clone.Marshal())
+	})
+
 	t.Run("empty presence converting test", func(t *testing.T) {
 		change, err := innerpresence.NewChangeFromJSON(`{"ChangeType":"put","Presence":{}}`)
 		assert.NoError(t, err)

--- a/api/converter/from_bytes.go
+++ b/api/converter/from_bytes.go
@@ -51,7 +51,7 @@ func BytesToSnapshot(snapshot []byte) (*crdt.Object, *innerpresence.Map, error) 
 // BytesToObject creates an Object from the given byte array.
 func BytesToObject(snapshot []byte) (*crdt.Object, error) {
 	if snapshot == nil {
-		return crdt.NewObject(crdt.NewElementRHT(), time.InitialTicket), nil
+		return nil, errors.New("snapshot should not be nil")
 	}
 
 	pbElem := &api.JSONElement{}

--- a/api/converter/from_bytes.go
+++ b/api/converter/from_bytes.go
@@ -67,6 +67,25 @@ func BytesToObject(snapshot []byte) (*crdt.Object, error) {
 	return obj, nil
 }
 
+// BytesToArray creates a Array from the given byte array.
+func BytesToArray(snapshot []byte) (*crdt.Array, error) {
+	if snapshot == nil {
+		return nil, errors.New("snapshot should not be nil")
+	}
+
+	pbArray := &api.JSONElement{}
+	if err := proto.Unmarshal(snapshot, pbArray); err != nil {
+		return nil, fmt.Errorf("unmarshal array: %w", err)
+	}
+
+	array, err := fromJSONArray(pbArray.GetJsonArray())
+	if err != nil {
+		return nil, err
+	}
+
+	return array, nil
+}
+
 // BytesToTree creates a Tree from the given byte array.
 func BytesToTree(snapshot []byte) (*crdt.Tree, error) {
 	if snapshot == nil {

--- a/api/converter/from_pb.go
+++ b/api/converter/from_pb.go
@@ -728,8 +728,26 @@ func fromTimeTicket(pbTicket *api.TimeTicket) (*time.Ticket, error) {
 func fromElement(pbElement *api.JSONElementSimple) (crdt.Element, error) {
 	switch pbType := pbElement.Type; pbType {
 	case api.ValueType_VALUE_TYPE_JSON_OBJECT:
+		if pbElement.Value == nil {
+			createdAt, err := fromTimeTicket(pbElement.CreatedAt)
+			if err != nil {
+				return nil, err
+			}
+			return crdt.NewObject(
+				crdt.NewElementRHT(),
+				createdAt,
+			), nil
+		}
 		return BytesToObject(pbElement.Value)
 	case api.ValueType_VALUE_TYPE_JSON_ARRAY:
+		if pbElement.Value == nil {
+			createdAt, err := fromTimeTicket(pbElement.CreatedAt)
+			if err != nil {
+				return nil, err
+			}
+			elements := crdt.NewRGATreeList()
+			return crdt.NewArray(elements, createdAt), nil
+		}
 		return BytesToArray(pbElement.Value)
 	case api.ValueType_VALUE_TYPE_NULL:
 		fallthrough

--- a/api/converter/from_pb.go
+++ b/api/converter/from_pb.go
@@ -728,21 +728,9 @@ func fromTimeTicket(pbTicket *api.TimeTicket) (*time.Ticket, error) {
 func fromElement(pbElement *api.JSONElementSimple) (crdt.Element, error) {
 	switch pbType := pbElement.Type; pbType {
 	case api.ValueType_VALUE_TYPE_JSON_OBJECT:
-		createdAt, err := fromTimeTicket(pbElement.CreatedAt)
-		if err != nil {
-			return nil, err
-		}
-		return crdt.NewObject(
-			crdt.NewElementRHT(),
-			createdAt,
-		), nil
+		return BytesToObject(pbElement.Value)
 	case api.ValueType_VALUE_TYPE_JSON_ARRAY:
-		createdAt, err := fromTimeTicket(pbElement.CreatedAt)
-		if err != nil {
-			return nil, err
-		}
-		elements := crdt.NewRGATreeList()
-		return crdt.NewArray(elements, createdAt), nil
+		return BytesToArray(pbElement.Value)
 	case api.ValueType_VALUE_TYPE_NULL:
 		fallthrough
 	case api.ValueType_VALUE_TYPE_BOOLEAN:

--- a/api/converter/to_bytes.go
+++ b/api/converter/to_bytes.go
@@ -62,6 +62,19 @@ func ObjectToBytes(obj *crdt.Object) ([]byte, error) {
 	return bytes, nil
 }
 
+// ArrayToBytes converts the given array to byte array.
+func ArrayToBytes(array *crdt.Array) ([]byte, error) {
+	pbArray, err := toJSONArray(array)
+	if err != nil {
+		return nil, err
+	}
+	bytes, err := proto.Marshal(pbArray)
+	if err != nil {
+		return nil, fmt.Errorf("marshal Array to bytes: %w", err)
+	}
+	return bytes, nil
+}
+
 // TreeToBytes converts the given tree to byte array.
 func TreeToBytes(tree *crdt.Tree) ([]byte, error) {
 	pbTree := toTree(tree)

--- a/api/converter/to_pb.go
+++ b/api/converter/to_pb.go
@@ -409,14 +409,24 @@ func toTreeStyle(style *operations.TreeStyle) (*api.Operation_TreeStyle_, error)
 func toJSONElementSimple(elem crdt.Element) (*api.JSONElementSimple, error) {
 	switch elem := elem.(type) {
 	case *crdt.Object:
+		bytes, err := ObjectToBytes(elem)
+		if err != nil {
+			return nil, err
+		}
 		return &api.JSONElementSimple{
 			Type:      api.ValueType_VALUE_TYPE_JSON_OBJECT,
 			CreatedAt: ToTimeTicket(elem.CreatedAt()),
+			Value:     bytes,
 		}, nil
 	case *crdt.Array:
+		bytes, err := ArrayToBytes(elem)
+		if err != nil {
+			return nil, err
+		}
 		return &api.JSONElementSimple{
 			Type:      api.ValueType_VALUE_TYPE_JSON_ARRAY,
 			CreatedAt: ToTimeTicket(elem.CreatedAt()),
+			Value:     bytes,
 		}, nil
 	case *crdt.Primitive:
 		pbValueType, err := toValueType(elem.ValueType())


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

> This PR is associated with https://github.com/yorkie-team/yorkie-js-sdk/pull/691. Since modifications have been made to allow setting values in set and add operations, it is necessary to update the converter accordingly. This involves enabling the setting of values for objects and arrays in the converter.

[PR#678 triggers the regression error](https://github.com/yorkie-team/yorkie/pull/678#issuecomment-1823708123), so I made corrections and re-submitted. I've added handling for cases where values are not set when converting to `PbJSONElementSimple`. In the `bytesToObject` function, It was previously creating a new object with initialTicket when the bytes were nil. However, this logic became inappropriate after separating it from `bytesToSnapshot`, so I removed it.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
