### PR TITLE
Refactor concurrency tests for basic Tree.Edit

### DIFF
--- a/test/integration/tree_concurrency_test.go
+++ b/test/integration/tree_concurrency_test.go
@@ -30,6 +30,16 @@ import (
 	"github.com/yorkie-team/yorkie/test/helper"
 )
 
+type rangeSelector int
+
+const (
+	RangeUnknown rangeSelector = iota
+	RangeFront
+	RangeMiddle
+	RangeBack
+	RangeAll
+)
+
 type rangeType struct {
 	from, to int
 }
@@ -43,16 +53,6 @@ type twoRangesType struct {
 	desc   string
 }
 
-type rangeSelector int
-
-const (
-	RangeUnknown rangeSelector = iota
-	RangeFront
-	RangeMiddle
-	RangeBack
-	RangeAll
-)
-
 func getRange(ranges twoRangesType, selector rangeSelector, user int) rangeType {
 	if selector == RangeFront {
 		return rangeType{ranges.ranges[user].from, ranges.ranges[user].from}
@@ -64,6 +64,31 @@ func getRange(ranges twoRangesType, selector rangeSelector, user int) rangeType 
 		return rangeType{ranges.ranges[user].from, ranges.ranges[user].to}
 	}
 	return rangeType{-1, -1}
+}
+
+func makeTwoRanges(from1, mid1, to1 int, from2, mid2, to2 int, desc string) twoRangesType {
+	range0 := rangeWithMiddleType{from1, mid1, to1}
+	range1 := rangeWithMiddleType{from2, mid2, to2}
+	return twoRangesType{[2]rangeWithMiddleType{range0, range1}, desc}
+}
+
+type styleOpCode int
+type editOpCode int
+
+const (
+	StyleUndefined styleOpCode = iota
+	StyleRemove
+	StyleSet
+)
+
+const (
+	EditUndefined editOpCode = iota
+	EditUpdate
+)
+
+type operationInterface interface {
+	run(t *testing.T, doc *document.Document, user int, ranges twoRangesType)
+	getDesc() string
 }
 
 type styleOperationType struct {
@@ -81,93 +106,47 @@ type editOperationType struct {
 	desc       string
 }
 
-type styleOpCode int
-type editOpCode int
-
-const (
-	StyleUndefined styleOpCode = iota
-	StyleRemove
-	StyleSet
-)
-
-const (
-	EditUndefined editOpCode = iota
-	EditUpdate
-)
-
-func makeTwoRanges(from1, mid1, to1 int, from2, mid2, to2 int, desc string) twoRangesType {
-	range0 := rangeWithMiddleType{from1, mid1, to1}
-	range1 := rangeWithMiddleType{from2, mid2, to2}
-	return twoRangesType{[2]rangeWithMiddleType{range0, range1}, desc}
+func (op styleOperationType) getDesc() string {
+	return op.desc
 }
 
-var rangesToTestSameTypeOperation = []twoRangesType{
-	makeTwoRanges(3, -1, 6, 3, -1, 6, `equal`),        // (3, 6) - (3, 6)
-	makeTwoRanges(0, -1, 9, 3, -1, 6, `contain`),      // (0, 9) - (3, 6)
-	makeTwoRanges(0, -1, 6, 3, -1, 9, `intersect`),    // (0, 6) - (3, 9)
-	makeTwoRanges(0, -1, 3, 3, -1, 6, `side-by-side`), // (0, 3) - (3, 6)
+func (op editOperationType) getDesc() string {
+	return op.desc
 }
 
-var rangesToTestMixedTypeOperation = []twoRangesType{
-	makeTwoRanges(3, 3, 6, 3, -1, 6, `equal`),        // (3, 6) - (3, 6)
-	makeTwoRanges(0, 3, 9, 3, -1, 6, `A contains B`), // (0, 9) - (3, 6)
-	makeTwoRanges(3, 3, 6, 0, -1, 9, `B contains A`), // (0, 9) - (3, 6)
-	makeTwoRanges(0, 3, 6, 3, -1, 9, `intersect`),    // (0, 6) - (3, 9)
-	makeTwoRanges(0, 3, 3, 3, -1, 6, `A -> B`),       // (0, 3) - (3, 6)
-	makeTwoRanges(3, 3, 6, 0, -1, 3, `B -> A`),       // (0, 3) - (3, 6)
-}
-
-func runStyleOperation(t *testing.T, doc *document.Document, user int, ranges twoRangesType, operation styleOperationType) {
-	interval := getRange(ranges, operation.selector, user)
+func (op styleOperationType) run(t *testing.T, doc *document.Document, user int, ranges twoRangesType) {
+	interval := getRange(ranges, op.selector, user)
 	from, to := interval.from, interval.to
 
 	assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
-		if operation.op == StyleRemove {
-			root.GetTree("t").RemoveStyle(from, to, []string{operation.key})
-		} else if operation.op == StyleSet {
-			root.GetTree("t").Style(from, to, map[string]string{operation.key: operation.value})
+		if op.op == StyleRemove {
+			root.GetTree("t").RemoveStyle(from, to, []string{op.key})
+		} else if op.op == StyleSet {
+			root.GetTree("t").Style(from, to, map[string]string{op.key: op.value})
 		}
 		return nil
 	}))
 }
 
-func runEditOperation(t *testing.T, doc *document.Document, user int, ranges twoRangesType, operation editOperationType) {
-	interval := getRange(ranges, operation.selector, user)
+func (op editOperationType) run(t *testing.T, doc *document.Document, user int, ranges twoRangesType) {
+	interval := getRange(ranges, op.selector, user)
 	from, to := interval.from, interval.to
 
 	assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
-		root.GetTree("t").Edit(from, to, operation.content, operation.splitLevel)
+		root.GetTree("t").Edit(from, to, op.content, op.splitLevel)
 		return nil
 	}))
 }
 
