### PR TITLE
Move Yorkie Related K8s Resources to Yorkie Namespace in Helm Chart

### DIFF
--- a/build/charts/yorkie-cluster/templates/istio/external-service.yaml
+++ b/build/charts/yorkie-cluster/templates/istio/external-service.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-ingressgateway
+  namespace: {{ .Values.yorkie.namespace }}
+spec:
+  type: ExternalName
+  externalName: istio-ingressgateway.istio-system.svc.cluster.local

--- a/build/charts/yorkie-cluster/templates/istio/ingress-envoy-filter.yaml
+++ b/build/charts/yorkie-cluster/templates/istio/ingress-envoy-filter.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: ingress-stream-idle-timeout-filter
-  namespace: istio-system
+  namespace: {{ .Values.yorkie.namespace }}
 spec:
   workloadSelector:
     labels:
@@ -26,7 +26,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: ingress-shard-key-header-filter
-  namespace: istio-system
+  namespace: {{ .Values.yorkie.namespace }}
 spec:
   workloadSelector:
     labels:

--- a/build/charts/yorkie-cluster/templates/istio/ingress.yaml
+++ b/build/charts/yorkie-cluster/templates/istio/ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Values.yorkie.name }}
-  namespace: istio-system
+  namespace: {{ .Values.yorkie.namespace }}
   {{ if .Values.ingress.alb.enabled }}
   annotations:
     alb.ingress.kubernetes.io/scheme: internet-facing


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

This PR aims to move Yorkie-related Kubernetes resources from the `istio-system` namespace to the `yorkie` namespace within the `yorkie-cluster` Helm chart.

Previously, some yorkie-related resources with Istio dependencies were in the `istio-system` namespace. Moving them to the `yorkie` namespace is essential to explicitly isolate Yorkie-related resources from other services using Istio, preventing potential conflicts or confusion.

By relocating the Yorkie resources to the dedicated `yorkie` namespace, we ensure a clean separation of concerns and avoid namespace clutter caused by mixing Yorkie resources with other services using Istio.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

[ExternalName typed Kubernetes Service](https://kubernetes.io/docs/concepts/services-networking/service/#externalname) has been added for Ingress object in `yorkie` namespace to communicate with istio-ingressgateway in `istio-system` namespace (which is in another namespace). 

Also, `ratelimit` resources are not considered in this PR.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
