### PR TITLE
Move `istio-ingressgateway` to Yorkie Namespace

### DIFF
--- a/build/charts/yorkie-cluster/README.md
+++ b/build/charts/yorkie-cluster/README.md
@@ -13,6 +13,7 @@ Installs the yorkie-cluster, which provides cluster mode for Yorkie server to ha
 Before installing the chart, you need to install Istio with [Istio Operator](https://istio.io/latest/docs/setup/install/operator/) using [istioctl](https://istio.io/latest/docs/setup/getting-started/#download).
 
 ```bash
+kubectl create namespace yorkie
 istioctl install -f <(curl -s https://raw.githubusercontent.com/yorkie-team/yorkie/main/build/charts/yorkie-cluster/istio-operator.yaml)
 ```
 
@@ -50,6 +51,7 @@ Also, you need to uninstall istio with [istioctl](https://istio.io/latest/docs/s
 
 ```bash
 istioctl uninstall --purge
+kubectl delete namespace yorkie
 ```
 
 This will remove all the istio components including CRDs.

--- a/build/charts/yorkie-cluster/istio-operator.yaml
+++ b/build/charts/yorkie-cluster/istio-operator.yaml
@@ -1,7 +1,7 @@
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 metadata:
-  name: istio-operator
+  name: yorkie-gateway-operator
   namespace: istio-system
 spec:
   profile: default
@@ -11,7 +11,12 @@ spec:
   components:
     ingressGateways:
       - name: istio-ingressgateway
+        enabled: false
+      - name: yorkie-gateway
+        namespace: yorkie
         enabled: true
+        label:
+          istio: yorkie-gateway
         k8s:
           service:
             type: NodePort

--- a/build/charts/yorkie-cluster/templates/istio/gateway.yaml
+++ b/build/charts/yorkie-cluster/templates/istio/gateway.yaml
@@ -4,9 +4,8 @@ metadata:
   name: {{ .Values.yorkie.name }}-gateway
   namespace: {{ .Values.yorkie.namespace }}
 spec:
-  # use istio default controller
   selector:
-    istio: ingressgateway
+    istio: yorkie-gateway
   servers:
     - port:
         number: 80

--- a/build/charts/yorkie-cluster/templates/istio/ingress-envoy-filter.yaml
+++ b/build/charts/yorkie-cluster/templates/istio/ingress-envoy-filter.yaml
@@ -2,11 +2,11 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: ingress-stream-idle-timeout-filter
-  namespace: istio-system
+  namespace: {{ .Values.yorkie.namespace }}
 spec:
   workloadSelector:
     labels:
-      istio: ingressgateway
+      istio: yorkie-gateway
   configPatches:
     - applyTo: NETWORK_FILTER
       match:
@@ -26,11 +26,11 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: ingress-shard-key-header-filter
-  namespace: istio-system
+  namespace: {{ .Values.yorkie.namespace }}
 spec:
   workloadSelector:
     labels:
-      istio: ingressgateway
+      istio: yorkie-gateway
   configPatches:
     - applyTo: HTTP_FILTER
       match:

--- a/build/charts/yorkie-cluster/templates/istio/ingress.yaml
+++ b/build/charts/yorkie-cluster/templates/istio/ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Values.yorkie.name }}
-  namespace: istio-system
+  namespace: {{ .Values.yorkie.namespace }}
   {{ if .Values.ingress.alb.enabled }}
   annotations:
     alb.ingress.kubernetes.io/scheme: internet-facing
@@ -29,6 +29,6 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: istio-ingressgateway
+                name: yorkie-gateway
                 port:
                   number: 80

--- a/build/charts/yorkie-cluster/templates/yorkie/namespace.yaml
+++ b/build/charts/yorkie-cluster/templates/yorkie/namespace.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.yorkie.namespace }}
-  labels:
-    ## Because we only need to load balance worklaods to Yorkie service,
-    ## we don't need sidecar proxy for service mesh.
-    ## We are only using Istio's ingressgateway envoy for load balancing.
-    istio-injection: disabled


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Relocate the `istio-ingressgateway` to the yorkie namespace under the name `yorkie-gateway`.

The purpose of this move is to clearly segregate yorkie-related Kubernetes resources from other services for better organization and management. 

Additionally, for production Istio deployments, it is crucial to separate the istio-ingressgateway and istiod components to enable independent operation.

In Istio, this gateway topology is called [Dedicated application gateway](https://istio.io/latest/docs/setup/additional-setup/gateway/#dedicated-application-gateway).

![image](https://github.com/yorkie-team/yorkie/assets/70474071/152d19e3-9ac8-48c8-9a98-0d97fd047d8b)


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
