### PR TITLE
Fix incorrect calculation in `indexTree.treePosToPath` operation

### DIFF
--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -917,7 +917,7 @@ func (t *Tree) FindTreeNodesWithSplitText(pos *TreePos, editedAt *time.Ticket) (
 	*TreeNode, *TreeNode, error,
 ) {
 	// 01. Find the parent and left sibling nodes of the given position.
-	parentNode, leftNode := t.toTreeNodes(pos)
+	parentNode, leftNode := t.ToTreeNodes(pos)
 	if parentNode == nil || leftNode == nil {
 		return nil, nil, fmt.Errorf("%p: %w", pos, ErrNodeNotFound)
 	}
@@ -1030,6 +1030,19 @@ func (t *Tree) ToIndex(parentNode, leftSiblingNode *TreeNode) (int, error) {
 	return idx, nil
 }
 
+// ToPath returns path from given CRDTTreePos
+func (t *Tree) ToPath(parentNode, leftSiblingNode *TreeNode) ([]int, error) {
+	treePos, err := t.toTreePos(parentNode, leftSiblingNode)
+	if err != nil {
+		return make([]int, 0), err
+	}
+	if treePos == nil {
+		return make([]int, 0), nil
+	}
+
+	return t.IndexTree.TreePosToPath(treePos)
+}
+
 // findFloorNode returns node from given id.
 func (t *Tree) findFloorNode(id *TreeNodeID) *TreeNode {
 	key, node := t.NodeMapByID.Floor(id)
@@ -1041,11 +1054,11 @@ func (t *Tree) findFloorNode(id *TreeNodeID) *TreeNode {
 	return node
 }
 
-// toTreeNodes converts the pos to parent and left sibling nodes.
+// ToTreeNodes converts the pos to parent and left sibling nodes.
 // If the position points to the middle of a node, then the left sibling node
 // is the node that contains the position. Otherwise, the left sibling node is
 // the node that is the left of the position.
-func (t *Tree) toTreeNodes(pos *TreePos) (*TreeNode, *TreeNode) {
+func (t *Tree) ToTreeNodes(pos *TreePos) (*TreeNode, *TreeNode) {
 	parentNode := t.findFloorNode(pos.ParentID)
 	leftNode := t.findFloorNode(pos.LeftSiblingID)
 

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -1037,7 +1037,7 @@ func (t *Tree) ToPath(parentNode, leftSiblingNode *TreeNode) ([]int, error) {
 		return nil, err
 	}
 	if treePos == nil {
-		return make([]int, 0), nil
+		return nil, nil
 	}
 
 	return t.IndexTree.TreePosToPath(treePos)

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -1034,7 +1034,7 @@ func (t *Tree) ToIndex(parentNode, leftSiblingNode *TreeNode) (int, error) {
 func (t *Tree) ToPath(parentNode, leftSiblingNode *TreeNode) ([]int, error) {
 	treePos, err := t.toTreePos(parentNode, leftSiblingNode)
 	if err != nil {
-		return make([]int, 0), err
+		return nil, err
 	}
 	if treePos == nil {
 		return make([]int, 0), nil

--- a/pkg/index/tree.go
+++ b/pkg/index/tree.go
@@ -595,7 +595,7 @@ func (n *Node[V]) InsertAfter(newNode, referenceNode *Node[V]) error {
 
 // HasTextChild returns true if the node's children consist of only text children.
 func (n *Node[V]) HasTextChild() bool {
-	if len(n.children) > 0 {
+	if len(n.Children()) > 0 {
 		for _, child := range n.Children() {
 			if !child.IsText() {
 				return false

--- a/pkg/index/tree.go
+++ b/pkg/index/tree.go
@@ -596,12 +596,12 @@ func (n *Node[V]) InsertAfter(newNode, referenceNode *Node[V]) error {
 // HasTextChild returns true if the node has a text child.
 func (n *Node[V]) HasTextChild() bool {
 	for _, child := range n.Children() {
-		if child.IsText() {
-			return true
+		if !child.IsText() {
+			return false
 		}
 	}
 
-	return false
+	return true
 }
 
 // OffsetOfChild returns offset of children of the given node.
@@ -728,6 +728,13 @@ func (t *Tree[V]) TreePosToPath(treePos *TreePos[V]) ([]int, error) {
 
 		node = node.Parent
 		path = append(path, leftSiblingsSize+treePos.Offset)
+	} else if node.HasTextChild() {
+		leftSiblingsSize, err := t.LeftSiblingsSize(node, treePos.Offset)
+		if err != nil {
+			return nil, err
+		}
+
+		path = append(path, leftSiblingsSize)
 	} else {
 		path = append(path, treePos.Offset)
 	}

--- a/pkg/index/tree.go
+++ b/pkg/index/tree.go
@@ -729,6 +729,8 @@ func (t *Tree[V]) TreePosToPath(treePos *TreePos[V]) ([]int, error) {
 		node = node.Parent
 		path = append(path, leftSiblingsSize+treePos.Offset)
 	} else if node.HasTextChild() {
+		// TODO(hackerwins): The function does not consider the situation
+		// where Element and Text nodes are mixed in the Element's Children.
 		leftSiblingsSize, err := t.LeftSiblingsSize(node, treePos.Offset)
 		if err != nil {
 			return nil, err

--- a/pkg/index/tree.go
+++ b/pkg/index/tree.go
@@ -593,15 +593,19 @@ func (n *Node[V]) InsertAfter(newNode, referenceNode *Node[V]) error {
 	return nil
 }
 
-// HasTextChild returns true if the node has a text child.
+// HasTextChild returns true if the node's children consist of only text children.
 func (n *Node[V]) HasTextChild() bool {
-	for _, child := range n.Children() {
-		if !child.IsText() {
-			return false
+	if len(n.children) > 0 {
+		for _, child := range n.Children() {
+			if !child.IsText() {
+				return false
+			}
 		}
+
+		return true
 	}
 
-	return true
+	return false
 }
 
 // OffsetOfChild returns offset of children of the given node.

--- a/pkg/index/tree.go
+++ b/pkg/index/tree.go
@@ -595,17 +595,18 @@ func (n *Node[V]) InsertAfter(newNode, referenceNode *Node[V]) error {
 
 // HasTextChild returns true if the node's children consist of only text children.
 func (n *Node[V]) HasTextChild() bool {
-	if len(n.Children()) > 0 {
-		for _, child := range n.Children() {
-			if !child.IsText() {
-				return false
-			}
-		}
-
-		return true
+	children := n.Children()
+	if len(children) == 0 {
+		return false
 	}
 
-	return false
+	for _, child := range children {
+		if !child.IsText() {
+			return false
+		}
+	}
+
+	return true
 }
 
 // OffsetOfChild returns offset of children of the given node.

--- a/test/integration/tree_test.go
+++ b/test/integration/tree_test.go
@@ -375,6 +375,127 @@ func TestTree(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	// TODO: test name
+	t.Run("", func(t *testing.T) {
+		ctx := context.Background()
+		d1 := document.New(helper.TestDocKey(t))
+		assert.NoError(t, c1.Attach(ctx, d1))
+
+		assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewTree("t", &json.TreeNode{
+				Type: "r",
+				Children: []json.TreeNode{{
+					Type: "c",
+					Children: []json.TreeNode{{
+						Type: "u",
+						Children: []json.TreeNode{{
+							Type: "p",
+							Children: []json.TreeNode{{
+								Type:     "n",
+								Children: []json.TreeNode{},
+							}},
+						}},
+					}},
+				}, {
+					Type: "c",
+					Children: []json.TreeNode{{
+						Type: "p",
+						Children: []json.TreeNode{{
+							Type:     "n",
+							Children: []json.TreeNode{},
+						}},
+					}},
+				}},
+			})
+			return nil
+		}))
+
+		assert.NoError(t, c1.Sync(ctx))
+		d2 := document.New(helper.TestDocKey(t))
+		assert.NoError(t, c2.Attach(ctx, d2))
+
+		assert.Equal(t, "<r><c><u><p><n></n></p></u></c><c><p><n></n></p></c></r>", d1.Root().GetTree("t").ToXML())
+		assert.Equal(t, "<r><c><u><p><n></n></p></u></c><c><p><n></n></p></c></r>", d2.Root().GetTree("t").ToXML())
+
+		assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetTree("t").EditByPath([]int{1, 0, 0, 0}, []int{1, 0, 0, 0}, &json.TreeNode{
+				Type:  "text",
+				Value: "1",
+			}, 0)
+			assert.Equal(t, "<r><c><u><p><n></n></p></u></c><c><p><n>1</n></p></c></r>", root.GetTree("t").ToXML())
+
+			root.GetTree("t").EditByPath([]int{1, 0, 0, 1}, []int{1, 0, 0, 1}, &json.TreeNode{
+				Type:  "text",
+				Value: "2",
+			}, 0)
+			assert.Equal(t, "<r><c><u><p><n></n></p></u></c><c><p><n>12</n></p></c></r>", root.GetTree("t").ToXML())
+
+			root.GetTree("t").EditByPath([]int{1, 0, 0, 2}, []int{1, 0, 0, 2}, &json.TreeNode{
+				Type:  "text",
+				Value: "3",
+			}, 0)
+			assert.Equal(t, "<r><c><u><p><n></n></p></u></c><c><p><n>123</n></p></c></r>", root.GetTree("t").ToXML())
+
+			return nil
+		}))
+
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c1.Sync(ctx))
+
+		assert.Equal(t, "<r><c><u><p><n></n></p></u></c><c><p><n>123</n></p></c></r>", d1.Root().GetTree("t").ToXML())
+		assert.Equal(t, "<r><c><u><p><n></n></p></u></c><c><p><n>123</n></p></c></r>", d2.Root().GetTree("t").ToXML())
+
+		assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetTree("t").EditByPath([]int{1, 0, 0, 1}, []int{1, 0, 0, 1}, &json.TreeNode{
+				Type:  "text",
+				Value: "abcdefgh",
+			}, 0)
+			assert.Equal(t, "<r><c><u><p><n></n></p></u></c><c><p><n>1abcdefgh23</n></p></c></r>", root.GetTree("t").ToXML())
+
+			return nil
+		}))
+
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+
+		assert.Equal(t, "<r><c><u><p><n></n></p></u></c><c><p><n>1abcdefgh23</n></p></c></r>", d1.Root().GetTree("t").ToXML())
+		assert.Equal(t, "<r><c><u><p><n></n></p></u></c><c><p><n>1abcdefgh23</n></p></c></r>", d2.Root().GetTree("t").ToXML())
+
+		assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetTree("t").EditByPath([]int{1, 0, 0, 5}, []int{1, 0, 0, 5}, &json.TreeNode{
+				Type:  "text",
+				Value: "4",
+			}, 0)
+			assert.Equal(t, "<r><c><u><p><n></n></p></u></c><c><p><n>1abcd4efgh23</n></p></c></r>", root.GetTree("t").ToXML())
+
+			root.GetTree("t").EditByPath([]int{1, 0, 0, 6}, []int{1, 0, 0, 7}, nil, 0)
+			assert.Equal(t, "<r><c><u><p><n></n></p></u></c><c><p><n>1abcd4fgh23</n></p></c></r>", root.GetTree("t").ToXML())
+
+			root.GetTree("t").EditByPath([]int{1, 0, 0, 6}, []int{1, 0, 0, 6}, &json.TreeNode{
+				Type:  "text",
+				Value: "5",
+			}, 0)
+			assert.Equal(t, "<r><c><u><p><n></n></p></u></c><c><p><n>1abcd45fgh23</n></p></c></r>", root.GetTree("t").ToXML())
+
+			return nil
+		}))
+
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c1.Sync(ctx))
+
+		assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetTree("t").EditByPath([]int{1, 0, 0, 7}, []int{1, 0, 0, 8}, nil, 0)
+			assert.Equal(t, "<r><c><u><p><n></n></p></u></c><c><p><n>1abcd45gh23</n></p></c></r>", root.GetTree("t").ToXML())
+
+			return nil
+		}))
+
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c1.Sync(ctx))
+
+		syncClientsThenAssertEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
+	})
+
 	t.Run("sync its content with other clients test", func(t *testing.T) {
 		ctx := context.Background()
 		d1 := document.New(helper.TestDocKey(t))

--- a/test/integration/tree_test.go
+++ b/test/integration/tree_test.go
@@ -417,7 +417,6 @@ func TestTree(t *testing.T) {
 
 		fromPos, _ := d2.Root().GetTree("t").PathToPos([]int{0, 5})
 		fromParent, fromLeft := d2.Root().GetTree("t").ToTreeNodes(fromPos)
-		fromPath, _ := d2.Root().GetTree("t").ToPath(fromParent, fromLeft)
 
 		assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
 			root.GetTree("t").EditByPath([]int{0, 4}, []int{0, 5}, nil, 0)
@@ -431,7 +430,8 @@ func TestTree(t *testing.T) {
 
 			return nil
 		}))
-		fromPath, _ = d2.Root().GetTree("t").ToPath(fromParent, fromLeft)
+		fromPath, err := d2.Root().GetTree("t").ToPath(fromParent, fromLeft)
+		assert.NoError(t, err)
 		assert.Equal(t, []int{0, 5}, fromPath)
 
 		assert.NoError(t, c2.Sync(ctx))


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This patch addresses an issue arising from the `tree.edit` operation in response to problem with calculating the `fromPath` when multiple `treePos` represent a single index-based coordinate, leading to inaccuracies.

This PR contains migration work for https://github.com/yorkie-team/yorkie-js-sdk/pull/751, so detailed information can also be found there.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Address [#749](https://github.com/yorkie-team/yorkie-js-sdk/issues/749)
Related https://github.com/yorkie-team/yorkie-js-sdk/pull/751

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
