### PR TITLE
Prevent RunTestConcurrency from creating garbage clients

### DIFF
--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -941,18 +941,21 @@ func (t *Tree) FindTreeNodesWithSplitText(pos *TreePos, editedAt *time.Ticket) (
 	// 04. Find the appropriate left node. If some nodes are inserted at the
 	// same position concurrently, then we need to find the appropriate left
 	// node. This is similar to RGA.
-	idx := 0
-	if !isLeftMost {
-		idx = realParentNode.Index.OffsetOfChild(leftNode.Index) + 1
-	}
 
-	parentChildren := realParentNode.Index.Children(true)
-	for i := idx; i < len(parentChildren); i++ {
-		next := parentChildren[i].Value
-		if !next.ID.CreatedAt.After(editedAt) {
-			break
+	if editedAt != nil {
+		idx := 0
+		if !isLeftMost {
+			idx = realParentNode.Index.OffsetOfChild(leftNode.Index) + 1
 		}
-		leftNode = next
+
+		parentChildren := realParentNode.Index.Children(true)
+		for i := idx; i < len(parentChildren); i++ {
+			next := parentChildren[i].Value
+			if !next.ID.CreatedAt.After(editedAt) {
+				break
+			}
+			leftNode = next
+		}
 	}
 
 	return realParentNode, leftNode, nil

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -941,21 +941,18 @@ func (t *Tree) FindTreeNodesWithSplitText(pos *TreePos, editedAt *time.Ticket) (
 	// 04. Find the appropriate left node. If some nodes are inserted at the
 	// same position concurrently, then we need to find the appropriate left
 	// node. This is similar to RGA.
+	idx := 0
+	if !isLeftMost {
+		idx = realParentNode.Index.OffsetOfChild(leftNode.Index) + 1
+	}
 
-	if editedAt != nil {
-		idx := 0
-		if !isLeftMost {
-			idx = realParentNode.Index.OffsetOfChild(leftNode.Index) + 1
+	parentChildren := realParentNode.Index.Children(true)
+	for i := idx; i < len(parentChildren); i++ {
+		next := parentChildren[i].Value
+		if !next.ID.CreatedAt.After(editedAt) {
+			break
 		}
-
-		parentChildren := realParentNode.Index.Children(true)
-		for i := idx; i < len(parentChildren); i++ {
-			next := parentChildren[i].Value
-			if !next.ID.CreatedAt.After(editedAt) {
-				break
-			}
-			leftNode = next
-		}
+		leftNode = next
 	}
 
 	return realParentNode, leftNode, nil

--- a/test/integration/tree_concurrency_test.go
+++ b/test/integration/tree_concurrency_test.go
@@ -207,16 +207,17 @@ func (op editOperationType) run(t *testing.T, doc *document.Document, user int, 
 func RunTestTreeConcurrency(testDesc string, t *testing.T, initialState json.TreeNode, initialXML string,
 	rangesArr []twoRangesType, opArr1, opArr2 []operationInterface) {
 
-	runTest := func(ranges twoRangesType, op1, op2 operationInterface) testResult {
-		clients := activeClients(t, 2)
-		c1, c2 := clients[0], clients[1]
-		defer deactivateAndCloseClients(t, clients)
+	clients := activeClients(t, 2)
+	c1, c2 := clients[0], clients[1]
+	defer deactivateAndCloseClients(t, clients)
 
-		ctx := context.Background()
-		d1 := document.New(helper.TestDocKey(t))
-		assert.NoError(t, c1.Attach(ctx, d1))
-		d2 := document.New(helper.TestDocKey(t))
-		assert.NoError(t, c2.Attach(ctx, d2))
+	ctx := context.Background()
+	d1 := document.New(helper.TestDocKey(t))
+	assert.NoError(t, c1.Attach(ctx, d1))
+	d2 := document.New(helper.TestDocKey(t))
+	assert.NoError(t, c2.Attach(ctx, d2))
+
+	runTest := func(ranges twoRangesType, op1, op2 operationInterface) testResult {
 
 		assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
 			root.SetNewTree("t", &initialState)

--- a/test/integration/tree_test.go
+++ b/test/integration/tree_test.go
@@ -425,7 +425,7 @@ func TestTree(t *testing.T) {
 			root.GetTree("t").EditBulk(3, 3, []*json.TreeNode{{
 				Type:  "text",
 				Value: "c",
-			}, &json.TreeNode{
+			}, {
 				Type:  "text",
 				Value: "d",
 			}}, 0)
@@ -451,7 +451,7 @@ func TestTree(t *testing.T) {
 			root.GetTree("t").EditBulk(4, 4, []*json.TreeNode{{
 				Type:     "p",
 				Children: []json.TreeNode{{Type: "text", Value: "cd"}},
-			}, &json.TreeNode{
+			}, {
 				Type:     "i",
 				Children: []json.TreeNode{{Type: "text", Value: "fg"}},
 			}}, 0)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Change `RunTestTreeConcurrency` function in `tree_concurrency_test.go` not to create and close clients in each test.

This PR can solve the performance degradation problem that occurs when vector clocks are used (#786).

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
