### PR TITLE
Return ErrAlreadyDetached when reattaching

### DIFF
--- a/pkg/document/change/pack.go
+++ b/pkg/document/change/pack.go
@@ -76,3 +76,8 @@ func (p *Pack) OperationsLen() int {
 	}
 	return operations
 }
+
+// IsAttached returns whether the document is attached or not.
+func (p *Pack) IsAttached() bool {
+	return p.Checkpoint.ServerSeq != 0
+}

--- a/server/backend/database/client_info.go
+++ b/server/backend/database/client_info.go
@@ -31,6 +31,7 @@ var (
 	ErrDocumentNotAttached     = errors.New("document not attached")
 	ErrDocumentNeverAttached   = errors.New("client has never attached the document")
 	ErrDocumentAlreadyAttached = errors.New("document already attached")
+	ErrDocumentAlreadyDetached = errors.New("document already detached")
 )
 
 // Below are statuses of the client.
@@ -104,7 +105,7 @@ func (i *ClientInfo) Deactivate() {
 }
 
 // AttachDocument attaches the given document to this client.
-func (i *ClientInfo) AttachDocument(docID types.ID) error {
+func (i *ClientInfo) AttachDocument(docID types.ID, alreadyAttached bool) error {
 	if i.Status != ClientActivated {
 		return fmt.Errorf("client(%s) attaches %s: %w",
 			i.ID, docID, ErrClientNotActivated)
@@ -112,6 +113,11 @@ func (i *ClientInfo) AttachDocument(docID types.ID) error {
 
 	if i.Documents == nil {
 		i.Documents = make(map[types.ID]*ClientDocInfo)
+	}
+
+	if alreadyAttached && i.hasDocument(docID) && i.Documents[docID].Status == DocumentDetached {
+		return fmt.Errorf("client(%s) attaches %s: %w",
+			i.ID, docID, ErrDocumentAlreadyDetached)
 	}
 
 	if i.hasDocument(docID) && i.Documents[docID].Status == DocumentAttached {

--- a/server/backend/database/client_info_test.go
+++ b/server/backend/database/client_info_test.go
@@ -36,7 +36,7 @@ func TestClientInfo(t *testing.T) {
 			Status: database.ClientActivated,
 		}
 
-		err := clientInfo.AttachDocument(dummyDocID)
+		err := clientInfo.AttachDocument(dummyDocID, false)
 		assert.NoError(t, err)
 		isAttached, err := clientInfo.IsAttached(dummyDocID)
 		assert.NoError(t, err)
@@ -54,7 +54,7 @@ func TestClientInfo(t *testing.T) {
 		assert.NoError(t, err)
 		assert.False(t, isAttached)
 
-		err = clientInfo.AttachDocument(dummyDocID)
+		err = clientInfo.AttachDocument(dummyDocID, false)
 		assert.NoError(t, err)
 		isAttached, err = clientInfo.IsAttached(dummyDocID)
 		assert.NoError(t, err)
@@ -85,7 +85,7 @@ func TestClientInfo(t *testing.T) {
 			Status: database.ClientActivated,
 		}
 
-		err := clientInfo.AttachDocument(dummyDocID)
+		err := clientInfo.AttachDocument(dummyDocID, false)
 		assert.NoError(t, err)
 		isAttached, err := clientInfo.IsAttached(dummyDocID)
 		assert.NoError(t, err)
@@ -102,7 +102,7 @@ func TestClientInfo(t *testing.T) {
 			Status: database.ClientDeactivated,
 		}
 
-		err := clientInfo.AttachDocument(dummyDocID)
+		err := clientInfo.AttachDocument(dummyDocID, false)
 		assert.ErrorIs(t, err, database.ErrClientNotActivated)
 
 		err = clientInfo.EnsureDocumentAttached(dummyDocID)
@@ -136,13 +136,13 @@ func TestClientInfo(t *testing.T) {
 			Status: database.ClientActivated,
 		}
 
-		err := clientInfo.AttachDocument(dummyDocID)
+		err := clientInfo.AttachDocument(dummyDocID, false)
 		assert.NoError(t, err)
 		isAttached, err := clientInfo.IsAttached(dummyDocID)
 		assert.NoError(t, err)
 		assert.True(t, isAttached)
 
-		err = clientInfo.AttachDocument(dummyDocID)
+		err = clientInfo.AttachDocument(dummyDocID, false)
 		assert.ErrorIs(t, err, database.ErrDocumentAlreadyAttached)
 	})
 }

--- a/server/backend/database/testcases/testcases.go
+++ b/server/backend/database/testcases/testcases.go
@@ -199,7 +199,7 @@ func RunFindChangesBetweenServerSeqsTest(
 		clientInfo, _ := db.ActivateClient(ctx, projectID, t.Name())
 		docInfo, _ := db.FindDocInfoByKeyAndOwner(ctx, clientInfo.RefKey(), docKey, true)
 		docRefKey := docInfo.RefKey()
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		bytesID, _ := clientInfo.ID.Bytes()
@@ -720,7 +720,7 @@ func RunCreateChangeInfosTest(t *testing.T, db database.Database, projectID type
 		clientInfo, _ := db.ActivateClient(ctx, projectID, t.Name())
 		docInfo, _ := db.FindDocInfoByKeyAndOwner(ctx, clientInfo.RefKey(), docKey, true)
 		docRefKey := docInfo.RefKey()
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		// 02. Remove the document and check the document is removed.
@@ -739,7 +739,7 @@ func RunCreateChangeInfosTest(t *testing.T, db database.Database, projectID type
 		clientInfo1, _ := db.ActivateClient(ctx, projectID, t.Name())
 		docInfo1, _ := db.FindDocInfoByKeyAndOwner(ctx, clientInfo1.RefKey(), docKey, true)
 		docRefKey1 := docInfo1.RefKey()
-		assert.NoError(t, clientInfo1.AttachDocument(docRefKey1.DocID))
+		assert.NoError(t, clientInfo1.AttachDocument(docRefKey1.DocID, false))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo1, docInfo1))
 
 		// 02. Remove the document.
@@ -750,7 +750,7 @@ func RunCreateChangeInfosTest(t *testing.T, db database.Database, projectID type
 		// 03. Create a document with same key and check they have same key but different id.
 		docInfo2, _ := db.FindDocInfoByKeyAndOwner(ctx, clientInfo1.RefKey(), docKey, true)
 		docRefKey2 := docInfo2.RefKey()
-		assert.NoError(t, clientInfo1.AttachDocument(docRefKey2.DocID))
+		assert.NoError(t, clientInfo1.AttachDocument(docRefKey2.DocID, false))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo1, docInfo2))
 		assert.Equal(t, docInfo1.Key, docInfo2.Key)
 		assert.NotEqual(t, docInfo1.ID, docInfo2.ID)
@@ -763,7 +763,7 @@ func RunCreateChangeInfosTest(t *testing.T, db database.Database, projectID type
 		clientInfo, _ := db.ActivateClient(ctx, projectID, t.Name())
 		docInfo, _ := db.FindDocInfoByKeyAndOwner(ctx, clientInfo.RefKey(), docKey, true)
 		docRefKey := docInfo.RefKey()
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		doc := document.New(key.Key(t.Name()))
@@ -801,7 +801,7 @@ func RunUpdateClientInfoAfterPushPullTest(t *testing.T, db database.Database, pr
 
 		err = db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo)
 		assert.ErrorIs(t, err, database.ErrDocumentNeverAttached)
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 	})
 
@@ -813,7 +813,7 @@ func RunUpdateClientInfoAfterPushPullTest(t *testing.T, db database.Database, pr
 		docInfo, err := db.FindDocInfoByKeyAndOwner(ctx, clientInfo.RefKey(), docKey, true)
 		assert.NoError(t, err)
 
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		result, err := db.FindClientInfoByRefKey(ctx, clientInfo.RefKey())
@@ -831,7 +831,7 @@ func RunUpdateClientInfoAfterPushPullTest(t *testing.T, db database.Database, pr
 		docInfo, err := db.FindDocInfoByKeyAndOwner(ctx, clientInfo.RefKey(), docKey, true)
 		assert.NoError(t, err)
 
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false))
 		clientInfo.Documents[docInfo.ID].ServerSeq = 1
 		clientInfo.Documents[docInfo.ID].ClientSeq = 1
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
@@ -873,7 +873,7 @@ func RunUpdateClientInfoAfterPushPullTest(t *testing.T, db database.Database, pr
 		docInfo, err := db.FindDocInfoByKeyAndOwner(ctx, clientInfo.RefKey(), docKey, true)
 		assert.NoError(t, err)
 
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false))
 		clientInfo.Documents[docInfo.ID].ServerSeq = 1
 		clientInfo.Documents[docInfo.ID].ClientSeq = 1
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
@@ -902,7 +902,7 @@ func RunUpdateClientInfoAfterPushPullTest(t *testing.T, db database.Database, pr
 		docInfo, err := db.FindDocInfoByKeyAndOwner(ctx, clientInfo.RefKey(), docKey, true)
 		assert.NoError(t, err)
 
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false))
 		clientInfo.Documents[docInfo.ID].ServerSeq = 1
 		clientInfo.Documents[docInfo.ID].ClientSeq = 1
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
@@ -931,7 +931,7 @@ func RunUpdateClientInfoAfterPushPullTest(t *testing.T, db database.Database, pr
 		docInfo, err := db.FindDocInfoByKeyAndOwner(ctx, clientInfo.RefKey(), docKey, true)
 		assert.NoError(t, err)
 
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		clientInfo.ID = "invalid clientInfo id"
@@ -962,7 +962,7 @@ func RunIsDocumentAttachedTest(t *testing.T, db database.Database, projectID typ
 		assert.False(t, attached)
 
 		// 02. Check if document is attached after attaching
-		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID))
+		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID, false))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c1, d1))
 		attached, err = db.IsDocumentAttached(ctx, docRefKey1, "")
 		assert.NoError(t, err)
