### PR TITLE
Add Test Server Wait Helper Function

### DIFF
--- a/server/rpc/server_test.go
+++ b/server/rpc/server_test.go
@@ -105,8 +105,11 @@ func TestMain(m *testing.M) {
 		log.Fatal(err)
 	}
 
-	if err := testRPCServer.Start(); err != nil {
+	if err = testRPCServer.Start(); err != nil {
 		log.Fatalf("failed rpc listen: %s\n", err)
+	}
+	if err = helper.WaitForServerToStart(testRPCAddr); err != nil {
+		log.Fatal(err)
 	}
 
 	authInterceptor := client.NewAuthInterceptor(project.PublicKey, "")

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net"
 	"strings"
 	"testing"
 	gotime "time"
@@ -453,4 +454,35 @@ func CreateDummyClientWithID(
 	}
 
 	return nil
+}
+
+// WaitForServerToStart waits for the server to start.
+func WaitForServerToStart(addr string) error {
+	maxRetries := 10
+	initialDelay := 100 * gotime.Millisecond
+	maxDelay := 5 * gotime.Second
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		// Exponential backoff calculation
+		delay := initialDelay * gotime.Duration(1<<uint(attempt))
+		fmt.Println("delay: ", delay)
+		if delay > maxDelay {
+			delay = maxDelay
+		}
+
+		conn, err := net.DialTimeout("tcp", addr, 1*gotime.Second)
+		if err != nil {
+			gotime.Sleep(delay)
+			continue
+		}
+
+		err = conn.Close()
+		if err != nil {
+			return fmt.Errorf("failed to close connection: %w", err)
+		}
+
+		return nil
+	}
+
+	return fmt.Errorf("failed to connect server via %s", addr)
 }

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -478,11 +478,11 @@ func WaitForServerToStart(addr string) error {
 
 		err = conn.Close()
 		if err != nil {
-			return fmt.Errorf("failed to close connection: %w", err)
+			return fmt.Errorf("close connection: %w", err)
 		}
 
 		return nil
 	}
 
-	return fmt.Errorf("failed to connect server via %s", addr)
+	return fmt.Errorf("timeout for server to start: %s", addr)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add test server wait helper function `WaitForServerToStart()` to resolve `Connection Refused` error in server-related tests.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #784 

**Special notes for your reviewer**:

To valify this, add `time.Sleep(10 * time.Second)` inside server's `listenAndServe()` goroutine to reproduce `Connection Refused` error and test it with and without `WaitForServerToStart()`.

```go
func (s *Server) listenAndServe() error {
	go func() {
		time.Sleep(5 * time.Second)
		logging.DefaultLogger().Infof(fmt.Sprintf("serving RPC on %d", s.conf.Port))
...
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
