### PR TITLE
Add merge and split concurrency tests

### DIFF
--- a/test/integration/tree_concurrency_test.go
+++ b/test/integration/tree_concurrency_test.go
@@ -330,13 +330,13 @@ func TestTreeConcurrencySplitEdit(t *testing.T) {
 		Type: "root",
 		Children: []json.TreeNode{
 			{Type: "p", Children: []json.TreeNode{
-				{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "abcd"}}},
-				{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "efgh"}}},
-			}},
-			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "ijkl"}}},
+				{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "abcd"}}, Attributes: map[string]string{"italic": "true"}},
+				{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "efgh"}}, Attributes: map[string]string{"italic": "true"}},
+			}, Attributes: map[string]string{"italic": "true"}},
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "ijkl"}}, Attributes: map[string]string{"italic": "true"}},
 		},
 	}
-	initialXML := `<root><p><p>abcd</p><p>efgh</p></p><p>ijkl</p></root>`
+	initialXML := `<root><p italic="true"><p italic="true">abcd</p><p italic="true">efgh</p></p><p italic="true">ijkl</p></root>`
 
 	content := &json.TreeNode{Type: "i", Children: []json.TreeNode{}}
 
@@ -374,7 +374,7 @@ func TestTreeConcurrencySplitEdit(t *testing.T) {
 		editOperationType{RangeAll, EditUpdate, nil, 0, `delete`},
 		editOperationType{RangeAll, MergeUpdate, nil, 0, `merge`},
 		styleOperationType{RangeAll, StyleSet, "bold", "aa", `style`},
-		styleOperationType{RangeAll, StyleRemove, "bold", "", `remove-style`},
+		styleOperationType{RangeAll, StyleRemove, "italic", "", `remove-style`},
 	}
 
 	RunTestTreeConcurrency("concurrently-split-edit-test", t, initialState, initialXML, ranges, splitOperations, editOperations)
@@ -430,12 +430,12 @@ func TestTreeConcurrencyEditStyle(t *testing.T) {
 	initialState := json.TreeNode{
 		Type: "root",
 		Children: []json.TreeNode{
-			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "a"}}},
-			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "b"}}},
-			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "c"}}},
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "a"}}, Attributes: map[string]string{"color": "red"}},
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "b"}}, Attributes: map[string]string{"color": "red"}},
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "c"}}, Attributes: map[string]string{"color": "red"}},
 		},
 	}
-	initialXML := `<root><p>a</p><p>b</p><p>c</p></root>`
+	initialXML := `<root><p color="red">a</p><p color="red">b</p><p color="red">c</p></root>`
 
 	content := &json.TreeNode{Type: "p", Attributes: map[string]string{"italic": "true"}, Children: []json.TreeNode{{Type: "text", Value: `d`}}}
 
@@ -466,7 +466,7 @@ func TestTreeConcurrencyEditStyle(t *testing.T) {
 	}
 
 	styleOperations := []operationInterface{
-		styleOperationType{RangeAll, StyleRemove, "bold", "", `remove-bold`},
+		styleOperationType{RangeAll, StyleRemove, "color", "", `remove-bold`},
 		styleOperationType{RangeAll, StyleSet, "bold", "aa", `set-bold-aa`},
 	}
 

--- a/test/integration/tree_concurrency_test.go
+++ b/test/integration/tree_concurrency_test.go
@@ -322,36 +322,37 @@ func TestTreeConcurrencyEditEdit(t *testing.T) {
 	RunTestTreeConcurrency("concurrently-edit-edit-test", t, initialState, initialXML, ranges, editOperations1, editOperations2)
 }
 