-func TestTreeConcurrencyStyle(t *testing.T) {
-	//       0   1 2    3   4 5    6   7 8    9
-	// <root> <p> a </p> <p> b </p> <p> c </p> </root>
-	// 0,3 : |----------|
-	// 3,6 :            |----------|
-	// 6,9 :                       |----------|
+// testDesc: description of test set
+// initialState, initialXML: initial state of document
+// rangeArr: ranges to perform operation
+// opArr1: operations to perform by first user
+// opArr2: operations to perform by second user
+func RunTestTreeConcurrency(testDesc string, t *testing.T, initialState json.TreeNode, initialXML string,
+	rangesArr []twoRangesType, opArr1, opArr2 []operationInterface) {
 
-	initialState := json.TreeNode{
-		Type: "root",
-		Children: []json.TreeNode{
-			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "a"}}},
-			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "b"}}},
-			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "c"}}},
-		},
-	}
-	initialXML := `<root><p>a</p><p>b</p><p>c</p></root>`
-
-	styleOperationsToTest := []styleOperationType{
-		{RangeAll, StyleRemove, "bold", "", `remove-bold`},
-		{RangeAll, StyleSet, "bold", "aa", `set-bold-aa`},
-		{RangeAll, StyleSet, "bold", "bb", `set-bold-bb`},
-		{RangeAll, StyleRemove, "italic", "", `remove-italic`},
-		{RangeAll, StyleSet, "italic", "aa", `set-italic-aa`},
-		{RangeAll, StyleSet, "italic", "bb", `set-italic-bb`},
-	}
-
-	runStyleTest := func(ranges twoRangesType, op1, op2 styleOperationType) {
+	runTest := func(ranges twoRangesType, op1, op2 operationInterface) bool {
 		clients := activeClients(t, 2)
 		c1, c2 := clients[0], clients[1]
 		defer deactivateAndCloseClients(t, clients)
@@ -187,24 +166,64 @@ func TestTreeConcurrencyStyle(t *testing.T) {
 		assert.Equal(t, initialXML, d1.Root().GetTree("t").ToXML())
 		assert.Equal(t, initialXML, d2.Root().GetTree("t").ToXML())
 
-		runStyleOperation(t, d1, 0, ranges, op1)
-		runStyleOperation(t, d2, 1, ranges, op2)
-		syncClientsThenAssertEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
+		op1.run(t, d1, 0, ranges)
+		op2.run(t, d2, 1, ranges)
+
+		return syncClientsThenCheckEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
 	}
 
-	for _, interval := range rangesToTestSameTypeOperation {
-		for _, op1 := range styleOperationsToTest {
-			for _, op2 := range styleOperationsToTest {
-				desc := "concurrently style-style test " + interval.desc + "(" + op1.desc + " " + op2.desc + ")"
+	for _, interval := range rangesArr {
+		for _, op1 := range opArr1 {
+			for _, op2 := range opArr2 {
+				desc := testDesc + "-" + interval.desc
+				desc += "(" + op1.getDesc() + "," + op2.getDesc() + ")"
 				t.Run(desc, func(t *testing.T) {
-					runStyleTest(interval, op1, op2)
+					if !runTest(interval, op1, op2) {
+						t.Skip()
+					}
 				})
 			}
 		}
 	}
 }
 
-func TestTreeConcurrencyEditAndStyle(t *testing.T) {
+func TestTreeConcurrencyStyleStyle(t *testing.T) {
+	//       0   1 2    3   4 5    6   7 8    9
+	// <root> <p> a </p> <p> b </p> <p> c </p> </root>
+	// 0,3 : |----------|
+	// 3,6 :            |----------|
+	// 6,9 :                       |----------|
+
+	initialState := json.TreeNode{
+		Type: "root",
+		Children: []json.TreeNode{
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "a"}}},
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "b"}}},
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "c"}}},
+		},
+	}
+	initialXML := `<root><p>a</p><p>b</p><p>c</p></root>`
+
+	ranges := []twoRangesType{
+		makeTwoRanges(3, -1, 6, 3, -1, 6, `equal`),        // (3, 6) - (3, 6)
+		makeTwoRanges(0, -1, 9, 3, -1, 6, `contain`),      // (0, 9) - (3, 6)
+		makeTwoRanges(0, -1, 6, 3, -1, 9, `intersect`),    // (0, 6) - (3, 9)
+		makeTwoRanges(0, -1, 3, 3, -1, 6, `side-by-side`), // (0, 3) - (3, 6)
+	}
+
+	styleOperations := []operationInterface{
+		styleOperationType{RangeAll, StyleRemove, "bold", "", `remove-bold`},
+		styleOperationType{RangeAll, StyleSet, "bold", "aa", `set-bold-aa`},
+		styleOperationType{RangeAll, StyleSet, "bold", "bb", `set-bold-bb`},
+		styleOperationType{RangeAll, StyleRemove, "italic", "", `remove-italic`},
+		styleOperationType{RangeAll, StyleSet, "italic", "aa", `set-italic-aa`},
+		styleOperationType{RangeAll, StyleSet, "italic", "bb", `set-italic-bb`},
+	}
+
+	RunTestTreeConcurrency("concurrently-style-style-test", t, initialState, initialXML, ranges, styleOperations, styleOperations)
+}
+
+func TestTreeConcurrencyEditStyle(t *testing.T) {
 	//       0   1 2    3   4 5    6   7 8    9
 	// <root> <p> a </p> <p> b </p> <p> c </p> </root>
 	// 0,3 : |----------|
@@ -223,56 +242,27 @@ func TestTreeConcurrencyEditAndStyle(t *testing.T) {
 
 	content := &json.TreeNode{Type: "p", Attributes: map[string]string{"italic": "true"}, Children: []json.TreeNode{{Type: "text", Value: `d`}}}
 
-	editOperationsToTest := []editOperationType{
-		{RangeFront, EditUpdate, content, 0, `insertFront`},
-		{RangeMiddle, EditUpdate, content, 0, `insertMiddle`},
-		{RangeBack, EditUpdate, content, 0, `insertBack`},
-		{RangeAll, EditUpdate, nil, 0, `erase`},
-		{RangeAll, EditUpdate, content, 0, `change`},
+	ranges := []twoRangesType{
+		makeTwoRanges(3, 3, 6, 3, -1, 6, `equal`),        // (3, 6) - (3, 6)
+		makeTwoRanges(0, 3, 9, 3, -1, 6, `A contains B`), // (0, 9) - (3, 6)
+		makeTwoRanges(3, 3, 6, 0, -1, 9, `B contains A`), // (0, 9) - (3, 6)
+		makeTwoRanges(0, 3, 6, 3, -1, 9, `intersect`),    // (0, 6) - (3, 9)
+		makeTwoRanges(0, 3, 3, 3, -1, 6, `A -> B`),       // (0, 3) - (3, 6)
+		makeTwoRanges(3, 3, 6, 0, -1, 3, `B -> A`),       // (0, 3) - (3, 6)
 	}
 
-	styleOperationsToTest := []styleOperationType{
-		{RangeAll, StyleRemove, "bold", "", `remove-bold`},
-		{RangeAll, StyleSet, "bold", "aa", `set-bold-aa`},
+	editOperations := []operationInterface{
+		editOperationType{RangeFront, EditUpdate, content, 0, `insertFront`},
+		editOperationType{RangeMiddle, EditUpdate, content, 0, `insertMiddle`},
+		editOperationType{RangeBack, EditUpdate, content, 0, `insertBack`},
+		editOperationType{RangeAll, EditUpdate, nil, 0, `erase`},
+		editOperationType{RangeAll, EditUpdate, content, 0, `change`},
 	}
 
-	runEditStyleTest := func(ranges twoRangesType, op1 editOperationType, op2 styleOperationType) bool {
-		clients := activeClients(t, 2)
-		c1, c2 := clients[0], clients[1]
-		defer deactivateAndCloseClients(t, clients)
-
-		ctx := context.Background()
-		d1 := document.New(helper.TestDocKey(t))
-		assert.NoError(t, c1.Attach(ctx, d1))
-		d2 := document.New(helper.TestDocKey(t))
-		assert.NoError(t, c2.Attach(ctx, d2))
-
-		assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
-			root.SetNewTree("t", &initialState)
-			return nil
-		}))
-		assert.NoError(t, c1.Sync(ctx))
-		assert.NoError(t, c2.Sync(ctx))
-		assert.Equal(t, initialXML, d1.Root().GetTree("t").ToXML())
-		assert.Equal(t, initialXML, d2.Root().GetTree("t").ToXML())
-
-		runEditOperation(t, d1, 0, ranges, op1)
-		runStyleOperation(t, d2, 1, ranges, op2)
-
-		return syncClientsThenCheckEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
+	styleOperations := []operationInterface{
+		styleOperationType{RangeAll, StyleRemove, "bold", "", `remove-bold`},
+		styleOperationType{RangeAll, StyleSet, "bold", "aa", `set-bold-aa`},
 	}
 
-	for _, interval := range rangesToTestMixedTypeOperation {
-		for _, op1 := range editOperationsToTest {
-			for _, op2 := range styleOperationsToTest {
-				desc := "concurrently edit-style test-" + interval.desc + "("
-				desc += op1.desc + "," + op2.desc + ")"
-				t.Run(desc, func(t *testing.T) {
-					if !runEditStyleTest(interval, op1, op2) {
-						t.Skip()
-					}
-				})
-			}
-		}
-	}
+	RunTestTreeConcurrency("concurrently-edit-style-test", t, initialState, initialXML, ranges, editOperations, styleOperations)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Refactored the concurrency test for `Tree.Edit` method for insert, delete, and replace operations.

Insert/Delete/Replace by 2 users (9 * 9 * 9 = 729 cases):
  - Ranges(9)
    - intersecting, element
    - intersecting, text
    - A contains B, element
    - A contains B, text
    - A contains B, A is element, B is text
    - side by side, element
    - side by side, text
    - A = B, element
    - A = B, text
  - Operations for both A and B(9)
    - Insert text front of range
    - Insert text middle of range
    - Insert text back of range
    - Replace to text node
    - Insert element front of range
    - Insert element middle of range
    - Insert element back of range
    - Replace to element node
    - Delete

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
