### PR TITLE
Fix missing escapeString in Tree Marshal

### DIFF
--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -478,7 +478,7 @@ func (t *Tree) purgeNode(node *TreeNode) error {
 // marshal returns the JSON encoding of this Tree.
 func marshal(builder *strings.Builder, node *TreeNode) {
 	if node.IsText() {
-		builder.WriteString(fmt.Sprintf(`{"type":"%s","value":"%s"}`, node.Type(), node.Value))
+		builder.WriteString(fmt.Sprintf(`{"type":"%s","value":"%s"}`, node.Type(), EscapeString(node.Value)))
 		return
 	}
 

--- a/pkg/document/crdt/tree_test.go
+++ b/pkg/document/crdt/tree_test.go
@@ -465,6 +465,26 @@ func TestTreeEdit(t *testing.T) {
 		assert.Equal(t, 0, idx)
 	})
 
+	t.Run("marshal test", func(t *testing.T) {
+		ctx := helper.TextChangeContext(helper.TestRoot())
+		tree := crdt.NewTree(crdt.NewTreeNode(helper.PosT(ctx), "root", nil), helper.TimeT(ctx))
+		_, err := tree.EditT(0, 0, []*crdt.TreeNode{crdt.NewTreeNode(helper.PosT(ctx), "p", nil)}, 0,
+			helper.TimeT(ctx), issueTimeTicket(ctx))
+		assert.NoError(t, err)
+		_, err = tree.EditT(1, 1, []*crdt.TreeNode{
+			crdt.NewTreeNode(helper.PosT(ctx), "text", nil, "\"Hello\" \n i'm yorkie!"),
+		}, 0,
+			helper.TimeT(ctx), issueTimeTicket(ctx))
+		assert.NoError(t, err)
+
+		assert.Equal(t, "<root><p>\"Hello\" \n i'm yorkie!</p></root>", tree.ToXML())
+		assert.Equal(
+			t,
+			"{\"type\":\"root\",\"children\":[{\"type\":\"p\","+
+				"\"children\":[{\"type\":\"text\",\"value\":\"\\\"Hello\\\" \\n i'm yorkie!\"}]}]}",
+			tree.Marshal(),
+		)
+	})
 }
 
 func TestTreeSplit(t *testing.T) {

--- a/pkg/document/crdt/tree_test.go
+++ b/pkg/document/crdt/tree_test.go
@@ -472,16 +472,16 @@ func TestTreeEdit(t *testing.T) {
 			helper.TimeT(ctx), issueTimeTicket(ctx))
 		assert.NoError(t, err)
 		_, err = tree.EditT(1, 1, []*crdt.TreeNode{
-			crdt.NewTreeNode(helper.PosT(ctx), "text", nil, "\"Hello\" \n i'm yorkie!"),
+			crdt.NewTreeNode(helper.PosT(ctx), "text", nil, `"Hello" \n i'm yorkie!`),
 		}, 0,
 			helper.TimeT(ctx), issueTimeTicket(ctx))
 		assert.NoError(t, err)
 
-		assert.Equal(t, "<root><p>\"Hello\" \n i'm yorkie!</p></root>", tree.ToXML())
+		assert.Equal(t, `<root><p>"Hello" \n i'm yorkie!</p></root>`, tree.ToXML())
 		assert.Equal(
 			t,
-			"{\"type\":\"root\",\"children\":[{\"type\":\"p\","+
-				"\"children\":[{\"type\":\"text\",\"value\":\"\\\"Hello\\\" \\n i'm yorkie!\"}]}]}",
+			`{"type":"root","children":[{"type":"p",`+
+				`"children":[{"type":"text","value":"\"Hello\" \\n i'm yorkie!"}]}]}`,
 			tree.Marshal(),
 		)
 	})

--- a/pkg/document/crdt/tree_test.go
+++ b/pkg/document/crdt/tree_test.go
@@ -468,20 +468,19 @@ func TestTreeEdit(t *testing.T) {
 	t.Run("marshal test", func(t *testing.T) {
 		ctx := helper.TextChangeContext(helper.TestRoot())
 		tree := crdt.NewTree(crdt.NewTreeNode(helper.PosT(ctx), "root", nil), helper.TimeT(ctx))
-		_, err := tree.EditT(0, 0, []*crdt.TreeNode{crdt.NewTreeNode(helper.PosT(ctx), "p", nil)}, 0,
-			helper.TimeT(ctx), issueTimeTicket(ctx))
+		_, err := tree.EditT(0, 0, []*crdt.TreeNode{
+			crdt.NewTreeNode(helper.PosT(ctx), "p", nil),
+		}, 0, helper.TimeT(ctx), issueTimeTicket(ctx))
 		assert.NoError(t, err)
 		_, err = tree.EditT(1, 1, []*crdt.TreeNode{
 			crdt.NewTreeNode(helper.PosT(ctx), "text", nil, `"Hello" \n i'm yorkie!`),
-		}, 0,
-			helper.TimeT(ctx), issueTimeTicket(ctx))
+		}, 0, helper.TimeT(ctx), issueTimeTicket(ctx))
 		assert.NoError(t, err)
 
 		assert.Equal(t, `<root><p>"Hello" \n i'm yorkie!</p></root>`, tree.ToXML())
 		assert.Equal(
 			t,
-			`{"type":"root","children":[{"type":"p",`+
-				`"children":[{"type":"text","value":"\"Hello\" \\n i'm yorkie!"}]}]}`,
+			`{"type":"root","children":[{"type":"p",children":[{"type":"text","value":"\"Hello\" \\n i'm yorkie!"}]}]}`,
 			tree.Marshal(),
 		)
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR addresses the issue of missing escape string processing in Tree Marshal. The absence of this processing causes errors in the dashboard when accessing a document containing special characters in Tree data type.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/yorkie-team/dashboard/issues/139
Related https://github.com/yorkie-team/yorkie-js-sdk/pull/700 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