-// TODO(justiceHui): add split test for splitLevel > 1
 func TestTreeConcurrencySplitSplit(t *testing.T) {
-	//       0   1   2   3 4 5 6 7    8   9 10 11 12 13    14    15   16 17 18 19 20    21    22
-	// <root> <p> <p> <p> a b c d </p> <p> e  f  g  h  </p>  </p>  <p>  i  j  k  l  </p>  </p>  </root>
+	//       0   1   2   3   4 5 6 7 8    9   10 11 12 13 14    15    16   17 18 19 20 21    22    23    24
+	// <root> <p> <p> <p> <p> a b c d </p> <p>  e  f  g  h  </p>  </p>  <p>  i  j  k  l  </p>  </p>  </p>  </root>
 
 	initialState := json.TreeNode{
 		Type: "root",
 		Children: []json.TreeNode{
 			{Type: "p", Children: []json.TreeNode{
 				{Type: "p", Children: []json.TreeNode{
-					{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "abcd"}}},
-					{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "efgh"}}},
+					{Type: "p", Children: []json.TreeNode{
+						{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "abcd"}}},
+						{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "efgh"}}},
+					}},
+					{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "ijkl"}}},
 				}},
-				{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "ijkl"}}},
 			}},
 		},
 	}
-	initialXML := `<root><p><p><p>abcd</p><p>efgh</p></p><p>ijkl</p></p></root>`
+	initialXML := `<root><p><p><p><p>abcd</p><p>efgh</p></p><p>ijkl</p></p></p></root>`
 
 	ranges := []twoRangesType{
 		// equal-single-element: <p>abcd</p>
-		makeTwoRanges(2, 5, 8, 2, 5, 8, `equal-single`),
+		makeTwoRanges(3, 6, 9, 3, 6, 9, `equal-single`),
 		// equal-multiple-element: <p>abcd</p><p>efgh</p>
-		makeTwoRanges(2, 8, 14, 2, 8, 14, `equal-multiple`),
+		makeTwoRanges(3, 9, 15, 3, 9, 15, `equal-multiple`),
 		// A contains B same level: <p>abcd</p><p>efgh</p> - <p>efgh</p>
-		makeTwoRanges(2, 8, 14, 8, 11, 14, `A contains B same level`),
+		makeTwoRanges(3, 9, 15, 9, 12, 15, `A contains B same level`),
 		// A contains B multiple level: <p><p>abcd</p><p>efgh</p></p><p>ijkl</p> - <p>efgh</p>
-		makeTwoRanges(1, 15, 21, 8, 11, 14, `A contains B multiple level`),
+		makeTwoRanges(2, 16, 22, 9, 12, 15, `A contains B multiple level`),
 		// side by side
-		makeTwoRanges(2, 5, 8, 8, 11, 14, `B is next to A`),
+		makeTwoRanges(3, 6, 9, 9, 12, 15, `B is next to A`),
 	}
 
 	splitOperations := []operationInterface{
@@ -359,6 +360,10 @@ func TestTreeConcurrencySplitSplit(t *testing.T) {
 		editOperationType{RangeOneQuarter, SplitUpdate, nil, 1, `split-one-quarter-1`},
 		editOperationType{RangeThreeQuarter, SplitUpdate, nil, 1, `split-three-quarter-1`},
 		editOperationType{RangeBack, SplitUpdate, nil, 1, `split-back-1`},
+		editOperationType{RangeFront, SplitUpdate, nil, 2, `split-front-2`},
+		editOperationType{RangeOneQuarter, SplitUpdate, nil, 2, `split-one-quarter-2`},
+		editOperationType{RangeThreeQuarter, SplitUpdate, nil, 2, `split-three-quarter-2`},
+		editOperationType{RangeBack, SplitUpdate, nil, 2, `split-back-2`},
 	}
 
 	RunTestTreeConcurrency("concurrently-split-split-test", t, initialState, initialXML, ranges, splitOperations, splitOperations)

--- a/test/integration/tree_concurrency_test.go
+++ b/test/integration/tree_concurrency_test.go
@@ -324,21 +324,19 @@ func TestTreeConcurrencyEditEdit(t *testing.T) {
 
 // TODO(justiceHui): add split test for splitLevel > 1
 func TestTreeConcurrencySplitSplit(t *testing.T) {
-	//       0   1   2   3 4 5 6  7   8   9 10 11 12 13    14    15   16 17 18 19 20    21    22
+	//       0   1   2   3 4 5 6 7    8   9 10 11 12 13    14    15   16 17 18 19 20    21    22
 	// <root> <p> <p> <p> a b c d </p> <p> e  f  g  h  </p>  </p>  <p>  i  j  k  l  </p>  </p>  </root>
 
 	initialState := json.TreeNode{
 		Type: "root",
 		Children: []json.TreeNode{
-			{
-				Type: "p", Children: []json.TreeNode{
-					{Type: "p", Children: []json.TreeNode{
-						{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "abcd"}}},
-						{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "efgh"}}},
-					}},
-					{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "ijkl"}}},
-				},
-			},
+			{Type: "p", Children: []json.TreeNode{
+				{Type: "p", Children: []json.TreeNode{
+					{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "abcd"}}},
+					{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "efgh"}}},
+				}},
+				{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "ijkl"}}},
+			}},
 		},
 	}
 	initialXML := `<root><p><p><p>abcd</p><p>efgh</p></p><p>ijkl</p></p></root>`
