### PR TITLE
Change CLI TLS configuration to HTTP2

### DIFF
--- a/admin/client.go
+++ b/admin/client.go
@@ -119,8 +119,12 @@ func Dial(rpcAddr string, opts ...Option) (*Client, error) {
 
 // Dial dials to the admin service.
 func (c *Client) Dial(rpcAddr string) error {
-	if !strings.HasPrefix(rpcAddr, "http") {
-		rpcAddr = "http://" + rpcAddr
+	if !strings.Contains(rpcAddr, "://") {
+		if c.conn.Transport == nil {
+			rpcAddr = "http://" + rpcAddr
+		} else {
+			rpcAddr = "https://" + rpcAddr
+		}
 	}
 
 	c.client = v1connect.NewAdminServiceClient(c.conn, rpcAddr, connect.WithInterceptors(c.authInterceptor))

--- a/admin/client.go
+++ b/admin/client.go
@@ -26,6 +26,7 @@ import (
 
 	"connectrpc.com/connect"
 	"go.uber.org/zap"
+	"golang.org/x/net/http2"
 
 	"github.com/yorkie-team/yorkie/api/converter"
 	"github.com/yorkie-team/yorkie/api/types"
@@ -83,7 +84,7 @@ func New(opts ...Option) (*Client, error) {
 	conn := &http.Client{}
 	if !options.IsInsecure {
 		tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
-		conn.Transport = &http.Transport{TLSClientConfig: tlsConfig}
+		conn.Transport = &http2.Transport{TLSClientConfig: tlsConfig}
 	}
 
 	logger := options.Logger

--- a/client/client.go
+++ b/client/client.go
@@ -181,8 +181,12 @@ func Dial(rpcAddr string, opts ...Option) (*Client, error) {
 
 // Dial dials the given rpcAddr.
 func (c *Client) Dial(rpcAddr string) error {
-	if !strings.HasPrefix(rpcAddr, "http") {
-		rpcAddr = "http://" + rpcAddr
+	if !strings.Contains(rpcAddr, "://") {
+		if c.conn.Transport == nil {
+			rpcAddr = "http://" + rpcAddr
+		} else {
+			rpcAddr = "https://" + rpcAddr
+		}
 	}
 
 	c.client = v1connect.NewYorkieServiceClient(c.conn, rpcAddr, c.clientOptions...)

--- a/client/client.go
+++ b/client/client.go
@@ -32,6 +32,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/rs/xid"
 	"go.uber.org/zap"
+	"golang.org/x/net/http2"
 
 	"github.com/yorkie-team/yorkie/api/converter"
 	"github.com/yorkie-team/yorkie/api/types"
@@ -133,7 +134,7 @@ func New(opts ...Option) (*Client, error) {
 			return nil, fmt.Errorf("create client tls from file: %w", err)
 		}
 
-		conn.Transport = &http.Transport{TLSClientConfig: tlsConfig}
+		conn.Transport = &http2.Transport{TLSClientConfig: tlsConfig}
 	}
 
 	var clientOptions []connect.ClientOption


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Change CLI TLS configuration to HTTP2.

There were two reasons for this bug:
- CLI was not requesting with HTTPS (default scheme was HTTP).
- HTTP/TLS version between AWS LB/TG(HTTP/2) and CLI request(HTTP/1.1) was different.

Therefore, I have updated:
- Default HTTP scheme configuration to either HTTP or HTTPS based on client configuration(`--insecure` flag).
- HTTP client transport protocol to explicit HTTP2.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #733

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
