### PR TITLE
Address duplicate nodeIDs in Tree.Split

### DIFF
--- a/pkg/document/json/tree.go
+++ b/pkg/document/json/tree.go
@@ -286,7 +286,15 @@ func (t *Tree) edit(fromPos, toPos *crdt.TreePos, contents []*TreeNode, splitLev
 	}
 
 	ticket = t.context.LastTimeTicket()
-	maxCreationMapByActor, err := t.Tree.Edit(fromPos, toPos, clones, splitLevel, ticket, nil)
+	maxCreationMapByActor, err := t.Tree.Edit(
+		fromPos,
+		toPos,
+		clones,
+		splitLevel,
+		ticket,
+		t.context.IssueTimeTicket,
+		nil,
+	)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR addresses duplicate nodeIDs in Tree.Split.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Addresses https://github.com/yorkie-team/yorkie-js-sdk/pull/707

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