@@ -367,46 +365,49 @@ func TestTreeConcurrencySplitSplit(t *testing.T) {
 }
 
 func TestTreeConcurrencySplitEdit(t *testing.T) {
-	//       0   1   2 3 4 5 6    7   8 9 10 11 12    13    14   15 16 17 18 19    20
-	// <root> <p> <p> a b c d </p> <p> e f  g  h  </p>  </p>  <p>  i  j  k  l  </p>  </root>
+	//       0   1   2   3 4 5 6 7    8   9 10 11 12 13    14    15   16 17 18 19 20    21    22
+	// <root> <p> <p> <p> a b c d </p> <p> e  f  g  h  </p>  </p>  <p>  i  j  k  l  </p>  </p>  </root>
 
 	initialState := json.TreeNode{
 		Type: "root",
 		Children: []json.TreeNode{
 			{Type: "p", Children: []json.TreeNode{
-				{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "abcd"}}, Attributes: map[string]string{"italic": "true"}},
-				{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "efgh"}}, Attributes: map[string]string{"italic": "true"}},
-			}, Attributes: map[string]string{"italic": "true"}},
-			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "ijkl"}}, Attributes: map[string]string{"italic": "true"}},
+				{Type: "p", Children: []json.TreeNode{
+					{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "abcd"}}, Attributes: map[string]string{"italic": "true"}},
+					{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "efgh"}}, Attributes: map[string]string{"italic": "true"}},
+				}, Attributes: map[string]string{"italic": "true"}},
+				{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "ijkl"}}, Attributes: map[string]string{"italic": "true"}},
+			}},
 		},
 	}
