### PR TITLE
Add Resource Configuration in `yorkie-mongodb` Helm chart

### DIFF
--- a/build/charts/yorkie-mongodb/values.yaml
+++ b/build/charts/yorkie-mongodb/values.yaml
@@ -120,6 +120,7 @@ mongodb-sharded:
       size: *configSize
       mountPath: /data/configdb
       storageClass: *storageClass
+    resources: {}
 
   # Configuration for shard server
   shardsvr:
@@ -154,6 +155,11 @@ mongodb-sharded:
       size: *dataSize
       mountPath: /data/db
       storageClass: *storageClass
+    resources:
+      requests:
+        memory: 1Gi
+      limits:
+        memory: 2Gi
 
   # Configuration for mongos
   mongos:
@@ -196,6 +202,7 @@ mongodb-sharded:
       enabled: false
     startupProbe:
       enabled: false
+    resources: {}
 
   # Configuration for Prometheus monitoring
   metrics:

--- a/build/charts/yorkie-mongodb/values.yaml
+++ b/build/charts/yorkie-mongodb/values.yaml
@@ -120,6 +120,15 @@ mongodb-sharded:
       size: *configSize
       mountPath: /data/configdb
       storageClass: *storageClass
+    ## @param configsvr.resources Set container requests and limits for different resources like CPU or memory (essential for production workloads)
+    ## Example:
+    ## resources:
+    ##   requests:
+    ##     cpu: 2
+    ##     memory: 512Mi
+    ##   limits:
+    ##     cpu: 3
+    ##     memory: 1024Mi
     resources: {}
 
   # Configuration for shard server
@@ -155,6 +164,7 @@ mongodb-sharded:
       size: *dataSize
       mountPath: /data/db
       storageClass: *storageClass
+    ## @param shardsvr.dataNode.resources Set container requests and limits for different resources like CPU or memory (essential for production workloads)
     resources:
       requests:
         memory: 1Gi
@@ -202,6 +212,15 @@ mongodb-sharded:
       enabled: false
     startupProbe:
       enabled: false
+    ## @param mongos.resources Set container requests and limits for different resources like CPU or memory (essential for production workloads)
+    ## Example:
+    ## resources:
+    ##   requests:
+    ##     cpu: 2
+    ##     memory: 512Mi
+    ##   limits:
+    ##     cpu: 3
+    ##     memory: 1024Mi
     resources: {}
 
   # Configuration for Prometheus monitoring


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add resource configuration in `yorkie-mongodb` Helm chart which is essential for production workloads.

Especially, this is to prevent shard data node's WiredTiger cache to over-consume host's memory.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/yorkie-team/devops/issues/94

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved resource management for `mongodb-sharded` components, including `shardsvr`, `configsvr`, and `mongos`.

- **Enhancements**
  - Set memory limits to 2Gi and memory requests to 1Gi for the `shardsvr` component to ensure better performance and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->