### PR TITLE
Implement RHT.GC

### DIFF
--- a/pkg/document/change/context.go
+++ b/pkg/document/change/context.go
@@ -85,6 +85,11 @@ func (c *Context) RegisterElementHasRemovedNodes(element crdt.GCElement) {
 	c.root.RegisterElementHasRemovedNodes(element)
 }
 
+// RegisterGCPair registers the given GC pair to the root.
+func (c *Context) RegisterGCPair(pair crdt.GCPair) {
+	c.root.RegisterGCPair(pair)
+}
+
 // LastTimeTicket returns the last time ticket issued by this context.
 func (c *Context) LastTimeTicket() *time.Ticket {
 	return c.id.NewTimeTicket(c.delimiter)

--- a/pkg/document/crdt/gc.go
+++ b/pkg/document/crdt/gc.go
@@ -18,6 +18,13 @@ package crdt
 
 import "github.com/yorkie-team/yorkie/pkg/document/time"
 
+// GCPair is a structure that represents a pair of parent and child for garbage
+// collection.
+type GCPair struct {
+	Parent GCParent
+	Child  GCChild
+}
+
 // GCParent is an interface for the parent of the garbage collection target.
 type GCParent interface {
 	Purge(node GCChild) error

--- a/pkg/document/crdt/gc.go
+++ b/pkg/document/crdt/gc.go
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package crdt
+
+import "github.com/yorkie-team/yorkie/pkg/document/time"
+
+// GCParent is an interface for the parent of the garbage collection target.
+type GCParent interface {
+	Purge(node GCChild)
+}
+
+// GCChild is an interface for the child of the garbage collection target.
+type GCChild interface {
+	ID() string
+	RemovedAt() *time.Ticket
+}

--- a/pkg/document/crdt/gc.go
+++ b/pkg/document/crdt/gc.go
@@ -20,7 +20,7 @@ import "github.com/yorkie-team/yorkie/pkg/document/time"
 
 // GCParent is an interface for the parent of the garbage collection target.
 type GCParent interface {
-	Purge(node GCChild)
+	Purge(node GCChild) error
 }
 
 // GCChild is an interface for the child of the garbage collection target.

--- a/pkg/document/crdt/rga_tree_split.go
+++ b/pkg/document/crdt/rga_tree_split.go
@@ -136,7 +136,7 @@ func (pos *RGATreeSplitNodePos) RelativeOffset() int {
 	return pos.relativeOffset
 }
 
-// Equal returns the whether the given pos equals or not.
+// Equal returns whether the given pos equals or not.
 func (pos *RGATreeSplitNodePos) Equal(other *RGATreeSplitNodePos) bool {
 	if !pos.id.Equal(other.id) {
 		return false

--- a/pkg/document/crdt/rht.go
+++ b/pkg/document/crdt/rht.go
@@ -108,14 +108,23 @@ func (rht *RHT) Has(key string) bool {
 }
 
 // Set sets the value of the given key.
-func (rht *RHT) Set(k, v string, executedAt *time.Ticket) {
-	if node, ok := rht.nodeMapByKey[k]; !ok || executedAt.After(node.updatedAt) {
-		if node != nil && node.isRemoved {
-			rht.numberOfRemovedElement--
-		}
+func (rht *RHT) Set(k, v string, executedAt *time.Ticket) *RHTNode {
+	node := rht.nodeMapByKey[k]
+
+	if node != nil && node.isRemoved {
+		rht.numberOfRemovedElement--
+	}
+
+	if node == nil || executedAt.After(node.updatedAt) {
 		newNode := newRHTNode(k, v, executedAt, false)
 		rht.nodeMapByKey[k] = newNode
 	}
+
+	if node != nil && node.isRemoved {
+		return node
+	}
+
+	return nil
 }
 
 // Remove removes the value of the given key.
@@ -223,7 +232,8 @@ func (rht *RHT) Marshal() string {
 // Purge purges the given child node.
 func (rht *RHT) Purge(child *RHTNode) error {
 	if node, ok := rht.nodeMapByKey[child.key]; !ok || node.ID() != child.ID() {
-		return ErrChildNotFound
+		//return ErrChildNotFound
+		return nil
 	}
 
 	delete(rht.nodeMapByKey, child.key)

--- a/pkg/document/crdt/rht.go
+++ b/pkg/document/crdt/rht.go
@@ -41,6 +41,11 @@ func newRHTNode(key, val string, updatedAt *time.Ticket, isRemoved bool) *RHTNod
 	}
 }
 
+// ID returns the ID of this node.
+func (n *RHTNode) ID() string {
+	return n.updatedAt.Key() + ":" + n.key
+}
+
 // Key returns the key of this node.
 func (n *RHTNode) Key() string {
 	return n.key
@@ -54,6 +59,15 @@ func (n *RHTNode) Value() string {
 // UpdatedAt returns the last update time.
 func (n *RHTNode) UpdatedAt() *time.Ticket {
 	return n.updatedAt
+}
+
+// RemovedAt returns the time when this node was removed.
+func (n *RHTNode) RemovedAt() *time.Ticket {
+	if n.isRemoved {
+		return n.updatedAt
+	}
+
+	return nil
 }
 
 // RHT is a hashtable with logical clock(Replicated hashtable).
@@ -105,30 +119,31 @@ func (rht *RHT) Set(k, v string, executedAt *time.Ticket) {
 }
 
 // Remove removes the Element of the given key.
-func (rht *RHT) Remove(k string, executedAt *time.Ticket) string {
+func (rht *RHT) Remove(k string, executedAt *time.Ticket) *RHTNode {
+	// TODO(hackerwins): We need to consider the logic and the policy of removing the element.
+	// A. RHT always overrides the value of the same key in a immutable way.
+	// B. Even if the key is not existed, RHT sets the flag `isRemoved` for concurrency.
 	if node, ok := rht.nodeMapByKey[k]; !ok || executedAt.After(node.updatedAt) {
 		// NOTE(justiceHui): Even if key is not existed, we must set flag `isRemoved` for concurrency
 		if node == nil {
 			rht.numberOfRemovedElement++
 			newNode := newRHTNode(k, ``, executedAt, true)
 			rht.nodeMapByKey[k] = newNode
-			return ""
+			return newNode
 		}
 
 		alreadyRemoved := node.isRemoved
 		if !alreadyRemoved {
 			rht.numberOfRemovedElement++
 		}
+
 		newNode := newRHTNode(k, node.val, executedAt, true)
 		rht.nodeMapByKey[k] = newNode
 
-		if alreadyRemoved {
-			return ""
-		}
-		return node.val
+		return newNode
 	}
 
-	return ""
+	return nil
 }
 
 // Elements returns a map of elements because the map easy to use for loop.
@@ -222,4 +237,13 @@ func (rht *RHT) ToXML() string {
 	}
 
 	return sb.String()
+}
+
+// Purge purges the given child node.
+func (rht *RHT) Purge(child *RHTNode) {
+	// NOTE(hackerwins): RHT always overrides the value of the same key.
+	// So, we don't know whether the given child is the same as the node in the map.
+	if node, ok := rht.nodeMapByKey[child.key]; ok && node.ID() == child.ID() {
+		delete(rht.nodeMapByKey, child.key)
+	}
 }

--- a/pkg/document/crdt/rht.go
+++ b/pkg/document/crdt/rht.go
@@ -118,32 +118,38 @@ func (rht *RHT) Set(k, v string, executedAt *time.Ticket) {
 	}
 }
 
-// Remove removes the Element of the given key.
-func (rht *RHT) Remove(k string, executedAt *time.Ticket) *RHTNode {
-	// TODO(hackerwins): We need to consider the logic and the policy of removing the element.
+// Remove removes the value of the given key.
+func (rht *RHT) Remove(k string, executedAt *time.Ticket) []*RHTNode {
+	// NOTE(hackerwins): We need to consider the logic and the policy of removing the element.
 	// A. RHT always overrides the value of the same key in a immutable way.
 	// B. Even if the key is not existed, RHT sets the flag `isRemoved` for concurrency.
-	if node, ok := rht.nodeMapByKey[k]; !ok || executedAt.After(node.updatedAt) {
-		// NOTE(justiceHui): Even if key is not existed, we must set flag `isRemoved` for concurrency
-		if node == nil {
-			rht.numberOfRemovedElement++
-			newNode := newRHTNode(k, ``, executedAt, true)
-			rht.nodeMapByKey[k] = newNode
-			return newNode
-		}
-
-		alreadyRemoved := node.isRemoved
-		if !alreadyRemoved {
-			rht.numberOfRemovedElement++
-		}
-
-		newNode := newRHTNode(k, node.val, executedAt, true)
+	node, ok := rht.nodeMapByKey[k]
+	if !ok {
+		rht.numberOfRemovedElement++
+		newNode := newRHTNode(k, "", executedAt, true)
 		rht.nodeMapByKey[k] = newNode
-
-		return newNode
+		return []*RHTNode{newNode}
 	}
 
-	return nil
+	if !executedAt.After(node.updatedAt) {
+		return nil
+	}
+
+	alreadyRemoved := node.isRemoved
+	if !alreadyRemoved {
+		rht.numberOfRemovedElement++
+	}
+
+	var gcNodes []*RHTNode
+	if alreadyRemoved {
+		gcNodes = append(gcNodes, node)
+	}
+
+	newNode := newRHTNode(k, node.val, executedAt, true)
+	rht.nodeMapByKey[k] = newNode
+	gcNodes = append(gcNodes, newNode)
+
+	return gcNodes
 }
 
 // Elements returns a map of elements because the map easy to use for loop.
@@ -215,10 +221,11 @@ func (rht *RHT) Marshal() string {
 }
 
 // Purge purges the given child node.
-func (rht *RHT) Purge(child *RHTNode) {
-	// NOTE(hackerwins): RHT always overrides the value of the same key.
-	// So, we don't know whether the given child is the same as the node in the map.
-	if node, ok := rht.nodeMapByKey[child.key]; ok && node.ID() == child.ID() {
-		delete(rht.nodeMapByKey, child.key)
+func (rht *RHT) Purge(child *RHTNode) error {
+	if node, ok := rht.nodeMapByKey[child.key]; !ok || node.ID() != child.ID() {
+		return ErrChildNotFound
 	}
+
+	delete(rht.nodeMapByKey, child.key)
+	return nil
 }

--- a/pkg/document/crdt/rht.go
+++ b/pkg/document/crdt/rht.go
@@ -111,7 +111,7 @@ func (rht *RHT) Has(key string) bool {
 func (rht *RHT) Set(k, v string, executedAt *time.Ticket) *RHTNode {
 	node := rht.nodeMapByKey[k]
 
-	if node != nil && node.isRemoved {
+	if node != nil && node.isRemoved && executedAt.After(node.updatedAt) {
 		rht.numberOfRemovedElement--
 	}
 
@@ -237,5 +237,6 @@ func (rht *RHT) Purge(child *RHTNode) error {
 	}
 
 	delete(rht.nodeMapByKey, child.key)
+	rht.numberOfRemovedElement--
 	return nil
 }

--- a/pkg/document/crdt/rht_test.go
+++ b/pkg/document/crdt/rht_test.go
@@ -191,8 +191,8 @@ func TestRHT_Remove(t *testing.T) {
 				rht.Set(key, tt.insertVal[i], ctx.IssueTimeTicket())
 			}
 			for i, key := range tt.deleteKey {
-				removedElement := rht.Remove(key, ctx.IssueTimeTicket())
-				assert.Equal(t, tt.deleteVal[i], removedElement.Value())
+				nodes := rht.Remove(key, ctx.IssueTimeTicket())
+				assert.Equal(t, tt.deleteVal[i], nodes[len(nodes)-1].Value())
 			}
 			assert.Equal(t, tt.expectJSON, rht.Marshal())
 			assert.Equal(t, tt.expectSize, rht.Len())

--- a/pkg/document/crdt/rht_test.go
+++ b/pkg/document/crdt/rht_test.go
@@ -195,7 +195,7 @@ func TestRHT_Remove(t *testing.T) {
 			insertKey:  []string{},
 			insertVal:  []string{},
 			deleteKey:  []string{key1},
-			deleteVal:  []string{``},
+			deleteVal:  []string{val11},
 			expectXML:  `key2="value22"`,
 			expectJSON: `{"key2":"value22"}`,
 			expectSize: 1,
@@ -234,7 +234,7 @@ func TestRHT_Remove(t *testing.T) {
 			}
 			for i, key := range tt.deleteKey {
 				removedElement := rht.Remove(key, ctx.IssueTimeTicket())
-				assert.Equal(t, tt.deleteVal[i], removedElement)
+				assert.Equal(t, tt.deleteVal[i], removedElement.Value())
 			}
 			assert.Equal(t, tt.expectXML, rht.ToXML())
 			assert.Equal(t, tt.expectJSON, rht.Marshal())

--- a/pkg/document/crdt/root.go
+++ b/pkg/document/crdt/root.go
@@ -29,13 +29,6 @@ type ElementPair struct {
 	elem   Element
 }
 
-// GCPair is a structure that represents a pair of parent and child for garbage
-// collection.
-type GCPair struct {
-	Parent GCParent
-	Child  GCChild
-}
-
 // Root is a structure represents the root of JSON. It has a hash table of
 // all JSON elements to find a specific element when applying remote changes
 // received from server.

--- a/pkg/document/crdt/root.go
+++ b/pkg/document/crdt/root.go
@@ -29,6 +29,13 @@ type ElementPair struct {
 	elem   Element
 }
 
+// GCPair is a structure that represents a pair of parent and child for garbage
+// collection.
+type GCPair struct {
+	Parent GCParent
+	Child  GCChild
+}
+
 // Root is a structure represents the root of JSON. It has a hash table of
 // all JSON elements to find a specific element when applying remote changes
 // received from server.
@@ -40,6 +47,7 @@ type Root struct {
 	elementMapByCreatedAt                map[string]Element
 	removedElementPairMapByCreatedAt     map[string]ElementPair
 	elementHasRemovedNodesSetByCreatedAt map[string]GCElement
+	gcPairMapByID                        map[string]GCPair
 }
 
 // NewRoot creates a new instance of Root.
@@ -48,6 +56,7 @@ func NewRoot(root *Object) *Root {
 		elementMapByCreatedAt:                make(map[string]Element),
 		removedElementPairMapByCreatedAt:     make(map[string]ElementPair),
 		elementHasRemovedNodesSetByCreatedAt: make(map[string]GCElement),
+		gcPairMapByID:                        make(map[string]GCPair),
 	}
 
 	r.object = root
@@ -200,4 +209,9 @@ func (r *Root) GarbageLen() int {
 	}
 
 	return count
+}
+
+// RegisterGCPair registers the given pair to hash table.
+func (r *Root) RegisterGCPair(pair GCPair) {
+	r.gcPairMapByID[pair.Child.ID()] = pair
 }

--- a/pkg/document/crdt/text_test.go
+++ b/pkg/document/crdt/text_test.go
@@ -80,7 +80,7 @@ func TestText(t *testing.T) {
 		assert.Equal(t, `[{"val":"Hello "},{"val":"Yorkie"}]`, text.Marshal())
 
 		fromPos, toPos, _ = text.CreateRange(0, 1)
-		_, err = text.Style(fromPos, toPos, nil, map[string]string{"b": "1"}, ctx.IssueTimeTicket())
+		_, _, err = text.Style(fromPos, toPos, nil, map[string]string{"b": "1"}, ctx.IssueTimeTicket())
 		assert.NoError(t, err)
 		assert.Equal(
 			t,

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -239,9 +239,9 @@ func (n *TreeNode) Child(offset int) (*TreeNode, error) {
 }
 
 // Purge removes the given child from the children.
-func (n *TreeNode) Purge(child GCChild) {
+func (n *TreeNode) Purge(child GCChild) error {
 	rhtNode := child.(*RHTNode)
-	n.Attrs.Purge(rhtNode)
+	return n.Attrs.Purge(rhtNode)
 }
 
 // Split splits the node at the given offset.
@@ -431,7 +431,7 @@ func (n *TreeNode) SetAttr(k string, v string, ticket *time.Ticket) {
 }
 
 // RemoveAttr removes the given attribute of the element.
-func (n *TreeNode) RemoveAttr(k string, ticket *time.Ticket) *RHTNode {
+func (n *TreeNode) RemoveAttr(k string, ticket *time.Ticket) []*RHTNode {
 	if n.Attrs == nil {
 		n.Attrs = NewRHT()
 	}
@@ -971,10 +971,11 @@ func (t *Tree) RemoveStyle(from, to *TreePos, attrs []string, editedAt *time.Tic
 		}
 
 		for _, attr := range attrs {
-			if valueNode := node.RemoveAttr(attr, editedAt); valueNode != nil {
+			rhtNodes := node.RemoveAttr(attr, editedAt)
+			for _, rhtNode := range rhtNodes {
 				pairs = append(pairs, GCPair{
 					Parent: node,
-					Child:  valueNode,
+					Child:  rhtNode,
 				})
 			}
 		}

--- a/pkg/document/crdt/tree_test.go
+++ b/pkg/document/crdt/tree_test.go
@@ -405,28 +405,28 @@ func TestTreeEdit(t *testing.T) {
 		assert.Equal(t, "<root><p>ab</p><p>cd</p></root>", tree.ToXML())
 
 		// style attributes with opening tag
-		_, err = tree.StyleByIndex(0, 1, map[string]string{"weight": "bold"}, helper.TimeT(ctx), nil)
+		_, _, err = tree.StyleByIndex(0, 1, map[string]string{"weight": "bold"}, helper.TimeT(ctx), nil)
 		assert.NoError(t, err)
 		assert.Equal(t, `<root><p weight="bold">ab</p><p>cd</p></root>`, tree.ToXML())
 
 		// style attributes with closing tag
-		_, err = tree.StyleByIndex(3, 4, map[string]string{"color": "red"}, helper.TimeT(ctx), nil)
+		_, _, err = tree.StyleByIndex(3, 4, map[string]string{"color": "red"}, helper.TimeT(ctx), nil)
 		assert.NoError(t, err)
 		assert.Equal(t, `<root><p color="red" weight="bold">ab</p><p>cd</p></root>`, tree.ToXML())
 
 		// style attributes with the whole
-		_, err = tree.StyleByIndex(0, 4, map[string]string{"size": "small"}, helper.TimeT(ctx), nil)
+		_, _, err = tree.StyleByIndex(0, 4, map[string]string{"size": "small"}, helper.TimeT(ctx), nil)
 		assert.NoError(t, err)
 		assert.Equal(t, `<root><p color="red" size="small" weight="bold">ab</p><p>cd</p></root>`, tree.ToXML())
 
 		// 02. style attributes to elements.
-		_, err = tree.StyleByIndex(0, 5, map[string]string{"style": "italic"}, helper.TimeT(ctx), nil)
+		_, _, err = tree.StyleByIndex(0, 5, map[string]string{"style": "italic"}, helper.TimeT(ctx), nil)
 		assert.NoError(t, err)
 		assert.Equal(t, `<root><p color="red" size="small" style="italic" weight="bold">ab</p>`+
 			`<p style="italic">cd</p></root>`, tree.ToXML())
 
 		// 03. Ignore styling attributes to text nodes.
-		_, err = tree.StyleByIndex(1, 3, map[string]string{"bold": "true"}, helper.TimeT(ctx), nil)
+		_, _, err = tree.StyleByIndex(1, 3, map[string]string{"bold": "true"}, helper.TimeT(ctx), nil)
 		assert.NoError(t, err)
 		assert.Equal(t, `<root><p color="red" size="small" style="italic" weight="bold">ab</p>`+
 			`<p style="italic">cd</p></root>`, tree.ToXML())

--- a/pkg/document/document_test.go
+++ b/pkg/document/document_test.go
@@ -664,12 +664,12 @@ func TestTreeAttributeWithTreeNodeGC(t *testing.T) {
 			gcBeforeDelete: false,
 		},
 		{
-			desc:       "Remove-Delete with flush test",
-			op:         styleOperationType{StyleRemove, "b", ""},
-			garbageLen: []int{1, 0, 1},
+			desc:       "Set-Delete with flush test",
+			op:         styleOperationType{StyleSet, "b", "t"},
+			garbageLen: []int{0, 0, 1},
 			expectXML: []string{
-				`<r><p></p></r>`,
-				`<r><p></p></r>`,
+				`<r><p b="t"></p></r>`,
+				`<r><p b="t"></p></r>`,
 				`<r></r>`,
 			},
 			gcBeforeDelete: true,

--- a/pkg/document/json/text.go
+++ b/pkg/document/json/text.go
@@ -107,7 +107,7 @@ func (p *Text) Style(from, to int, attributes map[string]string) *Text {
 	}
 
 	ticket := p.context.IssueTimeTicket()
-	maxCreationMapByActor, err := p.Text.Style(
+	maxCreationMapByActor, pairs, err := p.Text.Style(
 		fromPos,
 		toPos,
 		nil,
@@ -116,6 +116,10 @@ func (p *Text) Style(from, to int, attributes map[string]string) *Text {
 	)
 	if err != nil {
 		panic(err)
+	}
+
+	for _, pair := range pairs {
+		p.context.RegisterGCPair(pair)
 	}
 
 	p.context.Push(operations.NewStyle(

--- a/pkg/document/json/tree.go
+++ b/pkg/document/json/tree.go
@@ -258,8 +258,13 @@ func (t *Tree) RemoveStyle(fromIdx, toIdx int, attributesToRemove []string) bool
 	}
 
 	ticket := t.context.IssueTimeTicket()
-	if err := t.Tree.RemoveStyle(fromPos, toPos, attributesToRemove, ticket); err != nil {
+	gcPairs, err := t.Tree.RemoveStyle(fromPos, toPos, attributesToRemove, ticket)
+	if err != nil {
 		panic(err)
+	}
+
+	for _, pair := range gcPairs {
+		t.context.RegisterGCPair(pair)
 	}
 
 	t.context.Push(operations.NewTreeStyleRemove(

--- a/pkg/document/json/tree.go
+++ b/pkg/document/json/tree.go
@@ -221,9 +221,13 @@ func (t *Tree) Style(fromIdx, toIdx int, attributes map[string]string) bool {
 	}
 
 	ticket := t.context.IssueTimeTicket()
-	maxCreationMapByActor, err := t.Tree.Style(fromPos, toPos, attributes, ticket, nil)
+	maxCreationMapByActor, pairs, err := t.Tree.Style(fromPos, toPos, attributes, ticket, nil)
 	if err != nil {
 		panic(err)
+	}
+
+	for _, pair := range pairs {
+		t.context.RegisterGCPair(pair)
 	}
 
 	t.context.Push(operations.NewTreeStyle(

--- a/pkg/document/json/tree.go
+++ b/pkg/document/json/tree.go
@@ -258,12 +258,12 @@ func (t *Tree) RemoveStyle(fromIdx, toIdx int, attributesToRemove []string) bool
 	}
 
 	ticket := t.context.IssueTimeTicket()
-	gcPairs, err := t.Tree.RemoveStyle(fromPos, toPos, attributesToRemove, ticket)
+	pairs, err := t.Tree.RemoveStyle(fromPos, toPos, attributesToRemove, ticket)
 	if err != nil {
 		panic(err)
 	}
 
-	for _, pair := range gcPairs {
+	for _, pair := range pairs {
 		t.context.RegisterGCPair(pair)
 	}
 

--- a/pkg/document/operations/style.go
+++ b/pkg/document/operations/style.go
@@ -70,8 +70,16 @@ func (e *Style) Execute(root *crdt.Root) error {
 		return ErrNotApplicableDataType
 	}
 
-	_, err := obj.Style(e.from, e.to, e.maxCreatedAtMapByActor, e.attributes, e.executedAt)
-	return err
+	_, pairs, err := obj.Style(e.from, e.to, e.maxCreatedAtMapByActor, e.attributes, e.executedAt)
+	if err != nil {
+		return err
+	}
+
+	for _, pair := range pairs {
+		root.RegisterGCPair(pair)
+	}
+
+	return nil
 }
 
 // From returns the start point of the editing range.

--- a/pkg/document/operations/tree_style.go
+++ b/pkg/document/operations/tree_style.go
@@ -92,15 +92,18 @@ func (e *TreeStyle) Execute(root *crdt.Root) error {
 		return ErrNotApplicableDataType
 	}
 
+	var pairs []crdt.GCPair
+	var err error
 	if len(e.attributes) > 0 {
-		if _, err := obj.Style(e.from, e.to, e.attributes, e.executedAt, e.maxCreatedAtMapByActor); err != nil {
+		_, pairs, err = obj.Style(e.from, e.to, e.attributes, e.executedAt, e.maxCreatedAtMapByActor)
+		if err != nil {
 			return err
 		}
-	}
-
-	pairs, err := obj.RemoveStyle(e.from, e.to, e.attributesToRemove, e.executedAt)
-	if err != nil {
-		return err
+	} else {
+		pairs, err = obj.RemoveStyle(e.from, e.to, e.attributesToRemove, e.executedAt)
+		if err != nil {
+			return err
+		}
 	}
 
 	for _, pair := range pairs {

--- a/pkg/document/operations/tree_style.go
+++ b/pkg/document/operations/tree_style.go
@@ -98,7 +98,16 @@ func (e *TreeStyle) Execute(root *crdt.Root) error {
 		}
 	}
 
-	return obj.RemoveStyle(e.from, e.to, e.attributesToRemove, e.executedAt)
+	pairs, err := obj.RemoveStyle(e.from, e.to, e.attributesToRemove, e.executedAt)
+	if err != nil {
+		return err
+	}
+
+	for _, pair := range pairs {
+		root.RegisterGCPair(pair)
+	}
+
+	return nil
 }
 
 // FromPos returns the start point of the editing range.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Implement RHT.GC

This commit adds GC to RHT data structure. RHT is used in Tree and Text, and when Style methods are executed, values that need to be GC'ed are added to the GC cache. This commit generalizes GC logic by introducing abstract types `GCParent` and `GCChild` and managing them flatly from the root.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