-	initialXML := `<root><p italic="true"><p italic="true">abcd</p><p italic="true">efgh</p></p><p italic="true">ijkl</p></root>`
+	initialXML := `<root><p><p italic="true"><p italic="true">abcd</p><p italic="true">efgh</p></p><p italic="true">ijkl</p></p></root>`
 
 	content := &json.TreeNode{Type: "i", Children: []json.TreeNode{}}
 
 	ranges := []twoRangesType{
 		// equal: <p>ab'cd</p>
-		makeTwoRanges(1, 4, 7, 2, 4, 6, `equal`),
+		makeTwoRanges(2, 5, 8, 2, 5, 8, `equal`),
 		// A contains B: <p>ab'cd</p> - bc
-		makeTwoRanges(1, 4, 7, 3, 4, 5, `A contains B`),
+		makeTwoRanges(2, 5, 8, 4, 5, 6, `A contains B`),
 		// B contains A: <p>ab'cd</p> - <p>abcd</p><p>efgh</p>
-		makeTwoRanges(1, 4, 7, 1, 7, 13, `B contains A`),
+		makeTwoRanges(2, 5, 8, 2, 8, 14, `B contains A`),
 		// left node(text): <p>ab'cd</p> - ab
-		makeTwoRanges(1, 4, 7, 2, 3, 4, `left node(text)`),
+		makeTwoRanges(2, 5, 8, 3, 4, 5, `left node(text)`),
 		// right node(text): <p>ab'cd</p> - cd
-		makeTwoRanges(1, 4, 7, 4, 5, 6, `right node(text)`),
+		makeTwoRanges(2, 5, 8, 5, 6, 7, `right node(text)`),
 		// left node(element): <p>abcd</p>'<p>efgh</p> - <p>abcd</p>
-		makeTwoRanges(1, 7, 13, 1, 4, 7, `left node(element)`),
+		makeTwoRanges(2, 8, 14, 2, 5, 8, `left node(element)`),
 		// right node(element): <p>abcd</p>'<p>efgh</p> - <p>efgh</p>
-		makeTwoRanges(1, 7, 13, 7, 10, 13, `right node(element)`),
+		makeTwoRanges(2, 8, 14, 8, 11, 14, `right node(element)`),
 		// A -> B: <p>ab'cd</p> - <p>efgh</p>
-		makeTwoRanges(1, 4, 7, 7, 10, 13, `A -> B`),
+		makeTwoRanges(2, 5, 8, 8, 11, 14, `A -> B`),
 		// B -> A: <p>ef'gh</p> - <p>abcd</p>
-		makeTwoRanges(7, 10, 13, 1, 4, 7, `B -> A`),
+		makeTwoRanges(8, 11, 14, 2, 5, 8, `B -> A`),
 	}
 
 	splitOperations := []operationInterface{
 		editOperationType{RangeMiddle, SplitUpdate, nil, 1, `split-1`},
+		editOperationType{RangeMiddle, SplitUpdate, nil, 2, `split-2`},
 	}
 
 	editOperations := []operationInterface{

--- a/test/integration/tree_test.go
+++ b/test/integration/tree_test.go
@@ -1343,7 +1343,7 @@ func TestTree(t *testing.T) {
 		assert.Equal(t, "<root><p>a</p><p></p><p>b</p></root>", d1.Root().GetTree("t").ToXML())
 	})
 
