### PR TITLE
Add Swagger Serving Command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ tools: ## install tools for developing yorkie
 	go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.31.0
 	go install connectrpc.com/connect/cmd/protoc-gen-connect-go@v1.12.0
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.1
+	go install github.com/sudorandom/protoc-gen-connect-openapi@v0.5.0
 
 proto: ## generate proto files
 	buf generate

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ docker: ## builds docker images with the current version and latest tag
 docker-latest: ## builds docker images with latest tag
 	docker buildx build --push --platform linux/amd64,linux/arm64,linux/386 -t yorkieteam/yorkie:latest .
 
-docker-swagger: ## runs swagger-ui with the yorkie api docs
+swagger: ## runs swagger-ui with the yorkie api docs
 	docker run -p 3000:8080 \
   		-e URLS="[ \
 			{ url: 'docs/yorkie/v1/admin.openapi.yaml', name: 'Admin' }, \

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,16 @@ docker: ## builds docker images with the current version and latest tag
 docker-latest: ## builds docker images with latest tag
 	docker buildx build --push --platform linux/amd64,linux/arm64,linux/386 -t yorkieteam/yorkie:latest .
 
+docker-swagger:
+	docker run -p 3000:8080 \
+  		-e URLS="[ \
+			{ url: 'docs/yorkie/v1/admin.openapi.yaml', name: 'Admin' }, \
+			{ url: 'docs/yorkie/v1/resources.openapi.yaml', name: 'Resources' }, \
+			{ url: 'docs/yorkie/v1/yorkie.openapi.yaml', name: 'Yorkie' }  \
+		]" \
+		-v `pwd`/api/docs:/usr/share/nginx/html/docs/ \
+  		swaggerapi/swagger-ui
+
 help:
 	@echo 'Commands:'
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "    %-20s %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ docker: ## builds docker images with the current version and latest tag
 docker-latest: ## builds docker images with latest tag
 	docker buildx build --push --platform linux/amd64,linux/arm64,linux/386 -t yorkieteam/yorkie:latest .
 
-docker-swagger:
+docker-swagger: ## runs swagger-ui with the yorkie api docs
 	docker run -p 3000:8080 \
   		-e URLS="[ \
 			{ url: 'docs/yorkie/v1/admin.openapi.yaml', name: 'Admin' }, \

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ tools: ## install tools for developing yorkie
 	go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.31.0
 	go install connectrpc.com/connect/cmd/protoc-gen-connect-go@v1.12.0
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.1
-	go install github.com/sudorandom/protoc-gen-connect-openapi@v0.5.0
+	go install github.com/sudorandom/protoc-gen-connect-openapi@v0.5.5
 
 proto: ## generate proto files
 	buf generate

--- a/api/docs/yorkie.base.yaml
+++ b/api/docs/yorkie.base.yaml
@@ -1,0 +1,5 @@
+openapi: 3.1.0
+info:
+  title: Yorkie
+  description: "Yorkie is an open source document store for building collaborative editing applications."
+  version: v0.4.14

--- a/api/docs/yorkie.base.yaml
+++ b/api/docs/yorkie.base.yaml
@@ -3,3 +3,16 @@ info:
   title: Yorkie
   description: "Yorkie is an open source document store for building collaborative editing applications."
   version: v0.4.14
+servers:
+  - url: https://api.yorkie.dev
+    description: Production server
+  - url: http://localhost:8080
+    description: Local server
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: Authorization
+security:
+  - ApiKeyAuth: [] # use the same name as under securitySchemes

