### PR TITLE
Handle concurrent Tree.RemoveStyle

### DIFF
--- a/api/converter/from_pb.go
+++ b/api/converter/from_pb.go
@@ -511,21 +511,22 @@ func fromTreeStyle(pbTreeStyle *api.Operation_TreeStyle) (*operations.TreeStyle,
 		return nil, err
 	}
 
-	if len(pbTreeStyle.AttributesToRemove) > 0 {
-		return operations.NewTreeStyleRemove(
-			parentCreatedAt,
-			from,
-			to,
-			pbTreeStyle.AttributesToRemove,
-			executedAt,
-		), nil
-	}
-
 	createdAtMapByActor, err := fromCreatedAtMapByActor(
 		pbTreeStyle.CreatedAtMapByActor,
 	)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(pbTreeStyle.AttributesToRemove) > 0 {
+		return operations.NewTreeStyleRemove(
+			parentCreatedAt,
+			from,
+			to,
+			createdAtMapByActor,
+			pbTreeStyle.AttributesToRemove,
+			executedAt,
+		), nil
 	}
 
 	return operations.NewTreeStyle(

--- a/pkg/document/json/tree.go
+++ b/pkg/document/json/tree.go
@@ -262,7 +262,7 @@ func (t *Tree) RemoveStyle(fromIdx, toIdx int, attributesToRemove []string) bool
 	}
 
 	ticket := t.context.IssueTimeTicket()
-	pairs, err := t.Tree.RemoveStyle(fromPos, toPos, attributesToRemove, ticket)
+	maxCreationMapByActor, pairs, err := t.Tree.RemoveStyle(fromPos, toPos, attributesToRemove, ticket, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -275,6 +275,7 @@ func (t *Tree) RemoveStyle(fromIdx, toIdx int, attributesToRemove []string) bool
 		t.CreatedAt(),
 		fromPos,
 		toPos,
+		maxCreationMapByActor,
 		attributesToRemove,
 		ticket,
 	))

--- a/pkg/document/operations/tree_style.go
+++ b/pkg/document/operations/tree_style.go
@@ -71,16 +71,18 @@ func NewTreeStyleRemove(
 	parentCreatedAt *time.Ticket,
 	from *crdt.TreePos,
 	to *crdt.TreePos,
+	maxCreatedAtMapByActor map[string]*time.Ticket,
 	attributesToRemove []string,
 	executedAt *time.Ticket,
 ) *TreeStyle {
 	return &TreeStyle{
-		parentCreatedAt:    parentCreatedAt,
-		from:               from,
-		to:                 to,
-		attributes:         map[string]string{},
-		attributesToRemove: attributesToRemove,
-		executedAt:         executedAt,
+		parentCreatedAt:        parentCreatedAt,
+		from:                   from,
+		to:                     to,
+		maxCreatedAtMapByActor: maxCreatedAtMapByActor,
+		attributes:             map[string]string{},
+		attributesToRemove:     attributesToRemove,
+		executedAt:             executedAt,
 	}
 }
 
@@ -100,7 +102,7 @@ func (e *TreeStyle) Execute(root *crdt.Root) error {
 			return err
 		}
 	} else {
-		pairs, err = obj.RemoveStyle(e.from, e.to, e.attributesToRemove, e.executedAt)
+		_, pairs, err = obj.RemoveStyle(e.from, e.to, e.attributesToRemove, e.executedAt, e.maxCreatedAtMapByActor)
 		if err != nil {
 			return err
 		}

--- a/test/integration/tree_concurrency_test.go
+++ b/test/integration/tree_concurrency_test.go
@@ -490,7 +490,10 @@ func TestTreeConcurrencyEditStyle(t *testing.T) {
 	}
 	initialXML := `<root><p color="red">a</p><p color="red">b</p><p color="red">c</p></root>`
 
-	content := &json.TreeNode{Type: "p", Attributes: map[string]string{"italic": "true"}, Children: []json.TreeNode{{Type: "text", Value: `d`}}}
+	content := &json.TreeNode{Type: "p", Attributes: map[string]string{
+		"italic": "true",
+		"color":  "blue",
+	}, Children: []json.TreeNode{{Type: "text", Value: `d`}}}
 
 	ranges := []twoRangesType{
 		// equal: <p>b</p> - <p>b</p>
@@ -519,7 +522,7 @@ func TestTreeConcurrencyEditStyle(t *testing.T) {
 	}
 
 	styleOperations := []operationInterface{
-		styleOperationType{RangeAll, StyleRemove, "color", "", `remove-bold`},
+		styleOperationType{RangeAll, StyleRemove, "color", "", `remove-color`},
 		styleOperationType{RangeAll, StyleSet, "bold", "aa", `set-bold-aa`},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Handle concurrent Tree.RemoveStyle

This commit addresses an issue where if a node has an attribute with the same key as the RemoveStyle is simultaneously inserted by Tree.Edit functions, the attribute of the concurrently inserted Node with the same key gets deleted. To resolve this issue, this commit adds filtering logic in RemoveStyle to prevent attribute deletion from concurrently inserted nodes.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Address #884

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the order of operations for attribute removal and creation time mapping to enhance styling accuracy.
  
- **New Features**
  - Added support for handling text nodes differently during styling operations.
  - Introduced new parameters for more precise attribute management during styling and removal operations.
  
- **Tests**
  - Updated concurrency test cases to include new attributes and operations for styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->