-	t.Run("contained-split-and-split-at-diffrent-positions-on-the-same-node", func(t *testing.T) {
+	t.Run("contained-split-and-split-at-different-positions-on-the-same-node", func(t *testing.T) {
 		ctx := context.Background()
 		d1 := document.New(helper.TestDocKey(t))
 		assert.NoError(t, c1.Attach(ctx, d1))
@@ -2623,7 +2623,7 @@ func TestTree(t *testing.T) {
 		assert.Equal(t, "<root><p>a</p><p>b</p></root>", d1.Root().GetTree("t").ToXML())
 	})
 
-	t.Run("side-by-side-split-and-delete", func(t *testing.T) {
+	t.Run("side-by-side-split-and-merge", func(t *testing.T) {
 		ctx := context.Background()
 		d1 := document.New(helper.TestDocKey(t))
 		assert.NoError(t, c1.Attach(ctx, d1))


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Tests (144 + 84 + 900 + 320 + 144 = 1592 cases)
* Style and Style(4 * 6 * 6 = 144 cases):
  - Ranges(4)
    - A = B
    - A contains B
    - A and B are intersecting
    - not intersecting
  - Operations for both A and B(6)
    - `RemoveStyle({'bold'})`
    - `Style({'bold': 'aa'})`
    - `Style({'bold': 'bb'})`
    - `RemoveStyle({'italic'})`
    - `Style({'italic': 'aa'})`
    - `Style({'italic': 'bb'})`
* Edit and Style(7 * 6 * 2 = 84 cases):
  - Ranges(7)
    - A = B, A and B contain single element
    - **[ADDED]** A = B, A and B contain multiple elements 
    - A contains B
    - B contains A
    - A and B are intersecting
    - B is next to A
    - A is next to B
  - Operations for A(6)
    - Insert front of range
    - Insert back of range
    - Insert middle of range
    - Delete
    - Replace
    - **[ADDED]** Merge
  - Operations for B(2)
    - `RemoveStyle({'bold'})`
    - `Style({'bold': 'aa'})`
* Edit and Edit(9 * 10 * 10 = 900 cases):
  - Ranges(9)
    - A and B are intersecting (element)
    - A and B are intersecting (text)
    - A contains B (element)
    - A contains B (text)
    - A contains B (A is element, B is text)
    - B is next to A (element)
    - B is next to A (text)
    - A = B (element)
    - A = B (text)
  - Operations for both A and B(10)
    - Insert text front of range
    - Insert text middle of range
    - Insert text back of range
    - Replace to text node
    - Insert element front of range
    - Insert element middle of range
    - Insert element back of range
    - Replace to element node
    - Delete
    - **[ADDED]** Merge
* **[ADDED]** Split and Split(5 * 8 * 8 = 320 cases)
  - Ranges(5)
    - Equals, single element
    - Equals, multiple element
    - A contains B, same level
    - A contains B, multiple level
    - B is next to A
  - Operations for both A and B(8)
    - Split front of range, level = 1
    - Split front of range, level = 2
    - Split one-quarter of range, level = 1
    - Split one-quarter of range, level = 2
    - Split three-quarter of range, level = 1
    - Split three-quarter of range, level = 2
    - Split back of range, level = 1
    - Split back of range, level = 2
* **[ADDED]** Split and Edit(9 * 2 * 8 = 144 cases):
  - Ranges(9)
    - Equals
    - A contains B
    - B contains A
    - Left node(text) of split node
    - Right node(text) of split node
    - Left node(element) of split node
    - Right node(element) of split node
    - B is next to A
    - A is next to B
  - Operations for A(2)
    - splitLevel = 1
    - splitLevel = 2
  - Operations for B(8)
    - Insert front of range
    - Insert back of range
    - Insert middle of range
    - Delete
    - Replace
    - Merge
    - Style
    - RemoveStyle

Failure cases (0 + 15 + 3 + 60 + 46 = 124/1592 cases)
  - Style and Style (0/144 cases)
  - Edit and Style (15/84 cases)
    - (6) {equal, equal-multiple} / {insert-front, insert-middle, replace} / style
    - (4) {intersect, A -> B} / {insert-middle, insert-back} / style
    - (1) A contains B / insert-middle / style
    - (4) B contains A / {insert-front, insert-middle, insert-back, replace} / style
  - Edit and Edit (3/900 cases)
    - (1) intersect-element / merge / replace-text
      - d1: `<root><p>abcdef</p>B</root>`
      - d2: `<root><p>abc</p>B</root>`
    - (1) intersect-element / merge / replace-element
      - d1: `<root><p>abcdef</p><i></i></root>`
      - d2: `<root><p>abc</p><i></i></root>`
    - (1) intersect-element / merge / delete
      - d1: `<root><p>abcdef</p></root>`
      - d2: `<root><p>abc</p></root>`
  - Split and Split (60/320 cases)
    - (1) equal-single / split-one-quarter-1 / split-back-1
    - (1) equal-single / split-three-quarter-1 / split-back-1
    - (1) equal-multiple / split-three-quarter-1 / split-back-1
    - (1) A contains B same level / split-one-quarter-1 / split-front-1
    - (1) A contains B same level / split-three-quarter-1 / split-back-1
    - (1) A -> B / split-one-quarter-1 / split-front-1
    - (1) A -> B / split-three-quarter-1 / split-back-1
    - (53) and many cases with splitLevel > 1
  - Split and Edit (46/144 cases)
    - (6) equals / {split-1, split-2} / {insert-back, replace, delete}
    - (8) A contains B / {split-1, split-2} / {replace, delete, style, remove-style}
    - (8) B contains A / {split-1, split-2} / {insert-middle, replace, delete, style}
    - (1) B contains A / split-2 / remove-style
    - (8) {right node text, right node element} / {split-1, split-2} / {style, remove-style}
    - (4) {right node text, right node element} / split-2 / {replace, delete}
    - (8) A -> B / {split-1, split-2} / {insert-front, replace, delete, style}
    - (1) A -> B / split-2 / remove-style
    - (2) B -> A / split-2 / {replace, delete}

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
