### PR TITLE
Return ErrClientNotActivated for deactivated clients on WatchDocument

### DIFF
--- a/server/backend/database/client_info.go
+++ b/server/backend/database/client_info.go
@@ -193,6 +193,15 @@ func (i *ClientInfo) UpdateCheckpoint(
 	return nil
 }
 
+// EnsureActivated ensures the client is activated.
+func (i *ClientInfo) EnsureActivated() error {
+	if i.Status != ClientActivated {
+		return fmt.Errorf("ensure activated client(%s): %w", i.ID, ErrClientNotActivated)
+	}
+
+	return nil
+}
+
 // EnsureDocumentAttached ensures the given document is attached.
 func (i *ClientInfo) EnsureDocumentAttached(docID types.ID) error {
 	if i.Status != ClientActivated {

--- a/server/clients/clients.go
+++ b/server/clients/clients.go
@@ -88,11 +88,20 @@ func Deactivate(
 	return db.DeactivateClient(ctx, refKey)
 }
 
-// FindClientInfo finds the client with the given refKey.
-func FindClientInfo(
+// FindActiveClientInfo find the active client info by the given ref key.
+func FindActiveClientInfo(
 	ctx context.Context,
 	db database.Database,
 	refKey types.ClientRefKey,
 ) (*database.ClientInfo, error) {
-	return db.FindClientInfoByRefKey(ctx, refKey)
+	info, err := db.FindClientInfoByRefKey(ctx, refKey)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := info.EnsureActivated(); err != nil {
+		return nil, err
+	}
+
+	return info, nil
 }

--- a/server/rpc/yorkie_server.go
+++ b/server/rpc/yorkie_server.go
@@ -144,7 +144,7 @@ func (s *yorkieServer) AttachDocument(
 		}
 	}()
 
-	clientInfo, err := clients.FindClientInfo(ctx, s.backend.DB, types.ClientRefKey{
+	clientInfo, err := clients.FindActiveClientInfo(ctx, s.backend.DB, types.ClientRefKey{
 		ProjectID: project.ID,
 		ClientID:  types.IDFromActorID(actorID),
 	})
@@ -217,7 +217,7 @@ func (s *yorkieServer) DetachDocument(
 		}
 	}()
 
-	clientInfo, err := clients.FindClientInfo(ctx, s.backend.DB, types.ClientRefKey{
+	clientInfo, err := clients.FindActiveClientInfo(ctx, s.backend.DB, types.ClientRefKey{
 		ProjectID: project.ID,
 		ClientID:  types.IDFromActorID(actorID),
 	})
@@ -321,7 +321,7 @@ func (s *yorkieServer) PushPullChanges(
 		syncMode = types.SyncModePushOnly
 	}
 
-	clientInfo, err := clients.FindClientInfo(ctx, s.backend.DB, types.ClientRefKey{
+	clientInfo, err := clients.FindActiveClientInfo(ctx, s.backend.DB, types.ClientRefKey{
 		ProjectID: project.ID,
 		ClientID:  types.IDFromActorID(actorID),
 	})
@@ -395,7 +395,7 @@ func (s *yorkieServer) WatchDocument(
 		return err
 	}
 
-	if _, err = clients.FindClientInfo(ctx, s.backend.DB, types.ClientRefKey{
+	if _, err = clients.FindActiveClientInfo(ctx, s.backend.DB, types.ClientRefKey{
 		ProjectID: project.ID,
 		ClientID:  types.IDFromActorID(clientID),
 	}); err != nil {
@@ -514,7 +514,7 @@ func (s *yorkieServer) RemoveDocument(
 		}()
 	}
 
-	clientInfo, err := clients.FindClientInfo(ctx, s.backend.DB, types.ClientRefKey{
+	clientInfo, err := clients.FindActiveClientInfo(ctx, s.backend.DB, types.ClientRefKey{
 		ProjectID: project.ID,
 		ClientID:  types.IDFromActorID(actorID),
 	})
@@ -627,7 +627,7 @@ func (s *yorkieServer) Broadcast(
 		return nil, err
 	}
 
-	if _, err = clients.FindClientInfo(ctx, s.backend.DB, types.ClientRefKey{
+	if _, err = clients.FindActiveClientInfo(ctx, s.backend.DB, types.ClientRefKey{
 		ProjectID: project.ID,
 		ClientID:  types.IDFromActorID(clientID),
 	}); err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -20,11 +20,16 @@
 package server
 
 import (
+	"context"
 	gosync "sync"
 
+	"github.com/yorkie-team/yorkie/api/types"
+	"github.com/yorkie-team/yorkie/client"
 	"github.com/yorkie-team/yorkie/server/backend"
+	"github.com/yorkie-team/yorkie/server/clients"
 	"github.com/yorkie-team/yorkie/server/profiling"
 	"github.com/yorkie-team/yorkie/server/profiling/prometheus"
+	"github.com/yorkie-team/yorkie/server/projects"
 	"github.com/yorkie-team/yorkie/server/rpc"
 )
 
@@ -127,4 +132,18 @@ func (r *Yorkie) ShutdownCh() <-chan struct{} {
 // RPCAddr returns the address of the RPC.
 func (r *Yorkie) RPCAddr() string {
 	return r.conf.RPCAddr()
+}
+
+// DeactivateClient deactivates the given client. It is used for testing.
+func (r *Yorkie) DeactivateClient(ctx context.Context, c1 *client.Client) error {
+	project, err := projects.GetProjectFromAPIKey(ctx, r.backend, "")
+	if err != nil {
+		return err
+	}
+
+	_, err = clients.Deactivate(ctx, r.backend.DB, types.ClientRefKey{
+		ProjectID: project.ID,
+		ClientID:  types.IDFromActorID(c1.ID()),
+	})
+	return err
 }

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -20,8 +20,10 @@ package integration
 
 import (
 	"context"
+	"sync"
 	"testing"
 
+	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/yorkie-team/yorkie/client"
@@ -171,5 +173,37 @@ func TestClient(t *testing.T) {
 		assert.NoError(t, cli.Sync(ctx, client.WithDocKey(doc.Key())))
 		assert.Equal(t, doc.Checkpoint(), change.Checkpoint{ClientSeq: 4, ServerSeq: 4})
 		assert.Equal(t, "2", doc.Root().GetCounter("counter").Marshal())
+	})
+
+	t.Run("deactivated client's stream test", func(t *testing.T) {
+		ctx := context.Background()
+
+		c1, err := client.Dial(defaultServer.RPCAddr())
+		assert.NoError(t, err)
+		assert.NoError(t, c1.Activate(ctx))
+
+		d1 := document.New(helper.TestDocKey(t))
+
+		// 01. Attach the document and subscribe.
+		assert.NoError(t, c1.Attach(ctx, d1))
+
+		// 02. Deactivate the client and try to watch.
+		assert.NoError(t, defaultServer.DeactivateClient(ctx, c1))
+
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		stream, _ := c1.Watch(ctx, d1)
+
+		go func() {
+			defer wg.Done()
+
+			stream.Receive()
+			if err = stream.Err(); err != nil {
+				assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+				return
+			}
+		}()
+
+		wg.Wait()
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Return ErrClientNotActivated for deactivated clients

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to watch events on a document.
  - Added functionality to deactivate a client for testing purposes.

- **Enhancements**
  - Ensured that only activated clients can access client information.
  - Improved error handling for deactivated clients during stream operations.

- **Bug Fixes**
  - Corrected function calls to ensure client activation checks are performed.

- **Testing**
  - Added tests for stream behavior involving deactivated clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->