--- a/api/docs/yorkie/v1/admin.openapi.yaml
+++ b/api/docs/yorkie/v1/admin.openapi.yaml
@@ -1,0 +1,1932 @@
+openapi: 3.1.0
+info:
+  description: Yorkie is an open source document store for building collaborative
+    editing applications.
+  title: Yorkie
+  version: v0.4.14
+paths:
+  /yorkie.v1.AdminService/CreateProject:
+    post:
+      description: ""
+      requestBody:
+        $ref: '#/components/requestBodies/yorkie.v1.AdminService.CreateProject.yorkie.v1.CreateProjectRequest'
+      responses:
+        "200":
+          $ref: '#/components/responses/yorkie.v1.AdminService.CreateProject.yorkie.v1.CreateProjectResponse'
+        default:
+          $ref: '#/components/responses/connect.error'
+      tags:
+      - yorkie.v1.AdminService
+  /yorkie.v1.AdminService/GetDocument:
+    post:
+      description: ""
+      requestBody:
+        $ref: '#/components/requestBodies/yorkie.v1.AdminService.GetDocument.yorkie.v1.GetDocumentRequest'
+      responses:
+        "200":
+          $ref: '#/components/responses/yorkie.v1.AdminService.GetDocument.yorkie.v1.GetDocumentResponse'
+        default:
+          $ref: '#/components/responses/connect.error'
+      tags:
+      - yorkie.v1.AdminService
+  /yorkie.v1.AdminService/GetProject:
+    post:
+      description: ""
+      requestBody:
+        $ref: '#/components/requestBodies/yorkie.v1.AdminService.GetProject.yorkie.v1.GetProjectRequest'
+      responses:
+        "200":
+          $ref: '#/components/responses/yorkie.v1.AdminService.GetProject.yorkie.v1.GetProjectResponse'
+        default:
+          $ref: '#/components/responses/connect.error'
+      tags:
+      - yorkie.v1.AdminService
+  /yorkie.v1.AdminService/GetSnapshotMeta:
+    post:
+      description: ""
+      requestBody:
+        $ref: '#/components/requestBodies/yorkie.v1.AdminService.GetSnapshotMeta.yorkie.v1.GetSnapshotMetaRequest'
+      responses:
+        "200":
+          $ref: '#/components/responses/yorkie.v1.AdminService.GetSnapshotMeta.yorkie.v1.GetSnapshotMetaResponse'
+        default:
+          $ref: '#/components/responses/connect.error'
+      tags:
+      - yorkie.v1.AdminService
+  /yorkie.v1.AdminService/ListChanges:
+    post:
+      description: ""
+      requestBody:
+        $ref: '#/components/requestBodies/yorkie.v1.AdminService.ListChanges.yorkie.v1.ListChangesRequest'
+      responses:
+        "200":
+          $ref: '#/components/responses/yorkie.v1.AdminService.ListChanges.yorkie.v1.ListChangesResponse'
+        default:
+          $ref: '#/components/responses/connect.error'
+      tags:
+      - yorkie.v1.AdminService
+  /yorkie.v1.AdminService/ListDocuments:
+    post:
+      description: ""
+      requestBody:
+        $ref: '#/components/requestBodies/yorkie.v1.AdminService.ListDocuments.yorkie.v1.ListDocumentsRequest'
+      responses:
+        "200":
+          $ref: '#/components/responses/yorkie.v1.AdminService.ListDocuments.yorkie.v1.ListDocumentsResponse'
+        default:
+          $ref: '#/components/responses/connect.error'
+      tags:
+      - yorkie.v1.AdminService
+  /yorkie.v1.AdminService/ListProjects:
+    post:
+      description: ""
+      requestBody:
+        $ref: '#/components/requestBodies/yorkie.v1.AdminService.ListProjects.yorkie.v1.ListProjectsRequest'
+      responses:
+        "200":
+          $ref: '#/components/responses/yorkie.v1.AdminService.ListProjects.yorkie.v1.ListProjectsResponse'
+        default:
+          $ref: '#/components/responses/connect.error'
+      tags:
+      - yorkie.v1.AdminService
+  /yorkie.v1.AdminService/LogIn:
+    post:
+      description: ""
+      requestBody:
+        $ref: '#/components/requestBodies/yorkie.v1.AdminService.LogIn.yorkie.v1.LogInRequest'
+      responses:
+        "200":
+          $ref: '#/components/responses/yorkie.v1.AdminService.LogIn.yorkie.v1.LogInResponse'
+        default:
+          $ref: '#/components/responses/connect.error'
+      tags:
+      - yorkie.v1.AdminService
+  /yorkie.v1.AdminService/RemoveDocumentByAdmin:
+    post:
+      description: ""
+      requestBody:
+        $ref: '#/components/requestBodies/yorkie.v1.AdminService.RemoveDocumentByAdmin.yorkie.v1.RemoveDocumentByAdminRequest'
+      responses:
+        "200":
+          $ref: '#/components/responses/yorkie.v1.AdminService.RemoveDocumentByAdmin.yorkie.v1.RemoveDocumentByAdminResponse'
+        default:
+          $ref: '#/components/responses/connect.error'
+      tags:
+      - yorkie.v1.AdminService
+  /yorkie.v1.AdminService/SearchDocuments:
+    post:
+      description: ""
+      requestBody:
+        $ref: '#/components/requestBodies/yorkie.v1.AdminService.SearchDocuments.yorkie.v1.SearchDocumentsRequest'
+      responses:
+        "200":
+          $ref: '#/components/responses/yorkie.v1.AdminService.SearchDocuments.yorkie.v1.SearchDocumentsResponse'
+        default:
+          $ref: '#/components/responses/connect.error'
+      tags:
+      - yorkie.v1.AdminService
+  /yorkie.v1.AdminService/SignUp:
+    post:
+      description: ""
+      requestBody:
+        $ref: '#/components/requestBodies/yorkie.v1.AdminService.SignUp.yorkie.v1.SignUpRequest'
+      responses:
+        "200":
+          $ref: '#/components/responses/yorkie.v1.AdminService.SignUp.yorkie.v1.SignUpResponse'
+        default:
+          $ref: '#/components/responses/connect.error'
+      tags:
+      - yorkie.v1.AdminService
+  /yorkie.v1.AdminService/UpdateProject:
+    post:
+      description: ""
+      requestBody:
+        $ref: '#/components/requestBodies/yorkie.v1.AdminService.UpdateProject.yorkie.v1.UpdateProjectRequest'
+      responses:
+        "200":
+          $ref: '#/components/responses/yorkie.v1.AdminService.UpdateProject.yorkie.v1.UpdateProjectResponse'
+        default:
+          $ref: '#/components/responses/connect.error'
+      tags:
+      - yorkie.v1.AdminService
+components:
+  requestBodies:
+    yorkie.v1.AdminService.CreateProject.yorkie.v1.CreateProjectRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.CreateProjectRequest'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.CreateProjectRequest'
+      required: true
+    yorkie.v1.AdminService.GetDocument.yorkie.v1.GetDocumentRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.GetDocumentRequest'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.GetDocumentRequest'
+      required: true
+    yorkie.v1.AdminService.GetProject.yorkie.v1.GetProjectRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.GetProjectRequest'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.GetProjectRequest'
+      required: true
+    yorkie.v1.AdminService.GetSnapshotMeta.yorkie.v1.GetSnapshotMetaRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.GetSnapshotMetaRequest'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.GetSnapshotMetaRequest'
+      required: true
+    yorkie.v1.AdminService.ListChanges.yorkie.v1.ListChangesRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.ListChangesRequest'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.ListChangesRequest'
+      required: true
+    yorkie.v1.AdminService.ListDocuments.yorkie.v1.ListDocumentsRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.ListDocumentsRequest'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.ListDocumentsRequest'
+      required: true
+    yorkie.v1.AdminService.ListProjects.yorkie.v1.ListProjectsRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.ListProjectsRequest'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.ListProjectsRequest'
+      required: true
+    yorkie.v1.AdminService.LogIn.yorkie.v1.LogInRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.LogInRequest'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.LogInRequest'
+      required: true
+    yorkie.v1.AdminService.RemoveDocumentByAdmin.yorkie.v1.RemoveDocumentByAdminRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.RemoveDocumentByAdminRequest'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.RemoveDocumentByAdminRequest'
+      required: true
+    yorkie.v1.AdminService.SearchDocuments.yorkie.v1.SearchDocumentsRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.SearchDocumentsRequest'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.SearchDocumentsRequest'
+      required: true
+    yorkie.v1.AdminService.SignUp.yorkie.v1.SignUpRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.SignUpRequest'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.SignUpRequest'
+      required: true
+    yorkie.v1.AdminService.UpdateProject.yorkie.v1.UpdateProjectRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.UpdateProjectRequest'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.UpdateProjectRequest'
+      required: true
+  responses:
+    connect.error:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/connect.error'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/connect.error'
+      description: ""
+    yorkie.v1.AdminService.CreateProject.yorkie.v1.CreateProjectResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.CreateProjectResponse'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.CreateProjectResponse'
+      description: ""
+    yorkie.v1.AdminService.GetDocument.yorkie.v1.GetDocumentResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.GetDocumentResponse'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.GetDocumentResponse'
+      description: ""
+    yorkie.v1.AdminService.GetProject.yorkie.v1.GetProjectResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.GetProjectResponse'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.GetProjectResponse'
+      description: ""
+    yorkie.v1.AdminService.GetSnapshotMeta.yorkie.v1.GetSnapshotMetaResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.GetSnapshotMetaResponse'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.GetSnapshotMetaResponse'
+      description: ""
+    yorkie.v1.AdminService.ListChanges.yorkie.v1.ListChangesResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.ListChangesResponse'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.ListChangesResponse'
+      description: ""
+    yorkie.v1.AdminService.ListDocuments.yorkie.v1.ListDocumentsResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.ListDocumentsResponse'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.ListDocumentsResponse'
+      description: ""
+    yorkie.v1.AdminService.ListProjects.yorkie.v1.ListProjectsResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.ListProjectsResponse'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.ListProjectsResponse'
+      description: ""
+    yorkie.v1.AdminService.LogIn.yorkie.v1.LogInResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.LogInResponse'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.LogInResponse'
+      description: ""
+    yorkie.v1.AdminService.RemoveDocumentByAdmin.yorkie.v1.RemoveDocumentByAdminResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.RemoveDocumentByAdminResponse'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.RemoveDocumentByAdminResponse'
+      description: ""
+    yorkie.v1.AdminService.SearchDocuments.yorkie.v1.SearchDocumentsResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.SearchDocumentsResponse'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.SearchDocumentsResponse'
+      description: ""
+    yorkie.v1.AdminService.SignUp.yorkie.v1.SignUpResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.SignUpResponse'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.SignUpResponse'
+      description: ""
+    yorkie.v1.AdminService.UpdateProject.yorkie.v1.UpdateProjectResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.UpdateProjectResponse'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.UpdateProjectResponse'
+      description: ""
+  schemas:
+    connect.error:
+      additionalProperties: false
+      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
+      properties:
+        code:
+          enum:
+          - CodeCanceled
+          - CodeUnknown
+          - CodeInvalidArgument
+          - CodeDeadlineExceeded
+          - CodeNotFound
+          - CodeAlreadyExists
+          - CodePermissionDenied
+          - CodeResourceExhausted
+          - CodeFailedPrecondition
+          - CodeAborted
+          - CodeOutOfRange
+          - CodeInternal
+          - CodeUnavailable
+          - CodeDataLoss
+          - CodeUnauthenticated
+          examples:
+          - CodeNotFound
+          type: string
+        message:
+          type: string
+      title: Connect Error
+      type: object
+    google.protobuf.StringValue:
+      additionalProperties: false
+      description: |-
+        Wrapper message for `string`.
+
+         The JSON representation for `StringValue` is JSON string.
+      properties:
+        value:
+          additionalProperties: false
+          description: The string value.
+          title: value
+          type: string
+      title: StringValue
+      type: object
+    google.protobuf.Timestamp:
+      additionalProperties: false
+      description: |-
+        A Timestamp represents a point in time independent of any time zone or local
+         calendar, encoded as a count of seconds and fractions of seconds at
+         nanosecond resolution. The count is relative to an epoch at UTC midnight on
+         January 1, 1970, in the proleptic Gregorian calendar which extends the
+         Gregorian calendar backwards to year one.
+
+         All minutes are 60 seconds long. Leap seconds are "smeared" so that no leap
+         second table is needed for interpretation, using a [24-hour linear
+         smear](https://developers.google.com/time/smear).
+
+         The range is from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z. By
+         restricting to that range, we ensure that we can convert to and from [RFC
+         3339](https://www.ietf.org/rfc/rfc3339.txt) date strings.
+
+         # Examples
+
+         Example 1: Compute Timestamp from POSIX `time()`.
+
+             Timestamp timestamp;
+             timestamp.set_seconds(time(NULL));
+             timestamp.set_nanos(0);
+
+         Example 2: Compute Timestamp from POSIX `gettimeofday()`.
+
+             struct timeval tv;
+             gettimeofday(&tv, NULL);
+
+             Timestamp timestamp;
+             timestamp.set_seconds(tv.tv_sec);
+             timestamp.set_nanos(tv.tv_usec * 1000);
+
+         Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
+
+             FILETIME ft;
+             GetSystemTimeAsFileTime(&ft);
+             UINT64 ticks = (((UINT64)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+
+             // A Windows tick is 100 nanoseconds. Windows epoch 1601-01-01T00:00:00Z
+             // is 11644473600 seconds before Unix epoch 1970-01-01T00:00:00Z.
+             Timestamp timestamp;
+             timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
+             timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
+
+         Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
+
+             long millis = System.currentTimeMillis();
+
+             Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
+                 .setNanos((int) ((millis % 1000) * 1000000)).build();
+
+         Example 5: Compute Timestamp from Java `Instant.now()`.
+
+             Instant now = Instant.now();
+
+             Timestamp timestamp =
+                 Timestamp.newBuilder().setSeconds(now.getEpochSecond())
+                     .setNanos(now.getNano()).build();
+
+         Example 6: Compute Timestamp from current time in Python.
+
+             timestamp = Timestamp()
+             timestamp.GetCurrentTime()
+
+         # JSON Mapping
+
+         In JSON format, the Timestamp type is encoded as a string in the
+         [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
+         format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
+         where {year} is always expressed using four digits while {month}, {day},
+         {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+         seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
+         are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
+         is required. A proto3 JSON serializer should always use UTC (as indicated by
+         "Z") when printing the Timestamp type and a proto3 JSON parser should be
+         able to accept both UTC and other timezones (as indicated by an offset).
+
+         For example, "2017-01-15T01:30:15.01Z" encodes 15.01 seconds past
+         01:30 UTC on January 15, 2017.
+
+         In JavaScript, one can convert a Date object to this format using the
+         standard
+         [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString)
+         method. In Python, a standard `datetime.datetime` object can be converted
+         to this format using
+         [`strftime`](https://docs.python.org/2/library/time.html#time.strftime) with
+         the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one can use
+         the Joda Time's [`ISODateTimeFormat.dateTime()`](
+         http://joda-time.sourceforge.net/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime()
+         ) to obtain a formatter capable of generating timestamps in this format.
+      format: date-time
+      type: string
+    yorkie.v1.Change:
+      additionalProperties: false
+      description: ""
+      properties:
+        id:
+          $ref: '#/components/schemas/yorkie.v1.ChangeID'
+          additionalProperties: false
+          description: ""
+          title: id
+          type: object
+        message:
+          additionalProperties: false
+          description: ""
+          title: message
+          type: string
+        operations:
+          additionalProperties: false
+          description: ""
+          items:
+            $ref: '#/components/schemas/yorkie.v1.Operation'
+            type: object
+          title: operations
+          type: array
+        presenceChange:
+          $ref: '#/components/schemas/yorkie.v1.PresenceChange'
+          additionalProperties: false
+          description: ""
+          title: presence_change
+          type: object
+      title: Change
+      type: object
+    yorkie.v1.ChangeID:
+      additionalProperties: false
+      description: ""
+      properties:
+        actorId:
+          additionalProperties: false
+          description: ""
+          format: byte
+          title: actor_id
+          type: string
+        clientSeq:
+          additionalProperties: false
+          description: ""
+          title: client_seq
+          type: integer
+        lamport:
+          additionalProperties: false
+          description: ""
+          oneOf:
+          - type: string
+          - type: number
+          title: lamport
+        serverSeq:
+          additionalProperties: false
+          description: ""
+          oneOf:
+          - type: string
+          - type: number
+          title: server_seq
+      title: ChangeID
+      type: object
+    yorkie.v1.CreateProjectRequest:
+      additionalProperties: false
+      description: ""
+      properties:
+        name:
+          additionalProperties: false
+          description: ""
+          title: name
+          type: string
+      title: CreateProjectRequest
+      type: object
+    yorkie.v1.CreateProjectResponse:
+      additionalProperties: false
+      description: ""
+      properties:
+        project:
+          $ref: '#/components/schemas/yorkie.v1.Project'
+          additionalProperties: false
+          description: ""
+          title: project
+          type: object
+      title: CreateProjectResponse
+      type: object
+    yorkie.v1.DocumentSummary:
+      additionalProperties: false
+      description: ""
+      properties:
+        accessedAt:
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+          additionalProperties: false
+          description: ""
+          title: accessed_at
+          type: object
+        createdAt:
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+          additionalProperties: false
+          description: ""
+          title: created_at
+          type: object
+        id:
+          additionalProperties: false
+          description: ""
+          title: id
+          type: string
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        snapshot:
+          additionalProperties: false
+          description: ""
+          title: snapshot
+          type: string
+        updatedAt:
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+          additionalProperties: false
+          description: ""
+          title: updated_at
+          type: object
+      title: DocumentSummary
+      type: object
+    yorkie.v1.GetDocumentRequest:
+      additionalProperties: false
+      description: ""
+      properties:
+        documentKey:
+          additionalProperties: false
+          description: ""
+          title: document_key
+          type: string
+        projectName:
+          additionalProperties: false
+          description: ""
+          title: project_name
+          type: string
+      title: GetDocumentRequest
+      type: object
+    yorkie.v1.GetDocumentResponse:
+      additionalProperties: false
+      description: ""
+      properties:
+        document:
+          $ref: '#/components/schemas/yorkie.v1.DocumentSummary'
+          additionalProperties: false
+          description: ""
+          title: document
+          type: object
+      title: GetDocumentResponse
+      type: object
+    yorkie.v1.GetProjectRequest:
+      additionalProperties: false
+      description: ""
+      properties:
+        name:
+          additionalProperties: false
+          description: ""
+          title: name
+          type: string
+      title: GetProjectRequest
+      type: object
+    yorkie.v1.GetProjectResponse:
+      additionalProperties: false
+      description: ""
+      properties:
+        project:
+          $ref: '#/components/schemas/yorkie.v1.Project'
+          additionalProperties: false
+          description: ""
+          title: project
+          type: object
+      title: GetProjectResponse
+      type: object
+    yorkie.v1.GetSnapshotMetaRequest:
+      additionalProperties: false
+      description: ""
+      properties:
+        documentKey:
+          additionalProperties: false
+          description: ""
+          title: document_key
+          type: string
+        projectName:
+          additionalProperties: false
+          description: ""
+          title: project_name
+          type: string
+        serverSeq:
+          additionalProperties: false
+          description: ""
+          oneOf:
+          - type: string
+          - type: number
+          title: server_seq
+      title: GetSnapshotMetaRequest
+      type: object
+    yorkie.v1.GetSnapshotMetaResponse:
+      additionalProperties: false
+      description: ""
+      properties:
+        lamport:
+          additionalProperties: false
+          description: ""
+          oneOf:
+          - type: string
+          - type: number
+          title: lamport
+        snapshot:
+          additionalProperties: false
+          description: ""
+          format: byte
+          title: snapshot
+          type: string
+      title: GetSnapshotMetaResponse
+      type: object
+    yorkie.v1.JSONElementSimple:
+      additionalProperties: false
+      description: ""
+      properties:
+        createdAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: created_at
+          type: object
+        movedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: moved_at
+          type: object
+        removedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: removed_at
+          type: object
+        type:
+          $ref: '#/components/schemas/yorkie.v1.ValueType'
+          additionalProperties: false
+          description: ""
+          title: type
+        value:
+          additionalProperties: false
+          description: ""
+          format: byte
+          title: value
+          type: string
+      title: JSONElementSimple
+      type: object
+    yorkie.v1.ListChangesRequest:
+      additionalProperties: false
+      description: ""
+      properties:
+        documentKey:
+          additionalProperties: false
+          description: ""
+          title: document_key
+          type: string
+        isForward:
+          additionalProperties: false
+          description: ""
+          title: is_forward
+          type: boolean
+        pageSize:
+          additionalProperties: false
+          description: ""
+          title: page_size
+          type: integer
+        previousSeq:
+          additionalProperties: false
+          description: ""
+          oneOf:
+          - type: string
+          - type: number
+          title: previous_seq
+        projectName:
+          additionalProperties: false
+          description: ""
+          title: project_name
+          type: string
+      title: ListChangesRequest
+      type: object
+    yorkie.v1.ListChangesResponse:
+      additionalProperties: false
+      description: ""
+      properties:
+        changes:
+          additionalProperties: false
+          description: ""
+          items:
+            $ref: '#/components/schemas/yorkie.v1.Change'
+            type: object
+          title: changes
+          type: array
+      title: ListChangesResponse
+      type: object
+    yorkie.v1.ListDocumentsRequest:
+      additionalProperties: false
+      description: ""
+      properties:
+        includeSnapshot:
+          additionalProperties: false
+          description: ""
+          title: include_snapshot
+          type: boolean
+        isForward:
+          additionalProperties: false
+          description: ""
+          title: is_forward
+          type: boolean
+        pageSize:
+          additionalProperties: false
+          description: ""
+          title: page_size
+          type: integer
+        previousId:
+          additionalProperties: false
+          description: ""
+          title: previous_id
+          type: string
+        projectName:
+          additionalProperties: false
+          description: ""
+          title: project_name
+          type: string
+      title: ListDocumentsRequest
+      type: object
+    yorkie.v1.ListDocumentsResponse:
+      additionalProperties: false
+      description: ""
+      properties:
+        documents:
+          additionalProperties: false
+          description: ""
+          items:
+            $ref: '#/components/schemas/yorkie.v1.DocumentSummary'
+            type: object
+          title: documents
+          type: array
+      title: ListDocumentsResponse
+      type: object
+    yorkie.v1.ListProjectsRequest:
+      additionalProperties: false
+      description: ""
+      title: ListProjectsRequest
+      type: object
+    yorkie.v1.ListProjectsResponse:
+      additionalProperties: false
+      description: ""
+      properties:
+        projects:
+          additionalProperties: false
+          description: ""
+          items:
+            $ref: '#/components/schemas/yorkie.v1.Project'
+            type: object
+          title: projects
+          type: array
+      title: ListProjectsResponse
+      type: object
+    yorkie.v1.LogInRequest:
+      additionalProperties: false
+      description: ""
+      properties:
+        password:
+          additionalProperties: false
+          description: ""
+          title: password
+          type: string
+        username:
+          additionalProperties: false
+          description: ""
+          title: username
+          type: string
+      title: LogInRequest
+      type: object
+    yorkie.v1.LogInResponse:
+      additionalProperties: false
+      description: ""
+      properties:
+        token:
+          additionalProperties: false
+          description: ""
+          title: token
+          type: string
+      title: LogInResponse
+      type: object
+    yorkie.v1.NodeAttr:
+      additionalProperties: false
+      description: ""
+      properties:
+        updatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: updated_at
+          type: object
+        value:
+          additionalProperties: false
+          description: ""
+          title: value
+          type: string
+      title: NodeAttr
+      type: object
+    yorkie.v1.Operation:
+      additionalProperties: false
+      description: ""
+      properties:
+        add:
+          $ref: '#/components/schemas/yorkie.v1.Operation.Add'
+          additionalProperties: false
+          description: ""
+          title: add
+          type: object
+        edit:
+          $ref: '#/components/schemas/yorkie.v1.Operation.Edit'
+          additionalProperties: false
+          description: ""
+          title: edit
+          type: object
+        increase:
+          $ref: '#/components/schemas/yorkie.v1.Operation.Increase'
+          additionalProperties: false
+          description: ""
+          title: increase
+          type: object
+        move:
+          $ref: '#/components/schemas/yorkie.v1.Operation.Move'
+          additionalProperties: false
+          description: ""
+          title: move
+          type: object
+        remove:
+          $ref: '#/components/schemas/yorkie.v1.Operation.Remove'
+          additionalProperties: false
+          description: ""
+          title: remove
+          type: object
+        select:
+          $ref: '#/components/schemas/yorkie.v1.Operation.Select'
+          additionalProperties: false
+          description: ""
+          title: select
+          type: object
+        set:
+          $ref: '#/components/schemas/yorkie.v1.Operation.Set'
+          additionalProperties: false
+          description: ""
+          title: set
+          type: object
+        style:
+          $ref: '#/components/schemas/yorkie.v1.Operation.Style'
+          additionalProperties: false
+          description: ""
+          title: style
+          type: object
+        treeEdit:
+          $ref: '#/components/schemas/yorkie.v1.Operation.TreeEdit'
+          additionalProperties: false
+          description: ""
+          title: tree_edit
+          type: object
+        treeStyle:
+          $ref: '#/components/schemas/yorkie.v1.Operation.TreeStyle'
+          additionalProperties: false
+          description: ""
+          title: tree_style
+          type: object
+      title: Operation
+      type: object
+    yorkie.v1.Operation.Add:
+      additionalProperties: false
+      description: ""
+      properties:
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+        prevCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: prev_created_at
+          type: object
+        value:
+          $ref: '#/components/schemas/yorkie.v1.JSONElementSimple'
+          additionalProperties: false
+          description: ""
+          title: value
+          type: object
+      title: Add
+      type: object
+    yorkie.v1.Operation.Edit:
+      additionalProperties: false
+      description: ""
+      properties:
+        attributes:
+          additionalProperties: false
+          description: ""
+          title: attributes
+          type: object
+        content:
+          additionalProperties: false
+          description: ""
+          title: content
+          type: string
+        createdAtMapByActor:
+          additionalProperties: false
+          description: ""
+          title: created_at_map_by_actor
+          type: object
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        from:
+          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          additionalProperties: false
+          description: ""
+          title: from
+          type: object
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+        to:
+          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          additionalProperties: false
+          description: ""
+          title: to
+          type: object
+      title: Edit
+      type: object
+    yorkie.v1.Operation.Edit.AttributesEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          additionalProperties: false
+          description: ""
+          title: value
+          type: string
+      title: AttributesEntry
+      type: object
+    yorkie.v1.Operation.Edit.CreatedAtMapByActorEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: value
+          type: object
+      title: CreatedAtMapByActorEntry
+      type: object
+    yorkie.v1.Operation.Increase:
+      additionalProperties: false
+      description: ""
+      properties:
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+        value:
+          $ref: '#/components/schemas/yorkie.v1.JSONElementSimple'
+          additionalProperties: false
+          description: ""
+          title: value
+          type: object
+      title: Increase
+      type: object
+    yorkie.v1.Operation.Move:
+      additionalProperties: false
+      description: ""
+      properties:
+        createdAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: created_at
+          type: object
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+        prevCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: prev_created_at
+          type: object
+      title: Move
+      type: object
+    yorkie.v1.Operation.Remove:
+      additionalProperties: false
+      description: ""
+      properties:
+        createdAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: created_at
+          type: object
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+      title: Remove
+      type: object
+    yorkie.v1.Operation.Select:
+      additionalProperties: false
+      description: |-
+        NOTE(hackerwins): Select Operation is not used in the current version.
+         In the previous version, it was used to represent selection of Text.
+         However, it has been replaced by Presence now. It is retained for backward
+         compatibility purposes.
+      properties:
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        from:
+          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          additionalProperties: false
+          description: ""
+          title: from
+          type: object
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+        to:
+          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          additionalProperties: false
+          description: ""
+          title: to
+          type: object
+      title: Select
+      type: object
+    yorkie.v1.Operation.Set:
+      additionalProperties: false
+      description: ""
+      properties:
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+        value:
+          $ref: '#/components/schemas/yorkie.v1.JSONElementSimple'
+          additionalProperties: false
+          description: ""
+          title: value
+          type: object
+      title: Set
+      type: object
+    yorkie.v1.Operation.Style:
+      additionalProperties: false
+      description: ""
+      properties:
+        attributes:
+          additionalProperties: false
+          description: ""
+          title: attributes
+          type: object
+        createdAtMapByActor:
+          additionalProperties: false
+          description: ""
+          title: created_at_map_by_actor
+          type: object
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        from:
+          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          additionalProperties: false
+          description: ""
+          title: from
+          type: object
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+        to:
+          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          additionalProperties: false
+          description: ""
+          title: to
+          type: object
+      title: Style
+      type: object
+    yorkie.v1.Operation.Style.AttributesEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          additionalProperties: false
+          description: ""
+          title: value
+          type: string
+      title: AttributesEntry
+      type: object
+    yorkie.v1.Operation.Style.CreatedAtMapByActorEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: value
+          type: object
+      title: CreatedAtMapByActorEntry
+      type: object
+    yorkie.v1.Operation.TreeEdit:
+      additionalProperties: false
+      description: ""
+      properties:
+        contents:
+          additionalProperties: false
+          description: ""
+          items:
+            $ref: '#/components/schemas/yorkie.v1.TreeNodes'
+            type: object
+          title: contents
+          type: array
+        createdAtMapByActor:
+          additionalProperties: false
+          description: ""
+          title: created_at_map_by_actor
+          type: object
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        from:
+          $ref: '#/components/schemas/yorkie.v1.TreePos'
+          additionalProperties: false
+          description: ""
+          title: from
+          type: object
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+        splitLevel:
+          additionalProperties: false
+          description: ""
+          title: split_level
+          type: integer
+        to:
+          $ref: '#/components/schemas/yorkie.v1.TreePos'
+          additionalProperties: false
+          description: ""
+          title: to
+          type: object
+      title: TreeEdit
+      type: object
+    yorkie.v1.Operation.TreeEdit.CreatedAtMapByActorEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: value
+          type: object
+      title: CreatedAtMapByActorEntry
+      type: object
+    yorkie.v1.Operation.TreeStyle:
+      additionalProperties: false
+      description: ""
+      properties:
+        attributes:
+          additionalProperties: false
+          description: ""
+          title: attributes
+          type: object
+        attributesToRemove:
+          additionalProperties: false
+          description: ""
+          items:
+            type: string
+          title: attributes_to_remove
+          type: array
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        from:
+          $ref: '#/components/schemas/yorkie.v1.TreePos'
+          additionalProperties: false
+          description: ""
+          title: from
+          type: object
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+        to:
+          $ref: '#/components/schemas/yorkie.v1.TreePos'
+          additionalProperties: false
+          description: ""
+          title: to
+          type: object
+      title: TreeStyle
+      type: object
+    yorkie.v1.Operation.TreeStyle.AttributesEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          additionalProperties: false
+          description: ""
+          title: value
+          type: string
+      title: AttributesEntry
+      type: object
+    yorkie.v1.Presence:
+      additionalProperties: false
+      description: ""
+      properties:
+        data:
+          additionalProperties: false
+          description: ""
+          title: data
+          type: object
+      title: Presence
+      type: object
+    yorkie.v1.Presence.DataEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          additionalProperties: false
+          description: ""
+          title: value
+          type: string
+      title: DataEntry
+      type: object
+    yorkie.v1.PresenceChange:
+      additionalProperties: false
+      description: ""
+      properties:
+        presence:
+          $ref: '#/components/schemas/yorkie.v1.Presence'
+          additionalProperties: false
+          description: ""
+          title: presence
+          type: object
+        type:
+          $ref: '#/components/schemas/yorkie.v1.PresenceChange.ChangeType'
+          additionalProperties: false
+          description: ""
+          title: type
+      title: PresenceChange
+      type: object
+    yorkie.v1.PresenceChange.ChangeType:
+      description: ""
+      enum:
+      - - CHANGE_TYPE_UNSPECIFIED
+        - 0
+        - CHANGE_TYPE_PUT
+        - 1
+        - CHANGE_TYPE_DELETE
+        - 2
+        - CHANGE_TYPE_CLEAR
+        - 3
+      title: ChangeType
+      type: string
+    yorkie.v1.Project:
+      additionalProperties: false
+      description: ""
+      properties:
+        authWebhookMethods:
+          additionalProperties: false
+          description: ""
+          items:
+            type: string
+          title: auth_webhook_methods
+          type: array
+        authWebhookUrl:
+          additionalProperties: false
+          description: ""
+          title: auth_webhook_url
+          type: string
+        clientDeactivateThreshold:
+          additionalProperties: false
+          description: ""
+          title: client_deactivate_threshold
+          type: string
+        createdAt:
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+          additionalProperties: false
+          description: ""
+          title: created_at
+          type: object
+        id:
+          additionalProperties: false
+          description: ""
+          title: id
+          type: string
+        name:
+          additionalProperties: false
+          description: ""
+          title: name
+          type: string
+        publicKey:
+          additionalProperties: false
+          description: ""
+          title: public_key
+          type: string
+        secretKey:
+          additionalProperties: false
+          description: ""
+          title: secret_key
+          type: string
+        updatedAt:
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+          additionalProperties: false
+          description: ""
+          title: updated_at
+          type: object
+      title: Project
+      type: object
+    yorkie.v1.RemoveDocumentByAdminRequest:
+      additionalProperties: false
+      description: ""
+      properties:
+        documentKey:
+          additionalProperties: false
+          description: ""
+          title: document_key
+          type: string
+        force:
+          additionalProperties: false
+          description: ""
+          title: force
+          type: boolean
+        projectName:
+          additionalProperties: false
+          description: ""
+          title: project_name
+          type: string
+      title: RemoveDocumentByAdminRequest
+      type: object
+    yorkie.v1.RemoveDocumentByAdminResponse:
+      additionalProperties: false
+      description: ""
+      title: RemoveDocumentByAdminResponse
+      type: object
+    yorkie.v1.SearchDocumentsRequest:
+      additionalProperties: false
+      description: ""
+      properties:
+        pageSize:
+          additionalProperties: false
+          description: ""
+          title: page_size
+          type: integer
+        projectName:
+          additionalProperties: false
+          description: ""
+          title: project_name
+          type: string
+        query:
+          additionalProperties: false
+          description: ""
+          title: query
+          type: string
+      title: SearchDocumentsRequest
+      type: object
+    yorkie.v1.SearchDocumentsResponse:
+      additionalProperties: false
+      description: ""
+      properties:
+        documents:
+          additionalProperties: false
+          description: ""
+          items:
+            $ref: '#/components/schemas/yorkie.v1.DocumentSummary'
+            type: object
+          title: documents
+          type: array
+        totalCount:
+          additionalProperties: false
+          description: ""
+          title: total_count
+          type: integer
+      title: SearchDocumentsResponse
+      type: object
+    yorkie.v1.SignUpRequest:
+      additionalProperties: false
+      description: ""
+      properties:
+        password:
+          additionalProperties: false
+          description: ""
+          title: password
+          type: string
+        username:
+          additionalProperties: false
+          description: ""
+          title: username
+          type: string
+      title: SignUpRequest
+      type: object
+    yorkie.v1.SignUpResponse:
+      additionalProperties: false
+      description: ""
+      properties:
+        user:
+          $ref: '#/components/schemas/yorkie.v1.User'
+          additionalProperties: false
+          description: ""
+          title: user
+          type: object
+      title: SignUpResponse
+      type: object
+    yorkie.v1.TextNodePos:
+      additionalProperties: false
+      description: ""
+      properties:
+        createdAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: created_at
+          type: object
+        offset:
+          additionalProperties: false
+          description: ""
+          title: offset
+          type: integer
+        relativeOffset:
+          additionalProperties: false
+          description: ""
+          title: relative_offset
+          type: integer
+      title: TextNodePos
+      type: object
+    yorkie.v1.TimeTicket:
+      additionalProperties: false
+      description: ""
+      properties:
+        actorId:
+          additionalProperties: false
+          description: ""
+          format: byte
+          title: actor_id
+          type: string
+        delimiter:
+          additionalProperties: false
+          description: ""
+          title: delimiter
+          type: integer
+        lamport:
+          additionalProperties: false
+          description: ""
+          oneOf:
+          - type: string
+          - type: number
+          title: lamport
+      title: TimeTicket
+      type: object
+    yorkie.v1.TreeNode:
+      additionalProperties: false
+      description: ""
+      properties:
+        attributes:
+          additionalProperties: false
+          description: ""
+          title: attributes
+          type: object
+        depth:
+          additionalProperties: false
+          description: ""
+          title: depth
+          type: integer
+        id:
+          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          additionalProperties: false
+          description: ""
+          title: id
+          type: object
+        insNextId:
+          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          additionalProperties: false
+          description: ""
+          title: ins_next_id
+          type: object
+        insPrevId:
+          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          additionalProperties: false
+          description: ""
+          title: ins_prev_id
+          type: object
+        removedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: removed_at
+          type: object
+        type:
+          additionalProperties: false
+          description: ""
+          title: type
+          type: string
+        value:
+          additionalProperties: false
+          description: ""
+          title: value
+          type: string
+      title: TreeNode
+      type: object
+    yorkie.v1.TreeNode.AttributesEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          $ref: '#/components/schemas/yorkie.v1.NodeAttr'
+          additionalProperties: false
+          description: ""
+          title: value
+          type: object
+      title: AttributesEntry
+      type: object
+    yorkie.v1.TreeNodeID:
+      additionalProperties: false
+      description: ""
+      properties:
+        createdAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: created_at
+          type: object
+        offset:
+          additionalProperties: false
+          description: ""
+          title: offset
+          type: integer
+      title: TreeNodeID
+      type: object
+    yorkie.v1.TreeNodes:
+      additionalProperties: false
+      description: ""
+      properties:
+        content:
+          additionalProperties: false
+          description: ""
+          items:
+            $ref: '#/components/schemas/yorkie.v1.TreeNode'
+            type: object
+          title: content
+          type: array
+      title: TreeNodes
+      type: object
+    yorkie.v1.TreePos:
+      additionalProperties: false
+      description: ""
+      properties:
+        leftSiblingId:
+          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          additionalProperties: false
+          description: ""
+          title: left_sibling_id
+          type: object
+        parentId:
+          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          additionalProperties: false
+          description: ""
+          title: parent_id
+          type: object
+      title: TreePos
+      type: object
+    yorkie.v1.UpdatableProjectFields:
+      additionalProperties: false
+      description: ""
+      properties:
+        authWebhookMethods:
+          $ref: '#/components/schemas/yorkie.v1.UpdatableProjectFields.AuthWebhookMethods'
+          additionalProperties: false
+          description: ""
+          title: auth_webhook_methods
+          type: object
+        authWebhookUrl:
+          $ref: '#/components/schemas/google.protobuf.StringValue'
+          additionalProperties: false
+          description: ""
+          title: auth_webhook_url
+          type: object
+        clientDeactivateThreshold:
+          $ref: '#/components/schemas/google.protobuf.StringValue'
+          additionalProperties: false
+          description: ""
+          title: client_deactivate_threshold
+          type: object
+        name:
+          $ref: '#/components/schemas/google.protobuf.StringValue'
+          additionalProperties: false
+          description: ""
+          title: name
+          type: object
+      title: UpdatableProjectFields
+      type: object
+    yorkie.v1.UpdatableProjectFields.AuthWebhookMethods:
+      additionalProperties: false
+      description: ""
+      properties:
+        methods:
+          additionalProperties: false
+          description: ""
+          items:
+            type: string
+          title: methods
+          type: array
+      title: AuthWebhookMethods
+      type: object
+    yorkie.v1.UpdateProjectRequest:
+      additionalProperties: false
+      description: ""
+      properties:
+        fields:
+          $ref: '#/components/schemas/yorkie.v1.UpdatableProjectFields'
+          additionalProperties: false
+          description: ""
+          title: fields
+          type: object
+        id:
+          additionalProperties: false
+          description: ""
+          title: id
+          type: string
+      title: UpdateProjectRequest
+      type: object
+    yorkie.v1.UpdateProjectResponse:
+      additionalProperties: false
+      description: ""
+      properties:
+        project:
+          $ref: '#/components/schemas/yorkie.v1.Project'
+          additionalProperties: false
+          description: ""
+          title: project
+          type: object
+      title: UpdateProjectResponse
+      type: object
+    yorkie.v1.User:
+      additionalProperties: false
+      description: ""
+      properties:
+        createdAt:
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+          additionalProperties: false
+          description: ""
+          title: created_at
+          type: object
+        id:
+          additionalProperties: false
+          description: ""
+          title: id
+          type: string
+        username:
+          additionalProperties: false
+          description: ""
+          title: username
+          type: string
+      title: User
+      type: object
+    yorkie.v1.ValueType:
+      description: ""
+      enum:
+      - - VALUE_TYPE_NULL
+        - 0
+        - VALUE_TYPE_BOOLEAN
+        - 1
+        - VALUE_TYPE_INTEGER
+        - 2
+        - VALUE_TYPE_LONG
+        - 3
+        - VALUE_TYPE_DOUBLE
+        - 4
+        - VALUE_TYPE_STRING
+        - 5
+        - VALUE_TYPE_BYTES
+        - 6
+        - VALUE_TYPE_DATE
+        - 7
+        - VALUE_TYPE_JSON_OBJECT
+        - 8
+        - VALUE_TYPE_JSON_ARRAY
+        - 9
+        - VALUE_TYPE_TEXT
+        - 10
+        - VALUE_TYPE_INTEGER_CNT
+        - 11
+        - VALUE_TYPE_LONG_CNT
+        - 12
+        - VALUE_TYPE_TREE
+        - 13
+      title: ValueType
+      type: string
+tags:
+- description: Admin is a service that provides a API for Admin.
+  name: yorkie.v1.AdminService

--- a/api/docs/yorkie/v1/admin.openapi.yaml
+++ b/api/docs/yorkie/v1/admin.openapi.yaml
@@ -4,6 +4,11 @@ info:
     editing applications.
   title: Yorkie
   version: v0.4.14
+servers:
+- description: Production server
+  url: https://api.yorkie.dev
+- description: Local server
+  url: http://localhost:8080
 paths:
   /yorkie.v1.AdminService/CreateProject:
     post:
@@ -1927,6 +1932,13 @@ components:
         - 13
       title: ValueType
       type: string
+  securitySchemes:
+    ApiKeyAuth:
+      in: header
+      name: Authorization
+      type: apiKey
+security:
+- ApiKeyAuth: []
 tags:
 - description: Admin is a service that provides a API for Admin.
   name: yorkie.v1.AdminService

--- a/api/docs/yorkie/v1/resources.openapi.yaml
+++ b/api/docs/yorkie/v1/resources.openapi.yaml
@@ -1,0 +1,1685 @@
+openapi: 3.1.0
+info:
+  description: Yorkie is an open source document store for building collaborative
+    editing applications.
+  title: Yorkie
+  version: v0.4.14
+paths: {}
+components:
+  responses:
+    connect.error:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/connect.error'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/connect.error'
+      description: ""
+  schemas:
+    connect.error:
+      additionalProperties: false
+      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
+      properties:
+        code:
+          enum:
+          - CodeCanceled
+          - CodeUnknown
+          - CodeInvalidArgument
+          - CodeDeadlineExceeded
+          - CodeNotFound
+          - CodeAlreadyExists
+          - CodePermissionDenied
+          - CodeResourceExhausted
+          - CodeFailedPrecondition
+          - CodeAborted
+          - CodeOutOfRange
+          - CodeInternal
+          - CodeUnavailable
+          - CodeDataLoss
+          - CodeUnauthenticated
+          examples:
+          - CodeNotFound
+          type: string
+        message:
+          type: string
+      title: Connect Error
+      type: object
+    google.protobuf.StringValue:
+      additionalProperties: false
+      description: |-
+        Wrapper message for `string`.
+
+         The JSON representation for `StringValue` is JSON string.
+      properties:
+        value:
+          additionalProperties: false
+          description: The string value.
+          title: value
+          type: string
+      title: StringValue
+      type: object
+    google.protobuf.Timestamp:
+      additionalProperties: false
+      description: |-
+        A Timestamp represents a point in time independent of any time zone or local
+         calendar, encoded as a count of seconds and fractions of seconds at
+         nanosecond resolution. The count is relative to an epoch at UTC midnight on
+         January 1, 1970, in the proleptic Gregorian calendar which extends the
+         Gregorian calendar backwards to year one.
+
+         All minutes are 60 seconds long. Leap seconds are "smeared" so that no leap
+         second table is needed for interpretation, using a [24-hour linear
+         smear](https://developers.google.com/time/smear).
+
+         The range is from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z. By
+         restricting to that range, we ensure that we can convert to and from [RFC
+         3339](https://www.ietf.org/rfc/rfc3339.txt) date strings.
+
+         # Examples
+
+         Example 1: Compute Timestamp from POSIX `time()`.
+
+             Timestamp timestamp;
+             timestamp.set_seconds(time(NULL));
+             timestamp.set_nanos(0);
+
+         Example 2: Compute Timestamp from POSIX `gettimeofday()`.
+
+             struct timeval tv;
+             gettimeofday(&tv, NULL);
+
+             Timestamp timestamp;
+             timestamp.set_seconds(tv.tv_sec);
+             timestamp.set_nanos(tv.tv_usec * 1000);
+
+         Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
+
+             FILETIME ft;
+             GetSystemTimeAsFileTime(&ft);
+             UINT64 ticks = (((UINT64)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+
+             // A Windows tick is 100 nanoseconds. Windows epoch 1601-01-01T00:00:00Z
+             // is 11644473600 seconds before Unix epoch 1970-01-01T00:00:00Z.
+             Timestamp timestamp;
+             timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
+             timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
+
+         Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
+
+             long millis = System.currentTimeMillis();
+
+             Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
+                 .setNanos((int) ((millis % 1000) * 1000000)).build();
+
+         Example 5: Compute Timestamp from Java `Instant.now()`.
+
+             Instant now = Instant.now();
+
+             Timestamp timestamp =
+                 Timestamp.newBuilder().setSeconds(now.getEpochSecond())
+                     .setNanos(now.getNano()).build();
+
+         Example 6: Compute Timestamp from current time in Python.
+
+             timestamp = Timestamp()
+             timestamp.GetCurrentTime()
+
+         # JSON Mapping
+
+         In JSON format, the Timestamp type is encoded as a string in the
+         [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
+         format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
+         where {year} is always expressed using four digits while {month}, {day},
+         {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+         seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
+         are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
+         is required. A proto3 JSON serializer should always use UTC (as indicated by
+         "Z") when printing the Timestamp type and a proto3 JSON parser should be
+         able to accept both UTC and other timezones (as indicated by an offset).
+
+         For example, "2017-01-15T01:30:15.01Z" encodes 15.01 seconds past
+         01:30 UTC on January 15, 2017.
+
+         In JavaScript, one can convert a Date object to this format using the
+         standard
+         [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString)
+         method. In Python, a standard `datetime.datetime` object can be converted
+         to this format using
+         [`strftime`](https://docs.python.org/2/library/time.html#time.strftime) with
+         the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one can use
+         the Joda Time's [`ISODateTimeFormat.dateTime()`](
+         http://joda-time.sourceforge.net/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime()
+         ) to obtain a formatter capable of generating timestamps in this format.
+      format: date-time
+      type: string
+    yorkie.v1.Change:
+      additionalProperties: false
+      description: ""
+      properties:
+        id:
+          $ref: '#/components/schemas/yorkie.v1.ChangeID'
+          additionalProperties: false
+          description: ""
+          title: id
+          type: object
+        message:
+          additionalProperties: false
+          description: ""
+          title: message
+          type: string
+        operations:
+          additionalProperties: false
+          description: ""
+          items:
+            $ref: '#/components/schemas/yorkie.v1.Operation'
+            type: object
+          title: operations
+          type: array
+        presenceChange:
+          $ref: '#/components/schemas/yorkie.v1.PresenceChange'
+          additionalProperties: false
+          description: ""
+          title: presence_change
+          type: object
+      title: Change
+      type: object
+    yorkie.v1.ChangeID:
+      additionalProperties: false
+      description: ""
+      properties:
+        actorId:
+          additionalProperties: false
+          description: ""
+          format: byte
+          title: actor_id
+          type: string
+        clientSeq:
+          additionalProperties: false
+          description: ""
+          title: client_seq
+          type: integer
+        lamport:
+          additionalProperties: false
+          description: ""
+          oneOf:
+          - type: string
+          - type: number
+          title: lamport
+        serverSeq:
+          additionalProperties: false
+          description: ""
+          oneOf:
+          - type: string
+          - type: number
+          title: server_seq
+      title: ChangeID
+      type: object
+    yorkie.v1.ChangePack:
+      additionalProperties: false
+      description: |-
+        ChangePack is a message that contains all changes that occurred in a document.
+         It is used to synchronize changes between clients and servers.
+      properties:
+        changes:
+          additionalProperties: false
+          description: ""
+          items:
+            $ref: '#/components/schemas/yorkie.v1.Change'
+            type: object
+          title: changes
+          type: array
+        checkpoint:
+          $ref: '#/components/schemas/yorkie.v1.Checkpoint'
+          additionalProperties: false
+          description: ""
+          title: checkpoint
+          type: object
+        documentKey:
+          additionalProperties: false
+          description: ""
+          title: document_key
+          type: string
+        isRemoved:
+          additionalProperties: false
+          description: ""
+          title: is_removed
+          type: boolean
+        minSyncedTicket:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: min_synced_ticket
+          type: object
+        snapshot:
+          additionalProperties: false
+          description: ""
+          format: byte
+          title: snapshot
+          type: string
+      title: ChangePack
+      type: object
+    yorkie.v1.Checkpoint:
+      additionalProperties: false
+      description: ""
+      properties:
+        clientSeq:
+          additionalProperties: false
+          description: ""
+          title: client_seq
+          type: integer
+        serverSeq:
+          additionalProperties: false
+          description: ""
+          oneOf:
+          - type: string
+          - type: number
+          title: server_seq
+      title: Checkpoint
+      type: object
+    yorkie.v1.DocEvent:
+      additionalProperties: false
+      description: ""
+      properties:
+        body:
+          $ref: '#/components/schemas/yorkie.v1.DocEventBody'
+          additionalProperties: false
+          description: ""
+          title: body
+          type: object
+        publisher:
+          additionalProperties: false
+          description: ""
+          title: publisher
+          type: string
+        type:
+          $ref: '#/components/schemas/yorkie.v1.DocEventType'
+          additionalProperties: false
+          description: ""
+          title: type
+      title: DocEvent
+      type: object
+    yorkie.v1.DocEventBody:
+      additionalProperties: false
+      description: ""
+      properties:
+        payload:
+          additionalProperties: false
+          description: ""
+          format: byte
+          title: payload
+          type: string
+        topic:
+          additionalProperties: false
+          description: ""
+          title: topic
+          type: string
+      title: DocEventBody
+      type: object
+    yorkie.v1.DocEventType:
+      description: ""
+      enum:
+      - - DOC_EVENT_TYPE_DOCUMENT_CHANGED
+        - 0
+        - DOC_EVENT_TYPE_DOCUMENT_WATCHED
+        - 1
+        - DOC_EVENT_TYPE_DOCUMENT_UNWATCHED
+        - 2
+        - DOC_EVENT_TYPE_DOCUMENT_BROADCAST
+        - 3
+      title: DocEventType
+      type: string
+    yorkie.v1.DocumentSummary:
+      additionalProperties: false
+      description: ""
+      properties:
+        accessedAt:
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+          additionalProperties: false
+          description: ""
+          title: accessed_at
+          type: object
+        createdAt:
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+          additionalProperties: false
+          description: ""
+          title: created_at
+          type: object
+        id:
+          additionalProperties: false
+          description: ""
+          title: id
+          type: string
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        snapshot:
+          additionalProperties: false
+          description: ""
+          title: snapshot
+          type: string
+        updatedAt:
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+          additionalProperties: false
+          description: ""
+          title: updated_at
+          type: object
+      title: DocumentSummary
+      type: object
+    yorkie.v1.JSONElement:
+      additionalProperties: false
+      description: ""
+      properties:
+        counter:
+          $ref: '#/components/schemas/yorkie.v1.JSONElement.Counter'
+          additionalProperties: false
+          description: ""
+          title: counter
+          type: object
+        jsonArray:
+          $ref: '#/components/schemas/yorkie.v1.JSONElement.JSONArray'
+          additionalProperties: false
+          description: ""
+          title: json_array
+          type: object
+        jsonObject:
+          $ref: '#/components/schemas/yorkie.v1.JSONElement.JSONObject'
+          additionalProperties: false
+          description: ""
+          title: json_object
+          type: object
+        primitive:
+          $ref: '#/components/schemas/yorkie.v1.JSONElement.Primitive'
+          additionalProperties: false
+          description: ""
+          title: primitive
+          type: object
+        text:
+          $ref: '#/components/schemas/yorkie.v1.JSONElement.Text'
+          additionalProperties: false
+          description: ""
+          title: text
+          type: object
+        tree:
+          $ref: '#/components/schemas/yorkie.v1.JSONElement.Tree'
+          additionalProperties: false
+          description: ""
+          title: tree
+          type: object
+      title: JSONElement
+      type: object
+    yorkie.v1.JSONElement.Counter:
+      additionalProperties: false
+      description: ""
+      properties:
+        createdAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: created_at
+          type: object
+        movedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: moved_at
+          type: object
+        removedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: removed_at
+          type: object
+        type:
+          $ref: '#/components/schemas/yorkie.v1.ValueType'
+          additionalProperties: false
+          description: ""
+          title: type
+        value:
+          additionalProperties: false
+          description: ""
+          format: byte
+          title: value
+          type: string
+      title: Counter
+      type: object
+    yorkie.v1.JSONElement.JSONArray:
+      additionalProperties: false
+      description: ""
+      properties:
+        createdAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: created_at
+          type: object
+        movedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: moved_at
+          type: object
+        nodes:
+          additionalProperties: false
+          description: ""
+          items:
+            $ref: '#/components/schemas/yorkie.v1.RGANode'
+            type: object
+          title: nodes
+          type: array
+        removedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: removed_at
+          type: object
+      title: JSONArray
+      type: object
+    yorkie.v1.JSONElement.JSONObject:
+      additionalProperties: false
+      description: ""
+      properties:
+        createdAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: created_at
+          type: object
+        movedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: moved_at
+          type: object
+        nodes:
+          additionalProperties: false
+          description: ""
+          items:
+            $ref: '#/components/schemas/yorkie.v1.RHTNode'
+            type: object
+          title: nodes
+          type: array
+        removedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: removed_at
+          type: object
+      title: JSONObject
+      type: object
+    yorkie.v1.JSONElement.Primitive:
+      additionalProperties: false
+      description: ""
+      properties:
+        createdAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: created_at
+          type: object
+        movedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: moved_at
+          type: object
+        removedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: removed_at
+          type: object
+        type:
+          $ref: '#/components/schemas/yorkie.v1.ValueType'
+          additionalProperties: false
+          description: ""
+          title: type
+        value:
+          additionalProperties: false
+          description: ""
+          format: byte
+          title: value
+          type: string
+      title: Primitive
+      type: object
+    yorkie.v1.JSONElement.Text:
+      additionalProperties: false
+      description: ""
+      properties:
+        createdAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: created_at
+          type: object
+        movedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: moved_at
+          type: object
+        nodes:
+          additionalProperties: false
+          description: ""
+          items:
+            $ref: '#/components/schemas/yorkie.v1.TextNode'
+            type: object
+          title: nodes
+          type: array
+        removedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: removed_at
+          type: object
+      title: Text
+      type: object
+    yorkie.v1.JSONElement.Tree:
+      additionalProperties: false
+      description: ""
+      properties:
+        createdAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: created_at
+          type: object
+        movedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: moved_at
+          type: object
+        nodes:
+          additionalProperties: false
+          description: ""
+          items:
+            $ref: '#/components/schemas/yorkie.v1.TreeNode'
+            type: object
+          title: nodes
+          type: array
+        removedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: removed_at
+          type: object
+      title: Tree
+      type: object
+    yorkie.v1.JSONElementSimple:
+      additionalProperties: false
+      description: ""
+      properties:
+        createdAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: created_at
+          type: object
+        movedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: moved_at
+          type: object
+        removedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: removed_at
+          type: object
+        type:
+          $ref: '#/components/schemas/yorkie.v1.ValueType'
+          additionalProperties: false
+          description: ""
+          title: type
+        value:
+          additionalProperties: false
+          description: ""
+          format: byte
+          title: value
+          type: string
+      title: JSONElementSimple
+      type: object
+    yorkie.v1.NodeAttr:
+      additionalProperties: false
+      description: ""
+      properties:
+        updatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: updated_at
+          type: object
+        value:
+          additionalProperties: false
+          description: ""
+          title: value
+          type: string
+      title: NodeAttr
+      type: object
+    yorkie.v1.Operation:
+      additionalProperties: false
+      description: ""
+      properties:
+        add:
+          $ref: '#/components/schemas/yorkie.v1.Operation.Add'
+          additionalProperties: false
+          description: ""
+          title: add
+          type: object
+        edit:
+          $ref: '#/components/schemas/yorkie.v1.Operation.Edit'
+          additionalProperties: false
+          description: ""
+          title: edit
+          type: object
+        increase:
+          $ref: '#/components/schemas/yorkie.v1.Operation.Increase'
+          additionalProperties: false
+          description: ""
+          title: increase
+          type: object
+        move:
+          $ref: '#/components/schemas/yorkie.v1.Operation.Move'
+          additionalProperties: false
+          description: ""
+          title: move
+          type: object
+        remove:
+          $ref: '#/components/schemas/yorkie.v1.Operation.Remove'
+          additionalProperties: false
+          description: ""
+          title: remove
+          type: object
+        select:
+          $ref: '#/components/schemas/yorkie.v1.Operation.Select'
+          additionalProperties: false
+          description: ""
+          title: select
+          type: object
+        set:
+          $ref: '#/components/schemas/yorkie.v1.Operation.Set'
+          additionalProperties: false
+          description: ""
+          title: set
+          type: object
+        style:
+          $ref: '#/components/schemas/yorkie.v1.Operation.Style'
+          additionalProperties: false
+          description: ""
+          title: style
+          type: object
+        treeEdit:
+          $ref: '#/components/schemas/yorkie.v1.Operation.TreeEdit'
+          additionalProperties: false
+          description: ""
+          title: tree_edit
+          type: object
+        treeStyle:
+          $ref: '#/components/schemas/yorkie.v1.Operation.TreeStyle'
+          additionalProperties: false
+          description: ""
+          title: tree_style
+          type: object
+      title: Operation
+      type: object
+    yorkie.v1.Operation.Add:
+      additionalProperties: false
+      description: ""
+      properties:
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+        prevCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: prev_created_at
+          type: object
+        value:
+          $ref: '#/components/schemas/yorkie.v1.JSONElementSimple'
+          additionalProperties: false
+          description: ""
+          title: value
+          type: object
+      title: Add
+      type: object
+    yorkie.v1.Operation.Edit:
+      additionalProperties: false
+      description: ""
+      properties:
+        attributes:
+          additionalProperties: false
+          description: ""
+          title: attributes
+          type: object
+        content:
+          additionalProperties: false
+          description: ""
+          title: content
+          type: string
+        createdAtMapByActor:
+          additionalProperties: false
+          description: ""
+          title: created_at_map_by_actor
+          type: object
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        from:
+          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          additionalProperties: false
+          description: ""
+          title: from
+          type: object
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+        to:
+          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          additionalProperties: false
+          description: ""
+          title: to
+          type: object
+      title: Edit
+      type: object
+    yorkie.v1.Operation.Edit.AttributesEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          additionalProperties: false
+          description: ""
+          title: value
+          type: string
+      title: AttributesEntry
+      type: object
+    yorkie.v1.Operation.Edit.CreatedAtMapByActorEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: value
+          type: object
+      title: CreatedAtMapByActorEntry
+      type: object
+    yorkie.v1.Operation.Increase:
+      additionalProperties: false
+      description: ""
+      properties:
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+        value:
+          $ref: '#/components/schemas/yorkie.v1.JSONElementSimple'
+          additionalProperties: false
+          description: ""
+          title: value
+          type: object
+      title: Increase
+      type: object
+    yorkie.v1.Operation.Move:
+      additionalProperties: false
+      description: ""
+      properties:
+        createdAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: created_at
+          type: object
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+        prevCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: prev_created_at
+          type: object
+      title: Move
+      type: object
+    yorkie.v1.Operation.Remove:
+      additionalProperties: false
+      description: ""
+      properties:
+        createdAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: created_at
+          type: object
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+      title: Remove
+      type: object
+    yorkie.v1.Operation.Select:
+      additionalProperties: false
+      description: |-
+        NOTE(hackerwins): Select Operation is not used in the current version.
+         In the previous version, it was used to represent selection of Text.
+         However, it has been replaced by Presence now. It is retained for backward
+         compatibility purposes.
+      properties:
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        from:
+          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          additionalProperties: false
+          description: ""
+          title: from
+          type: object
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+        to:
+          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          additionalProperties: false
+          description: ""
+          title: to
+          type: object
+      title: Select
+      type: object
+    yorkie.v1.Operation.Set:
+      additionalProperties: false
+      description: ""
+      properties:
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+        value:
+          $ref: '#/components/schemas/yorkie.v1.JSONElementSimple'
+          additionalProperties: false
+          description: ""
+          title: value
+          type: object
+      title: Set
+      type: object
+    yorkie.v1.Operation.Style:
+      additionalProperties: false
+      description: ""
+      properties:
+        attributes:
+          additionalProperties: false
+          description: ""
+          title: attributes
+          type: object
+        createdAtMapByActor:
+          additionalProperties: false
+          description: ""
+          title: created_at_map_by_actor
+          type: object
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        from:
+          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          additionalProperties: false
+          description: ""
+          title: from
+          type: object
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+        to:
+          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          additionalProperties: false
+          description: ""
+          title: to
+          type: object
+      title: Style
+      type: object
+    yorkie.v1.Operation.Style.AttributesEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          additionalProperties: false
+          description: ""
+          title: value
+          type: string
+      title: AttributesEntry
+      type: object
+    yorkie.v1.Operation.Style.CreatedAtMapByActorEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: value
+          type: object
+      title: CreatedAtMapByActorEntry
+      type: object
+    yorkie.v1.Operation.TreeEdit:
+      additionalProperties: false
+      description: ""
+      properties:
+        contents:
+          additionalProperties: false
+          description: ""
+          items:
+            $ref: '#/components/schemas/yorkie.v1.TreeNodes'
+            type: object
+          title: contents
+          type: array
+        createdAtMapByActor:
+          additionalProperties: false
+          description: ""
+          title: created_at_map_by_actor
+          type: object
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        from:
+          $ref: '#/components/schemas/yorkie.v1.TreePos'
+          additionalProperties: false
+          description: ""
+          title: from
+          type: object
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+        splitLevel:
+          additionalProperties: false
+          description: ""
+          title: split_level
+          type: integer
+        to:
+          $ref: '#/components/schemas/yorkie.v1.TreePos'
+          additionalProperties: false
+          description: ""
+          title: to
+          type: object
+      title: TreeEdit
+      type: object
+    yorkie.v1.Operation.TreeEdit.CreatedAtMapByActorEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: value
+          type: object
+      title: CreatedAtMapByActorEntry
+      type: object
+    yorkie.v1.Operation.TreeStyle:
+      additionalProperties: false
+      description: ""
+      properties:
+        attributes:
+          additionalProperties: false
+          description: ""
+          title: attributes
+          type: object
+        attributesToRemove:
+          additionalProperties: false
+          description: ""
+          items:
+            type: string
+          title: attributes_to_remove
+          type: array
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        from:
+          $ref: '#/components/schemas/yorkie.v1.TreePos'
+          additionalProperties: false
+          description: ""
+          title: from
+          type: object
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+        to:
+          $ref: '#/components/schemas/yorkie.v1.TreePos'
+          additionalProperties: false
+          description: ""
+          title: to
+          type: object
+      title: TreeStyle
+      type: object
+    yorkie.v1.Operation.TreeStyle.AttributesEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          additionalProperties: false
+          description: ""
+          title: value
+          type: string
+      title: AttributesEntry
+      type: object
+    yorkie.v1.Presence:
+      additionalProperties: false
+      description: ""
+      properties:
+        data:
+          additionalProperties: false
+          description: ""
+          title: data
+          type: object
+      title: Presence
+      type: object
+    yorkie.v1.Presence.DataEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          additionalProperties: false
+          description: ""
+          title: value
+          type: string
+      title: DataEntry
+      type: object
+    yorkie.v1.PresenceChange:
+      additionalProperties: false
+      description: ""
+      properties:
+        presence:
+          $ref: '#/components/schemas/yorkie.v1.Presence'
+          additionalProperties: false
+          description: ""
+          title: presence
+          type: object
+        type:
+          $ref: '#/components/schemas/yorkie.v1.PresenceChange.ChangeType'
+          additionalProperties: false
+          description: ""
+          title: type
+      title: PresenceChange
+      type: object
+    yorkie.v1.PresenceChange.ChangeType:
+      description: ""
+      enum:
+      - - CHANGE_TYPE_UNSPECIFIED
+        - 0
+        - CHANGE_TYPE_PUT
+        - 1
+        - CHANGE_TYPE_DELETE
+        - 2
+        - CHANGE_TYPE_CLEAR
+        - 3
+      title: ChangeType
+      type: string
+    yorkie.v1.Project:
+      additionalProperties: false
+      description: ""
+      properties:
+        authWebhookMethods:
+          additionalProperties: false
+          description: ""
+          items:
+            type: string
+          title: auth_webhook_methods
+          type: array
+        authWebhookUrl:
+          additionalProperties: false
+          description: ""
+          title: auth_webhook_url
+          type: string
+        clientDeactivateThreshold:
+          additionalProperties: false
+          description: ""
+          title: client_deactivate_threshold
+          type: string
+        createdAt:
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+          additionalProperties: false
+          description: ""
+          title: created_at
+          type: object
+        id:
+          additionalProperties: false
+          description: ""
+          title: id
+          type: string
+        name:
+          additionalProperties: false
+          description: ""
+          title: name
+          type: string
+        publicKey:
+          additionalProperties: false
+          description: ""
+          title: public_key
+          type: string
+        secretKey:
+          additionalProperties: false
+          description: ""
+          title: secret_key
+          type: string
+        updatedAt:
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+          additionalProperties: false
+          description: ""
+          title: updated_at
+          type: object
+      title: Project
+      type: object
+    yorkie.v1.RGANode:
+      additionalProperties: false
+      description: ""
+      properties:
+        element:
+          $ref: '#/components/schemas/yorkie.v1.JSONElement'
+          additionalProperties: false
+          description: ""
+          title: element
+          type: object
+        next:
+          $ref: '#/components/schemas/yorkie.v1.RGANode'
+          additionalProperties: false
+          description: ""
+          title: next
+          type: object
+      title: RGANode
+      type: object
+    yorkie.v1.RHTNode:
+      additionalProperties: false
+      description: ""
+      properties:
+        element:
+          $ref: '#/components/schemas/yorkie.v1.JSONElement'
+          additionalProperties: false
+          description: ""
+          title: element
+          type: object
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+      title: RHTNode
+      type: object
+    yorkie.v1.Snapshot:
+      additionalProperties: false
+      description: |-
+        ///////////////////////////////////////
+         Messages for Snapshot               //
+        ///////////////////////////////////////
+      properties:
+        presences:
+          additionalProperties: false
+          description: ""
+          title: presences
+          type: object
+        root:
+          $ref: '#/components/schemas/yorkie.v1.JSONElement'
+          additionalProperties: false
+          description: ""
+          title: root
+          type: object
+      title: Snapshot
+      type: object
+    yorkie.v1.Snapshot.PresencesEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          $ref: '#/components/schemas/yorkie.v1.Presence'
+          additionalProperties: false
+          description: ""
+          title: value
+          type: object
+      title: PresencesEntry
+      type: object
+    yorkie.v1.TextNode:
+      additionalProperties: false
+      description: ""
+      properties:
+        attributes:
+          additionalProperties: false
+          description: ""
+          title: attributes
+          type: object
+        id:
+          $ref: '#/components/schemas/yorkie.v1.TextNodeID'
+          additionalProperties: false
+          description: ""
+          title: id
+          type: object
+        insPrevId:
+          $ref: '#/components/schemas/yorkie.v1.TextNodeID'
+          additionalProperties: false
+          description: ""
+          title: ins_prev_id
+          type: object
+        removedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: removed_at
+          type: object
+        value:
+          additionalProperties: false
+          description: ""
+          title: value
+          type: string
+      title: TextNode
+      type: object
+    yorkie.v1.TextNode.AttributesEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          $ref: '#/components/schemas/yorkie.v1.NodeAttr'
+          additionalProperties: false
+          description: ""
+          title: value
+          type: object
+      title: AttributesEntry
+      type: object
+    yorkie.v1.TextNodeID:
+      additionalProperties: false
+      description: ""
+      properties:
+        createdAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: created_at
+          type: object
+        offset:
+          additionalProperties: false
+          description: ""
+          title: offset
+          type: integer
+      title: TextNodeID
+      type: object
+    yorkie.v1.TextNodePos:
+      additionalProperties: false
+      description: ""
+      properties:
+        createdAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: created_at
+          type: object
+        offset:
+          additionalProperties: false
+          description: ""
+          title: offset
+          type: integer
+        relativeOffset:
+          additionalProperties: false
+          description: ""
+          title: relative_offset
+          type: integer
+      title: TextNodePos
+      type: object
+    yorkie.v1.TimeTicket:
+      additionalProperties: false
+      description: ""
+      properties:
+        actorId:
+          additionalProperties: false
+          description: ""
+          format: byte
+          title: actor_id
+          type: string
+        delimiter:
+          additionalProperties: false
+          description: ""
+          title: delimiter
+          type: integer
+        lamport:
+          additionalProperties: false
+          description: ""
+          oneOf:
+          - type: string
+          - type: number
+          title: lamport
+      title: TimeTicket
+      type: object
+    yorkie.v1.TreeNode:
+      additionalProperties: false
+      description: ""
+      properties:
+        attributes:
+          additionalProperties: false
+          description: ""
+          title: attributes
+          type: object
+        depth:
+          additionalProperties: false
+          description: ""
+          title: depth
+          type: integer
+        id:
+          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          additionalProperties: false
+          description: ""
+          title: id
+          type: object
+        insNextId:
+          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          additionalProperties: false
+          description: ""
+          title: ins_next_id
+          type: object
+        insPrevId:
+          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          additionalProperties: false
+          description: ""
+          title: ins_prev_id
+          type: object
+        removedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: removed_at
+          type: object
+        type:
+          additionalProperties: false
+          description: ""
+          title: type
+          type: string
+        value:
+          additionalProperties: false
+          description: ""
+          title: value
+          type: string
+      title: TreeNode
+      type: object
+    yorkie.v1.TreeNode.AttributesEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          $ref: '#/components/schemas/yorkie.v1.NodeAttr'
+          additionalProperties: false
+          description: ""
+          title: value
+          type: object
+      title: AttributesEntry
+      type: object
+    yorkie.v1.TreeNodeID:
+      additionalProperties: false
+      description: ""
+      properties:
+        createdAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: created_at
+          type: object
+        offset:
+          additionalProperties: false
+          description: ""
+          title: offset
+          type: integer
+      title: TreeNodeID
+      type: object
+    yorkie.v1.TreeNodes:
+      additionalProperties: false
+      description: ""
+      properties:
+        content:
+          additionalProperties: false
+          description: ""
+          items:
+            $ref: '#/components/schemas/yorkie.v1.TreeNode'
+            type: object
+          title: content
+          type: array
+      title: TreeNodes
+      type: object
+    yorkie.v1.TreePos:
+      additionalProperties: false
+      description: ""
+      properties:
+        leftSiblingId:
+          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          additionalProperties: false
+          description: ""
+          title: left_sibling_id
+          type: object
+        parentId:
+          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          additionalProperties: false
+          description: ""
+          title: parent_id
+          type: object
+      title: TreePos
+      type: object
+    yorkie.v1.UpdatableProjectFields:
+      additionalProperties: false
+      description: ""
+      properties:
+        authWebhookMethods:
+          $ref: '#/components/schemas/yorkie.v1.UpdatableProjectFields.AuthWebhookMethods'
+          additionalProperties: false
+          description: ""
+          title: auth_webhook_methods
+          type: object
+        authWebhookUrl:
+          $ref: '#/components/schemas/google.protobuf.StringValue'
+          additionalProperties: false
+          description: ""
+          title: auth_webhook_url
+          type: object
+        clientDeactivateThreshold:
+          $ref: '#/components/schemas/google.protobuf.StringValue'
+          additionalProperties: false
+          description: ""
+          title: client_deactivate_threshold
+          type: object
+        name:
+          $ref: '#/components/schemas/google.protobuf.StringValue'
+          additionalProperties: false
+          description: ""
+          title: name
+          type: object
+      title: UpdatableProjectFields
+      type: object
+    yorkie.v1.UpdatableProjectFields.AuthWebhookMethods:
+      additionalProperties: false
+      description: ""
+      properties:
+        methods:
+          additionalProperties: false
+          description: ""
+          items:
+            type: string
+          title: methods
+          type: array
+      title: AuthWebhookMethods
+      type: object
+    yorkie.v1.User:
+      additionalProperties: false
+      description: ""
+      properties:
+        createdAt:
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+          additionalProperties: false
+          description: ""
+          title: created_at
+          type: object
+        id:
+          additionalProperties: false
+          description: ""
+          title: id
+          type: string
+        username:
+          additionalProperties: false
+          description: ""
+          title: username
+          type: string
+      title: User
+      type: object
+    yorkie.v1.ValueType:
+      description: ""
+      enum:
+      - - VALUE_TYPE_NULL
+        - 0
+        - VALUE_TYPE_BOOLEAN
+        - 1
+        - VALUE_TYPE_INTEGER
+        - 2
+        - VALUE_TYPE_LONG
+        - 3
+        - VALUE_TYPE_DOUBLE
+        - 4
+        - VALUE_TYPE_STRING
+        - 5
+        - VALUE_TYPE_BYTES
+        - 6
+        - VALUE_TYPE_DATE
+        - 7
+        - VALUE_TYPE_JSON_OBJECT
+        - 8
+        - VALUE_TYPE_JSON_ARRAY
+        - 9
+        - VALUE_TYPE_TEXT
+        - 10
+        - VALUE_TYPE_INTEGER_CNT
+        - 11
+        - VALUE_TYPE_LONG_CNT
+        - 12
+        - VALUE_TYPE_TREE
+        - 13
+      title: ValueType
+      type: string

--- a/api/docs/yorkie/v1/resources.openapi.yaml
+++ b/api/docs/yorkie/v1/resources.openapi.yaml
@@ -4,6 +4,11 @@ info:
     editing applications.
   title: Yorkie
   version: v0.4.14
+servers:
+- description: Production server
+  url: https://api.yorkie.dev
+- description: Local server
+  url: http://localhost:8080
 paths: {}
 components:
   responses:
@@ -1683,3 +1688,10 @@ components:
         - 13
       title: ValueType
       type: string
+  securitySchemes:
+    ApiKeyAuth:
+      in: header
+      name: Authorization
+      type: apiKey
+security:
+- ApiKeyAuth: []

--- a/api/docs/yorkie/v1/yorkie.openapi.yaml
+++ b/api/docs/yorkie/v1/yorkie.openapi.yaml
@@ -1,0 +1,1532 @@
+openapi: 3.1.0
+info:
+  description: Yorkie is an open source document store for building collaborative
+    editing applications.
+  title: Yorkie
+  version: v0.4.14
+paths:
+  /yorkie.v1.YorkieService/ActivateClient:
+    post:
+      description: ""
+      requestBody:
+        $ref: '#/components/requestBodies/yorkie.v1.YorkieService.ActivateClient.yorkie.v1.ActivateClientRequest'
+      responses:
+        "200":
+          $ref: '#/components/responses/yorkie.v1.YorkieService.ActivateClient.yorkie.v1.ActivateClientResponse'
+        default:
+          $ref: '#/components/responses/connect.error'
+      tags:
+      - yorkie.v1.YorkieService
+  /yorkie.v1.YorkieService/AttachDocument:
+    post:
+      description: ""
+      requestBody:
+        $ref: '#/components/requestBodies/yorkie.v1.YorkieService.AttachDocument.yorkie.v1.AttachDocumentRequest'
+      responses:
+        "200":
+          $ref: '#/components/responses/yorkie.v1.YorkieService.AttachDocument.yorkie.v1.AttachDocumentResponse'
+        default:
+          $ref: '#/components/responses/connect.error'
+      tags:
+      - yorkie.v1.YorkieService
+  /yorkie.v1.YorkieService/Broadcast:
+    post:
+      description: ""
+      requestBody:
+        $ref: '#/components/requestBodies/yorkie.v1.YorkieService.Broadcast.yorkie.v1.BroadcastRequest'
+      responses:
+        "200":
+          $ref: '#/components/responses/yorkie.v1.YorkieService.Broadcast.yorkie.v1.BroadcastResponse'
+        default:
+          $ref: '#/components/responses/connect.error'
+      tags:
+      - yorkie.v1.YorkieService
+  /yorkie.v1.YorkieService/DeactivateClient:
+    post:
+      description: ""
+      requestBody:
+        $ref: '#/components/requestBodies/yorkie.v1.YorkieService.DeactivateClient.yorkie.v1.DeactivateClientRequest'
+      responses:
+        "200":
+          $ref: '#/components/responses/yorkie.v1.YorkieService.DeactivateClient.yorkie.v1.DeactivateClientResponse'
+        default:
+          $ref: '#/components/responses/connect.error'
+      tags:
+      - yorkie.v1.YorkieService
+  /yorkie.v1.YorkieService/DetachDocument:
+    post:
+      description: ""
+      requestBody:
+        $ref: '#/components/requestBodies/yorkie.v1.YorkieService.DetachDocument.yorkie.v1.DetachDocumentRequest'
+      responses:
+        "200":
+          $ref: '#/components/responses/yorkie.v1.YorkieService.DetachDocument.yorkie.v1.DetachDocumentResponse'
+        default:
+          $ref: '#/components/responses/connect.error'
+      tags:
+      - yorkie.v1.YorkieService
+  /yorkie.v1.YorkieService/PushPullChanges:
+    post:
+      description: ""
+      requestBody:
+        $ref: '#/components/requestBodies/yorkie.v1.YorkieService.PushPullChanges.yorkie.v1.PushPullChangesRequest'
+      responses:
+        "200":
+          $ref: '#/components/responses/yorkie.v1.YorkieService.PushPullChanges.yorkie.v1.PushPullChangesResponse'
+        default:
+          $ref: '#/components/responses/connect.error'
+      tags:
+      - yorkie.v1.YorkieService
+  /yorkie.v1.YorkieService/RemoveDocument:
+    post:
+      description: ""
+      requestBody:
+        $ref: '#/components/requestBodies/yorkie.v1.YorkieService.RemoveDocument.yorkie.v1.RemoveDocumentRequest'
+      responses:
+        "200":
+          $ref: '#/components/responses/yorkie.v1.YorkieService.RemoveDocument.yorkie.v1.RemoveDocumentResponse'
+        default:
+          $ref: '#/components/responses/connect.error'
+      tags:
+      - yorkie.v1.YorkieService
+  /yorkie.v1.YorkieService/WatchDocument:
+    post:
+      description: ""
+      requestBody:
+        $ref: '#/components/requestBodies/yorkie.v1.YorkieService.WatchDocument.yorkie.v1.WatchDocumentRequest'
+      responses:
+        "200":
+          $ref: '#/components/responses/yorkie.v1.YorkieService.WatchDocument.yorkie.v1.WatchDocumentResponse'
+        default:
+          $ref: '#/components/responses/connect.error'
+      tags:
+      - yorkie.v1.YorkieService
+components:
+  requestBodies:
+    yorkie.v1.YorkieService.ActivateClient.yorkie.v1.ActivateClientRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.ActivateClientRequest'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.ActivateClientRequest'
+      required: true
+    yorkie.v1.YorkieService.AttachDocument.yorkie.v1.AttachDocumentRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.AttachDocumentRequest'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.AttachDocumentRequest'
+      required: true
+    yorkie.v1.YorkieService.Broadcast.yorkie.v1.BroadcastRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.BroadcastRequest'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.BroadcastRequest'
+      required: true
+    yorkie.v1.YorkieService.DeactivateClient.yorkie.v1.DeactivateClientRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.DeactivateClientRequest'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.DeactivateClientRequest'
+      required: true
+    yorkie.v1.YorkieService.DetachDocument.yorkie.v1.DetachDocumentRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.DetachDocumentRequest'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.DetachDocumentRequest'
+      required: true
+    yorkie.v1.YorkieService.PushPullChanges.yorkie.v1.PushPullChangesRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.PushPullChangesRequest'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.PushPullChangesRequest'
+      required: true
+    yorkie.v1.YorkieService.RemoveDocument.yorkie.v1.RemoveDocumentRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.RemoveDocumentRequest'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.RemoveDocumentRequest'
+      required: true
+    yorkie.v1.YorkieService.WatchDocument.yorkie.v1.WatchDocumentRequest:
+      content: {}
+      required: true
+  responses:
+    connect.error:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/connect.error'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/connect.error'
+      description: ""
+    yorkie.v1.YorkieService.ActivateClient.yorkie.v1.ActivateClientResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.ActivateClientResponse'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.ActivateClientResponse'
+      description: ""
+    yorkie.v1.YorkieService.AttachDocument.yorkie.v1.AttachDocumentResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.AttachDocumentResponse'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.AttachDocumentResponse'
+      description: ""
+    yorkie.v1.YorkieService.Broadcast.yorkie.v1.BroadcastResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.BroadcastResponse'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.BroadcastResponse'
+      description: ""
+    yorkie.v1.YorkieService.DeactivateClient.yorkie.v1.DeactivateClientResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.DeactivateClientResponse'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.DeactivateClientResponse'
+      description: ""
+    yorkie.v1.YorkieService.DetachDocument.yorkie.v1.DetachDocumentResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.DetachDocumentResponse'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.DetachDocumentResponse'
+      description: ""
+    yorkie.v1.YorkieService.PushPullChanges.yorkie.v1.PushPullChangesResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.PushPullChangesResponse'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.PushPullChangesResponse'
+      description: ""
+    yorkie.v1.YorkieService.RemoveDocument.yorkie.v1.RemoveDocumentResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.RemoveDocumentResponse'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.RemoveDocumentResponse'
+      description: ""
+    yorkie.v1.YorkieService.WatchDocument.yorkie.v1.WatchDocumentResponse:
+      description: ""
+  schemas:
+    connect.error:
+      additionalProperties: false
+      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
+      properties:
+        code:
+          enum:
+          - CodeCanceled
+          - CodeUnknown
+          - CodeInvalidArgument
+          - CodeDeadlineExceeded
+          - CodeNotFound
+          - CodeAlreadyExists
+          - CodePermissionDenied
+          - CodeResourceExhausted
+          - CodeFailedPrecondition
+          - CodeAborted
+          - CodeOutOfRange
+          - CodeInternal
+          - CodeUnavailable
+          - CodeDataLoss
+          - CodeUnauthenticated
+          examples:
+          - CodeNotFound
+          type: string
+        message:
+          type: string
+      title: Connect Error
+      type: object
+    yorkie.v1.ActivateClientRequest:
+      additionalProperties: false
+      description: ""
+      properties:
+        clientKey:
+          additionalProperties: false
+          description: ""
+          title: client_key
+          type: string
+      title: ActivateClientRequest
+      type: object
+    yorkie.v1.ActivateClientResponse:
+      additionalProperties: false
+      description: ""
+      properties:
+        clientId:
+          additionalProperties: false
+          description: ""
+          title: client_id
+          type: string
+      title: ActivateClientResponse
+      type: object
+    yorkie.v1.AttachDocumentRequest:
+      additionalProperties: false
+      description: ""
+      properties:
+        changePack:
+          $ref: '#/components/schemas/yorkie.v1.ChangePack'
+          additionalProperties: false
+          description: ""
+          title: change_pack
+          type: object
+        clientId:
+          additionalProperties: false
+          description: ""
+          title: client_id
+          type: string
+      title: AttachDocumentRequest
+      type: object
+    yorkie.v1.AttachDocumentResponse:
+      additionalProperties: false
+      description: ""
+      properties:
+        changePack:
+          $ref: '#/components/schemas/yorkie.v1.ChangePack'
+          additionalProperties: false
+          description: ""
+          title: change_pack
+          type: object
+        documentId:
+          additionalProperties: false
+          description: ""
+          title: document_id
+          type: string
+      title: AttachDocumentResponse
+      type: object
+    yorkie.v1.BroadcastRequest:
+      additionalProperties: false
+      description: ""
+      properties:
+        clientId:
+          additionalProperties: false
+          description: ""
+          title: client_id
+          type: string
+        documentId:
+          additionalProperties: false
+          description: ""
+          title: document_id
+          type: string
+        payload:
+          additionalProperties: false
+          description: ""
+          format: byte
+          title: payload
+          type: string
+        topic:
+          additionalProperties: false
+          description: ""
+          title: topic
+          type: string
+      title: BroadcastRequest
+      type: object
+    yorkie.v1.BroadcastResponse:
+      additionalProperties: false
+      description: ""
+      title: BroadcastResponse
+      type: object
+    yorkie.v1.Change:
+      additionalProperties: false
+      description: ""
+      properties:
+        id:
+          $ref: '#/components/schemas/yorkie.v1.ChangeID'
+          additionalProperties: false
+          description: ""
+          title: id
+          type: object
+        message:
+          additionalProperties: false
+          description: ""
+          title: message
+          type: string
+        operations:
+          additionalProperties: false
+          description: ""
+          items:
+            $ref: '#/components/schemas/yorkie.v1.Operation'
+            type: object
+          title: operations
+          type: array
+        presenceChange:
+          $ref: '#/components/schemas/yorkie.v1.PresenceChange'
+          additionalProperties: false
+          description: ""
+          title: presence_change
+          type: object
+      title: Change
+      type: object
+    yorkie.v1.ChangeID:
+      additionalProperties: false
+      description: ""
+      properties:
+        actorId:
+          additionalProperties: false
+          description: ""
+          format: byte
+          title: actor_id
+          type: string
+        clientSeq:
+          additionalProperties: false
+          description: ""
+          title: client_seq
+          type: integer
+        lamport:
+          additionalProperties: false
+          description: ""
+          oneOf:
+          - type: string
+          - type: number
+          title: lamport
+        serverSeq:
+          additionalProperties: false
+          description: ""
+          oneOf:
+          - type: string
+          - type: number
+          title: server_seq
+      title: ChangeID
+      type: object
+    yorkie.v1.ChangePack:
+      additionalProperties: false
+      description: |-
+        ChangePack is a message that contains all changes that occurred in a document.
+         It is used to synchronize changes between clients and servers.
+      properties:
+        changes:
+          additionalProperties: false
+          description: ""
+          items:
+            $ref: '#/components/schemas/yorkie.v1.Change'
+            type: object
+          title: changes
+          type: array
+        checkpoint:
+          $ref: '#/components/schemas/yorkie.v1.Checkpoint'
+          additionalProperties: false
+          description: ""
+          title: checkpoint
+          type: object
+        documentKey:
+          additionalProperties: false
+          description: ""
+          title: document_key
+          type: string
+        isRemoved:
+          additionalProperties: false
+          description: ""
+          title: is_removed
+          type: boolean
+        minSyncedTicket:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: min_synced_ticket
+          type: object
+        snapshot:
+          additionalProperties: false
+          description: ""
+          format: byte
+          title: snapshot
+          type: string
+      title: ChangePack
+      type: object
+    yorkie.v1.Checkpoint:
+      additionalProperties: false
+      description: ""
+      properties:
+        clientSeq:
+          additionalProperties: false
+          description: ""
+          title: client_seq
+          type: integer
+        serverSeq:
+          additionalProperties: false
+          description: ""
+          oneOf:
+          - type: string
+          - type: number
+          title: server_seq
+      title: Checkpoint
+      type: object
+    yorkie.v1.DeactivateClientRequest:
+      additionalProperties: false
+      description: ""
+      properties:
+        clientId:
+          additionalProperties: false
+          description: ""
+          title: client_id
+          type: string
+      title: DeactivateClientRequest
+      type: object
+    yorkie.v1.DeactivateClientResponse:
+      additionalProperties: false
+      description: ""
+      title: DeactivateClientResponse
+      type: object
+    yorkie.v1.DetachDocumentRequest:
+      additionalProperties: false
+      description: ""
+      properties:
+        changePack:
+          $ref: '#/components/schemas/yorkie.v1.ChangePack'
+          additionalProperties: false
+          description: ""
+          title: change_pack
+          type: object
+        clientId:
+          additionalProperties: false
+          description: ""
+          title: client_id
+          type: string
+        documentId:
+          additionalProperties: false
+          description: ""
+          title: document_id
+          type: string
+        removeIfNotAttached:
+          additionalProperties: false
+          description: ""
+          title: remove_if_not_attached
+          type: boolean
+      title: DetachDocumentRequest
+      type: object
+    yorkie.v1.DetachDocumentResponse:
+      additionalProperties: false
+      description: ""
+      properties:
+        changePack:
+          $ref: '#/components/schemas/yorkie.v1.ChangePack'
+          additionalProperties: false
+          description: ""
+          title: change_pack
+          type: object
+      title: DetachDocumentResponse
+      type: object
+    yorkie.v1.DocEvent:
+      additionalProperties: false
+      description: ""
+      properties:
+        body:
+          $ref: '#/components/schemas/yorkie.v1.DocEventBody'
+          additionalProperties: false
+          description: ""
+          title: body
+          type: object
+        publisher:
+          additionalProperties: false
+          description: ""
+          title: publisher
+          type: string
+        type:
+          $ref: '#/components/schemas/yorkie.v1.DocEventType'
+          additionalProperties: false
+          description: ""
+          title: type
+      title: DocEvent
+      type: object
+    yorkie.v1.DocEventBody:
+      additionalProperties: false
+      description: ""
+      properties:
+        payload:
+          additionalProperties: false
+          description: ""
+          format: byte
+          title: payload
+          type: string
+        topic:
+          additionalProperties: false
+          description: ""
+          title: topic
+          type: string
+      title: DocEventBody
+      type: object
+    yorkie.v1.DocEventType:
+      description: ""
+      enum:
+      - - DOC_EVENT_TYPE_DOCUMENT_CHANGED
+        - 0
+        - DOC_EVENT_TYPE_DOCUMENT_WATCHED
+        - 1
+        - DOC_EVENT_TYPE_DOCUMENT_UNWATCHED
+        - 2
+        - DOC_EVENT_TYPE_DOCUMENT_BROADCAST
+        - 3
+      title: DocEventType
+      type: string
+    yorkie.v1.JSONElementSimple:
+      additionalProperties: false
+      description: ""
+      properties:
+        createdAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: created_at
+          type: object
+        movedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: moved_at
+          type: object
+        removedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: removed_at
+          type: object
+        type:
+          $ref: '#/components/schemas/yorkie.v1.ValueType'
+          additionalProperties: false
+          description: ""
+          title: type
+        value:
+          additionalProperties: false
+          description: ""
+          format: byte
+          title: value
+          type: string
+      title: JSONElementSimple
+      type: object
+    yorkie.v1.NodeAttr:
+      additionalProperties: false
+      description: ""
+      properties:
+        updatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: updated_at
+          type: object
+        value:
+          additionalProperties: false
+          description: ""
+          title: value
+          type: string
+      title: NodeAttr
+      type: object
+    yorkie.v1.Operation:
+      additionalProperties: false
+      description: ""
+      properties:
+        add:
+          $ref: '#/components/schemas/yorkie.v1.Operation.Add'
+          additionalProperties: false
+          description: ""
+          title: add
+          type: object
+        edit:
+          $ref: '#/components/schemas/yorkie.v1.Operation.Edit'
+          additionalProperties: false
+          description: ""
+          title: edit
+          type: object
+        increase:
+          $ref: '#/components/schemas/yorkie.v1.Operation.Increase'
+          additionalProperties: false
+          description: ""
+          title: increase
+          type: object
+        move:
+          $ref: '#/components/schemas/yorkie.v1.Operation.Move'
+          additionalProperties: false
+          description: ""
+          title: move
+          type: object
+        remove:
+          $ref: '#/components/schemas/yorkie.v1.Operation.Remove'
+          additionalProperties: false
+          description: ""
+          title: remove
+          type: object
+        select:
+          $ref: '#/components/schemas/yorkie.v1.Operation.Select'
+          additionalProperties: false
+          description: ""
+          title: select
+          type: object
+        set:
+          $ref: '#/components/schemas/yorkie.v1.Operation.Set'
+          additionalProperties: false
+          description: ""
+          title: set
+          type: object
+        style:
+          $ref: '#/components/schemas/yorkie.v1.Operation.Style'
+          additionalProperties: false
+          description: ""
+          title: style
+          type: object
+        treeEdit:
+          $ref: '#/components/schemas/yorkie.v1.Operation.TreeEdit'
+          additionalProperties: false
+          description: ""
+          title: tree_edit
+          type: object
+        treeStyle:
+          $ref: '#/components/schemas/yorkie.v1.Operation.TreeStyle'
+          additionalProperties: false
+          description: ""
+          title: tree_style
+          type: object
+      title: Operation
+      type: object
+    yorkie.v1.Operation.Add:
+      additionalProperties: false
+      description: ""
+      properties:
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+        prevCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: prev_created_at
+          type: object
+        value:
+          $ref: '#/components/schemas/yorkie.v1.JSONElementSimple'
+          additionalProperties: false
+          description: ""
+          title: value
+          type: object
+      title: Add
+      type: object
+    yorkie.v1.Operation.Edit:
+      additionalProperties: false
+      description: ""
+      properties:
+        attributes:
+          additionalProperties: false
+          description: ""
+          title: attributes
+          type: object
+        content:
+          additionalProperties: false
+          description: ""
+          title: content
+          type: string
+        createdAtMapByActor:
+          additionalProperties: false
+          description: ""
+          title: created_at_map_by_actor
+          type: object
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        from:
+          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          additionalProperties: false
+          description: ""
+          title: from
+          type: object
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+        to:
+          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          additionalProperties: false
+          description: ""
+          title: to
+          type: object
+      title: Edit
+      type: object
+    yorkie.v1.Operation.Edit.AttributesEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          additionalProperties: false
+          description: ""
+          title: value
+          type: string
+      title: AttributesEntry
+      type: object
+    yorkie.v1.Operation.Edit.CreatedAtMapByActorEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: value
+          type: object
+      title: CreatedAtMapByActorEntry
+      type: object
+    yorkie.v1.Operation.Increase:
+      additionalProperties: false
+      description: ""
+      properties:
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+        value:
+          $ref: '#/components/schemas/yorkie.v1.JSONElementSimple'
+          additionalProperties: false
+          description: ""
+          title: value
+          type: object
+      title: Increase
+      type: object
+    yorkie.v1.Operation.Move:
+      additionalProperties: false
+      description: ""
+      properties:
+        createdAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: created_at
+          type: object
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+        prevCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: prev_created_at
+          type: object
+      title: Move
+      type: object
+    yorkie.v1.Operation.Remove:
+      additionalProperties: false
+      description: ""
+      properties:
+        createdAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: created_at
+          type: object
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+      title: Remove
+      type: object
+    yorkie.v1.Operation.Select:
+      additionalProperties: false
+      description: |-
+        NOTE(hackerwins): Select Operation is not used in the current version.
+         In the previous version, it was used to represent selection of Text.
+         However, it has been replaced by Presence now. It is retained for backward
+         compatibility purposes.
+      properties:
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        from:
+          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          additionalProperties: false
+          description: ""
+          title: from
+          type: object
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+        to:
+          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          additionalProperties: false
+          description: ""
+          title: to
+          type: object
+      title: Select
+      type: object
+    yorkie.v1.Operation.Set:
+      additionalProperties: false
+      description: ""
+      properties:
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+        value:
+          $ref: '#/components/schemas/yorkie.v1.JSONElementSimple'
+          additionalProperties: false
+          description: ""
+          title: value
+          type: object
+      title: Set
+      type: object
+    yorkie.v1.Operation.Style:
+      additionalProperties: false
+      description: ""
+      properties:
+        attributes:
+          additionalProperties: false
+          description: ""
+          title: attributes
+          type: object
+        createdAtMapByActor:
+          additionalProperties: false
+          description: ""
+          title: created_at_map_by_actor
+          type: object
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        from:
+          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          additionalProperties: false
+          description: ""
+          title: from
+          type: object
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+        to:
+          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          additionalProperties: false
+          description: ""
+          title: to
+          type: object
+      title: Style
+      type: object
+    yorkie.v1.Operation.Style.AttributesEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          additionalProperties: false
+          description: ""
+          title: value
+          type: string
+      title: AttributesEntry
+      type: object
+    yorkie.v1.Operation.Style.CreatedAtMapByActorEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: value
+          type: object
+      title: CreatedAtMapByActorEntry
+      type: object
+    yorkie.v1.Operation.TreeEdit:
+      additionalProperties: false
+      description: ""
+      properties:
+        contents:
+          additionalProperties: false
+          description: ""
+          items:
+            $ref: '#/components/schemas/yorkie.v1.TreeNodes'
+            type: object
+          title: contents
+          type: array
+        createdAtMapByActor:
+          additionalProperties: false
+          description: ""
+          title: created_at_map_by_actor
+          type: object
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        from:
+          $ref: '#/components/schemas/yorkie.v1.TreePos'
+          additionalProperties: false
+          description: ""
+          title: from
+          type: object
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+        splitLevel:
+          additionalProperties: false
+          description: ""
+          title: split_level
+          type: integer
+        to:
+          $ref: '#/components/schemas/yorkie.v1.TreePos'
+          additionalProperties: false
+          description: ""
+          title: to
+          type: object
+      title: TreeEdit
+      type: object
+    yorkie.v1.Operation.TreeEdit.CreatedAtMapByActorEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: value
+          type: object
+      title: CreatedAtMapByActorEntry
+      type: object
+    yorkie.v1.Operation.TreeStyle:
+      additionalProperties: false
+      description: ""
+      properties:
+        attributes:
+          additionalProperties: false
+          description: ""
+          title: attributes
+          type: object
+        attributesToRemove:
+          additionalProperties: false
+          description: ""
+          items:
+            type: string
+          title: attributes_to_remove
+          type: array
+        executedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: executed_at
+          type: object
+        from:
+          $ref: '#/components/schemas/yorkie.v1.TreePos'
+          additionalProperties: false
+          description: ""
+          title: from
+          type: object
+        parentCreatedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: parent_created_at
+          type: object
+        to:
+          $ref: '#/components/schemas/yorkie.v1.TreePos'
+          additionalProperties: false
+          description: ""
+          title: to
+          type: object
+      title: TreeStyle
+      type: object
+    yorkie.v1.Operation.TreeStyle.AttributesEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          additionalProperties: false
+          description: ""
+          title: value
+          type: string
+      title: AttributesEntry
+      type: object
+    yorkie.v1.Presence:
+      additionalProperties: false
+      description: ""
+      properties:
+        data:
+          additionalProperties: false
+          description: ""
+          title: data
+          type: object
+      title: Presence
+      type: object
+    yorkie.v1.Presence.DataEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          additionalProperties: false
+          description: ""
+          title: value
+          type: string
+      title: DataEntry
+      type: object
+    yorkie.v1.PresenceChange:
+      additionalProperties: false
+      description: ""
+      properties:
+        presence:
+          $ref: '#/components/schemas/yorkie.v1.Presence'
+          additionalProperties: false
+          description: ""
+          title: presence
+          type: object
+        type:
+          $ref: '#/components/schemas/yorkie.v1.PresenceChange.ChangeType'
+          additionalProperties: false
+          description: ""
+          title: type
+      title: PresenceChange
+      type: object
+    yorkie.v1.PresenceChange.ChangeType:
+      description: ""
+      enum:
+      - - CHANGE_TYPE_UNSPECIFIED
+        - 0
+        - CHANGE_TYPE_PUT
+        - 1
+        - CHANGE_TYPE_DELETE
+        - 2
+        - CHANGE_TYPE_CLEAR
+        - 3
+      title: ChangeType
+      type: string
+    yorkie.v1.PushPullChangesRequest:
+      additionalProperties: false
+      description: ""
+      properties:
+        changePack:
+          $ref: '#/components/schemas/yorkie.v1.ChangePack'
+          additionalProperties: false
+          description: ""
+          title: change_pack
+          type: object
+        clientId:
+          additionalProperties: false
+          description: ""
+          title: client_id
+          type: string
+        documentId:
+          additionalProperties: false
+          description: ""
+          title: document_id
+          type: string
+        pushOnly:
+          additionalProperties: false
+          description: ""
+          title: push_only
+          type: boolean
+      title: PushPullChangesRequest
+      type: object
+    yorkie.v1.PushPullChangesResponse:
+      additionalProperties: false
+      description: ""
+      properties:
+        changePack:
+          $ref: '#/components/schemas/yorkie.v1.ChangePack'
+          additionalProperties: false
+          description: ""
+          title: change_pack
+          type: object
+      title: PushPullChangesResponse
+      type: object
+    yorkie.v1.RemoveDocumentRequest:
+      additionalProperties: false
+      description: ""
+      properties:
+        changePack:
+          $ref: '#/components/schemas/yorkie.v1.ChangePack'
+          additionalProperties: false
+          description: ""
+          title: change_pack
+          type: object
+        clientId:
+          additionalProperties: false
+          description: ""
+          title: client_id
+          type: string
+        documentId:
+          additionalProperties: false
+          description: ""
+          title: document_id
+          type: string
+      title: RemoveDocumentRequest
+      type: object
+    yorkie.v1.RemoveDocumentResponse:
+      additionalProperties: false
+      description: ""
+      properties:
+        changePack:
+          $ref: '#/components/schemas/yorkie.v1.ChangePack'
+          additionalProperties: false
+          description: ""
+          title: change_pack
+          type: object
+      title: RemoveDocumentResponse
+      type: object
+    yorkie.v1.TextNodePos:
+      additionalProperties: false
+      description: ""
+      properties:
+        createdAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: created_at
+          type: object
+        offset:
+          additionalProperties: false
+          description: ""
+          title: offset
+          type: integer
+        relativeOffset:
+          additionalProperties: false
+          description: ""
+          title: relative_offset
+          type: integer
+      title: TextNodePos
+      type: object
+    yorkie.v1.TimeTicket:
+      additionalProperties: false
+      description: ""
+      properties:
+        actorId:
+          additionalProperties: false
+          description: ""
+          format: byte
+          title: actor_id
+          type: string
+        delimiter:
+          additionalProperties: false
+          description: ""
+          title: delimiter
+          type: integer
+        lamport:
+          additionalProperties: false
+          description: ""
+          oneOf:
+          - type: string
+          - type: number
+          title: lamport
+      title: TimeTicket
+      type: object
+    yorkie.v1.TreeNode:
+      additionalProperties: false
+      description: ""
+      properties:
+        attributes:
+          additionalProperties: false
+          description: ""
+          title: attributes
+          type: object
+        depth:
+          additionalProperties: false
+          description: ""
+          title: depth
+          type: integer
+        id:
+          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          additionalProperties: false
+          description: ""
+          title: id
+          type: object
+        insNextId:
+          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          additionalProperties: false
+          description: ""
+          title: ins_next_id
+          type: object
+        insPrevId:
+          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          additionalProperties: false
+          description: ""
+          title: ins_prev_id
+          type: object
+        removedAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: removed_at
+          type: object
+        type:
+          additionalProperties: false
+          description: ""
+          title: type
+          type: string
+        value:
+          additionalProperties: false
+          description: ""
+          title: value
+          type: string
+      title: TreeNode
+      type: object
+    yorkie.v1.TreeNode.AttributesEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          $ref: '#/components/schemas/yorkie.v1.NodeAttr'
+          additionalProperties: false
+          description: ""
+          title: value
+          type: object
+      title: AttributesEntry
+      type: object
+    yorkie.v1.TreeNodeID:
+      additionalProperties: false
+      description: ""
+      properties:
+        createdAt:
+          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          additionalProperties: false
+          description: ""
+          title: created_at
+          type: object
+        offset:
+          additionalProperties: false
+          description: ""
+          title: offset
+          type: integer
+      title: TreeNodeID
+      type: object
+    yorkie.v1.TreeNodes:
+      additionalProperties: false
+      description: ""
+      properties:
+        content:
+          additionalProperties: false
+          description: ""
+          items:
+            $ref: '#/components/schemas/yorkie.v1.TreeNode'
+            type: object
+          title: content
+          type: array
+      title: TreeNodes
+      type: object
+    yorkie.v1.TreePos:
+      additionalProperties: false
+      description: ""
+      properties:
+        leftSiblingId:
+          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          additionalProperties: false
+          description: ""
+          title: left_sibling_id
+          type: object
+        parentId:
+          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          additionalProperties: false
+          description: ""
+          title: parent_id
+          type: object
+      title: TreePos
+      type: object
+    yorkie.v1.ValueType:
+      description: ""
+      enum:
+      - - VALUE_TYPE_NULL
+        - 0
+        - VALUE_TYPE_BOOLEAN
+        - 1
+        - VALUE_TYPE_INTEGER
+        - 2
+        - VALUE_TYPE_LONG
+        - 3
+        - VALUE_TYPE_DOUBLE
+        - 4
+        - VALUE_TYPE_STRING
+        - 5
+        - VALUE_TYPE_BYTES
+        - 6
+        - VALUE_TYPE_DATE
+        - 7
+        - VALUE_TYPE_JSON_OBJECT
+        - 8
+        - VALUE_TYPE_JSON_ARRAY
+        - 9
+        - VALUE_TYPE_TEXT
+        - 10
+        - VALUE_TYPE_INTEGER_CNT
+        - 11
+        - VALUE_TYPE_LONG_CNT
+        - 12
+        - VALUE_TYPE_TREE
+        - 13
+      title: ValueType
+      type: string
+    yorkie.v1.WatchDocumentRequest:
+      additionalProperties: false
+      description: ""
+      properties:
+        clientId:
+          additionalProperties: false
+          description: ""
+          title: client_id
+          type: string
+        documentId:
+          additionalProperties: false
+          description: ""
+          title: document_id
+          type: string
+      title: WatchDocumentRequest
+      type: object
+    yorkie.v1.WatchDocumentResponse:
+      additionalProperties: false
+      description: ""
+      properties:
+        event:
+          $ref: '#/components/schemas/yorkie.v1.DocEvent'
+          additionalProperties: false
+          description: ""
+          title: event
+          type: object
+        initialization:
+          $ref: '#/components/schemas/yorkie.v1.WatchDocumentResponse.Initialization'
+          additionalProperties: false
+          description: ""
+          title: initialization
+          type: object
+      title: WatchDocumentResponse
+      type: object
+    yorkie.v1.WatchDocumentResponse.Initialization:
+      additionalProperties: false
+      description: ""
+      properties:
+        clientIds:
+          additionalProperties: false
+          description: ""
+          items:
+            type: string
+          title: client_ids
+          type: array
+      title: Initialization
+      type: object
+tags:
+- description: Yorkie is a service that provides a API for SDKs.
+  name: yorkie.v1.YorkieService

--- a/api/docs/yorkie/v1/yorkie.openapi.yaml
+++ b/api/docs/yorkie/v1/yorkie.openapi.yaml
@@ -4,6 +4,11 @@ info:
     editing applications.
   title: Yorkie
   version: v0.4.14
+servers:
+- description: Production server
+  url: https://api.yorkie.dev
+- description: Local server
+  url: http://localhost:8080
 paths:
   /yorkie.v1.YorkieService/ActivateClient:
     post:
@@ -1527,6 +1532,13 @@ components:
           type: array
       title: Initialization
       type: object
+  securitySchemes:
+    ApiKeyAuth:
+      in: header
+      name: Authorization
+      type: apiKey
+security:
+- ApiKeyAuth: []
 tags:
 - description: Yorkie is a service that provides a API for SDKs.
   name: yorkie.v1.YorkieService

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -6,3 +6,7 @@ plugins:
   - plugin: connect-go
     out: api
     opt: paths=source_relative
+  - plugin: connect-openapi
+    out: api/docs
+    opt:
+      - base=api/docs/yorkie.base.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

<img width="1477" alt="image" src="https://github.com/yorkie-team/yorkie/assets/52884648/9b521f5b-92ff-483a-b3d6-d81f74ca2d5b">

This PR focuses on defining the ConnectRPC API Docs as an OpenAPI Spec and includes adding a Swagger serving command. By converting the API docs to an OpenAPI Spec, it enhances the readability, consistency, and ease of use for developers utilizing the ConnectRPC API.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #804 

**Special notes for your reviewer**:

To access swagger, run `make docker-swagger` and access to `localhost:3000`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
