### PR TITLE
Remove commit revision in version command

### DIFF
--- a/cmd/yorkie/version.go
+++ b/cmd/yorkie/version.go
@@ -19,43 +19,23 @@ package main
 import (
 	"fmt"
 	"runtime"
-	"runtime/debug"
 
 	"github.com/spf13/cobra"
 
 	"github.com/yorkie-team/yorkie/internal/version"
 )
 
-const commitRevisionKey = "vcs.revision"
-
 func newVersionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Print the version number of Yorkie",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			revision := settingByKey(commitRevisionKey)
 			fmt.Printf("Yorkie: %s\n", version.Version)
-			fmt.Printf("Commit: %s\n", revision[:7])
 			fmt.Printf("Go: %s\n", runtime.Version())
 			fmt.Printf("Build date: %s\n", version.BuildDate)
 			return nil
 		},
 	}
-}
-
-func settingByKey(key string) string {
-	info, ok := debug.ReadBuildInfo()
-	if !ok {
-		return ""
-	}
-
-	for _, setting := range info.Settings {
-		if setting.Key == key {
-			return setting.Value
-		}
-	}
-
-	return ""
 }
 
 func init() {

--- a/server/backend/backend.go
+++ b/server/backend/backend.go
@@ -118,7 +118,7 @@ func New(
 	}
 
 	logging.DefaultLogger().Infof(
-		"backend created: id: %s, rpc: %s",
+		"backend created: id: %s, db: %s",
 		serverInfo.ID,
 		dbInfo,
 	)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Remove commit revision in version command

The following error occurs when running `$ yorkie version`.

```sh
$ yorkie version
Yorkie: 0.4.24
panic: runtime error: slice bounds out of range [:7] with length 0

goroutine 1 [running]:
main.init.5.newVersionCmd.func1(0x1400022f800?, {0x102d8a3b0?, 0x4?, 0x102d8a3b4?})
        github.com/yorkie-team/yorkie/cmd/yorkie/version.go:38 +0x15c
github.com/spf13/cobra.(*Command).execute(0x140001c0dc8, {0x1038bc520, 0x0, 0x0})
        github.com/spf13/cobra@v1.5.0/command.go:872 +0x574
github.com/spf13/cobra.(*Command).ExecuteC(0x1038493c0)
        github.com/spf13/cobra@v1.5.0/command.go:990 +0x318
github.com/spf13/cobra.(*Command).Execute(...)
        github.com/spf13/cobra@v1.5.0/command.go:918
main.Run(...)
        github.com/yorkie-team/yorkie/cmd/yorkie/commands.go:39
main.main()
        github.com/yorkie-team/yorkie/cmd/yorkie/main.go:24 +0x24
```

The cause was not found, but since revision wasn't strictly necessary, this commit removes `revision` from `version` command.

Starting with 0.4.18, BrewTestBot started automatically deploying to Homebrew. It is assumed that the error occurs after this point.

- https://github.com/Homebrew/homebrew-core/pull/169849

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related to #870

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
