### PR TITLE
Add snapshot-disable-gc flag

### DIFF
--- a/cmd/yorkie/server.go
+++ b/cmd/yorkie/server.go
@@ -291,6 +291,12 @@ func init() {
 		server.DefaultSnapshotWithPurgingChanges,
 		"Whether to delete previous changes when the snapshot is created.",
 	)
+	cmd.Flags().BoolVar(
+		&conf.Backend.SnapshotDisableGC,
+		"backend-snapshot-disable-gc",
+		server.DefaultSnapshotDisableGC,
+		"Whether to disable garbage collection of snapshots.",
+	)
 	cmd.Flags().Uint64Var(
 		&conf.Backend.AuthWebhookMaxRetries,
 		"auth-webhook-max-retries",

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -65,6 +65,22 @@ type BroadcastRequest struct {
 	Payload []byte
 }
 
+// Option configures Options.
+type Option func(*Options)
+
+// Options configures how we set up the document.
+type Options struct {
+	// DisableGC disables garbage collection.
+	DisableGC bool
+}
+
+// WithDisableGC configures the document to disable garbage collection.
+func WithDisableGC() Option {
+	return func(o *Options) {
+		o.DisableGC = true
+	}
+}
+
 // Document represents a document accessible to the user.
 //
 // How document works:
@@ -75,6 +91,9 @@ type BroadcastRequest struct {
 type Document struct {
 	// doc is the original data of the actual document.
 	doc *InternalDocument
+
+	// options is the options to configure the document.
+	options Options
 
 	// cloneRoot is a copy of `doc.root` to be exposed to the user and is used to
 	// protect `doc.root`.
@@ -100,9 +119,15 @@ type Document struct {
 }
 
 // New creates a new instance of Document.
-func New(key key.Key) *Document {
+func New(key key.Key, opts ...Option) *Document {
+	var options Options
+	for _, opt := range opts {
+		opt(&options)
+	}
+
 	return &Document{
 		doc:                NewInternalDocument(key),
+		options:            options,
 		events:             make(chan DocEvent, 1),
 		broadcastRequests:  make(chan BroadcastRequest, 1),
 		broadcastResponses: make(chan error, 1),
@@ -197,7 +222,9 @@ func (d *Document) ApplyChangePack(pack *change.Pack) error {
 	d.doc.checkpoint = d.doc.checkpoint.Forward(pack.Checkpoint)
 
 	// 04. Do Garbage collection.
-	d.GarbageCollect(pack.MinSyncedTicket)
+	if !d.options.DisableGC {
+		d.GarbageCollect(pack.MinSyncedTicket)
+	}
 
 	// 05. Update the status.
 	if pack.IsRemoved {

--- a/pkg/document/internal_document.go
+++ b/pkg/document/internal_document.go
@@ -142,7 +142,7 @@ func (d *InternalDocument) HasLocalChanges() bool {
 }
 
 // ApplyChangePack applies the given change pack into this document.
-func (d *InternalDocument) ApplyChangePack(pack *change.Pack) error {
+func (d *InternalDocument) ApplyChangePack(pack *change.Pack, disableGC bool) error {
 	// 01. Apply remote changes to both the cloneRoot and the document.
 	if len(pack.Snapshot) > 0 {
 		if err := d.applySnapshot(pack.Snapshot, pack.Checkpoint.ServerSeq); err != nil {
@@ -166,7 +166,7 @@ func (d *InternalDocument) ApplyChangePack(pack *change.Pack) error {
 	// 03. Update the checkpoint.
 	d.checkpoint = d.checkpoint.Forward(pack.Checkpoint)
 
-	if pack.MinSyncedTicket != nil {
+	if !disableGC && pack.MinSyncedTicket != nil {
 		if _, err := d.GarbageCollect(pack.MinSyncedTicket); err != nil {
 			return err
 		}

--- a/server/backend/config.go
+++ b/server/backend/config.go
@@ -55,6 +55,9 @@ type Config struct {
 	// SnapshotWithPurgingChanges is whether to delete previous changes when the snapshot is created.
 	SnapshotWithPurgingChanges bool `yaml:"SnapshotWithPurgingChages"`
 
+	// SnapshotDisableGC is whether to disable garbage collection of snapshots.
+	SnapshotDisableGC bool
+
 	// AuthWebhookMaxRetries is the max count that retries the authorization webhook.
 	AuthWebhookMaxRetries uint64 `yaml:"AuthWebhookMaxRetries"`
 

--- a/server/config.go
+++ b/server/config.go
@@ -58,6 +58,7 @@ const (
 	DefaultSnapshotThreshold          = 500
 	DefaultSnapshotInterval           = 1000
 	DefaultSnapshotWithPurgingChanges = false
+	DefaultSnapshotDisableGC          = false
 
 	DefaultAuthWebhookMaxRetries      = 10
 	DefaultAuthWebhookMaxWaitInterval = 3000 * time.Millisecond

--- a/server/packs/packs.go
+++ b/server/packs/packs.go
@@ -236,7 +236,7 @@ func BuildDocumentForServerSeq(
 		change.InitialCheckpoint.NextServerSeq(serverSeq),
 		changes,
 		nil,
-	)); err != nil {
+	), be.Config.SnapshotDisableGC); err != nil {
 		return nil, err
 	}
 

--- a/server/packs/pushpull.go
+++ b/server/packs/pushpull.go
@@ -151,7 +151,7 @@ func pullSnapshot(
 			doc.Checkpoint().NextServerSeq(docInfo.ServerSeq),
 			reqPack.Changes,
 			nil,
-		)); err != nil {
+		), be.Config.SnapshotDisableGC); err != nil {
 			return nil, err
 		}
 	}

--- a/server/packs/snapshots.go
+++ b/server/packs/snapshots.go
@@ -91,7 +91,7 @@ func storeSnapshot(
 	)
 	pack.MinSyncedTicket = minSyncedTicket
 
-	if err := doc.ApplyChangePack(pack); err != nil {
+	if err := doc.ApplyChangePack(pack, be.Config.SnapshotDisableGC); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add snapshot-disable-gc flag

GC defects are found for sequence data types such as Array, Text, and
Tree. This commit provides the option to temporarily turn off GC on
the server.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related to https://github.com/yorkie-team/yorkie/issues/723

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration option to disable garbage collection for snapshots.

- **Improvements**
  - Enhanced document creation with customizable options including the ability to disable garbage collection.
  - Improved server configuration to control snapshot garbage collection behavior.

- **Tests**
  - Added new test cases to ensure the correct behavior when garbage collection is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->