### PR TITLE
Update 'updated_at' only if there are more than one operation in changes

### DIFF
--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -900,7 +900,14 @@ func (d *DB) CreateChangeInfos(
 
 	now := gotime.Now()
 	loadedDocInfo.ServerSeq = docInfo.ServerSeq
-	loadedDocInfo.UpdatedAt = now
+
+	for _, cn := range changes {
+		if len(cn.Operations()) > 0 {
+			loadedDocInfo.UpdatedAt = now
+			break
+		}
+	}
+
 	if isRemoved {
 		loadedDocInfo.RemovedAt = now
 	}

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -891,8 +891,15 @@ func (c *Client) CreateChangeInfos(
 	now := gotime.Now()
 	updateFields := bson.M{
 		"server_seq": docInfo.ServerSeq,
-		"updated_at": now,
 	}
+
+	for _, cn := range changes {
+		if len(cn.Operations()) > 0 {
+			updateFields["updated_at"] = now
+			break
+		}
+	}
+
 	if isRemoved {
 		updateFields["removed_at"] = now
 	}

--- a/server/backend/database/testcases/testcases.go
+++ b/server/backend/database/testcases/testcases.go
@@ -919,6 +919,46 @@ func RunCreateChangeInfosTest(t *testing.T, db database.Database, projectID type
 		assert.NoError(t, err)
 		assert.NotEqual(t, database.DocumentRemoved, clientInfo.Documents[docInfo.ID].Status)
 	})
+
+	t.Run("set updated_at in docInfo test", func(t *testing.T) {
+		ctx := context.Background()
+		docKey := helper.TestDocKey(t)
+
+		// 01. Create a client and a document then attach the document to the client.
+		clientInfo, _ := db.ActivateClient(ctx, projectID, t.Name())
+		docInfo1, _ := db.FindDocInfoByKeyAndOwner(ctx, clientInfo.RefKey(), docKey, true)
+		docRefKey := docInfo1.RefKey()
+		assert.NoError(t, clientInfo.AttachDocument(docRefKey.DocID, false))
+		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo1))
+
+		bytesID, _ := clientInfo.ID.Bytes()
+		actorID, _ := time.ActorIDFromBytes(bytesID)
+		doc := document.New(key.Key(t.Name()))
+		doc.SetActor(actorID)
+
+		// 02. update document only presence
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			p.Set("key", "val")
+			return nil
+		}))
+		pack := doc.CreateChangePack()
+		updatedAt := docInfo1.UpdatedAt
+		assert.NoError(t, db.CreateChangeInfos(ctx, projectID, docInfo1, 0, pack.Changes, false))
+		docInfo2, _ := db.FindDocInfoByKeyAndOwner(ctx, clientInfo.RefKey(), docKey, true)
+		assert.Equal(t, updatedAt, docInfo2.UpdatedAt)
+
+		// 03. update document presence and operation
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			p.Set("key", "val")
+			root.SetNewArray("array")
+			return nil
+		}))
+		pack = doc.CreateChangePack()
+		updatedAt = docInfo2.UpdatedAt
+		assert.NoError(t, db.CreateChangeInfos(ctx, projectID, docInfo2, 0, pack.Changes, false))
+		docInfo3, _ := db.FindDocInfoByKeyAndOwner(ctx, clientInfo.RefKey(), docKey, true)
+		assert.NotEqual(t, updatedAt, docInfo3.UpdatedAt)
+	})
 }
 
 // RunUpdateClientInfoAfterPushPullTest runs the UpdateClientInfoAfterPushPull tests for the given db.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The current implementation updates the 'updated_at' field of a document even if the content itself remains unchanged. This happens because changes reported by the client may contain both "presence" and "operations." With the changes introduced in this commit, the 'updated_at' timestamp will only be updated when there is more than one operation in the change list.

Initially, I attempted to address this issue by avoiding database operations when the changes were limited to presence updates. However, this approach was unsuccessful for the following reasons:

- Changes that include only presence still carry a ClientSeq. If these are not recorded, it can lead to inconsistencies between the client and the server states.

Consequently, it is necessary to store all changes in the database, even if they do not modify the core content, to maintain consistency.

In the context of applications like a whiteboard, where numerous operations can occur simply from moving a mouse pointer, this issue becomes more pronounced. Such frequent minor updates lead to a high volume of changes that primarily involve presence, inflating the ClientSeq and triggering server snapshots, which add to the server's load.

#### Proposed Solution

Initially, I considered separating presence data from document updates and managing it through an in-memory database like Redis. This would involve removing presence data from the push-pull synchronization mechanism and introducing a new API dedicated to presence management. However, this approach would require extensive modifications to the existing codebase and protocols, affecting not just the current system but other SDKs as well.

Given the complexities involved, I recommend keeping the current push-pull mechanism unchanged for stability and introducing a new API dedicated to broadcasting user presence. This strategy is ideal for applications where excessive updates are driven primarily by presence changes. Developers can shift presence management from the standard update method to this new broadcast API.

This broadcast API is specifically designed to manage presence updates independently. It broadcasts changes to all document subscribers efficiently without modifying the sequence number (ClientSeq) or permanently storing the updates. This design ensures optimal performance by minimizing unnecessary data load and sequence adjustments, making it highly suitable for managing frequent, low-impact changes.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #916

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logic for updating the `UpdatedAt` timestamp, now only updating when there are actual operations present.

- **Tests**
	- Added a new test case to verify the behavior of the `UpdatedAt` timestamp based on document updates and operations.

- **Bug Fixes**
	- Corrected the conditions under which the `UpdatedAt` field is updated, ensuring more accurate timestamp management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->