### PR TITLE
Remove unnecessary `String()` calls with `stringer` interface

### DIFF
--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -1143,7 +1143,7 @@ func (d *DB) UpdateAndFindMinSyncedTicket(
 		time.InitialActorID.String(),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("fetch smallest syncedseq of %s: %w", docRefKey.DocID.String(), err)
+		return nil, fmt.Errorf("fetch smallest syncedseq of %s: %w", docRefKey.DocID, err)
 	}
 
 	var syncedSeqInfo *database.SyncedSeqInfo
@@ -1192,7 +1192,7 @@ func (d *DB) UpdateSyncedSeq(
 			docRefKey.DocID.String(),
 			clientInfo.ID.String(),
 		); err != nil {
-			return fmt.Errorf("delete syncedseqs of %s: %w", docRefKey.DocID.String(), err)
+			return fmt.Errorf("delete syncedseqs of %s: %w", docRefKey.DocID, err)
 		}
 		txn.Commit()
 		return nil
@@ -1210,7 +1210,7 @@ func (d *DB) UpdateSyncedSeq(
 		clientInfo.ID.String(),
 	)
 	if err != nil {
-		return fmt.Errorf("fetch syncedseqs of %s: %w", docRefKey.DocID.String(), err)
+		return fmt.Errorf("fetch syncedseqs of %s: %w", docRefKey.DocID, err)
 	}
 
 	syncedSeqInfo := &database.SyncedSeqInfo{
@@ -1228,7 +1228,7 @@ func (d *DB) UpdateSyncedSeq(
 	}
 
 	if err := txn.Insert(tblSyncedSeqs, syncedSeqInfo); err != nil {
-		return fmt.Errorf("insert syncedseqs of %s: %w", docRefKey.DocID.String(), err)
+		return fmt.Errorf("insert syncedseqs of %s: %w", docRefKey.DocID, err)
 	}
 
 	txn.Commit()
@@ -1267,7 +1267,7 @@ func (d *DB) FindDocInfosByPaging(
 		)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("fetch documents of %s: %w", projectID.String(), err)
+		return nil, fmt.Errorf("fetch documents of %s: %w", projectID, err)
 	}
 
 	var docInfos []*database.DocInfo
@@ -1366,12 +1366,12 @@ func (d *DB) findTicketByServerSeq(
 		serverSeq,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("fetch change of %s: %w", docRefKey.DocID.String(), err)
+		return nil, fmt.Errorf("fetch change of %s: %w", docRefKey.DocID, err)
 	}
 	if raw == nil {
 		return nil, fmt.Errorf(
 			"docID %s, serverSeq %d: %w",
-			docRefKey.DocID.String(),
+			docRefKey.DocID,
 			serverSeq,
 			database.ErrDocumentNotFound,
 		)

--- a/server/backend/sync/memory/pubsub.go
+++ b/server/backend/sync/memory/pubsub.go
@@ -104,7 +104,7 @@ func (m *PubSub) Subscribe(
 		logging.From(ctx).Debugf(
 			`Subscribe(%s,%s) End`,
 			documentRefKey,
-			subscriber.String(),
+			subscriber,
 		)
 	}
 	return sub, nil
@@ -123,7 +123,7 @@ func (m *PubSub) Unsubscribe(
 		logging.From(ctx).Debugf(
 			`Unsubscribe(%s,%s) Start`,
 			documentRefKey,
-			sub.Subscriber().String(),
+			sub.Subscriber(),
 		)
 	}
 
@@ -141,7 +141,7 @@ func (m *PubSub) Unsubscribe(
 		logging.From(ctx).Debugf(
 			`Unsubscribe(%s,%s) End`,
 			documentRefKey,
-			sub.Subscriber().String(),
+			sub.Subscriber(),
 		)
 	}
 }
@@ -159,7 +159,7 @@ func (m *PubSub) Publish(
 	if logging.Enabled(zap.DebugLevel) {
 		logging.From(ctx).Debugf(`Publish(%s,%s) Start`,
 			documentRefKey,
-			publisherID.String())
+			publisherID)
 	}
 
 	if subs, ok := m.subscriptionsMapByDocRefKey[documentRefKey]; ok {
@@ -173,8 +173,8 @@ func (m *PubSub) Publish(
 					`Publish %s(%s,%s) to %s`,
 					event.Type,
 					documentRefKey,
-					publisherID.String(),
-					sub.Subscriber().String(),
+					publisherID,
+					sub.Subscriber(),
 				)
 			}
 
@@ -186,8 +186,8 @@ func (m *PubSub) Publish(
 				logging.From(ctx).Warnf(
 					`Publish(%s,%s) to %s timeout`,
 					documentRefKey,
-					publisherID.String(),
-					sub.Subscriber().String(),
+					publisherID,
+					sub.Subscriber(),
 				)
 			}
 		}
@@ -195,7 +195,7 @@ func (m *PubSub) Publish(
 	if logging.Enabled(zap.DebugLevel) {
 		logging.From(ctx).Debugf(`Publish(%s,%s) End`,
 			documentRefKey,
-			publisherID.String())
+			publisherID)
 	}
 }
 

--- a/server/packs/pushpull.go
+++ b/server/packs/pushpull.go
@@ -72,7 +72,7 @@ func pushChanges(
 			len(reqPack.Changes)-len(pushedChanges),
 			initialServerSeq,
 			docInfo.ServerSeq,
-			cp.String(),
+			cp,
 		)
 	}
 
@@ -168,7 +168,7 @@ func pullSnapshot(
 		reqPack.Checkpoint.ServerSeq+1,
 		initialServerSeq,
 		docInfo.Key,
-		cpAfterPull.String(),
+		cpAfterPull,
 	)
 
 	return NewServerPack(docInfo.Key, cpAfterPull, nil, snapshot), err
@@ -218,7 +218,7 @@ func pullChangeInfos(
 			pulledChanges[0].ServerSeq,
 			pulledChanges[len(pulledChanges)-1].ServerSeq,
 			docInfo.Key,
-			cpAfterPull.String(),
+			cpAfterPull,
 			len(filteredChanges),
 		)
 	}

--- a/server/rpc/yorkie_server.go
+++ b/server/rpc/yorkie_server.go
@@ -404,7 +404,7 @@ func (s *yorkieServer) WatchDocument(
 
 	locker, err := s.backend.Coordinator.NewLocker(
 		ctx,
-		sync.NewKey(fmt.Sprintf("watchdoc-%s-%s", clientID.String(), docID)),
+		sync.NewKey(fmt.Sprintf("watchdoc-%s-%s", clientID, docID)),
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR removes unnecessary `String()` calls with [`stringer`](https://pkg.go.dev/golang.org/x/tools/cmd/stringer) interface.
We hope this style to be applied to the overall code base to keep it simple.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
