### PR TITLE
Ensure proper deletion of documents in MemDB

### DIFF
--- a/server/backend/database/testcases/testcases.go
+++ b/server/backend/database/testcases/testcases.go
@@ -71,6 +71,26 @@ func RunFindDocInfoTest(
 		assert.NoError(t, err)
 		assert.Equal(t, docKey, docInfo.Key)
 	})
+
+	t.Run("find docInfo by key test", func(t *testing.T) {
+		ctx := context.Background()
+		clientInfo, err := db.ActivateClient(ctx, projectID, t.Name())
+		assert.NoError(t, err)
+
+		// 01. Create a document
+		docKey := helper.TestDocKey(t)
+		info, err := db.FindDocInfoByKeyAndOwner(ctx, clientInfo.RefKey(), docKey, true)
+		assert.NoError(t, err)
+		assert.Equal(t, docKey, info.Key)
+
+		// 02. Remove the document
+		err = db.CreateChangeInfos(ctx, projectID, info, 0, []*change.Change{}, true)
+		assert.NoError(t, err)
+
+		// 03. Find the document
+		info, err = db.FindDocInfoByKey(ctx, projectID, docKey)
+		assert.ErrorIs(t, err, database.ErrDocumentNotFound)
+	})
 }
 
 // RunFindProjectInfoBySecretKeyTest runs the FindProjectInfoBySecretKey test for the given db.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Ensure proper deletion of documents in MemDB

In Dashboard, there was an issue where re-creating and deleting a previously deleted document did not remove the document as expected. This issue occurred because the already deleted document was not properly filtered out and returned again upon re-deletion. This commit fixes this issue by adding a filter to prevent previously deleted documents from being returned during document retrieval for deletion.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #919

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