@@ -976,9 +976,9 @@ func RunIsDocumentAttachedTest(t *testing.T, db database.Database, projectID typ
 		assert.False(t, attached)
 
 		// 04. Check if document is attached after two clients attaching
-		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID))
+		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID, false))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c1, d1))
-		assert.NoError(t, c2.AttachDocument(docRefKey1.DocID))
+		assert.NoError(t, c2.AttachDocument(docRefKey1.DocID, false))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c2, d1))
 		attached, err = db.IsDocumentAttached(ctx, docRefKey1, "")
 		assert.NoError(t, err)
@@ -1012,14 +1012,14 @@ func RunIsDocumentAttachedTest(t *testing.T, db database.Database, projectID typ
 
 		// 01. Check if documents are attached after attaching
 		docRefKey1 := d1.RefKey()
-		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID))
+		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID, false))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c1, d1))
 		attached, err := db.IsDocumentAttached(ctx, docRefKey1, "")
 		assert.NoError(t, err)
 		assert.True(t, attached)
 
 		docRefKey2 := d2.RefKey()
-		assert.NoError(t, c1.AttachDocument(docRefKey2.DocID))
+		assert.NoError(t, c1.AttachDocument(docRefKey2.DocID, false))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c1, d2))
 		attached, err = db.IsDocumentAttached(ctx, docRefKey2, "")
 		assert.NoError(t, err)
