### PR TITLE
Remove node from index during GC

### DIFF
--- a/pkg/document/crdt/rga_tree_split.go
+++ b/pkg/document/crdt/rga_tree_split.go
@@ -628,6 +628,9 @@ func (s *RGATreeSplit[V]) ToTestString() string {
 func (s *RGATreeSplit[V]) Purge(child GCChild) error {
 	node := child.(*RGATreeSplitNode[V])
 
+	s.treeByIndex.Delete(node.indexNode)
+	s.treeByID.Remove(node.id)
+
 	node.prev.next = node.next
 	if node.next != nil {
 		node.next.prev = node.prev

--- a/pkg/document/crdt/text.go
+++ b/pkg/document/crdt/text.go
@@ -18,6 +18,8 @@ package crdt
 
 import (
 	"fmt"
+	"github.com/yorkie-team/yorkie/pkg/llrb"
+	"github.com/yorkie-team/yorkie/pkg/splay"
 	"strings"
 	"unicode/utf16"
 
@@ -365,4 +367,13 @@ func (t *Text) ToTestString() string {
 // for debugging purpose.
 func (t *Text) CheckWeight() bool {
 	return t.rgaTreeSplit.CheckWeight()
+}
+
+func (t *Text) TreeByIndex() *splay.Tree[*RGATreeSplitNode[*TextValue]] {
+	return t.rgaTreeSplit.treeByIndex
+}
+
+// TreeByID returns the tree by ID for debugging purpose.
+func (t *Text) TreeByID() *llrb.Tree[*RGATreeSplitNodeID, *RGATreeSplitNode[*TextValue]] {
+	return t.rgaTreeSplit.treeByID
 }

--- a/pkg/document/crdt/text.go
+++ b/pkg/document/crdt/text.go
@@ -18,12 +18,12 @@ package crdt
 
 import (
 	"fmt"
-	"github.com/yorkie-team/yorkie/pkg/llrb"
-	"github.com/yorkie-team/yorkie/pkg/splay"
 	"strings"
 	"unicode/utf16"
 
 	"github.com/yorkie-team/yorkie/pkg/document/time"
+	"github.com/yorkie-team/yorkie/pkg/llrb"
+	"github.com/yorkie-team/yorkie/pkg/splay"
 )
 
 // TextValue is a value of Text which has an attributes that represent
@@ -369,6 +369,7 @@ func (t *Text) CheckWeight() bool {
 	return t.rgaTreeSplit.CheckWeight()
 }
 
+// TreeByIndex returns IndexTree of the text for debugging purpose.
 func (t *Text) TreeByIndex() *splay.Tree[*RGATreeSplitNode[*TextValue]] {
 	return t.rgaTreeSplit.treeByIndex
 }

--- a/pkg/document/document_test.go
+++ b/pkg/document/document_test.go
@@ -535,15 +535,13 @@ func TestDocument(t *testing.T) {
 		assert.Equal(t, 1, doc.Root().GetText("k1").TreeByID().Len())
 
 		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
-			text := root.GetText("k1")
-			text.Edit(0, 0, "ABC", nil)
+			root.GetText("k1").Edit(0, 0, "ABC", nil)
 			return nil
 		}))
 		assert.Equal(t, 2, doc.Root().GetText("k1").TreeByID().Len())
 
 		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
-			text := root.GetText("k1")
-			text.Edit(1, 3, "", nil)
+			root.GetText("k1").Edit(1, 3, "", nil)
 			return nil
 		}))
 		assert.Equal(t, 3, doc.Root().GetText("k1").TreeByID().Len())

--- a/test/integration/text_test.go
+++ b/test/integration/text_test.go
@@ -262,6 +262,8 @@ func TestText(t *testing.T) {
 		syncClientsThenAssertEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
 		assert.True(t, d1.Root().GetText("k1").CheckWeight())
 		assert.True(t, d2.Root().GetText("k1").CheckWeight())
+		assert.True(t, d1.Root().GetText("k1").TreeByIndex().CheckWeight())
+		assert.True(t, d2.Root().GetText("k1").TreeByIndex().CheckWeight())
 	})
 
 	// Peritext test


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Remove node from indexes during GC

While improving GC structure, we missed removing nodes from internal
indexes of Text when purging tombstones.

This commit fixes #866.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Addresses https://github.com/yorkie-team/yorkie/issues/914

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new methods `TreeByIndex()` and `TreeByID()` to facilitate debugging.
  
- **Bug Fixes**
  - Improved garbage collection to ensure consistent deletion of nodes in internal data structures.

- **Tests**
  - Introduced a new test case for validating node purges during garbage collection.
  - Added assertions to verify text weight consistency in documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->