### PR TITLE
Use DBConnectionURI directly

### DIFF
--- a/build/charts/yorkie-cluster/templates/yorkie/deployment.yaml
+++ b/build/charts/yorkie-cluster/templates/yorkie/deployment.yaml
@@ -39,7 +39,7 @@ spec:
         args: [
           "server",
           "--mongo-connection-uri",
-          "mongodb://{{ .Values.yorkie.args.dbUrl }}:{{ .Values.yorkie.args.dbPort }}/yorkie-meta",
+          "{{ .Values.yorkie.args.dbConnectionUri }}",
           "--enable-pprof",
           "--rpc-port",
           "{{ .Values.yorkie.ports.rpcPort }}",

--- a/build/charts/yorkie-cluster/values.yaml
+++ b/build/charts/yorkie-cluster/values.yaml
@@ -13,8 +13,7 @@ yorkie:
     tag: ""
 
   args:
-    dbUrl: mongodb.mongodb.svc.cluster.local
-    dbPort: 27017
+    dbConnectionUri: mongodb://mongodb.mongodb.svc.cluster.local:27017/yorkie-meta
 
   ports:
     rpcPort: 8080


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This commit changes the yorkie-cluster chart to allow direct input of the DBConnectionURI.

Users can set options such as `authmechanism` in the MongoDB Connection URI. However, the current chart separates port and URI, making it impossible to configure settings. This commit enables users to directly set `DBConnectionURI`, allowing them to specify options when connecting to MongoDB.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
