### PR TITLE
Fix miscalculation of tree size in concurrent editing

### DIFF
--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -373,11 +373,7 @@ func (n *TreeNode) remove(removedAt *time.Ticket) bool {
 	if n.removedAt == nil || n.removedAt.Compare(removedAt) > 0 {
 		n.removedAt = removedAt
 		if justRemoved {
-			if n.Index.Parent.Value.removedAt == nil {
-				n.Index.UpdateAncestorsSize()
-			} else {
-				n.Index.Parent.Length -= n.Index.PaddedLength()
-			}
+			n.Index.UpdateAncestorsSize()
 		}
 		return justRemoved
 	}

--- a/pkg/document/internal_document.go
+++ b/pkg/document/internal_document.go
@@ -18,7 +18,6 @@ package document
 
 import (
 	"errors"
-	"fmt"
 	gosync "sync"
 
 	"github.com/yorkie-team/yorkie/api/converter"
@@ -254,10 +253,7 @@ func (d *InternalDocument) applySnapshot(snapshot []byte, serverSeq int64) error
 // ApplyChanges applies remote changes to the document.
 func (d *InternalDocument) ApplyChanges(changes ...*change.Change) ([]DocEvent, error) {
 	var events []DocEvent
-	for i, c := range changes {
-		if i == 158 {
-			fmt.Println("do sth")
-		}
+	for _, c := range changes {
 		if c.PresenceChange() != nil {
 			clientID := c.ID().ActorID().String()
 			if _, ok := d.onlineClients.Load(clientID); ok {

--- a/pkg/document/internal_document.go
+++ b/pkg/document/internal_document.go
@@ -18,6 +18,7 @@ package document
 
 import (
 	"errors"
+	"fmt"
 	gosync "sync"
 
 	"github.com/yorkie-team/yorkie/api/converter"
@@ -253,7 +254,10 @@ func (d *InternalDocument) applySnapshot(snapshot []byte, serverSeq int64) error
 // ApplyChanges applies remote changes to the document.
 func (d *InternalDocument) ApplyChanges(changes ...*change.Change) ([]DocEvent, error) {
 	var events []DocEvent
-	for _, c := range changes {
+	for i, c := range changes {
+		if i == 158 {
+			fmt.Println("do sth")
+		}
 		if c.PresenceChange() != nil {
 			clientID := c.ID().ActorID().String()
 			if _, ok := d.onlineClients.Load(clientID); ok {

--- a/pkg/index/tree.go
+++ b/pkg/index/tree.go
@@ -336,6 +336,9 @@ func (n *Node[V]) UpdateAncestorsSize() {
 
 	for parent != nil {
 		parent.Length += n.PaddedLength() * sign
+		if parent.Value.IsRemoved() {
+			break
+		}
 
 		parent = parent.Parent
 	}
@@ -344,17 +347,17 @@ func (n *Node[V]) UpdateAncestorsSize() {
 // UpdateDescendantsSize updates the size of descendants. It is used when
 // the tree is newly created and the size of the descendants is not calculated.
 func (n *Node[V]) UpdateDescendantsSize() int {
-	if n.Value.IsRemoved() {
-		n.Length = 0
-		return 0
-	}
-
-	sum := 0
+	size := 0
 	for _, child := range n.Children(true) {
-		sum += child.UpdateDescendantsSize()
+		childSize := child.UpdateDescendantsSize()
+		if child.Value.IsRemoved() {
+			continue
+		}
+
+		size += childSize
 	}
 
-	n.Length += sum
+	n.Length += size
 
 	return n.PaddedLength()
 }

--- a/test/integration/tree_test.go
+++ b/test/integration/tree_test.go
@@ -20,13 +20,13 @@ package integration
 
 import (
 	"context"
-	"github.com/yorkie-team/yorkie/api/converter"
-	"github.com/yorkie-team/yorkie/pkg/document/crdt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/yorkie-team/yorkie/api/converter"
 	"github.com/yorkie-team/yorkie/pkg/document"
+	"github.com/yorkie-team/yorkie/pkg/document/crdt"
 	"github.com/yorkie-team/yorkie/pkg/document/json"
 	"github.com/yorkie-team/yorkie/pkg/document/presence"
 	"github.com/yorkie-team/yorkie/pkg/index"

--- a/test/integration/tree_test.go
+++ b/test/integration/tree_test.go
@@ -20,6 +20,8 @@ package integration
 
 import (
 	"context"
+	"github.com/yorkie-team/yorkie/api/converter"
+	"github.com/yorkie-team/yorkie/pkg/document/crdt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -3499,6 +3501,140 @@ func TestTree(t *testing.T) {
 		assert.NoError(t, c2.Attach(ctx, d2))
 		size := d1.Root().GetTree("t").IndexTree.Root().Len()
 		assert.Equal(t, size, d2.Root().GetTree("t").IndexTree.Root().Len())
+	})
+
+	t.Run("can calculate size of index tree correctly during concurrent editing", func(t *testing.T) {
+		ctx := context.Background()
+		d1 := document.New(helper.TestDocKey(t))
+		assert.NoError(t, c1.Attach(ctx, d1))
+		d2 := document.New(helper.TestDocKey(t))
+		assert.NoError(t, c2.Attach(ctx, d2))
+
+		assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewTree("t", &json.TreeNode{
+				Type: "doc",
+				Children: []json.TreeNode{{
+					Type:     "p",
+					Children: []json.TreeNode{{Type: "text", Value: "hello"}},
+				}},
+			})
+			return nil
+		}))
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+
+		assert.Equal(t, "<doc><p>hello</p></doc>", d1.Root().GetTree("t").ToXML())
+		assert.Equal(t, "<doc><p>hello</p></doc>", d2.Root().GetTree("t").ToXML())
+
+		assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetTree("t").Edit(0, 7, nil, 0)
+			return nil
+		}))
+		assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetTree("t").Edit(1, 2, &json.TreeNode{
+				Type:  "text",
+				Value: "p",
+			}, 0)
+			return nil
+		}))
+		assert.Equal(t, "<doc></doc>", d1.Root().GetTree("t").ToXML())
+		assert.Equal(t, 0, d1.Root().GetTree("t").Len())
+		assert.Equal(t, "<doc><p>pello</p></doc>", d2.Root().GetTree("t").ToXML())
+		assert.Equal(t, 7, d2.Root().GetTree("t").Len())
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c1.Sync(ctx))
+
+		assert.Equal(t, "<doc></doc>", d1.Root().GetTree("t").ToXML())
+		assert.Equal(t, "<doc></doc>", d2.Root().GetTree("t").ToXML())
+		assert.Equal(t, d1.Root().GetTree("t").Len(), d2.Root().GetTree("t").Len())
+	})
+
+	t.Run("can keep index tree consistent from snapshot", func(t *testing.T) {
+		ctx := context.Background()
+		d1 := document.New(helper.TestDocKey(t))
+		assert.NoError(t, c1.Attach(ctx, d1))
+		d2 := document.New(helper.TestDocKey(t))
+		assert.NoError(t, c2.Attach(ctx, d2))
+
+		assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewTree("t", &json.TreeNode{
+				Type: "r",
+				Children: []json.TreeNode{{
+					Type:     "p",
+					Children: []json.TreeNode{},
+				}},
+			})
+			return nil
+		}))
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+
+		assert.Equal(t, "<r><p></p></r>", d1.Root().GetTree("t").ToXML())
+		assert.Equal(t, "<r><p></p></r>", d2.Root().GetTree("t").ToXML())
+
+		assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetTree("t").Edit(0, 2, nil, 0)
+			return nil
+		}))
+		assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetTree("t").Edit(1, 1, &json.TreeNode{
+				Type:     "i",
+				Children: []json.TreeNode{{Type: "text", Value: "a"}},
+			}, 0)
+			root.GetTree("t").Edit(2, 3, &json.TreeNode{
+				Type:  "text",
+				Value: "b",
+			}, 0)
+			return nil
+		}))
+		assert.Equal(t, "<r></r>", d1.Root().GetTree("t").ToXML())
+		assert.Equal(t, 0, d1.Root().GetTree("t").Len())
+		assert.Equal(t, "<r><p><i>b</i></p></r>", d2.Root().GetTree("t").ToXML())
+		assert.Equal(t, 5, d2.Root().GetTree("t").Len())
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c1.Sync(ctx))
+
+		assert.Equal(t, "<r></r>", d1.Root().GetTree("t").ToXML())
+		assert.Equal(t, "<r></r>", d2.Root().GetTree("t").ToXML())
+
+		type Node struct {
+			xml       string
+			len       int
+			isRemoved bool
+		}
+		var d1Nodes []Node
+		var d2Nodes []Node
+		var sNodes []Node
+
+		index.TraverseNode(d1.Root().GetTree("t").IndexTree.Root(), func(node *index.Node[*crdt.TreeNode], depth int) {
+			d1Nodes = append(d1Nodes, Node{
+				xml:       index.ToXML(node),
+				len:       node.Len(),
+				isRemoved: node.Value.IsRemoved(),
+			})
+		})
+		index.TraverseNode(d2.Root().GetTree("t").IndexTree.Root(), func(node *index.Node[*crdt.TreeNode], depth int) {
+			d2Nodes = append(d2Nodes, Node{
+				xml:       index.ToXML(node),
+				len:       node.Len(),
+				isRemoved: node.Value.IsRemoved(),
+			})
+		})
+		obj, err := converter.ObjectToBytes(d1.RootObject())
+		assert.NoError(t, err)
+		sRoot, err := converter.BytesToObject(obj)
+		assert.NoError(t, err)
+		index.TraverseNode(sRoot.Get("t").(*crdt.Tree).IndexTree.Root(), func(node *index.Node[*crdt.TreeNode], depth int) {
+			sNodes = append(sNodes, Node{
+				xml:       index.ToXML(node),
+				len:       node.Len(),
+				isRemoved: node.Value.IsRemoved(),
+			})
+		})
+		assert.ObjectsAreEqual(d1Nodes, d2Nodes)
+		assert.ObjectsAreEqual(d1Nodes, sNodes)
 	})
 
 	t.Run("can split and merge with empty paragraph: left", func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Fix miscalculation of tree size in concurrent editing

This commit addresses the issue where the `updateAncestorsSize` method
subtracts the size of a tombstoned node from its ancestors' sizes when
the node is removed. However, the previous logic did not consider
cases where ancestors node are tombstoned. In such cases, the update
should not propagate to the parent's ancestors. This commit introduces
recursive checks on ancestors and stops updating process if a
tombstoned ancestor is encountered.

Furthermore, the PR ensures consistency between the size maintenance
policies of updateDescendantsSize and updateAncestorsSize.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Address https://github.com/yorkie-team/yorkie/issues/889
Related to https://github.com/yorkie-team/yorkie-js-sdk/pull/846

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved logic for updating ancestors' and descendants' sizes to ensure accurate calculations and prevent errors when nodes are marked as removed.

- **Tests**
  - Added new test cases for concurrent editing and tree consistency checks in document collaboration scenarios to ensure reliability and correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->