### PR TITLE
Handling errors in concurrent editing and styling

### DIFF
--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -860,6 +860,10 @@ func (t *Tree) Style(from, to *TreePos, attributes map[string]string, editedAt *
 		func(token index.TreeToken[*TreeNode], _ bool) {
 			node := token.Node
 			if !node.IsRemoved() && !node.IsText() && len(attributes) > 0 {
+				if editedAt.After(node.ID.CreatedAt) {
+					return
+				}
+
 				if node.Attrs == nil {
 					node.Attrs = NewRHT()
 				}
@@ -893,6 +897,9 @@ func (t *Tree) RemoveStyle(from, to *TreePos, attributesToRemove []string, edite
 			node := token.Node
 			// NOTE(justiceHui): Even if key is not existed, we must set flag `isRemoved` for concurrency
 			if !node.IsRemoved() && !node.IsText() {
+				if editedAt.After(node.ID.CreatedAt) {
+					return
+				}
 				if node.Attrs == nil {
 					node.Attrs = NewRHT()
 				}

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -860,7 +860,7 @@ func (t *Tree) Style(from, to *TreePos, attributes map[string]string, editedAt *
 		func(token index.TreeToken[*TreeNode], _ bool) {
 			node := token.Node
 			if !node.IsRemoved() && !node.IsText() && len(attributes) > 0 {
-				if editedAt.After(node.ID.CreatedAt) {
+				if node.ID.CreatedAt.Compare(editedAt) <= 0 {
 					return
 				}
 
@@ -897,7 +897,7 @@ func (t *Tree) RemoveStyle(from, to *TreePos, attributesToRemove []string, edite
 			node := token.Node
 			// NOTE(justiceHui): Even if key is not existed, we must set flag `isRemoved` for concurrency
 			if !node.IsRemoved() && !node.IsText() {
-				if editedAt.After(node.ID.CreatedAt) {
+				if node.ID.CreatedAt.Compare(editedAt) <= 0 {
 					return
 				}
 				if node.Attrs == nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Refer to #780 , there is an error occurring in the concurrent editing and styling (Edit+Style) handling.
In a concurrent editing and styling situation, I've concerned the difference between **the creation time of nodes included in the style operation range** and **the time ticket for concurrent editing**.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #788 
Related #780 

**Special notes for your reviewer**:
For handle this error, I added logic to ignore style operation(+ removeStyle) for nodes created before concurrency edit writed below. A list of tests resolved with this change can be found in #788 (All test cases related to Style).
* AS-IS:
```go
err = t.traverseInPosRange(fromParent, fromLeft, toParent, toLeft,
func(token index.TreeToken[*TreeNode], _ bool) {
	node := token.Node
	if !node.IsRemoved() && !node.IsText() && len(attributes) > 0 {
		if node.Attrs == nil {
			node.Attrs = NewRHT()
		}

		for key, value := range attributes {
			node.Attrs.Set(key, value, editedAt)
		}
	}
})
```
* TO-BE:
```go
err = t.traverseInPosRange(fromParent, fromLeft, toParent, toLeft,
func(token index.TreeToken[*TreeNode], _ bool) {
	node := token.Node
	if !node.IsRemoved() && !node.IsText() && len(attributes) > 0 {
		// Added here
		if editedAt.After(node.ID.CreatedAt) {
			return
		}
		if node.Attrs == nil {
			node.Attrs = NewRHT()
		}

		for key, value := range attributes {
			node.Attrs.Set(key, value, editedAt)
		}
	}
})
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
