### PR TITLE
Fix RHT.Remove and Add test code

### DIFF
--- a/pkg/document/crdt/rht.go
+++ b/pkg/document/crdt/rht.go
@@ -29,7 +29,6 @@ type RHTNode struct {
 	key       string
 	val       string
 	updatedAt *time.Ticket
-	removedAt *time.Ticket
 	isRemoved bool
 }
 
@@ -38,20 +37,19 @@ func newRHTNode(key, val string, updatedAt *time.Ticket) *RHTNode {
 		key:       key,
 		val:       val,
 		updatedAt: updatedAt,
+		isRemoved: false,
 	}
 }
 
 // Remove removes this node. It only marks the deleted time (tombstone).
 func (n *RHTNode) Remove(removedAt *time.Ticket) {
-	if n.removedAt == nil || removedAt.After(n.removedAt) {
-		n.removedAt = removedAt
-		n.isRemoved = true
-	}
+	n.updatedAt = removedAt
+	n.isRemoved = true
 }
 
 // IsRemoved returns the node has been removed.
 func (n *RHTNode) IsRemoved() bool {
-	return n.removedAt != nil && n.isRemoved
+	return n.isRemoved
 }
 
 // Key returns the key of this node.
@@ -67,11 +65,6 @@ func (n *RHTNode) Value() string {
 // UpdatedAt returns the last update time.
 func (n *RHTNode) UpdatedAt() *time.Ticket {
 	return n.updatedAt
-}
-
-// RemovedAt returns the deletion time of this node.
-func (n *RHTNode) RemovedAt() *time.Ticket {
-	return n.removedAt
 }
 
 // RHT is a hashtable with logical clock(Replicated hashtable).

--- a/pkg/document/crdt/rht.go
+++ b/pkg/document/crdt/rht.go
@@ -121,13 +121,18 @@ func (rht *RHT) Set(k, v string, executedAt *time.Ticket) {
 // Remove removes the Element of the given key.
 func (rht *RHT) Remove(k string, executedAt *time.Ticket) string {
 	if node, ok := rht.nodeMapByKey[k]; ok && executedAt.After(node.updatedAt) {
-		if !node.isRemoved() {
+		alreadyRemoved := node.isRemoved()
+		if !alreadyRemoved {
 			rht.numberOfRemovedElement++
 		}
 		// node is removed if and only if updatedAt = removedAt
 		newNode := newRHTNode(k, node.val, executedAt)
 		rht.nodeMapByKey[k] = newNode
 		newNode.Remove(executedAt)
+
+		if alreadyRemoved {
+			return ""
+		}
 		return node.val
 	}
 

--- a/pkg/document/crdt/rht.go
+++ b/pkg/document/crdt/rht.go
@@ -95,7 +95,7 @@ func (rht *RHT) Has(key string) bool {
 
 // Set sets the value of the given key.
 func (rht *RHT) Set(k, v string, executedAt *time.Ticket) {
-	if node, ok := rht.nodeMapByKey[k]; !ok || node.updatedAt == nil || executedAt.After(node.updatedAt) {
+	if node, ok := rht.nodeMapByKey[k]; !ok || executedAt.After(node.updatedAt) {
 		if node != nil && node.isRemoved {
 			rht.numberOfRemovedElement--
 		}
@@ -106,7 +106,7 @@ func (rht *RHT) Set(k, v string, executedAt *time.Ticket) {
 
 // Remove removes the Element of the given key.
 func (rht *RHT) Remove(k string, executedAt *time.Ticket) string {
-	if node, ok := rht.nodeMapByKey[k]; ok && (node.updatedAt == nil || executedAt.After(node.updatedAt)) {
+	if node, ok := rht.nodeMapByKey[k]; ok && executedAt.After(node.updatedAt) {
 		alreadyRemoved := node.isRemoved
 		if !alreadyRemoved {
 			rht.numberOfRemovedElement++

--- a/pkg/document/crdt/rht.go
+++ b/pkg/document/crdt/rht.go
@@ -111,7 +111,6 @@ func (rht *RHT) Remove(k string, executedAt *time.Ticket) string {
 		if !alreadyRemoved {
 			rht.numberOfRemovedElement++
 		}
-		// node is removed if and only if updatedAt = removedAt
 		newNode := newRHTNode(k, node.val, executedAt, true)
 		rht.nodeMapByKey[k] = newNode
 

--- a/pkg/document/crdt/rht.go
+++ b/pkg/document/crdt/rht.go
@@ -48,7 +48,7 @@ func (n *RHTNode) Remove(removedAt *time.Ticket) {
 }
 
 func (n *RHTNode) isRemoved() bool {
-	return n.removedAt != nil && n.removedAt.Compare(n.updatedAt) == 0
+	return n.removedAt != nil && n.updatedAt != nil && n.removedAt.Compare(n.updatedAt) == 0
 }
 
 // Key returns the key of this node.
@@ -109,7 +109,7 @@ func (rht *RHT) Has(key string) bool {
 
 // Set sets the value of the given key.
 func (rht *RHT) Set(k, v string, executedAt *time.Ticket) {
-	if node, ok := rht.nodeMapByKey[k]; !ok || executedAt.After(node.updatedAt) {
+	if node, ok := rht.nodeMapByKey[k]; !ok || node.updatedAt == nil || executedAt.After(node.updatedAt) {
 		if node != nil && node.isRemoved() {
 			rht.numberOfRemovedElement--
 		}
@@ -120,7 +120,7 @@ func (rht *RHT) Set(k, v string, executedAt *time.Ticket) {
 
 // Remove removes the Element of the given key.
 func (rht *RHT) Remove(k string, executedAt *time.Ticket) string {
-	if node, ok := rht.nodeMapByKey[k]; ok && executedAt.After(node.updatedAt) {
+	if node, ok := rht.nodeMapByKey[k]; ok && (node.updatedAt == nil || executedAt.After(node.updatedAt)) {
 		alreadyRemoved := node.isRemoved()
 		if !alreadyRemoved {
 			rht.numberOfRemovedElement++

--- a/pkg/document/crdt/rht.go
+++ b/pkg/document/crdt/rht.go
@@ -127,7 +127,7 @@ func (rht *RHT) Remove(k string, executedAt *time.Ticket) string {
 		// node is removed if and only if updatedAt = removedAt
 		newNode := newRHTNode(k, node.val, executedAt)
 		rht.nodeMapByKey[k] = newNode
-		node.Remove(executedAt)
+		newNode.Remove(executedAt)
 		return node.val
 	}
 

--- a/pkg/document/crdt/rht_test.go
+++ b/pkg/document/crdt/rht_test.go
@@ -1,23 +1,150 @@
-package crdt
+package crdt_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/pkg/document/crdt"
+	"github.com/yorkie-team/yorkie/test/helper"
 )
 
-func TestMarshal(t *testing.T) {
+func TestRHT(t *testing.T) {
 	t.Run("marshal test", func(t *testing.T) {
 		key1 := `hello\\\t`
 		value1 := "world\"\f\b"
 		key2 := "hi"
 		value2 := `test\r`
-		expected := `{"hello\\\\\\t":"world\"\f\b","hi":"test\\r"}`
+		expected1 := `{}`
+		expected2 := `{"hello\\\\\\t":"world\"\f\b"}`
+		expected3 := `{"hello\\\\\\t":"world\"\f\b","hi":"test\\r"}`
 
-		rht := NewRHT()
+		// 1. empty hash table
+		rht := crdt.NewRHT()
+		actual1 := rht.Marshal()
+		assert.Equal(t, expected1, actual1)
+
+		// 2. only one element
 		rht.Set(key1, value1, nil)
+		actual2 := rht.Marshal()
+		assert.Equal(t, expected2, actual2)
+
+		// 3. non-empty hash table
 		rht.Set(key2, value2, nil)
-		actual := rht.Marshal()
-		assert.Equal(t, expected, actual)
+		actual3 := rht.Marshal()
+		assert.Equal(t, expected3, actual3)
+	})
+
+	t.Run("xml test", func(t *testing.T) {
+		key1 := `hello\\\t`
+		value1 := "world\"\f\b"
+		key2 := "hi"
+		value2 := `test\r`
+		expected1 := ``
+		expected2 := `hello\\\t="world\"\f\b"`
+		expected3 := `hello\\\t="world\"\f\b" hi="test\\r"`
+
+		// 1. empty hash table
+		rht := crdt.NewRHT()
+		actual1 := rht.ToXML()
+		assert.Equal(t, expected1, actual1)
+
+		// 2. only one element
+		rht.Set(key1, value1, nil)
+		actual2 := rht.ToXML()
+		assert.Equal(t, expected2, actual2)
+
+		// 3. non-empty hash table
+		rht.Set(key2, value2, nil)
+		actual3 := rht.ToXML()
+		assert.Equal(t, expected3, actual3)
+	})
+
+	t.Run("change value test", func(t *testing.T) {
+		root := helper.TestRoot()
+		ctx := helper.TextChangeContext(root)
+
+		rht := crdt.NewRHT()
+		key1 := `key1`
+		value1 := `value1`
+		key2 := `key2`
+		value2 := `value2`
+
+		// 1. set elements
+		rht.Set(key1, value1, ctx.IssueTimeTicket())
+		rht.Set(key2, value2, ctx.IssueTimeTicket())
+		expected1 := `{"key1":"value1","key2":"value2"}`
+		actual1 := rht.Marshal()
+		assert.Equal(t, expected1, actual1)
+		assert.Equal(t, 2, rht.Len())
+
+		// 2. change elements
+		rht.Set(key1, value2, ctx.IssueTimeTicket())
+		rht.Set(key2, value1, ctx.IssueTimeTicket())
+		expected2 := `{"key1":"value2","key2":"value1"}`
+		actual2 := rht.Marshal()
+		assert.Equal(t, expected2, actual2)
+		assert.Equal(t, 2, rht.Len())
+	})
+
+	t.Run("remove test", func(t *testing.T) {
+		root := helper.TestRoot()
+		ctx := helper.TextChangeContext(root)
+
+		rht := crdt.NewRHT()
+		key1 := `key1`
+		value1 := `value1`
+		key2 := `key2`
+		value2 := `value2`
+
+		value11 := `value11`
+		value22 := `value22`
+
+		// 1. set elements
+		rht.Set(key1, value1, ctx.IssueTimeTicket())
+		rht.Set(key2, value2, ctx.IssueTimeTicket())
+		expected1 := `{"key1":"value1","key2":"value2"}`
+		actual1 := rht.Marshal()
+		assert.Equal(t, expected1, actual1)
+		assert.Equal(t, 2, rht.Len())
+
+		// 2. remove element
+		rht.Remove(key1, ctx.IssueTimeTicket())
+		expected2 := `{"key2":"value2"}`
+		actual2 := rht.Marshal()
+		assert.Equal(t, expected2, actual2)
+		assert.Equal(t, 1, rht.Len())
+
+		// 3. set after remove
+		rht.Set(key1, value11, ctx.IssueTimeTicket())
+		expected3 := `{"key1":"value11","key2":"value2"}`
+		actual3 := rht.Marshal()
+		assert.Equal(t, expected3, actual3)
+		assert.Equal(t, 2, rht.Len())
+		assert.Equal(t, `key1="value11" key2="value2"`, rht.ToXML())
+
+		// 4. remove element
+		rht.Remove(key1, ctx.IssueTimeTicket())
+		rht.Set(key2, value22, ctx.IssueTimeTicket())
+		expected4 := `{"key2":"value22"}`
+		actual4 := rht.Marshal()
+		assert.Equal(t, expected4, actual4)
+		assert.Equal(t, 1, rht.Len())
+
+		// 5. remove element again
+		rht.Remove(key1, ctx.IssueTimeTicket())
+		expected5 := `{"key2":"value22"}`
+		actual5 := rht.Marshal()
+		assert.Equal(t, expected5, actual5)
+		assert.Equal(t, 1, rht.Len())
+		assert.Equal(t, `key2="value22"`, rht.ToXML())
+
+		// 6. remove element -> clear
+		rht.Remove(key2, ctx.IssueTimeTicket())
+		expected6 := `{}`
+		actual6 := rht.Marshal()
+		assert.Equal(t, expected6, actual6)
+		assert.Equal(t, 0, rht.Len())
+		assert.Equal(t, ``, rht.ToXML())
 	})
 }

--- a/pkg/document/crdt/rht_test.go
+++ b/pkg/document/crdt/rht_test.go
@@ -107,6 +107,8 @@ func TestRHT(t *testing.T) {
 		actual1 := rht.Marshal()
 		assert.Equal(t, expected1, actual1)
 		assert.Equal(t, 2, rht.Len())
+		assert.Equal(t, 2, len(rht.Nodes()))
+		assert.Equal(t, 2, len(rht.Elements()))
 
 		// 2. remove element
 		rht.Remove(key1, ctx.IssueTimeTicket())
@@ -114,6 +116,8 @@ func TestRHT(t *testing.T) {
 		actual2 := rht.Marshal()
 		assert.Equal(t, expected2, actual2)
 		assert.Equal(t, 1, rht.Len())
+		assert.Equal(t, 1, len(rht.Nodes()))
+		assert.Equal(t, 1, len(rht.Elements()))
 
 		// 3. set after remove
 		rht.Set(key1, value11, ctx.IssueTimeTicket())
@@ -121,6 +125,8 @@ func TestRHT(t *testing.T) {
 		actual3 := rht.Marshal()
 		assert.Equal(t, expected3, actual3)
 		assert.Equal(t, 2, rht.Len())
+		assert.Equal(t, 2, len(rht.Nodes()))
+		assert.Equal(t, 2, len(rht.Elements()))
 		assert.Equal(t, `key1="value11" key2="value2"`, rht.ToXML())
 
 		// 4. remove element
@@ -130,13 +136,17 @@ func TestRHT(t *testing.T) {
 		actual4 := rht.Marshal()
 		assert.Equal(t, expected4, actual4)
 		assert.Equal(t, 1, rht.Len())
+		assert.Equal(t, 1, len(rht.Nodes()))
+		assert.Equal(t, 1, len(rht.Elements()))
 
 		// 5. remove element again
-		rht.Remove(key1, ctx.IssueTimeTicket())
+		assert.Equal(t, ``, rht.Remove(key1, ctx.IssueTimeTicket()))
 		expected5 := `{"key2":"value22"}`
 		actual5 := rht.Marshal()
 		assert.Equal(t, expected5, actual5)
 		assert.Equal(t, 1, rht.Len())
+		assert.Equal(t, 1, len(rht.Nodes()))
+		assert.Equal(t, 1, len(rht.Elements()))
 		assert.Equal(t, `key2="value22"`, rht.ToXML())
 
 		// 6. remove element -> clear
@@ -145,6 +155,18 @@ func TestRHT(t *testing.T) {
 		actual6 := rht.Marshal()
 		assert.Equal(t, expected6, actual6)
 		assert.Equal(t, 0, rht.Len())
+		assert.Equal(t, 0, len(rht.Nodes()))
+		assert.Equal(t, 0, len(rht.Elements()))
 		assert.Equal(t, ``, rht.ToXML())
+
+		// 7. remove not exist key
+		assert.Equal(t, ``, rht.Remove(`key3`, ctx.IssueTimeTicket()))
+		expected7 := `{}`
+		actual7 := rht.Marshal()
+		assert.Equal(t, expected7, actual7)
+		assert.Equal(t, 0, rht.Len())
+		assert.Equal(t, ``, rht.ToXML())
+		assert.Equal(t, 0, len(rht.Nodes()))
+		assert.Equal(t, 0, len(rht.Elements()))
 	})
 }

--- a/pkg/document/crdt/rht_test.go
+++ b/pkg/document/crdt/rht_test.go
@@ -9,189 +9,226 @@ import (
 	"github.com/yorkie-team/yorkie/test/helper"
 )
 
-func TestRHT(t *testing.T) {
-	t.Run("marshal test", func(t *testing.T) {
-		jsonTests := []struct {
-			insertKey string
-			insertVal string
-			expectStr string
-		}{
-			{ // 1. empty hash table
-				insertKey: ``,
-				insertVal: ``,
-				expectStr: `{}`,
-			},
-			{ // 2. only one element
-				insertKey: "hello\\\\\\t",
-				insertVal: "world\"\f\b",
-				expectStr: `{"hello\\\\\\t":"world\"\f\b"}`,
-			},
-			{ // 3. non-empty hash table
-				insertKey: "hi",
-				insertVal: `test\r`,
-				expectStr: `{"hello\\\\\\t":"world\"\f\b","hi":"test\\r"}`,
-			},
-		}
+func TestRHT_Marshal(t *testing.T) {
+	tests := []struct {
+		desc      string
+		insertKey string
+		insertVal string
+		expectStr string
+	}{
+		{
+			desc:      `1. empty hash table`,
+			insertKey: ``,
+			insertVal: ``,
+			expectStr: `{}`,
+		},
+		{
+			desc:      `2. only one element`,
+			insertKey: "hello\\\\\\t",
+			insertVal: "world\"\f\b",
+			expectStr: `{"hello\\\\\\t":"world\"\f\b"}`,
+		},
+		{
+			desc:      `3. non-empty hash table`,
+			insertKey: "hi",
+			insertVal: `test\r`,
+			expectStr: `{"hello\\\\\\t":"world\"\f\b","hi":"test\\r"}`,
+		},
+	}
 
-		rht := crdt.NewRHT()
+	root := helper.TestRoot()
+	ctx := helper.TextChangeContext(root)
 
-		for _, tt := range jsonTests {
+	rht := crdt.NewRHT()
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
 			if len(tt.insertKey) > 0 {
-				rht.Set(tt.insertKey, tt.insertVal, nil)
+				rht.Set(tt.insertKey, tt.insertVal, ctx.IssueTimeTicket())
 			}
 			assert.Equal(t, tt.expectStr, rht.Marshal())
-		}
-	})
+		})
+	}
+}
 
-	t.Run("xml test", func(t *testing.T) {
-		xmlTests := []struct {
-			insertKey string
-			insertVal string
-			expectStr string
-		}{
-			{ // 1. empty hash table
-				insertKey: ``,
-				insertVal: ``,
-				expectStr: ``,
-			},
-			{ // 2. only one element
-				insertKey: "hello\\\\\\t",
-				insertVal: "world\"\f\b",
-				expectStr: `hello\\\t="world\"\f\b"`,
-			},
-			{ // 3. non-empty hash table
-				insertKey: "hi",
-				insertVal: `test\r`,
-				expectStr: `hello\\\t="world\"\f\b" hi="test\\r"`,
-			},
-		}
+func TestRHT_ToXML(t *testing.T) {
+	tests := []struct {
+		desc      string
+		insertKey string
+		insertVal string
+		expectStr string
+	}{
+		{
+			desc:      `1. empty hash table`,
+			insertKey: ``,
+			insertVal: ``,
+			expectStr: ``,
+		},
+		{
+			desc:      `2. only one element`,
+			insertKey: "hello\\\\\\t",
+			insertVal: "world\"\f\b",
+			expectStr: `hello\\\t="world\"\f\b"`,
+		},
+		{
+			desc:      `3. non-empty hash table`,
+			insertKey: "hi",
+			insertVal: `test\r`,
+			expectStr: `hello\\\t="world\"\f\b" hi="test\\r"`,
+		},
+	}
 
-		rht := crdt.NewRHT()
+	root := helper.TestRoot()
+	ctx := helper.TextChangeContext(root)
 
-		for _, tt := range xmlTests {
+	rht := crdt.NewRHT()
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
 			if len(tt.insertKey) > 0 {
-				rht.Set(tt.insertKey, tt.insertVal, nil)
+				rht.Set(tt.insertKey, tt.insertVal, ctx.IssueTimeTicket())
 			}
 			assert.Equal(t, tt.expectStr, rht.ToXML())
-		}
-	})
+		})
+	}
+}
 
-	t.Run("change value test", func(t *testing.T) {
-		root := helper.TestRoot()
-		ctx := helper.TextChangeContext(root)
+func TestRHT_Set(t *testing.T) {
+	key1, val1 := `key1`, `value1`
+	key2, val2 := `key2`, `value2`
 
-		rht := crdt.NewRHT()
-		key1 := `key1`
-		value1 := `value1`
-		key2 := `key2`
-		value2 := `value2`
+	tests := []struct {
+		desc       string
+		insertKey  []string
+		insertVal  []string
+		expectStr  string
+		expectSize int
+	}{
+		{
+			desc:       `1. set elements`,
+			insertKey:  []string{key1, key2},
+			insertVal:  []string{val1, val2},
+			expectStr:  `{"key1":"value1","key2":"value2"}`,
+			expectSize: 2,
+		},
+		{
+			desc:       `2. change elements`,
+			insertKey:  []string{key1, key2},
+			insertVal:  []string{val2, val1},
+			expectStr:  `{"key1":"value2","key2":"value1"}`,
+			expectSize: 2,
+		},
+	}
 
-		// 1. set elements
-		rht.Set(key1, value1, ctx.IssueTimeTicket())
-		rht.Set(key2, value2, ctx.IssueTimeTicket())
-		expected1 := `{"key1":"value1","key2":"value2"}`
-		actual1 := rht.Marshal()
-		assert.Equal(t, expected1, actual1)
-		assert.Equal(t, 2, rht.Len())
+	root := helper.TestRoot()
+	ctx := helper.TextChangeContext(root)
 
-		// 2. change elements
-		rht.Set(key1, value2, ctx.IssueTimeTicket())
-		rht.Set(key2, value1, ctx.IssueTimeTicket())
-		expected2 := `{"key1":"value2","key2":"value1"}`
-		actual2 := rht.Marshal()
-		assert.Equal(t, expected2, actual2)
-		assert.Equal(t, 2, rht.Len())
-	})
+	rht := crdt.NewRHT()
 
-	t.Run("remove test", func(t *testing.T) {
-		key1 := `key1`
-		val1 := `value1`
-		val11 := `value11`
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			for i, key := range tt.insertKey {
+				rht.Set(key, tt.insertVal[i], ctx.IssueTimeTicket())
+			}
+			assert.Equal(t, tt.expectStr, rht.Marshal())
+			assert.Equal(t, tt.expectSize, rht.Len())
+		})
+	}
+}
 
-		key2 := `key2`
-		val2 := `value2`
-		val22 := `value22`
+func TestRHT_Remove(t *testing.T) {
+	key1, val1, val11 := `key1`, `value1`, `value11`
+	key2, val2, val22 := `key2`, `value2`, `value22`
 
-		removeTests := []struct {
-			insertKey  []string
-			insertVal  []string
-			deleteKey  []string
-			deleteVal  []string
-			expectXML  string
-			expectJSON string
-			expectSize int
-		}{
-			{ // 1. set elements
-				insertKey:  []string{key1, key2},
-				insertVal:  []string{val1, val2},
-				deleteKey:  []string{},
-				deleteVal:  []string{},
-				expectXML:  `key1="value1" key2="value2"`,
-				expectJSON: `{"key1":"value1","key2":"value2"}`,
-				expectSize: 2,
-			},
-			{ // 2. remove element
-				insertKey:  []string{},
-				insertVal:  []string{},
-				deleteKey:  []string{key1},
-				deleteVal:  []string{val1},
-				expectXML:  `key2="value2"`,
-				expectJSON: `{"key2":"value2"}`,
-				expectSize: 1,
-			},
-			{ // 3. set after remove
-				insertKey:  []string{key1},
-				insertVal:  []string{val11},
-				deleteKey:  []string{},
-				deleteVal:  []string{},
-				expectXML:  `key1="value11" key2="value2"`,
-				expectJSON: `{"key1":"value11","key2":"value2"}`,
-				expectSize: 2,
-			},
-			{ // 4. remove element
-				insertKey:  []string{key2},
-				insertVal:  []string{val22},
-				deleteKey:  []string{key1},
-				deleteVal:  []string{val11},
-				expectXML:  `key2="value22"`,
-				expectJSON: `{"key2":"value22"}`,
-				expectSize: 1,
-			},
-			{ // 5. remove element again
-				insertKey:  []string{},
-				insertVal:  []string{},
-				deleteKey:  []string{key1},
-				deleteVal:  []string{``},
-				expectXML:  `key2="value22"`,
-				expectJSON: `{"key2":"value22"}`,
-				expectSize: 1,
-			},
-			{ // 6. remove element -> clear
-				insertKey:  []string{},
-				insertVal:  []string{},
-				deleteKey:  []string{key2},
-				deleteVal:  []string{val22},
-				expectXML:  ``,
-				expectJSON: `{}`,
-				expectSize: 0,
-			},
-			{ // 7. remove not exist key
-				insertKey:  []string{},
-				insertVal:  []string{},
-				deleteKey:  []string{`not-exist-key`},
-				deleteVal:  []string{``},
-				expectXML:  ``,
-				expectJSON: `{}`,
-				expectSize: 0,
-			},
-		}
+	tests := []struct {
+		desc       string
+		insertKey  []string
+		insertVal  []string
+		deleteKey  []string
+		deleteVal  []string
+		expectXML  string
+		expectJSON string
+		expectSize int
+	}{
+		{
+			desc:       `1. set elements`,
+			insertKey:  []string{key1, key2},
+			insertVal:  []string{val1, val2},
+			deleteKey:  []string{},
+			deleteVal:  []string{},
+			expectXML:  `key1="value1" key2="value2"`,
+			expectJSON: `{"key1":"value1","key2":"value2"}`,
+			expectSize: 2,
+		},
+		{
+			desc:       `2. remove element`,
+			insertKey:  []string{},
+			insertVal:  []string{},
+			deleteKey:  []string{key1},
+			deleteVal:  []string{val1},
+			expectXML:  `key2="value2"`,
+			expectJSON: `{"key2":"value2"}`,
+			expectSize: 1,
+		},
+		{
+			desc:       `3. set after remove`,
+			insertKey:  []string{key1},
+			insertVal:  []string{val11},
+			deleteKey:  []string{},
+			deleteVal:  []string{},
+			expectXML:  `key1="value11" key2="value2"`,
+			expectJSON: `{"key1":"value11","key2":"value2"}`,
+			expectSize: 2,
+		},
+		{
+			desc:       `4. remove element`,
+			insertKey:  []string{key2},
+			insertVal:  []string{val22},
+			deleteKey:  []string{key1},
+			deleteVal:  []string{val11},
+			expectXML:  `key2="value22"`,
+			expectJSON: `{"key2":"value22"}`,
+			expectSize: 1,
+		},
+		{
+			desc:       `5. remove element again`,
+			insertKey:  []string{},
+			insertVal:  []string{},
+			deleteKey:  []string{key1},
+			deleteVal:  []string{``},
+			expectXML:  `key2="value22"`,
+			expectJSON: `{"key2":"value22"}`,
+			expectSize: 1,
+		},
+		{
+			desc:       `6. remove element(cleared)`,
+			insertKey:  []string{},
+			insertVal:  []string{},
+			deleteKey:  []string{key2},
+			deleteVal:  []string{val22},
+			expectXML:  ``,
+			expectJSON: `{}`,
+			expectSize: 0,
+		},
+		{
+			desc:       `7. remove not exist key`,
+			insertKey:  []string{},
+			insertVal:  []string{},
+			deleteKey:  []string{`not-exist-key`},
+			deleteVal:  []string{``},
+			expectXML:  ``,
+			expectJSON: `{}`,
+			expectSize: 0,
+		},
+	}
 
-		root := helper.TestRoot()
-		ctx := helper.TextChangeContext(root)
+	root := helper.TestRoot()
+	ctx := helper.TextChangeContext(root)
 
-		rht := crdt.NewRHT()
+	rht := crdt.NewRHT()
 
-		for _, tt := range removeTests {
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
 			for i, key := range tt.insertKey {
 				rht.Set(key, tt.insertVal[i], ctx.IssueTimeTicket())
 			}
@@ -204,6 +241,6 @@ func TestRHT(t *testing.T) {
 			assert.Equal(t, tt.expectSize, rht.Len())
 			assert.Equal(t, tt.expectSize, len(rht.Nodes()))
 			assert.Equal(t, tt.expectSize, len(rht.Elements()))
-		}
-	})
+		})
+	}
 }

--- a/pkg/document/crdt/rht_test.go
+++ b/pkg/document/crdt/rht_test.go
@@ -11,53 +11,69 @@ import (
 
 func TestRHT(t *testing.T) {
 	t.Run("marshal test", func(t *testing.T) {
-		key1 := `hello\\\t`
-		value1 := "world\"\f\b"
-		key2 := "hi"
-		value2 := `test\r`
-		expected1 := `{}`
-		expected2 := `{"hello\\\\\\t":"world\"\f\b"}`
-		expected3 := `{"hello\\\\\\t":"world\"\f\b","hi":"test\\r"}`
+		jsonTests := []struct {
+			insertKey string
+			insertVal string
+			expectStr string
+		}{
+			{ // 1. empty hash table
+				insertKey: ``,
+				insertVal: ``,
+				expectStr: `{}`,
+			},
+			{ // 2. only one element
+				insertKey: "hello\\\\\\t",
+				insertVal: "world\"\f\b",
+				expectStr: `{"hello\\\\\\t":"world\"\f\b"}`,
+			},
+			{ // 3. non-empty hash table
+				insertKey: "hi",
+				insertVal: `test\r`,
+				expectStr: `{"hello\\\\\\t":"world\"\f\b","hi":"test\\r"}`,
+			},
+		}
 
-		// 1. empty hash table
 		rht := crdt.NewRHT()
-		actual1 := rht.Marshal()
-		assert.Equal(t, expected1, actual1)
 
-		// 2. only one element
-		rht.Set(key1, value1, nil)
-		actual2 := rht.Marshal()
-		assert.Equal(t, expected2, actual2)
-
-		// 3. non-empty hash table
-		rht.Set(key2, value2, nil)
-		actual3 := rht.Marshal()
-		assert.Equal(t, expected3, actual3)
+		for _, tt := range jsonTests {
+			if len(tt.insertKey) > 0 {
+				rht.Set(tt.insertKey, tt.insertVal, nil)
+			}
+			assert.Equal(t, tt.expectStr, rht.Marshal())
+		}
 	})
 
 	t.Run("xml test", func(t *testing.T) {
-		key1 := `hello\\\t`
-		value1 := "world\"\f\b"
-		key2 := "hi"
-		value2 := `test\r`
-		expected1 := ``
-		expected2 := `hello\\\t="world\"\f\b"`
-		expected3 := `hello\\\t="world\"\f\b" hi="test\\r"`
+		xmlTests := []struct {
+			insertKey string
+			insertVal string
+			expectStr string
+		}{
+			{ // 1. empty hash table
+				insertKey: ``,
+				insertVal: ``,
+				expectStr: ``,
+			},
+			{ // 2. only one element
+				insertKey: "hello\\\\\\t",
+				insertVal: "world\"\f\b",
+				expectStr: `hello\\\t="world\"\f\b"`,
+			},
+			{ // 3. non-empty hash table
+				insertKey: "hi",
+				insertVal: `test\r`,
+				expectStr: `hello\\\t="world\"\f\b" hi="test\\r"`,
+			},
+		}
 
-		// 1. empty hash table
 		rht := crdt.NewRHT()
-		actual1 := rht.ToXML()
-		assert.Equal(t, expected1, actual1)
 
-		// 2. only one element
-		rht.Set(key1, value1, nil)
-		actual2 := rht.ToXML()
-		assert.Equal(t, expected2, actual2)
-
-		// 3. non-empty hash table
-		rht.Set(key2, value2, nil)
-		actual3 := rht.ToXML()
-		assert.Equal(t, expected3, actual3)
+		for _, tt := range xmlTests {
+			if len(tt.insertKey) > 0 {
+				rht.Set(tt.insertKey, tt.insertVal, nil)
+			}
+			assert.Equal(t, tt.expectStr, rht.ToXML())
+		}
 	})
 
 	t.Run("change value test", func(t *testing.T) {
@@ -88,85 +104,106 @@ func TestRHT(t *testing.T) {
 	})
 
 	t.Run("remove test", func(t *testing.T) {
+		key1 := `key1`
+		val1 := `value1`
+		val11 := `value11`
+
+		key2 := `key2`
+		val2 := `value2`
+		val22 := `value22`
+
+		removeTests := []struct {
+			insertKey  []string
+			insertVal  []string
+			deleteKey  []string
+			deleteVal  []string
+			expectXML  string
+			expectJSON string
+			expectSize int
+		}{
+			{ // 1. set elements
+				insertKey:  []string{key1, key2},
+				insertVal:  []string{val1, val2},
+				deleteKey:  []string{},
+				deleteVal:  []string{},
+				expectXML:  `key1="value1" key2="value2"`,
+				expectJSON: `{"key1":"value1","key2":"value2"}`,
+				expectSize: 2,
+			},
+			{ // 2. remove element
+				insertKey:  []string{},
+				insertVal:  []string{},
+				deleteKey:  []string{key1},
+				deleteVal:  []string{val1},
+				expectXML:  `key2="value2"`,
+				expectJSON: `{"key2":"value2"}`,
+				expectSize: 1,
+			},
+			{ // 3. set after remove
+				insertKey:  []string{key1},
+				insertVal:  []string{val11},
+				deleteKey:  []string{},
+				deleteVal:  []string{},
+				expectXML:  `key1="value11" key2="value2"`,
+				expectJSON: `{"key1":"value11","key2":"value2"}`,
+				expectSize: 2,
+			},
+			{ // 4. remove element
+				insertKey:  []string{key2},
+				insertVal:  []string{val22},
+				deleteKey:  []string{key1},
+				deleteVal:  []string{val11},
+				expectXML:  `key2="value22"`,
+				expectJSON: `{"key2":"value22"}`,
+				expectSize: 1,
+			},
+			{ // 5. remove element again
+				insertKey:  []string{},
+				insertVal:  []string{},
+				deleteKey:  []string{key1},
+				deleteVal:  []string{``},
+				expectXML:  `key2="value22"`,
+				expectJSON: `{"key2":"value22"}`,
+				expectSize: 1,
+			},
+			{ // 6. remove element -> clear
+				insertKey:  []string{},
+				insertVal:  []string{},
+				deleteKey:  []string{key2},
+				deleteVal:  []string{val22},
+				expectXML:  ``,
+				expectJSON: `{}`,
+				expectSize: 0,
+			},
+			{ // 7. remove not exist key
+				insertKey:  []string{},
+				insertVal:  []string{},
+				deleteKey:  []string{`not-exist-key`},
+				deleteVal:  []string{``},
+				expectXML:  ``,
+				expectJSON: `{}`,
+				expectSize: 0,
+			},
+		}
+
 		root := helper.TestRoot()
 		ctx := helper.TextChangeContext(root)
 
 		rht := crdt.NewRHT()
-		key1 := `key1`
-		value1 := `value1`
-		key2 := `key2`
-		value2 := `value2`
 
-		value11 := `value11`
-		value22 := `value22`
-
-		// 1. set elements
-		rht.Set(key1, value1, ctx.IssueTimeTicket())
-		rht.Set(key2, value2, ctx.IssueTimeTicket())
-		expected1 := `{"key1":"value1","key2":"value2"}`
-		actual1 := rht.Marshal()
-		assert.Equal(t, expected1, actual1)
-		assert.Equal(t, 2, rht.Len())
-		assert.Equal(t, 2, len(rht.Nodes()))
-		assert.Equal(t, 2, len(rht.Elements()))
-
-		// 2. remove element
-		rht.Remove(key1, ctx.IssueTimeTicket())
-		expected2 := `{"key2":"value2"}`
-		actual2 := rht.Marshal()
-		assert.Equal(t, expected2, actual2)
-		assert.Equal(t, 1, rht.Len())
-		assert.Equal(t, 1, len(rht.Nodes()))
-		assert.Equal(t, 1, len(rht.Elements()))
-
-		// 3. set after remove
-		rht.Set(key1, value11, ctx.IssueTimeTicket())
-		expected3 := `{"key1":"value11","key2":"value2"}`
-		actual3 := rht.Marshal()
-		assert.Equal(t, expected3, actual3)
-		assert.Equal(t, 2, rht.Len())
-		assert.Equal(t, 2, len(rht.Nodes()))
-		assert.Equal(t, 2, len(rht.Elements()))
-		assert.Equal(t, `key1="value11" key2="value2"`, rht.ToXML())
-
-		// 4. remove element
-		rht.Remove(key1, ctx.IssueTimeTicket())
-		rht.Set(key2, value22, ctx.IssueTimeTicket())
-		expected4 := `{"key2":"value22"}`
-		actual4 := rht.Marshal()
-		assert.Equal(t, expected4, actual4)
-		assert.Equal(t, 1, rht.Len())
-		assert.Equal(t, 1, len(rht.Nodes()))
-		assert.Equal(t, 1, len(rht.Elements()))
-
-		// 5. remove element again
-		assert.Equal(t, ``, rht.Remove(key1, ctx.IssueTimeTicket()))
-		expected5 := `{"key2":"value22"}`
-		actual5 := rht.Marshal()
-		assert.Equal(t, expected5, actual5)
-		assert.Equal(t, 1, rht.Len())
-		assert.Equal(t, 1, len(rht.Nodes()))
-		assert.Equal(t, 1, len(rht.Elements()))
-		assert.Equal(t, `key2="value22"`, rht.ToXML())
-
-		// 6. remove element -> clear
-		rht.Remove(key2, ctx.IssueTimeTicket())
-		expected6 := `{}`
-		actual6 := rht.Marshal()
-		assert.Equal(t, expected6, actual6)
-		assert.Equal(t, 0, rht.Len())
-		assert.Equal(t, 0, len(rht.Nodes()))
-		assert.Equal(t, 0, len(rht.Elements()))
-		assert.Equal(t, ``, rht.ToXML())
-
-		// 7. remove not exist key
-		assert.Equal(t, ``, rht.Remove(`key3`, ctx.IssueTimeTicket()))
-		expected7 := `{}`
-		actual7 := rht.Marshal()
-		assert.Equal(t, expected7, actual7)
-		assert.Equal(t, 0, rht.Len())
-		assert.Equal(t, ``, rht.ToXML())
-		assert.Equal(t, 0, len(rht.Nodes()))
-		assert.Equal(t, 0, len(rht.Elements()))
+		for _, tt := range removeTests {
+			for i, key := range tt.insertKey {
+				rht.Set(key, tt.insertVal[i], ctx.IssueTimeTicket())
+			}
+			for i, key := range tt.deleteKey {
+				removedElement := rht.Remove(key, ctx.IssueTimeTicket())
+				assert.Equal(t, tt.deleteVal[i], removedElement)
+			}
+			assert.Equal(t, tt.expectXML, rht.ToXML())
+			assert.Equal(t, tt.expectJSON, rht.Marshal())
+			assert.Equal(t, tt.expectSize, rht.Len())
+			assert.Equal(t, tt.expectSize, len(rht.Nodes()))
+			assert.Equal(t, tt.expectSize, len(rht.Elements()))
+		}
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

* Fixed nil pointer dereference error in `RHT.Remove`.
* Fixed `RHT.Len` to exclude the removed elements.
* Fixed `RHT.Nodes` to exclude the removed elements.
* Fixed an error in `RHT.Set` when modifying an already deleted key.

Related to #748

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