@@ -1061,7 +1061,7 @@ func RunIsDocumentAttachedTest(t *testing.T, db database.Database, projectID typ
 		assert.False(t, attached)
 
 		// 02. Check if document is attached after attaching
-		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID))
+		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID, false))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c1, d1))
 		attached, err = db.IsDocumentAttached(ctx, docRefKey1, "")
 		assert.NoError(t, err)
@@ -1081,9 +1081,9 @@ func RunIsDocumentAttachedTest(t *testing.T, db database.Database, projectID typ
 		assert.False(t, attached)
 
 		// 04. Check if document is attached after two clients attaching
-		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID))
+		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID, false))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c1, d1))
-		assert.NoError(t, c2.AttachDocument(docRefKey1.DocID))
+		assert.NoError(t, c2.AttachDocument(docRefKey1.DocID, false))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c2, d1))
 		attached, err = db.IsDocumentAttached(ctx, docRefKey1, "")
 		assert.NoError(t, err)

--- a/server/rpc/connecthelper/status.go
+++ b/server/rpc/connecthelper/status.go
@@ -65,6 +65,7 @@ var errorToCode = map[error]connect.Code{
 	database.ErrClientNotActivated:      connect.CodeFailedPrecondition,
 	database.ErrDocumentNotAttached:     connect.CodeFailedPrecondition,
 	database.ErrDocumentAlreadyAttached: connect.CodeFailedPrecondition,
+	database.ErrDocumentAlreadyDetached: connect.CodeFailedPrecondition,
 	documents.ErrDocumentAttached:       connect.CodeFailedPrecondition,
 	packs.ErrInvalidServerSeq:           connect.CodeFailedPrecondition,
 	database.ErrConflictOnUpdate:        connect.CodeFailedPrecondition,

--- a/server/rpc/yorkie_server.go
+++ b/server/rpc/yorkie_server.go
@@ -157,7 +157,7 @@ func (s *yorkieServer) AttachDocument(
 		return nil, err
 	}
 
-	if err := clientInfo.AttachDocument(docInfo.ID); err != nil {
+	if err := clientInfo.AttachDocument(docInfo.ID, pack.IsAttached()); err != nil {
 		return nil, err
 	}
 

--- a/test/bench/push_pull_bench_test.go
+++ b/test/bench/push_pull_bench_test.go
@@ -90,7 +90,7 @@ func setUpClientsAndDocs(
 		assert.NoError(b, err)
 		docInfo, err := be.DB.FindDocInfoByKeyAndOwner(ctx, clientInfo.RefKey(), docKey, true)
 		assert.NoError(b, err)
-		assert.NoError(b, clientInfo.AttachDocument(docInfo.ID))
+		assert.NoError(b, clientInfo.AttachDocument(docInfo.ID, false))
 		assert.NoError(b, be.DB.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		bytesID, _ := clientInfo.ID.Bytes()


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Return ErrAlreadyDetached when reattaching

This commit addresses the need for handling reattaching detached
documents. When reattaching a document that was previously detached,
special processing is required to prevent attachment in cases where
tombstone nodes may have been garbage collected by another client during
editing.

If attaching a new document with the same key, it should attach normally.
Therefore, there needs to be a distinction between attaching a new
document and reattaching.

While there is no difference in DB.ClientInfo, the Request ChangePack's
Checkpoint.ServerSeq value can be used to distinguish between attaching
a new document and reattaching a detached document. In cases where
Checkpoint.ServerSeq is greater than 0, the ErrAlreadyDetached error
should be returned.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
