### PR TITLE
Prevent exposure of removed documents when searching

### DIFF
--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -1313,6 +1313,9 @@ func (d *DB) FindDocInfosByQuery(
 	for raw := iterator.Next(); raw != nil; raw = iterator.Next() {
 		if count < pageSize {
 			info := raw.(*database.DocInfo)
+			if info.IsRemoved() {
+				continue
+			}
 			docInfos = append(docInfos, info)
 		}
 		count++

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -1201,6 +1201,9 @@ func (c *Client) FindDocInfosByQuery(
 		"key": bson.M{"$regex": primitive.Regex{
 			Pattern: "^" + escapeRegex(query),
 		}},
+		"removed_at": bson.M{
+			"$exists": false,
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("find document infos: %w", err)

--- a/test/integration/admin_test.go
+++ b/test/integration/admin_test.go
@@ -150,12 +150,12 @@ func TestAdmin(t *testing.T) {
 
 	t.Run("unauthentication test", func(t *testing.T) {
 		// 01. try to call admin API without token.
-		adminCli2, err := admin.Dial(defaultServer.RPCAddr(), admin.WithInsecure(true))
+		cli, err := admin.Dial(defaultServer.RPCAddr(), admin.WithInsecure(true))
 		assert.NoError(t, err)
 		defer func() {
-			adminCli2.Close()
+			cli.Close()
 		}()
-		_, err = adminCli2.GetProject(ctx, "default")
+		_, err = cli.GetProject(ctx, "default")
 
 		// 02. server should return unauthenticated error.
 		assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))

--- a/test/integration/restapi_test.go
+++ b/test/integration/restapi_test.go
@@ -19,7 +19,6 @@
 package integration
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -30,8 +29,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/yorkie-team/yorkie/api/types"
-	"github.com/yorkie-team/yorkie/client"
-	"github.com/yorkie-team/yorkie/pkg/document"
 	"github.com/yorkie-team/yorkie/test/helper"
 )
 
@@ -46,93 +43,92 @@ type documentSummary struct {
 }
 
 func TestRESTAPI(t *testing.T) {
-	project, docs := createProjectAndDocuments(t, 3)
-
 	t.Run("document retrieval test", func(t *testing.T) {
-		httpClient := http.Client{}
-
-		url := fmt.Sprintf("http://%s/yorkie.v1.AdminService/GetDocument", defaultServer.RPCAddr())
-		req, err := http.NewRequest("POST", url, strings.NewReader(
+		project, docs := helper.CreateProjectAndDocuments(t, defaultServer, 3)
+		res := post(
+			t,
+			project,
+			fmt.Sprintf("http://%s/yorkie.v1.AdminService/GetDocument", defaultServer.RPCAddr()),
 			fmt.Sprintf(`{"project_name": "%s", "document_key": "%s"}`, project.Name, docs[0].Key()),
-		))
-		assert.NoError(t, err)
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Authorization", project.SecretKey)
-
-		res, err := httpClient.Do(req)
-		assert.NoError(t, err)
-		assert.Equal(t, http.StatusOK, res.StatusCode)
-
-		resBody, err := io.ReadAll(res.Body)
-		assert.NoError(t, err)
+		)
 
 		summary := &documentSummary{}
-		assert.NoError(t, json.Unmarshal(resBody, summary))
+		assert.NoError(t, json.Unmarshal(res, summary))
 		assert.Equal(t, docs[0].Key(), summary.Document.Key)
 	})
 
 	t.Run("bulk document retrieval test", func(t *testing.T) {
-		httpClient := http.Client{}
-
-		url := fmt.Sprintf("http://%s/yorkie.v1.AdminService/GetDocuments", defaultServer.RPCAddr())
-		req, err := http.NewRequest("POST", url, strings.NewReader(
+		project, docs := helper.CreateProjectAndDocuments(t, defaultServer, 3)
+		res := post(
+			t,
+			project,
+			fmt.Sprintf("http://%s/yorkie.v1.AdminService/GetDocuments", defaultServer.RPCAddr()),
 			fmt.Sprintf(`{"project_name": "%s", "document_keys": ["%s", "%s"]}`, project.Name, docs[0].Key(), docs[1].Key()),
-		))
-		assert.NoError(t, err)
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Authorization", project.SecretKey)
-
-		res, err := httpClient.Do(req)
-		assert.NoError(t, err)
-		assert.Equal(t, http.StatusOK, res.StatusCode)
-
-		resBody, err := io.ReadAll(res.Body)
-		assert.NoError(t, err)
+		)
 
 		summaries := &documentSummaries{}
-		assert.NoError(t, json.Unmarshal(resBody, summaries))
+		assert.NoError(t, json.Unmarshal(res, summaries))
 		assert.Len(t, summaries.Documents, 2)
 	})
 
 	t.Run("list documents test", func(t *testing.T) {
-		httpClient := http.Client{}
-
-		url := fmt.Sprintf("http://%s/yorkie.v1.AdminService/ListDocuments", defaultServer.RPCAddr())
-		req, err := http.NewRequest("POST", url, strings.NewReader(
+		project, _ := helper.CreateProjectAndDocuments(t, defaultServer, 3)
+		res := post(
+			t,
+			project,
+			fmt.Sprintf("http://%s/yorkie.v1.AdminService/ListDocuments", defaultServer.RPCAddr()),
 			fmt.Sprintf(`{"project_name": "%s", "document_key": "test"}`, project.Name),
-		))
-		assert.NoError(t, err)
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Authorization", project.SecretKey)
-
-		res, err := httpClient.Do(req)
-		assert.NoError(t, err)
-		assert.Equal(t, http.StatusOK, res.StatusCode)
-
-		resBody, err := io.ReadAll(res.Body)
-		assert.NoError(t, err)
+		)
 
 		summaries := &documentSummaries{}
-		assert.NoError(t, json.Unmarshal(resBody, summaries))
+		assert.NoError(t, json.Unmarshal(res, summaries))
 		assert.Len(t, summaries.Documents, 3)
+	})
+
+	t.Run("search documents test", func(t *testing.T) {
+		project, docs := helper.CreateProjectAndDocuments(t, defaultServer, 3)
+		res := post(
+			t,
+			project,
+			fmt.Sprintf("http://%s/yorkie.v1.AdminService/SearchDocuments", defaultServer.RPCAddr()),
+			fmt.Sprintf(`{"project_name": "%s", "query": "0-", "page_size": 3}`, project.Name),
+		)
+		summaries := &documentSummaries{}
+		assert.NoError(t, json.Unmarshal(res, summaries))
+		assert.Len(t, summaries.Documents, 1)
+
+		_ = post(
+			t,
+			project,
+			fmt.Sprintf("http://%s/yorkie.v1.AdminService/RemoveDocumentByAdmin", defaultServer.RPCAddr()),
+			fmt.Sprintf(`{"project_name": "%s", "document_key": "%s", "force": true}`, project.Name, docs[0].Key()),
+		)
+
+		res = post(
+			t,
+			project,
+			fmt.Sprintf("http://%s/yorkie.v1.AdminService/SearchDocuments", defaultServer.RPCAddr()),
+			fmt.Sprintf(`{"project_name": "%s", "query": "0-", "page_size": 3}`, project.Name),
+		)
+		summaries = &documentSummaries{}
+		assert.NoError(t, json.Unmarshal(res, summaries))
+		assert.Len(t, summaries.Documents, 0)
 	})
 }
 
-func createProjectAndDocuments(t *testing.T, count int) (*types.Project, []*document.Document) {
-	ctx := context.Background()
-	project, err := defaultServer.CreateProject(ctx, t.Name())
+// post sends a POST request to the given URL with the given body.
+func post(t *testing.T, project *types.Project, url, body string) []byte {
+	req, err := http.NewRequest("POST", url, strings.NewReader(body))
 	assert.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", project.SecretKey)
 
-	cli, err := client.Dial(defaultServer.RPCAddr(), client.WithAPIKey(project.PublicKey))
+	httpClient := http.Client{}
+	res, err := httpClient.Do(req)
 	assert.NoError(t, err)
-	assert.NoError(t, cli.Activate(ctx))
+	assert.Equal(t, http.StatusOK, res.StatusCode)
 
-	var docs []*document.Document
-	for i := 0; i < count; i++ {
-		doc := document.New(helper.TestDocKey(t, i))
-		assert.NoError(t, cli.Attach(ctx, doc))
-		docs = append(docs, doc)
-	}
-
-	return project, docs
+	resBody, err := io.ReadAll(res.Body)
+	assert.NoError(t, err)
+	return resBody
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Prevent exposure of removed documents when searching

Removed documents were being exposed when searching in Dashboard. This commit modifies to prevent exposure by adding a filter to the query.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
