### PR TITLE
Support `yorkie-monitoring` and `yorkie-argocd` Charts on NCP

### DIFF
--- a/build/charts/yorkie-argocd/templates/ingress.yaml
+++ b/build/charts/yorkie-argocd/templates/ingress.yaml
@@ -3,15 +3,28 @@ kind: Ingress
 metadata:
   name: {{ .Values.argocd.name }}
   namespace: {{ .Values.argocd.namespace }}
-  {{ if .Values.ingress.alb.enabled }}
+  {{ if .Values.ingress.awsAlb.enabled }}
   annotations:
     alb.ingress.kubernetes.io/scheme: internet-facing
-    # Set alb.ingress.kubernetes.io/certificate-arn annotation to TLS certificate's ARN issued in AWS ACM 
-    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.alb.certArn }}
+    # Set alb.ingress.kubernetes.io/certificate-arn annotation to TLS certificate's ARN issued by AWS ACM
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.awsAlb.certArn }}
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
     alb.ingress.kubernetes.io/group.name: {{ .Values.ingress.hosts.apiHost }}
     alb.ingress.kubernetes.io/group.order: '2'
     {{ end }}
+  {{ if .Values.ingress.ncpAlb.enabled }}
+  annotations:
+    # Set alb.ingress.kubernetes.io/ssl-certificate-no annotation to TLS certificate's number issued by NCP
+    alb.ingress.kubernetes.io/ssl-certificate-no: "{{ .Values.ingress.ncpAlb.certNo }}"
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80},{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+    alb.ingress.kubernetes.io/backend-protocol: HTTP
+    alb.ingress.kubernetes.io/enable-http2: "true"
+    # Set alb.ingress.kubernetes.io/healthcheck-path annotation to health check path in yorkie
+    # NCP ALB will use this path to check the health of the service
+    # If the health check fails, NCP ALB will not route the traffic to the service
+    alb.ingress.kubernetes.io/healthcheck-path: /healthz
+  {{ end }}
 spec:
   ingressClassName: {{ .Values.ingress.ingressClassName }}
   rules:

--- a/build/charts/yorkie-argocd/values.yaml
+++ b/build/charts/yorkie-argocd/values.yaml
@@ -42,10 +42,10 @@ ingress:
     apiHost: api.yorkie.dev
     argoCDPath: /argocd
 
-  alb:
+  awsAlb:
     enabled: false
     certArn: arn:aws:acm:ap-northeast-2:123412341234:certificate/1234-1234-1234-1234-1234
 
   ncpAlb:
-    enabled: false
+    enabled: true
     certNo: 1234

--- a/build/charts/yorkie-argocd/values.yaml
+++ b/build/charts/yorkie-argocd/values.yaml
@@ -33,7 +33,7 @@ argocd:
 # Configuration for ingress (eg: AWS ALB)
 ingress:
   ingressClassName: nginx
-  ## Set to alb if you are using AWS ALB
+  ## Set to alb if you are using AWS, NCP ALB
   # ingressClassName: alb
 
   # Use same host for yorkie cluster
@@ -44,5 +44,8 @@ ingress:
 
   alb:
     enabled: false
-
     certArn: arn:aws:acm:ap-northeast-2:123412341234:certificate/1234-1234-1234-1234-1234
+
+  ncpAlb:
+    enabled: false
+    certNo: 1234

--- a/build/charts/yorkie-cluster/templates/istio/ingress.yaml
+++ b/build/charts/yorkie-cluster/templates/istio/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
   {{ if .Values.ingress.ncpAlb.enabled }}
   annotations:
     # Set alb.ingress.kubernetes.io/ssl-certificate-no annotation to TLS certificate's number issued by NCP
-    alb.ingress.kubernetes.io/ssl-certificate-no: {{ .Values.ingress.ncpAlb.certNo }}
+    alb.ingress.kubernetes.io/ssl-certificate-no: "{{ .Values.ingress.ncpAlb.certNo }}"
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80},{"HTTPS":443}]'
     alb.ingress.kubernetes.io/ssl-redirect: "443"
     alb.ingress.kubernetes.io/backend-protocol: HTTP

--- a/build/charts/yorkie-monitoring/templates/ingress.yaml
+++ b/build/charts/yorkie-monitoring/templates/ingress.yaml
@@ -3,16 +3,29 @@ kind: Ingress
 metadata:
   name: {{ .Values.monitoring.name }}
   namespace: {{ .Values.monitoring.namespace }}
-  {{ if .Values.ingress.alb.enabled }}
+  {{ if .Values.ingress.awsAlb.enabled }}
   annotations:
     alb.ingress.kubernetes.io/scheme: internet-facing
-    # Set alb.ingress.kubernetes.io/certificate-arn annotation to TLS certificate's ARN issued in AWS ACM
-    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.alb.certArn }}
+    # Set alb.ingress.kubernetes.io/certificate-arn annotation to TLS certificate's ARN issued by AWS ACM
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.awsAlb.certArn }}
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
     alb.ingress.kubernetes.io/backend-protocol: HTTP
     alb.ingress.kubernetes.io/group.name: {{ .Values.ingress.hosts.apiHost }}
     alb.ingress.kubernetes.io/group.order: '1'
     {{ end }}
+  {{ if .Values.ingress.ncpAlb.enabled }}
+  annotations:
+    # Set alb.ingress.kubernetes.io/ssl-certificate-no annotation to TLS certificate's number issued by NCP
+    alb.ingress.kubernetes.io/ssl-certificate-no: "{{ .Values.ingress.ncpAlb.certNo }}"
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80},{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+    alb.ingress.kubernetes.io/backend-protocol: HTTP
+    alb.ingress.kubernetes.io/enable-http2: "true"
+    # Set alb.ingress.kubernetes.io/healthcheck-path annotation to health check path in yorkie
+    # NCP ALB will use this path to check the health of the service
+    # If the health check fails, NCP ALB will not route the traffic to the service
+    alb.ingress.kubernetes.io/healthcheck-path: /healthz
+  {{ end }}
 spec:
   ingressClassName: {{ .Values.ingress.ingressClassName }}
   rules:

--- a/build/charts/yorkie-monitoring/values.yaml
+++ b/build/charts/yorkie-monitoring/values.yaml
@@ -12,7 +12,7 @@ monitoring:
 # Configuration for ingress (eg: AWS ALB)
 ingress:
   ingressClassName: nginx
-  ## Set to alb if you are using AWS ALB
+  ## Set to alb if you are using AWS, NCP ALB
   # ingressClassName: alb
 
   # Use same host for yorkie cluster
@@ -21,10 +21,13 @@ ingress:
     apiHost: &apiHost api.yorkie.dev
     grafanaPath: /grafana
 
-  alb:
+  awsAlb:
     enabled: false
-
     certArn: arn:aws:acm:ap-northeast-2:123412341234:certificate/1234-1234-1234-1234-1234
+
+  ncpAlb:
+    enabled: false
+    certNo: 1234
 
 # Configuration for manual prometheus monitoring stack
 kube-prometheus-stack:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR adds support for `yorkie-monitoring` and `yorkie-argocd` charts on NCP. Additionally, it addresses a small parsing error in the annotation of `alb.ingress.kubernetes.io/ssl-certificate-no` by converting the value from number to string.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #844

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything