### PR TITLE
Add testcode for Duplicate deregister in GC

### DIFF
--- a/test/integration/gc_test.go
+++ b/test/integration/gc_test.go
@@ -430,4 +430,23 @@ func TestGarbageCollection(t *testing.T) {
 		assert.Equal(t, d1.GarbageCollect(time.MaxTicket), 3)
 		assert.Equal(t, d2.GarbageCollect(time.MaxTicket), 3)
 	})
+
+	t.Run("Garbage collection for nested object test", func(t *testing.T) {
+		ctx := context.Background()
+		d1 := document.New(helper.TestDocKey(t))
+		err := c1.Attach(ctx, d1)
+		assert.NoError(t, err)
+
+		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewObject("shape").
+				SetNewObject("point").
+				SetInteger("point.x", 0).
+				SetInteger("point.y", 0)
+			root.Delete("shape")
+			return nil
+		})
+
+		assert.Equal(t, d1.GarbageLen(), 4) // shape, point, x, y
+		assert.Equal(t, d1.GarbageCollect(time.MaxTicket), 4)
+	})
 }

--- a/test/integration/gc_test.go
+++ b/test/integration/gc_test.go
@@ -440,8 +440,8 @@ func TestGarbageCollection(t *testing.T) {
 		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
 			root.SetNewObject("shape").
 				SetNewObject("point").
-				SetInteger("point.x", 0).
-				SetInteger("point.y", 0)
+				SetInteger("x", 0).
+				SetInteger("y", 0)
 			root.Delete("shape")
 			return nil
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

There was [Duplicate deregister in Nested Object GC ](https://github.com/yorkie-team/yorkie-js-sdk/issues/715) error in js sdk.
It was solved by js [yorkie-js-sdk/PR #761](https://github.com/yorkie-team/yorkie-js-sdk/pull/716).

There is no problem with [existing code](https://github.com/yorkie-team/yorkie/blob/64cbc24e29378b45d5ec6b9a52ab7b6a002cdb61/pkg/document/crdt/root.go#L177), but add test code that coverage this problem for later in case.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #


**Checklist**:
- [ ] Added relevant tests or not required
- [x] Didn't break anything
