### PR TITLE
Fix Issue with Non-ConnectError

### DIFF
--- a/server/rpc/interceptors/admin_auth.go
+++ b/server/rpc/interceptors/admin_auth.go
@@ -31,6 +31,9 @@ import (
 	"github.com/yorkie-team/yorkie/server/users"
 )
 
+// ErrUnauthenticated is returned when authentication is failed.
+var ErrUnauthenticated = errors.New("authorization is not provided")
+
 // AdminAuthInterceptor is an interceptor for authentication.
 type AdminAuthInterceptor struct {
 	backend      *backend.Backend
@@ -155,17 +158,17 @@ func (i *AdminAuthInterceptor) authenticate(
 ) (*types.User, error) {
 	authorization := header.Get(types.AuthorizationKey)
 	if authorization == "" {
-		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("authorization is not provided"))
+		return nil, connect.NewError(connect.CodeUnauthenticated, ErrUnauthenticated)
 	}
 
 	claims, err := i.tokenManager.Verify(authorization)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("authorization is invalid"))
+		return nil, connect.NewError(connect.CodeUnauthenticated, ErrUnauthenticated)
 	}
 
 	user, err := users.GetUser(ctx, i.backend, claims.Username)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("authorization is invalid"))
+		return nil, connect.NewError(connect.CodeUnauthenticated, ErrUnauthenticated)
 	}
 
 	return user, nil

--- a/server/rpc/interceptors/admin_auth.go
+++ b/server/rpc/interceptors/admin_auth.go
@@ -18,13 +18,11 @@ package interceptors
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 
 	"connectrpc.com/connect"
-
-	"google.golang.org/grpc/codes"
-	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/yorkie-team/yorkie/api/types"
 	"github.com/yorkie-team/yorkie/server/backend"
@@ -157,17 +155,17 @@ func (i *AdminAuthInterceptor) authenticate(
 ) (*types.User, error) {
 	authorization := header.Get(types.AuthorizationKey)
 	if authorization == "" {
-		return nil, grpcstatus.Errorf(codes.Unauthenticated, "authorization is not provided")
+		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("authorization is not provided"))
 	}
 
 	claims, err := i.tokenManager.Verify(authorization)
 	if err != nil {
-		return nil, grpcstatus.Errorf(codes.Unauthenticated, "authorization is invalid")
+		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("authorization is invalid"))
 	}
 
 	user, err := users.GetUser(ctx, i.backend, claims.Username)
 	if err != nil {
-		return nil, grpcstatus.Errorf(codes.Unauthenticated, "authorization is invalid")
+		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("authorization is invalid"))
 	}
 
 	return user, nil

--- a/test/integration/admin_test.go
+++ b/test/integration/admin_test.go
@@ -148,4 +148,17 @@ func TestAdmin(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, document.StatusDetached, doc.Status())
 	})
+
+	t.Run("unauthentication test", func(t *testing.T) {
+		// 01. try to call admin API without token.
+		adminCli2, err := admin.Dial(defaultServer.RPCAddr(), admin.WithInsecure(true))
+		assert.NoError(t, err)
+		defer func() {
+			adminCli2.Close()
+		}()
+		_, err = adminCli2.GetProject(ctx, "default")
+
+		// 02. server should return unauthenticated error.
+		assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Previously, there was an issue in [Dashboard](https://github.com/yorkie-team/dashboard/pull/135) where errors were not being properly distinguished as `ConnectError`. To address this problem, I replaced the usage of gRPC status error with `connect.NewError`.

- as-is:
![image](https://github.com/yorkie-team/yorkie/assets/81357083/e62de95a-e96e-4549-ab59-567d6b8c3290)
- to-be:
![image](https://github.com/yorkie-team/yorkie/assets/81357083/09fb0f1d-1e27-4e68-8f6a-642de121b13b)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Related #703 

**Special notes for your reviewer**:

I'm unsure about how to validate this change in the test code, as it is currently passing test using the existing approach.

https://github.com/yorkie-team/yorkie/blob/d932b59ae4f68203d953b91a31ace24c56c8ad41/test/integration/auth_webhook_test.go#L92-L141

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
