### PR TITLE
Fix inconsistent garbage collection for multiple nodes in text and tree type

### DIFF
--- a/pkg/document/crdt/root.go
+++ b/pkg/document/crdt/root.go
@@ -157,7 +157,7 @@ func (r *Root) GarbageCollect(ticket *time.Ticket) (int, error) {
 			return 0, err
 		}
 
-		if purgedNodes > 0 {
+		if node.removedNodesLen() == 0 {
 			delete(r.elementHasRemovedNodesSetByCreatedAt, node.CreatedAt().Key())
 		}
 		count += purgedNodes

--- a/test/integration/gc_test.go
+++ b/test/integration/gc_test.go
@@ -452,4 +452,154 @@ func TestGarbageCollection(t *testing.T) {
 		assert.Equal(t, 5, d1.GarbageCollect(time.MaxTicket))
 	})
 
+	t.Run("Should work properly when there are multiple nodes to be collected in text type", func(t *testing.T) {
+		ctx := context.Background()
+		d1 := document.New(helper.TestDocKey(t))
+		err := c1.Attach(ctx, d1)
+		assert.NoError(t, err)
+
+		d2 := document.New(helper.TestDocKey(t))
+		err = c2.Attach(ctx, d2)
+		assert.NoError(t, err)
+
+		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewText("text").Edit(0, 0, "z")
+			return nil
+		})
+		assert.NoError(t, err)
+		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(0, 1, "a")
+			return nil
+		})
+		assert.NoError(t, err)
+		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(1, 1, "b")
+			return nil
+		})
+		assert.NoError(t, err)
+		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(2, 2, "d")
+			return nil
+		})
+		assert.NoError(t, err)
+		err = c1.Sync(ctx)
+		assert.NoError(t, err)
+		err = c2.Sync(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, `{"text":[{"val":"a"},{"val":"b"},{"val":"d"}]}`, d1.Marshal())
+		assert.Equal(t, `{"text":[{"val":"a"},{"val":"b"},{"val":"d"}]}`, d2.Marshal())
+		assert.Equal(t, 1, d1.GarbageLen()) // z
+
+		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(2, 2, "c")
+			return nil
+		})
+		assert.NoError(t, err)
+		err = c1.Sync(ctx)
+		assert.NoError(t, err)
+		err = c2.Sync(ctx)
+		assert.NoError(t, err)
+		err = c2.Sync(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, `{"text":[{"val":"a"},{"val":"b"},{"val":"c"},{"val":"d"}]}`, d1.Marshal())
+		assert.Equal(t, `{"text":[{"val":"a"},{"val":"b"},{"val":"c"},{"val":"d"}]}`, d2.Marshal())
+
+		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(1, 3, "")
+			return nil
+		})
+		assert.NoError(t, err)
+		err = c1.Sync(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, `{"text":[{"val":"a"},{"val":"d"}]}`, d1.Marshal())
+		assert.Equal(t, 2, d1.GarbageLen()) // b,c
+
+		err = c2.Sync(ctx)
+		assert.NoError(t, err)
+		err = c2.Sync(ctx)
+		assert.NoError(t, err)
+		err = c1.Sync(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, `{"text":[{"val":"a"},{"val":"d"}]}`, d2.Marshal())
+		assert.Equal(t, 0, d1.GarbageLen())
+	})
+
+	t.Run("Should work properly when there are multiple nodes to be collected in tree type", func(t *testing.T) {
+		ctx := context.Background()
+		d1 := document.New(helper.TestDocKey(t))
+		err := c1.Attach(ctx, d1)
+		assert.NoError(t, err)
+
+		d2 := document.New(helper.TestDocKey(t))
+		err = c2.Attach(ctx, d2)
+		assert.NoError(t, err)
+
+		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewTree("tree", &json.TreeNode{
+				Type: "r",
+				Children: []json.TreeNode{{
+					Type: "text", Value: "z",
+				}},
+			})
+			return nil
+		})
+		assert.NoError(t, err)
+		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetTree("tree").EditByPath([]int{0}, []int{1}, &json.TreeNode{Type: "text", Value: "a"}, 0)
+			return nil
+		})
+		assert.NoError(t, err)
+		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetTree("tree").EditByPath([]int{1}, []int{1}, &json.TreeNode{Type: "text", Value: "b"}, 0)
+			return nil
+		})
+		assert.NoError(t, err)
+		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetTree("tree").EditByPath([]int{2}, []int{2}, &json.TreeNode{Type: "text", Value: "d"}, 0)
+			return nil
+		})
+		assert.NoError(t, err)
+		err = c1.Sync(ctx)
+		assert.NoError(t, err)
+		err = c2.Sync(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, `<r>abd</r>`, d1.Root().GetTree("tree").ToXML())
+		assert.Equal(t, `<r>abd</r>`, d2.Root().GetTree("tree").ToXML())
+		assert.Equal(t, 1, d1.GarbageLen()) // z
+
+		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetTree("tree").EditByPath([]int{2}, []int{2}, &json.TreeNode{Type: "text", Value: "c"}, 0)
+			return nil
+		})
+		assert.NoError(t, err)
+		err = c1.Sync(ctx)
+		assert.NoError(t, err)
+		err = c2.Sync(ctx)
+		assert.NoError(t, err)
+		err = c2.Sync(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, `<r>abcd</r>`, d1.Root().GetTree("tree").ToXML())
+		assert.Equal(t, `<r>abcd</r>`, d2.Root().GetTree("tree").ToXML())
+
+		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetTree("tree").EditByPath([]int{1}, []int{3}, nil, 0)
+			return nil
+		})
+		assert.NoError(t, err)
+		err = c1.Sync(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, `<r>ad</r>`, d1.Root().GetTree("tree").ToXML())
+		assert.Equal(t, 2, d1.GarbageLen()) // b,c
+
+		err = c2.Sync(ctx)
+		assert.NoError(t, err)
+		err = c2.Sync(ctx)
+		assert.NoError(t, err)
+		err = c1.Sync(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, `<r>ad</r>`, d2.Root().GetTree("tree").ToXML())
+		assert.Equal(t, 0, d1.GarbageLen())
+	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

> There was an issue in the garbage collection process when dealing with multiple nodes in text(tree) types. When some nodes in text were collected, the corresponding text was removed from `elementHasRemovedNodesSetByCreatedAt` in the root, preventing the GC from correctly processing the remaining nodes.
>
> This PR addresses the inconsistency in the GC process by modifying the condition under which text is removed from `elementHasRemovedNodesSetByCreatedAt`. Instead of removing text when _**some**_ nodes are garbage collected, text will now only be removed when _**all**_ nodes have been garbage collected. This change ensures that GC behaves consistently even when multiple nodes are involved.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related https://github.com/yorkie-team/yorkie-js-sdk/pull/806 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
