### PR TITLE
Move Client.Watch inside Client.Attach

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -83,7 +83,7 @@ type Attachment struct {
 	doc   *document.Document
 	docID types.ID
 
-	// TODO(krapie): assuming that a client do not open multiple subscriptions for the same document.
+	// TODO(krapie): We need to consider the case where a client opens multiple subscriptions for the same document.
 	isSubscribed atomic.Bool
 
 	rch              <-chan WatchResponse
@@ -437,10 +437,9 @@ func (c *Client) Subscribe(
 		return nil, nil, ErrDocumentNotAttached
 	}
 
-	if attachment.isSubscribed.Load() {
+	if !attachment.isSubscribed.CompareAndSwap(false, true) {
 		return nil, nil, ErrAlreadySubscribed
 	}
-	attachment.isSubscribed.Store(true)
 
 	return attachment.rch, attachment.closeWatchStream, nil
 }

--- a/test/bench/grpc_bench_test.go
+++ b/test/bench/grpc_bench_test.go
@@ -221,9 +221,9 @@ func BenchmarkRPC(b *testing.B) {
 		})
 		assert.NoError(b, err)
 
-		rch1, err := c1.Watch(ctx, d1)
+		rch1, _, err := c1.Subscribe(d1)
 		assert.NoError(b, err)
-		rch2, err := c2.Watch(ctx, d2)
+		rch2, _, err := c2.Subscribe(d2)
 		assert.NoError(b, err)
 
 		done1 := make(chan bool)

--- a/test/integration/admin_test.go
+++ b/test/integration/admin_test.go
@@ -83,15 +83,14 @@ func TestAdmin(t *testing.T) {
 
 	t.Run("document event propagation on removal test", func(t *testing.T) {
 		ctx := context.Background()
-		watchCtx, cancel := context.WithCancel(ctx)
-		defer cancel()
 
 		// 01. c1 attaches and watches d1.
 		d1 := document.New(helper.TestDocKey(t))
 		assert.NoError(t, c1.Attach(ctx, d1))
 		wg := sync.WaitGroup{}
 		wg.Add(1)
-		rch, err := c1.Watch(watchCtx, d1)
+		rch, cancel, err := c1.Subscribe(d1)
+		defer cancel()
 		assert.NoError(t, err)
 		go func() {
 			defer wg.Done()

--- a/test/integration/auth_webhook_test.go
+++ b/test/integration/auth_webhook_test.go
@@ -177,7 +177,7 @@ func TestProjectAuthWebhook(t *testing.T) {
 		err = cli.Attach(ctx, doc)
 		assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
 
-		_, err = cli.Watch(ctx, doc)
+		_, _, err = cli.Subscribe(doc)
 		assert.Equal(t, client.ErrDocumentNotAttached, err)
 	})
 }

--- a/test/integration/document_test.go
+++ b/test/integration/document_test.go
@@ -166,7 +166,6 @@ func TestDocument(t *testing.T) {
 		rch, _, err := c1.Subscribe(d1)
 		assert.NoError(t, err)
 
-		isPresenceChangedEvent := true
 		go func() {
 			defer wg.Done()
 
@@ -178,16 +177,7 @@ func TestDocument(t *testing.T) {
 				}
 				assert.NoError(t, resp.Err)
 
-				// TODO(krapie): event includes presence changes in the document too.
-				// therefore, there will be
-				// 1. DocumentChanged from client 2 (Presence change)
-				// 2. DocumentWatched from client 2 (Watch event)
-				// 3. DocumentChanged from client 2 (Document change)
 				if resp.Type == client.DocumentChanged {
-					if isPresenceChangedEvent {
-						isPresenceChangedEvent = false
-						continue
-					}
 					err := c1.Sync(ctx, client.WithDocKey(d1.Key()))
 					assert.NoError(t, err)
 					return

--- a/test/integration/presence_test.go
+++ b/test/integration/presence_test.go
@@ -139,9 +139,8 @@ func TestPresence(t *testing.T) {
 		wgEvents := sync.WaitGroup{}
 		wgEvents.Add(1)
 
-		watch1Ctx, cancel1 := context.WithCancel(ctx)
+		wrch, cancel1, err := c1.Subscribe(d1)
 		defer cancel1()
-		wrch, err := c1.Watch(watch1Ctx, d1)
 		assert.NoError(t, err)
 		go func() {
 			defer func() {
@@ -177,8 +176,7 @@ func TestPresence(t *testing.T) {
 				c2.ID().String(): {},
 			},
 		})
-		watch2Ctx, cancel2 := context.WithCancel(ctx)
-		_, err = c2.Watch(watch2Ctx, d2)
+		_, cancel2, err := c2.Subscribe(d2)
 		assert.NoError(t, err)
 
 		// 04. Update the second client's presence.
@@ -224,9 +222,8 @@ func TestPresence(t *testing.T) {
 		wgEvents := sync.WaitGroup{}
 		wgEvents.Add(1)
 
-		watch1Ctx, cancel1 := context.WithCancel(ctx)
+		wrch, cancel1, err := c1.Subscribe(d1)
 		defer cancel1()
-		wrch, err := c1.Watch(watch1Ctx, d1)
 		assert.NoError(t, err)
 		go func() {
 			defer func() {
@@ -263,9 +260,8 @@ func TestPresence(t *testing.T) {
 				c2.ID().String(): {},
 			},
 		})
-		watch2Ctx, cancel2 := context.WithCancel(ctx)
+		_, cancel2, err := c2.Subscribe(d2)
 		defer cancel2()
-		_, err = c2.Watch(watch2Ctx, d2)
 		assert.NoError(t, err)
 
 		// 04. Update the second client's presence.
@@ -313,9 +309,8 @@ func TestPresence(t *testing.T) {
 		wgEvents := sync.WaitGroup{}
 		wgEvents.Add(1)
 
-		watch1Ctx, cancel1 := context.WithCancel(ctx)
+		wrch, cancel1, err := c1.Subscribe(d1)
 		defer cancel1()
-		wrch, err := c1.Watch(watch1Ctx, d1)
 		assert.NoError(t, err)
 		go func() {
 			defer func() {
@@ -352,9 +347,8 @@ func TestPresence(t *testing.T) {
 				c2.ID().String(): {},
 			},
 		})
-		watch2Ctx, cancel2 := context.WithCancel(ctx)
+		_, cancel2, err := c2.Subscribe(d2)
 		defer cancel2()
-		_, err = c2.Watch(watch2Ctx, d2)
 		assert.NoError(t, err)
 
 		// 04. Update the second client's presence.
@@ -405,9 +399,8 @@ func TestPresence(t *testing.T) {
 		wgEvents := sync.WaitGroup{}
 		wgEvents.Add(1)
 
-		watch1Ctx, cancel1 := context.WithCancel(ctx)
+		wrch, cancel1, err := c1.Subscribe(d1)
 		defer cancel1()
-		wrch, err := c1.Watch(watch1Ctx, d1)
 		assert.NoError(t, err)
 		go func() {
 			defer func() {
@@ -452,13 +445,11 @@ func TestPresence(t *testing.T) {
 				c2.ID().String(): d2.MyPresence(),
 			},
 		})
-		watch2Ctx, cancel2 := context.WithCancel(ctx)
-		_, err = c2.Watch(watch2Ctx, d2)
+		_, cancel2, err := c2.Subscribe(d2)
 		assert.NoError(t, err)
 		assert.NoError(t, c1.Sync(ctx, client.WithDocKey(helper.TestDocKey(t))))
 
-		watch3Ctx, cancel3 := context.WithCancel(ctx)
-		_, err = c2.Watch(watch3Ctx, d3)
+		_, cancel3, err := c2.Subscribe(d3)
 		assert.NoError(t, err)
 
 		// 05. The second client unwatch the documents attached by itself.

--- a/test/integration/server_test.go
+++ b/test/integration/server_test.go
@@ -45,7 +45,7 @@ func TestServer(t *testing.T) {
 		assert.NoError(t, cli.Attach(ctx, doc))
 
 		wg := sync.WaitGroup{}
-		wrch, err := cli.Watch(ctx, doc)
+		wrch, _, err := cli.Subscribe(doc)
 		assert.NoError(t, err)
 
 		go func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Move `Client.Watch()` inside `Client.Attach()` to hide it from external interface.
This PR also introduces `Client.Subscribe()` which performs similar functionality with other SDKs. 

This PR is recreated from https://github.com/yorkie-team/yorkie/pull/593 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Address #584

**Special notes for your reviewer**:

I prefer keeping this PR size as small as possible to wrap up this task on time.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Go SDK user will use `Client.Subscribe()` instead of `Client.Watch()`, just like other SDKs.
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
