### PR TITLE
Update CHANGELOG.md for v0.4.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and Yorkie adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## [0.4.28] - 2024-07-25
+
+### Added
+
+- Enhance housekeeping to add variety of tasks by @hackerwins in https://github.com/yorkie-team/yorkie/pull/932
+- Enhance GetDocuments API by adding bulk retrieval by @kokodak in https://github.com/yorkie-team/yorkie/pull/931
+- Improve performance for creating crdt.TreeNode by @m4ushold in https://github.com/yorkie-team/yorkie/pull/939
+
+### Changed
+
+- Update `updated_at` only when there are operations in changes by @window9u in https://github.com/yorkie-team/yorkie/pull/935
+
 ## [0.4.27] - 2024-07-11
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-YORKIE_VERSION := 0.4.27
+YORKIE_VERSION := 0.4.28
 
 GO_PROJECT = github.com/yorkie-team/yorkie
 

--- a/api/docs/yorkie.base.yaml
+++ b/api/docs/yorkie.base.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Yorkie
   description: "Yorkie is an open source document store for building collaborative editing applications."
-  version: v0.4.27
+  version: v0.4.28
 servers:
   - url: https://api.yorkie.dev
     description: Production server

--- a/api/docs/yorkie/v1/admin.openapi.yaml
+++ b/api/docs/yorkie/v1/admin.openapi.yaml
@@ -1,441 +1,442 @@
 openapi: 3.1.0
 info:
-  description: Yorkie is an open source document store for building collaborative
+  description:
+    Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.4.27
+  version: v0.4.28
 servers:
-- description: Production server
-  url: https://api.yorkie.dev
-- description: Local server
-  url: http://localhost:8080
+  - description: Production server
+    url: https://api.yorkie.dev
+  - description: Local server
+    url: http://localhost:8080
 paths:
   /yorkie.v1.AdminService/CreateProject:
     post:
       description: ""
       requestBody:
-        $ref: '#/components/requestBodies/yorkie.v1.AdminService.CreateProject.yorkie.v1.CreateProjectRequest'
+        $ref: "#/components/requestBodies/yorkie.v1.AdminService.CreateProject.yorkie.v1.CreateProjectRequest"
       responses:
         "200":
-          $ref: '#/components/responses/yorkie.v1.AdminService.CreateProject.yorkie.v1.CreateProjectResponse'
+          $ref: "#/components/responses/yorkie.v1.AdminService.CreateProject.yorkie.v1.CreateProjectResponse"
         default:
-          $ref: '#/components/responses/connect.error'
+          $ref: "#/components/responses/connect.error"
       tags:
-      - yorkie.v1.AdminService
+        - yorkie.v1.AdminService
   /yorkie.v1.AdminService/GetDocument:
     post:
       description: ""
       requestBody:
-        $ref: '#/components/requestBodies/yorkie.v1.AdminService.GetDocument.yorkie.v1.GetDocumentRequest'
+        $ref: "#/components/requestBodies/yorkie.v1.AdminService.GetDocument.yorkie.v1.GetDocumentRequest"
       responses:
         "200":
-          $ref: '#/components/responses/yorkie.v1.AdminService.GetDocument.yorkie.v1.GetDocumentResponse'
+          $ref: "#/components/responses/yorkie.v1.AdminService.GetDocument.yorkie.v1.GetDocumentResponse"
         default:
-          $ref: '#/components/responses/connect.error'
+          $ref: "#/components/responses/connect.error"
       tags:
-      - yorkie.v1.AdminService
+        - yorkie.v1.AdminService
   /yorkie.v1.AdminService/GetDocuments:
     post:
       description: ""
       requestBody:
-        $ref: '#/components/requestBodies/yorkie.v1.AdminService.GetDocuments.yorkie.v1.GetDocumentsRequest'
+        $ref: "#/components/requestBodies/yorkie.v1.AdminService.GetDocuments.yorkie.v1.GetDocumentsRequest"
       responses:
         "200":
-          $ref: '#/components/responses/yorkie.v1.AdminService.GetDocuments.yorkie.v1.GetDocumentsResponse'
+          $ref: "#/components/responses/yorkie.v1.AdminService.GetDocuments.yorkie.v1.GetDocumentsResponse"
         default:
-          $ref: '#/components/responses/connect.error'
+          $ref: "#/components/responses/connect.error"
       tags:
-      - yorkie.v1.AdminService
+        - yorkie.v1.AdminService
   /yorkie.v1.AdminService/GetProject:
     post:
       description: ""
       requestBody:
-        $ref: '#/components/requestBodies/yorkie.v1.AdminService.GetProject.yorkie.v1.GetProjectRequest'
+        $ref: "#/components/requestBodies/yorkie.v1.AdminService.GetProject.yorkie.v1.GetProjectRequest"
       responses:
         "200":
-          $ref: '#/components/responses/yorkie.v1.AdminService.GetProject.yorkie.v1.GetProjectResponse'
+          $ref: "#/components/responses/yorkie.v1.AdminService.GetProject.yorkie.v1.GetProjectResponse"
         default:
-          $ref: '#/components/responses/connect.error'
+          $ref: "#/components/responses/connect.error"
       tags:
-      - yorkie.v1.AdminService
+        - yorkie.v1.AdminService
   /yorkie.v1.AdminService/GetSnapshotMeta:
     post:
       description: ""
       requestBody:
-        $ref: '#/components/requestBodies/yorkie.v1.AdminService.GetSnapshotMeta.yorkie.v1.GetSnapshotMetaRequest'
+        $ref: "#/components/requestBodies/yorkie.v1.AdminService.GetSnapshotMeta.yorkie.v1.GetSnapshotMetaRequest"
       responses:
         "200":
-          $ref: '#/components/responses/yorkie.v1.AdminService.GetSnapshotMeta.yorkie.v1.GetSnapshotMetaResponse'
+          $ref: "#/components/responses/yorkie.v1.AdminService.GetSnapshotMeta.yorkie.v1.GetSnapshotMetaResponse"
         default:
-          $ref: '#/components/responses/connect.error'
+          $ref: "#/components/responses/connect.error"
       tags:
-      - yorkie.v1.AdminService
+        - yorkie.v1.AdminService
   /yorkie.v1.AdminService/ListChanges:
     post:
       description: ""
       requestBody:
-        $ref: '#/components/requestBodies/yorkie.v1.AdminService.ListChanges.yorkie.v1.ListChangesRequest'
+        $ref: "#/components/requestBodies/yorkie.v1.AdminService.ListChanges.yorkie.v1.ListChangesRequest"
       responses:
         "200":
-          $ref: '#/components/responses/yorkie.v1.AdminService.ListChanges.yorkie.v1.ListChangesResponse'
+          $ref: "#/components/responses/yorkie.v1.AdminService.ListChanges.yorkie.v1.ListChangesResponse"
         default:
-          $ref: '#/components/responses/connect.error'
+          $ref: "#/components/responses/connect.error"
       tags:
-      - yorkie.v1.AdminService
+        - yorkie.v1.AdminService
   /yorkie.v1.AdminService/ListDocuments:
     post:
       description: ""
       requestBody:
-        $ref: '#/components/requestBodies/yorkie.v1.AdminService.ListDocuments.yorkie.v1.ListDocumentsRequest'
+        $ref: "#/components/requestBodies/yorkie.v1.AdminService.ListDocuments.yorkie.v1.ListDocumentsRequest"
       responses:
         "200":
-          $ref: '#/components/responses/yorkie.v1.AdminService.ListDocuments.yorkie.v1.ListDocumentsResponse'
+          $ref: "#/components/responses/yorkie.v1.AdminService.ListDocuments.yorkie.v1.ListDocumentsResponse"
         default:
-          $ref: '#/components/responses/connect.error'
+          $ref: "#/components/responses/connect.error"
       tags:
-      - yorkie.v1.AdminService
+        - yorkie.v1.AdminService
   /yorkie.v1.AdminService/ListProjects:
     post:
       description: ""
       requestBody:
-        $ref: '#/components/requestBodies/yorkie.v1.AdminService.ListProjects.yorkie.v1.ListProjectsRequest'
+        $ref: "#/components/requestBodies/yorkie.v1.AdminService.ListProjects.yorkie.v1.ListProjectsRequest"
       responses:
         "200":
-          $ref: '#/components/responses/yorkie.v1.AdminService.ListProjects.yorkie.v1.ListProjectsResponse'
+          $ref: "#/components/responses/yorkie.v1.AdminService.ListProjects.yorkie.v1.ListProjectsResponse"
         default:
-          $ref: '#/components/responses/connect.error'
+          $ref: "#/components/responses/connect.error"
       tags:
-      - yorkie.v1.AdminService
+        - yorkie.v1.AdminService
   /yorkie.v1.AdminService/LogIn:
     post:
       description: ""
       requestBody:
-        $ref: '#/components/requestBodies/yorkie.v1.AdminService.LogIn.yorkie.v1.LogInRequest'
+        $ref: "#/components/requestBodies/yorkie.v1.AdminService.LogIn.yorkie.v1.LogInRequest"
       responses:
         "200":
-          $ref: '#/components/responses/yorkie.v1.AdminService.LogIn.yorkie.v1.LogInResponse'
+          $ref: "#/components/responses/yorkie.v1.AdminService.LogIn.yorkie.v1.LogInResponse"
         default:
-          $ref: '#/components/responses/connect.error'
+          $ref: "#/components/responses/connect.error"
       tags:
-      - yorkie.v1.AdminService
+        - yorkie.v1.AdminService
   /yorkie.v1.AdminService/RemoveDocumentByAdmin:
     post:
       description: ""
       requestBody:
-        $ref: '#/components/requestBodies/yorkie.v1.AdminService.RemoveDocumentByAdmin.yorkie.v1.RemoveDocumentByAdminRequest'
+        $ref: "#/components/requestBodies/yorkie.v1.AdminService.RemoveDocumentByAdmin.yorkie.v1.RemoveDocumentByAdminRequest"
       responses:
         "200":
-          $ref: '#/components/responses/yorkie.v1.AdminService.RemoveDocumentByAdmin.yorkie.v1.RemoveDocumentByAdminResponse'
+          $ref: "#/components/responses/yorkie.v1.AdminService.RemoveDocumentByAdmin.yorkie.v1.RemoveDocumentByAdminResponse"
         default:
-          $ref: '#/components/responses/connect.error'
+          $ref: "#/components/responses/connect.error"
       tags:
-      - yorkie.v1.AdminService
+        - yorkie.v1.AdminService
   /yorkie.v1.AdminService/SearchDocuments:
     post:
       description: ""
       requestBody:
-        $ref: '#/components/requestBodies/yorkie.v1.AdminService.SearchDocuments.yorkie.v1.SearchDocumentsRequest'
+        $ref: "#/components/requestBodies/yorkie.v1.AdminService.SearchDocuments.yorkie.v1.SearchDocumentsRequest"
       responses:
         "200":
-          $ref: '#/components/responses/yorkie.v1.AdminService.SearchDocuments.yorkie.v1.SearchDocumentsResponse'
+          $ref: "#/components/responses/yorkie.v1.AdminService.SearchDocuments.yorkie.v1.SearchDocumentsResponse"
         default:
-          $ref: '#/components/responses/connect.error'
+          $ref: "#/components/responses/connect.error"
       tags:
-      - yorkie.v1.AdminService
+        - yorkie.v1.AdminService
   /yorkie.v1.AdminService/SignUp:
     post:
       description: ""
       requestBody:
-        $ref: '#/components/requestBodies/yorkie.v1.AdminService.SignUp.yorkie.v1.SignUpRequest'
+        $ref: "#/components/requestBodies/yorkie.v1.AdminService.SignUp.yorkie.v1.SignUpRequest"
       responses:
         "200":
-          $ref: '#/components/responses/yorkie.v1.AdminService.SignUp.yorkie.v1.SignUpResponse'
+          $ref: "#/components/responses/yorkie.v1.AdminService.SignUp.yorkie.v1.SignUpResponse"
         default:
-          $ref: '#/components/responses/connect.error'
+          $ref: "#/components/responses/connect.error"
       tags:
-      - yorkie.v1.AdminService
+        - yorkie.v1.AdminService
   /yorkie.v1.AdminService/UpdateProject:
     post:
       description: ""
       requestBody:
-        $ref: '#/components/requestBodies/yorkie.v1.AdminService.UpdateProject.yorkie.v1.UpdateProjectRequest'
+        $ref: "#/components/requestBodies/yorkie.v1.AdminService.UpdateProject.yorkie.v1.UpdateProjectRequest"
       responses:
         "200":
-          $ref: '#/components/responses/yorkie.v1.AdminService.UpdateProject.yorkie.v1.UpdateProjectResponse'
+          $ref: "#/components/responses/yorkie.v1.AdminService.UpdateProject.yorkie.v1.UpdateProjectResponse"
         default:
-          $ref: '#/components/responses/connect.error'
+          $ref: "#/components/responses/connect.error"
       tags:
-      - yorkie.v1.AdminService
+        - yorkie.v1.AdminService
 components:
   requestBodies:
     yorkie.v1.AdminService.CreateProject.yorkie.v1.CreateProjectRequest:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.CreateProjectRequest'
+            $ref: "#/components/schemas/yorkie.v1.CreateProjectRequest"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.CreateProjectRequest'
+            $ref: "#/components/schemas/yorkie.v1.CreateProjectRequest"
       required: true
     yorkie.v1.AdminService.GetDocument.yorkie.v1.GetDocumentRequest:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.GetDocumentRequest'
+            $ref: "#/components/schemas/yorkie.v1.GetDocumentRequest"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.GetDocumentRequest'
+            $ref: "#/components/schemas/yorkie.v1.GetDocumentRequest"
       required: true
     yorkie.v1.AdminService.GetDocuments.yorkie.v1.GetDocumentsRequest:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.GetDocumentsRequest'
+            $ref: "#/components/schemas/yorkie.v1.GetDocumentsRequest"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.GetDocumentsRequest'
+            $ref: "#/components/schemas/yorkie.v1.GetDocumentsRequest"
       required: true
     yorkie.v1.AdminService.GetProject.yorkie.v1.GetProjectRequest:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.GetProjectRequest'
+            $ref: "#/components/schemas/yorkie.v1.GetProjectRequest"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.GetProjectRequest'
+            $ref: "#/components/schemas/yorkie.v1.GetProjectRequest"
       required: true
     yorkie.v1.AdminService.GetSnapshotMeta.yorkie.v1.GetSnapshotMetaRequest:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.GetSnapshotMetaRequest'
+            $ref: "#/components/schemas/yorkie.v1.GetSnapshotMetaRequest"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.GetSnapshotMetaRequest'
+            $ref: "#/components/schemas/yorkie.v1.GetSnapshotMetaRequest"
       required: true
     yorkie.v1.AdminService.ListChanges.yorkie.v1.ListChangesRequest:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.ListChangesRequest'
+            $ref: "#/components/schemas/yorkie.v1.ListChangesRequest"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.ListChangesRequest'
+            $ref: "#/components/schemas/yorkie.v1.ListChangesRequest"
       required: true
     yorkie.v1.AdminService.ListDocuments.yorkie.v1.ListDocumentsRequest:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.ListDocumentsRequest'
+            $ref: "#/components/schemas/yorkie.v1.ListDocumentsRequest"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.ListDocumentsRequest'
+            $ref: "#/components/schemas/yorkie.v1.ListDocumentsRequest"
       required: true
     yorkie.v1.AdminService.ListProjects.yorkie.v1.ListProjectsRequest:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.ListProjectsRequest'
+            $ref: "#/components/schemas/yorkie.v1.ListProjectsRequest"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.ListProjectsRequest'
+            $ref: "#/components/schemas/yorkie.v1.ListProjectsRequest"
       required: true
     yorkie.v1.AdminService.LogIn.yorkie.v1.LogInRequest:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.LogInRequest'
+            $ref: "#/components/schemas/yorkie.v1.LogInRequest"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.LogInRequest'
+            $ref: "#/components/schemas/yorkie.v1.LogInRequest"
       required: true
     yorkie.v1.AdminService.RemoveDocumentByAdmin.yorkie.v1.RemoveDocumentByAdminRequest:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.RemoveDocumentByAdminRequest'
+            $ref: "#/components/schemas/yorkie.v1.RemoveDocumentByAdminRequest"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.RemoveDocumentByAdminRequest'
+            $ref: "#/components/schemas/yorkie.v1.RemoveDocumentByAdminRequest"
       required: true
     yorkie.v1.AdminService.SearchDocuments.yorkie.v1.SearchDocumentsRequest:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.SearchDocumentsRequest'
+            $ref: "#/components/schemas/yorkie.v1.SearchDocumentsRequest"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.SearchDocumentsRequest'
+            $ref: "#/components/schemas/yorkie.v1.SearchDocumentsRequest"
       required: true
     yorkie.v1.AdminService.SignUp.yorkie.v1.SignUpRequest:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.SignUpRequest'
+            $ref: "#/components/schemas/yorkie.v1.SignUpRequest"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.SignUpRequest'
+            $ref: "#/components/schemas/yorkie.v1.SignUpRequest"
       required: true
     yorkie.v1.AdminService.UpdateProject.yorkie.v1.UpdateProjectRequest:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.UpdateProjectRequest'
+            $ref: "#/components/schemas/yorkie.v1.UpdateProjectRequest"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.UpdateProjectRequest'
+            $ref: "#/components/schemas/yorkie.v1.UpdateProjectRequest"
       required: true
   responses:
     connect.error:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/connect.error'
+            $ref: "#/components/schemas/connect.error"
         application/proto:
           schema:
-            $ref: '#/components/schemas/connect.error'
+            $ref: "#/components/schemas/connect.error"
       description: ""
     yorkie.v1.AdminService.CreateProject.yorkie.v1.CreateProjectResponse:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.CreateProjectResponse'
+            $ref: "#/components/schemas/yorkie.v1.CreateProjectResponse"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.CreateProjectResponse'
+            $ref: "#/components/schemas/yorkie.v1.CreateProjectResponse"
       description: ""
     yorkie.v1.AdminService.GetDocument.yorkie.v1.GetDocumentResponse:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.GetDocumentResponse'
+            $ref: "#/components/schemas/yorkie.v1.GetDocumentResponse"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.GetDocumentResponse'
+            $ref: "#/components/schemas/yorkie.v1.GetDocumentResponse"
       description: ""
     yorkie.v1.AdminService.GetDocuments.yorkie.v1.GetDocumentsResponse:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.GetDocumentsResponse'
+            $ref: "#/components/schemas/yorkie.v1.GetDocumentsResponse"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.GetDocumentsResponse'
+            $ref: "#/components/schemas/yorkie.v1.GetDocumentsResponse"
       description: ""
     yorkie.v1.AdminService.GetProject.yorkie.v1.GetProjectResponse:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.GetProjectResponse'
+            $ref: "#/components/schemas/yorkie.v1.GetProjectResponse"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.GetProjectResponse'
+            $ref: "#/components/schemas/yorkie.v1.GetProjectResponse"
       description: ""
     yorkie.v1.AdminService.GetSnapshotMeta.yorkie.v1.GetSnapshotMetaResponse:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.GetSnapshotMetaResponse'
+            $ref: "#/components/schemas/yorkie.v1.GetSnapshotMetaResponse"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.GetSnapshotMetaResponse'
+            $ref: "#/components/schemas/yorkie.v1.GetSnapshotMetaResponse"
       description: ""
     yorkie.v1.AdminService.ListChanges.yorkie.v1.ListChangesResponse:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.ListChangesResponse'
+            $ref: "#/components/schemas/yorkie.v1.ListChangesResponse"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.ListChangesResponse'
+            $ref: "#/components/schemas/yorkie.v1.ListChangesResponse"
       description: ""
     yorkie.v1.AdminService.ListDocuments.yorkie.v1.ListDocumentsResponse:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.ListDocumentsResponse'
+            $ref: "#/components/schemas/yorkie.v1.ListDocumentsResponse"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.ListDocumentsResponse'
+            $ref: "#/components/schemas/yorkie.v1.ListDocumentsResponse"
       description: ""
     yorkie.v1.AdminService.ListProjects.yorkie.v1.ListProjectsResponse:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.ListProjectsResponse'
+            $ref: "#/components/schemas/yorkie.v1.ListProjectsResponse"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.ListProjectsResponse'
+            $ref: "#/components/schemas/yorkie.v1.ListProjectsResponse"
       description: ""
     yorkie.v1.AdminService.LogIn.yorkie.v1.LogInResponse:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.LogInResponse'
+            $ref: "#/components/schemas/yorkie.v1.LogInResponse"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.LogInResponse'
+            $ref: "#/components/schemas/yorkie.v1.LogInResponse"
       description: ""
     yorkie.v1.AdminService.RemoveDocumentByAdmin.yorkie.v1.RemoveDocumentByAdminResponse:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.RemoveDocumentByAdminResponse'
+            $ref: "#/components/schemas/yorkie.v1.RemoveDocumentByAdminResponse"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.RemoveDocumentByAdminResponse'
+            $ref: "#/components/schemas/yorkie.v1.RemoveDocumentByAdminResponse"
       description: ""
     yorkie.v1.AdminService.SearchDocuments.yorkie.v1.SearchDocumentsResponse:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.SearchDocumentsResponse'
+            $ref: "#/components/schemas/yorkie.v1.SearchDocumentsResponse"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.SearchDocumentsResponse'
+            $ref: "#/components/schemas/yorkie.v1.SearchDocumentsResponse"
       description: ""
     yorkie.v1.AdminService.SignUp.yorkie.v1.SignUpResponse:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.SignUpResponse'
+            $ref: "#/components/schemas/yorkie.v1.SignUpResponse"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.SignUpResponse'
+            $ref: "#/components/schemas/yorkie.v1.SignUpResponse"
       description: ""
     yorkie.v1.AdminService.UpdateProject.yorkie.v1.UpdateProjectResponse:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.UpdateProjectResponse'
+            $ref: "#/components/schemas/yorkie.v1.UpdateProjectResponse"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.UpdateProjectResponse'
+            $ref: "#/components/schemas/yorkie.v1.UpdateProjectResponse"
       description: ""
   schemas:
     connect.error:
       additionalProperties: false
-      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
+      description: "Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation"
       properties:
         code:
           enum:
-          - CodeCanceled
-          - CodeUnknown
-          - CodeInvalidArgument
-          - CodeDeadlineExceeded
-          - CodeNotFound
-          - CodeAlreadyExists
-          - CodePermissionDenied
-          - CodeResourceExhausted
-          - CodeFailedPrecondition
-          - CodeAborted
-          - CodeOutOfRange
-          - CodeInternal
-          - CodeUnavailable
-          - CodeDataLoss
-          - CodeUnauthenticated
+            - CodeCanceled
+            - CodeUnknown
+            - CodeInvalidArgument
+            - CodeDeadlineExceeded
+            - CodeNotFound
+            - CodeAlreadyExists
+            - CodePermissionDenied
+            - CodeResourceExhausted
+            - CodeFailedPrecondition
+            - CodeAborted
+            - CodeOutOfRange
+            - CodeInternal
+            - CodeUnavailable
+            - CodeDataLoss
+            - CodeUnauthenticated
           examples:
-          - CodeNotFound
+            - CodeNotFound
           type: string
         message:
           type: string
@@ -554,7 +555,7 @@ components:
       description: ""
       properties:
         id:
-          $ref: '#/components/schemas/yorkie.v1.ChangeID'
+          $ref: "#/components/schemas/yorkie.v1.ChangeID"
           additionalProperties: false
           description: ""
           title: id
@@ -568,12 +569,12 @@ components:
           additionalProperties: false
           description: ""
           items:
-            $ref: '#/components/schemas/yorkie.v1.Operation'
+            $ref: "#/components/schemas/yorkie.v1.Operation"
             type: object
           title: operations
           type: array
         presenceChange:
-          $ref: '#/components/schemas/yorkie.v1.PresenceChange'
+          $ref: "#/components/schemas/yorkie.v1.PresenceChange"
           additionalProperties: false
           description: ""
           title: presence_change
@@ -599,15 +600,15 @@ components:
           additionalProperties: false
           description: ""
           oneOf:
-          - type: string
-          - type: number
+            - type: string
+            - type: number
           title: lamport
         serverSeq:
           additionalProperties: false
           description: ""
           oneOf:
-          - type: string
-          - type: number
+            - type: string
+            - type: number
           title: server_seq
       title: ChangeID
       type: object
@@ -627,7 +628,7 @@ components:
       description: ""
       properties:
         project:
-          $ref: '#/components/schemas/yorkie.v1.Project'
+          $ref: "#/components/schemas/yorkie.v1.Project"
           additionalProperties: false
           description: ""
           title: project
@@ -639,13 +640,13 @@ components:
       description: ""
       properties:
         accessedAt:
-          $ref: '#/components/schemas/google.protobuf.Timestamp'
+          $ref: "#/components/schemas/google.protobuf.Timestamp"
           additionalProperties: false
           description: ""
           title: accessed_at
           type: object
         createdAt:
-          $ref: '#/components/schemas/google.protobuf.Timestamp'
+          $ref: "#/components/schemas/google.protobuf.Timestamp"
           additionalProperties: false
           description: ""
           title: created_at
@@ -666,7 +667,7 @@ components:
           title: snapshot
           type: string
         updatedAt:
-          $ref: '#/components/schemas/google.protobuf.Timestamp'
+          $ref: "#/components/schemas/google.protobuf.Timestamp"
           additionalProperties: false
           description: ""
           title: updated_at
@@ -694,7 +695,7 @@ components:
       description: ""
       properties:
         document:
-          $ref: '#/components/schemas/yorkie.v1.DocumentSummary'
+          $ref: "#/components/schemas/yorkie.v1.DocumentSummary"
           additionalProperties: false
           description: ""
           title: document
@@ -732,7 +733,7 @@ components:
           additionalProperties: false
           description: ""
           items:
-            $ref: '#/components/schemas/yorkie.v1.DocumentSummary'
+            $ref: "#/components/schemas/yorkie.v1.DocumentSummary"
             type: object
           title: documents
           type: array
@@ -754,7 +755,7 @@ components:
       description: ""
       properties:
         project:
-          $ref: '#/components/schemas/yorkie.v1.Project'
+          $ref: "#/components/schemas/yorkie.v1.Project"
           additionalProperties: false
           description: ""
           title: project
@@ -779,8 +780,8 @@ components:
           additionalProperties: false
           description: ""
           oneOf:
-          - type: string
-          - type: number
+            - type: string
+            - type: number
           title: server_seq
       title: GetSnapshotMetaRequest
       type: object
@@ -792,8 +793,8 @@ components:
           additionalProperties: false
           description: ""
           oneOf:
-          - type: string
-          - type: number
+            - type: string
+            - type: number
           title: lamport
         snapshot:
           additionalProperties: false
@@ -808,25 +809,25 @@ components:
       description: ""
       properties:
         createdAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: created_at
           type: object
         movedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: moved_at
           type: object
         removedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: removed_at
           type: object
         type:
-          $ref: '#/components/schemas/yorkie.v1.ValueType'
+          $ref: "#/components/schemas/yorkie.v1.ValueType"
           additionalProperties: false
           description: ""
           title: type
@@ -861,8 +862,8 @@ components:
           additionalProperties: false
           description: ""
           oneOf:
-          - type: string
-          - type: number
+            - type: string
+            - type: number
           title: previous_seq
         projectName:
           additionalProperties: false
@@ -879,7 +880,7 @@ components:
           additionalProperties: false
           description: ""
           items:
-            $ref: '#/components/schemas/yorkie.v1.Change'
+            $ref: "#/components/schemas/yorkie.v1.Change"
             type: object
           title: changes
           type: array
@@ -924,7 +925,7 @@ components:
           additionalProperties: false
           description: ""
           items:
-            $ref: '#/components/schemas/yorkie.v1.DocumentSummary'
+            $ref: "#/components/schemas/yorkie.v1.DocumentSummary"
             type: object
           title: documents
           type: array
@@ -943,7 +944,7 @@ components:
           additionalProperties: false
           description: ""
           items:
-            $ref: '#/components/schemas/yorkie.v1.Project'
+            $ref: "#/components/schemas/yorkie.v1.Project"
             type: object
           title: projects
           type: array
@@ -986,7 +987,7 @@ components:
           title: is_removed
           type: boolean
         updatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: updated_at
@@ -1003,61 +1004,61 @@ components:
       description: ""
       properties:
         add:
-          $ref: '#/components/schemas/yorkie.v1.Operation.Add'
+          $ref: "#/components/schemas/yorkie.v1.Operation.Add"
           additionalProperties: false
           description: ""
           title: add
           type: object
         edit:
-          $ref: '#/components/schemas/yorkie.v1.Operation.Edit'
+          $ref: "#/components/schemas/yorkie.v1.Operation.Edit"
           additionalProperties: false
           description: ""
           title: edit
           type: object
         increase:
-          $ref: '#/components/schemas/yorkie.v1.Operation.Increase'
+          $ref: "#/components/schemas/yorkie.v1.Operation.Increase"
           additionalProperties: false
           description: ""
           title: increase
           type: object
         move:
-          $ref: '#/components/schemas/yorkie.v1.Operation.Move'
+          $ref: "#/components/schemas/yorkie.v1.Operation.Move"
           additionalProperties: false
           description: ""
           title: move
           type: object
         remove:
-          $ref: '#/components/schemas/yorkie.v1.Operation.Remove'
+          $ref: "#/components/schemas/yorkie.v1.Operation.Remove"
           additionalProperties: false
           description: ""
           title: remove
           type: object
         select:
-          $ref: '#/components/schemas/yorkie.v1.Operation.Select'
+          $ref: "#/components/schemas/yorkie.v1.Operation.Select"
           additionalProperties: false
           description: ""
           title: select
           type: object
         set:
-          $ref: '#/components/schemas/yorkie.v1.Operation.Set'
+          $ref: "#/components/schemas/yorkie.v1.Operation.Set"
           additionalProperties: false
           description: ""
           title: set
           type: object
         style:
-          $ref: '#/components/schemas/yorkie.v1.Operation.Style'
+          $ref: "#/components/schemas/yorkie.v1.Operation.Style"
           additionalProperties: false
           description: ""
           title: style
           type: object
         treeEdit:
-          $ref: '#/components/schemas/yorkie.v1.Operation.TreeEdit'
+          $ref: "#/components/schemas/yorkie.v1.Operation.TreeEdit"
           additionalProperties: false
           description: ""
           title: tree_edit
           type: object
         treeStyle:
-          $ref: '#/components/schemas/yorkie.v1.Operation.TreeStyle'
+          $ref: "#/components/schemas/yorkie.v1.Operation.TreeStyle"
           additionalProperties: false
           description: ""
           title: tree_style
@@ -1069,25 +1070,25 @@ components:
       description: ""
       properties:
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
           type: object
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
           type: object
         prevCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: prev_created_at
           type: object
         value:
-          $ref: '#/components/schemas/yorkie.v1.JSONElementSimple'
+          $ref: "#/components/schemas/yorkie.v1.JSONElementSimple"
           additionalProperties: false
           description: ""
           title: value
@@ -1114,25 +1115,25 @@ components:
           title: created_at_map_by_actor
           type: object
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
           type: object
         from:
-          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          $ref: "#/components/schemas/yorkie.v1.TextNodePos"
           additionalProperties: false
           description: ""
           title: from
           type: object
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
           type: object
         to:
-          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          $ref: "#/components/schemas/yorkie.v1.TextNodePos"
           additionalProperties: false
           description: ""
           title: to
@@ -1165,7 +1166,7 @@ components:
           title: key
           type: string
         value:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: value
@@ -1177,19 +1178,19 @@ components:
       description: ""
       properties:
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
           type: object
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
           type: object
         value:
-          $ref: '#/components/schemas/yorkie.v1.JSONElementSimple'
+          $ref: "#/components/schemas/yorkie.v1.JSONElementSimple"
           additionalProperties: false
           description: ""
           title: value
@@ -1201,25 +1202,25 @@ components:
       description: ""
       properties:
         createdAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: created_at
           type: object
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
           type: object
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
           type: object
         prevCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: prev_created_at
@@ -1231,19 +1232,19 @@ components:
       description: ""
       properties:
         createdAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: created_at
           type: object
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
           type: object
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
@@ -1259,25 +1260,25 @@ components:
          compatibility purposes.
       properties:
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
           type: object
         from:
-          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          $ref: "#/components/schemas/yorkie.v1.TextNodePos"
           additionalProperties: false
           description: ""
           title: from
           type: object
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
           type: object
         to:
-          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          $ref: "#/components/schemas/yorkie.v1.TextNodePos"
           additionalProperties: false
           description: ""
           title: to
@@ -1289,7 +1290,7 @@ components:
       description: ""
       properties:
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
@@ -1300,13 +1301,13 @@ components:
           title: key
           type: string
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
           type: object
         value:
-          $ref: '#/components/schemas/yorkie.v1.JSONElementSimple'
+          $ref: "#/components/schemas/yorkie.v1.JSONElementSimple"
           additionalProperties: false
           description: ""
           title: value
@@ -1328,25 +1329,25 @@ components:
           title: created_at_map_by_actor
           type: object
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
           type: object
         from:
-          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          $ref: "#/components/schemas/yorkie.v1.TextNodePos"
           additionalProperties: false
           description: ""
           title: from
           type: object
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
           type: object
         to:
-          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          $ref: "#/components/schemas/yorkie.v1.TextNodePos"
           additionalProperties: false
           description: ""
           title: to
@@ -1379,7 +1380,7 @@ components:
           title: key
           type: string
         value:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: value
@@ -1394,7 +1395,7 @@ components:
           additionalProperties: false
           description: ""
           items:
-            $ref: '#/components/schemas/yorkie.v1.TreeNodes'
+            $ref: "#/components/schemas/yorkie.v1.TreeNodes"
             type: object
           title: contents
           type: array
@@ -1404,19 +1405,19 @@ components:
           title: created_at_map_by_actor
           type: object
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
           type: object
         from:
-          $ref: '#/components/schemas/yorkie.v1.TreePos'
+          $ref: "#/components/schemas/yorkie.v1.TreePos"
           additionalProperties: false
           description: ""
           title: from
           type: object
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
@@ -1427,7 +1428,7 @@ components:
           title: split_level
           type: integer
         to:
-          $ref: '#/components/schemas/yorkie.v1.TreePos'
+          $ref: "#/components/schemas/yorkie.v1.TreePos"
           additionalProperties: false
           description: ""
           title: to
@@ -1444,7 +1445,7 @@ components:
           title: key
           type: string
         value:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: value
@@ -1473,25 +1474,25 @@ components:
           title: created_at_map_by_actor
           type: object
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
           type: object
         from:
-          $ref: '#/components/schemas/yorkie.v1.TreePos'
+          $ref: "#/components/schemas/yorkie.v1.TreePos"
           additionalProperties: false
           description: ""
           title: from
           type: object
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
           type: object
         to:
-          $ref: '#/components/schemas/yorkie.v1.TreePos'
+          $ref: "#/components/schemas/yorkie.v1.TreePos"
           additionalProperties: false
           description: ""
           title: to
@@ -1524,7 +1525,7 @@ components:
           title: key
           type: string
         value:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: value
@@ -1563,13 +1564,13 @@ components:
       description: ""
       properties:
         presence:
-          $ref: '#/components/schemas/yorkie.v1.Presence'
+          $ref: "#/components/schemas/yorkie.v1.Presence"
           additionalProperties: false
           description: ""
           title: presence
           type: object
         type:
-          $ref: '#/components/schemas/yorkie.v1.PresenceChange.ChangeType'
+          $ref: "#/components/schemas/yorkie.v1.PresenceChange.ChangeType"
           additionalProperties: false
           description: ""
           title: type
@@ -1578,14 +1579,14 @@ components:
     yorkie.v1.PresenceChange.ChangeType:
       description: ""
       enum:
-      - - CHANGE_TYPE_UNSPECIFIED
-        - 0
-        - CHANGE_TYPE_PUT
-        - 1
-        - CHANGE_TYPE_DELETE
-        - 2
-        - CHANGE_TYPE_CLEAR
-        - 3
+        - - CHANGE_TYPE_UNSPECIFIED
+          - 0
+          - CHANGE_TYPE_PUT
+          - 1
+          - CHANGE_TYPE_DELETE
+          - 2
+          - CHANGE_TYPE_CLEAR
+          - 3
       title: ChangeType
       type: string
     yorkie.v1.Project:
@@ -1610,7 +1611,7 @@ components:
           title: client_deactivate_threshold
           type: string
         createdAt:
-          $ref: '#/components/schemas/google.protobuf.Timestamp'
+          $ref: "#/components/schemas/google.protobuf.Timestamp"
           additionalProperties: false
           description: ""
           title: created_at
@@ -1636,7 +1637,7 @@ components:
           title: secret_key
           type: string
         updatedAt:
-          $ref: '#/components/schemas/google.protobuf.Timestamp'
+          $ref: "#/components/schemas/google.protobuf.Timestamp"
           additionalProperties: false
           description: ""
           title: updated_at
@@ -1698,7 +1699,7 @@ components:
           additionalProperties: false
           description: ""
           items:
-            $ref: '#/components/schemas/yorkie.v1.DocumentSummary'
+            $ref: "#/components/schemas/yorkie.v1.DocumentSummary"
             type: object
           title: documents
           type: array
@@ -1730,7 +1731,7 @@ components:
       description: ""
       properties:
         user:
-          $ref: '#/components/schemas/yorkie.v1.User'
+          $ref: "#/components/schemas/yorkie.v1.User"
           additionalProperties: false
           description: ""
           title: user
@@ -1742,7 +1743,7 @@ components:
       description: ""
       properties:
         createdAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: created_at
@@ -1778,8 +1779,8 @@ components:
           additionalProperties: false
           description: ""
           oneOf:
-          - type: string
-          - type: number
+            - type: string
+            - type: number
           title: lamport
       title: TimeTicket
       type: object
@@ -1798,25 +1799,25 @@ components:
           title: depth
           type: integer
         id:
-          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          $ref: "#/components/schemas/yorkie.v1.TreeNodeID"
           additionalProperties: false
           description: ""
           title: id
           type: object
         insNextId:
-          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          $ref: "#/components/schemas/yorkie.v1.TreeNodeID"
           additionalProperties: false
           description: ""
           title: ins_next_id
           type: object
         insPrevId:
-          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          $ref: "#/components/schemas/yorkie.v1.TreeNodeID"
           additionalProperties: false
           description: ""
           title: ins_prev_id
           type: object
         removedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: removed_at
@@ -1843,7 +1844,7 @@ components:
           title: key
           type: string
         value:
-          $ref: '#/components/schemas/yorkie.v1.NodeAttr'
+          $ref: "#/components/schemas/yorkie.v1.NodeAttr"
           additionalProperties: false
           description: ""
           title: value
@@ -1855,7 +1856,7 @@ components:
       description: ""
       properties:
         createdAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: created_at
@@ -1875,7 +1876,7 @@ components:
           additionalProperties: false
           description: ""
           items:
-            $ref: '#/components/schemas/yorkie.v1.TreeNode'
+            $ref: "#/components/schemas/yorkie.v1.TreeNode"
             type: object
           title: content
           type: array
@@ -1886,13 +1887,13 @@ components:
       description: ""
       properties:
         leftSiblingId:
-          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          $ref: "#/components/schemas/yorkie.v1.TreeNodeID"
           additionalProperties: false
           description: ""
           title: left_sibling_id
           type: object
         parentId:
-          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          $ref: "#/components/schemas/yorkie.v1.TreeNodeID"
           additionalProperties: false
           description: ""
           title: parent_id
@@ -1904,25 +1905,25 @@ components:
       description: ""
       properties:
         authWebhookMethods:
-          $ref: '#/components/schemas/yorkie.v1.UpdatableProjectFields.AuthWebhookMethods'
+          $ref: "#/components/schemas/yorkie.v1.UpdatableProjectFields.AuthWebhookMethods"
           additionalProperties: false
           description: ""
           title: auth_webhook_methods
           type: object
         authWebhookUrl:
-          $ref: '#/components/schemas/google.protobuf.StringValue'
+          $ref: "#/components/schemas/google.protobuf.StringValue"
           additionalProperties: false
           description: ""
           title: auth_webhook_url
           type: object
         clientDeactivateThreshold:
-          $ref: '#/components/schemas/google.protobuf.StringValue'
+          $ref: "#/components/schemas/google.protobuf.StringValue"
           additionalProperties: false
           description: ""
           title: client_deactivate_threshold
           type: object
         name:
-          $ref: '#/components/schemas/google.protobuf.StringValue'
+          $ref: "#/components/schemas/google.protobuf.StringValue"
           additionalProperties: false
           description: ""
           title: name
@@ -1947,7 +1948,7 @@ components:
       description: ""
       properties:
         fields:
-          $ref: '#/components/schemas/yorkie.v1.UpdatableProjectFields'
+          $ref: "#/components/schemas/yorkie.v1.UpdatableProjectFields"
           additionalProperties: false
           description: ""
           title: fields
@@ -1964,7 +1965,7 @@ components:
       description: ""
       properties:
         project:
-          $ref: '#/components/schemas/yorkie.v1.Project'
+          $ref: "#/components/schemas/yorkie.v1.Project"
           additionalProperties: false
           description: ""
           title: project
@@ -1976,7 +1977,7 @@ components:
       description: ""
       properties:
         createdAt:
-          $ref: '#/components/schemas/google.protobuf.Timestamp'
+          $ref: "#/components/schemas/google.protobuf.Timestamp"
           additionalProperties: false
           description: ""
           title: created_at
@@ -1996,34 +1997,34 @@ components:
     yorkie.v1.ValueType:
       description: ""
       enum:
-      - - VALUE_TYPE_NULL
-        - 0
-        - VALUE_TYPE_BOOLEAN
-        - 1
-        - VALUE_TYPE_INTEGER
-        - 2
-        - VALUE_TYPE_LONG
-        - 3
-        - VALUE_TYPE_DOUBLE
-        - 4
-        - VALUE_TYPE_STRING
-        - 5
-        - VALUE_TYPE_BYTES
-        - 6
-        - VALUE_TYPE_DATE
-        - 7
-        - VALUE_TYPE_JSON_OBJECT
-        - 8
-        - VALUE_TYPE_JSON_ARRAY
-        - 9
-        - VALUE_TYPE_TEXT
-        - 10
-        - VALUE_TYPE_INTEGER_CNT
-        - 11
-        - VALUE_TYPE_LONG_CNT
-        - 12
-        - VALUE_TYPE_TREE
-        - 13
+        - - VALUE_TYPE_NULL
+          - 0
+          - VALUE_TYPE_BOOLEAN
+          - 1
+          - VALUE_TYPE_INTEGER
+          - 2
+          - VALUE_TYPE_LONG
+          - 3
+          - VALUE_TYPE_DOUBLE
+          - 4
+          - VALUE_TYPE_STRING
+          - 5
+          - VALUE_TYPE_BYTES
+          - 6
+          - VALUE_TYPE_DATE
+          - 7
+          - VALUE_TYPE_JSON_OBJECT
+          - 8
+          - VALUE_TYPE_JSON_ARRAY
+          - 9
+          - VALUE_TYPE_TEXT
+          - 10
+          - VALUE_TYPE_INTEGER_CNT
+          - 11
+          - VALUE_TYPE_LONG_CNT
+          - 12
+          - VALUE_TYPE_TREE
+          - 13
       title: ValueType
       type: string
   securitySchemes:
@@ -2032,7 +2033,7 @@ components:
       name: Authorization
       type: apiKey
 security:
-- ApiKeyAuth: []
+  - ApiKeyAuth: []
 tags:
-- description: Admin is a service that provides a API for Admin.
-  name: yorkie.v1.AdminService
+  - description: Admin is a service that provides a API for Admin.
+    name: yorkie.v1.AdminService

--- a/api/docs/yorkie/v1/resources.openapi.yaml
+++ b/api/docs/yorkie/v1/resources.openapi.yaml
@@ -1,14 +1,15 @@
 openapi: 3.1.0
 info:
-  description: Yorkie is an open source document store for building collaborative
+  description:
+    Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.4.27
+  version: v0.4.28
 servers:
-- description: Production server
-  url: https://api.yorkie.dev
-- description: Local server
-  url: http://localhost:8080
+  - description: Production server
+    url: https://api.yorkie.dev
+  - description: Local server
+    url: http://localhost:8080
 paths: {}
 components:
   responses:
@@ -16,35 +17,35 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/connect.error'
+            $ref: "#/components/schemas/connect.error"
         application/proto:
           schema:
-            $ref: '#/components/schemas/connect.error'
+            $ref: "#/components/schemas/connect.error"
       description: ""
   schemas:
     connect.error:
       additionalProperties: false
-      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
+      description: "Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation"
       properties:
         code:
           enum:
-          - CodeCanceled
-          - CodeUnknown
-          - CodeInvalidArgument
-          - CodeDeadlineExceeded
-          - CodeNotFound
-          - CodeAlreadyExists
-          - CodePermissionDenied
-          - CodeResourceExhausted
-          - CodeFailedPrecondition
-          - CodeAborted
-          - CodeOutOfRange
-          - CodeInternal
-          - CodeUnavailable
-          - CodeDataLoss
-          - CodeUnauthenticated
+            - CodeCanceled
+            - CodeUnknown
+            - CodeInvalidArgument
+            - CodeDeadlineExceeded
+            - CodeNotFound
+            - CodeAlreadyExists
+            - CodePermissionDenied
+            - CodeResourceExhausted
+            - CodeFailedPrecondition
+            - CodeAborted
+            - CodeOutOfRange
+            - CodeInternal
+            - CodeUnavailable
+            - CodeDataLoss
+            - CodeUnauthenticated
           examples:
-          - CodeNotFound
+            - CodeNotFound
           type: string
         message:
           type: string
@@ -163,7 +164,7 @@ components:
       description: ""
       properties:
         id:
-          $ref: '#/components/schemas/yorkie.v1.ChangeID'
+          $ref: "#/components/schemas/yorkie.v1.ChangeID"
           additionalProperties: false
           description: ""
           title: id
@@ -177,12 +178,12 @@ components:
           additionalProperties: false
           description: ""
           items:
-            $ref: '#/components/schemas/yorkie.v1.Operation'
+            $ref: "#/components/schemas/yorkie.v1.Operation"
             type: object
           title: operations
           type: array
         presenceChange:
-          $ref: '#/components/schemas/yorkie.v1.PresenceChange'
+          $ref: "#/components/schemas/yorkie.v1.PresenceChange"
           additionalProperties: false
           description: ""
           title: presence_change
@@ -208,15 +209,15 @@ components:
           additionalProperties: false
           description: ""
           oneOf:
-          - type: string
-          - type: number
+            - type: string
+            - type: number
           title: lamport
         serverSeq:
           additionalProperties: false
           description: ""
           oneOf:
-          - type: string
-          - type: number
+            - type: string
+            - type: number
           title: server_seq
       title: ChangeID
       type: object
@@ -230,12 +231,12 @@ components:
           additionalProperties: false
           description: ""
           items:
-            $ref: '#/components/schemas/yorkie.v1.Change'
+            $ref: "#/components/schemas/yorkie.v1.Change"
             type: object
           title: changes
           type: array
         checkpoint:
-          $ref: '#/components/schemas/yorkie.v1.Checkpoint'
+          $ref: "#/components/schemas/yorkie.v1.Checkpoint"
           additionalProperties: false
           description: ""
           title: checkpoint
@@ -251,7 +252,7 @@ components:
           title: is_removed
           type: boolean
         minSyncedTicket:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: min_synced_ticket
@@ -277,8 +278,8 @@ components:
           additionalProperties: false
           description: ""
           oneOf:
-          - type: string
-          - type: number
+            - type: string
+            - type: number
           title: server_seq
       title: Checkpoint
       type: object
@@ -287,7 +288,7 @@ components:
       description: ""
       properties:
         body:
-          $ref: '#/components/schemas/yorkie.v1.DocEventBody'
+          $ref: "#/components/schemas/yorkie.v1.DocEventBody"
           additionalProperties: false
           description: ""
           title: body
@@ -298,7 +299,7 @@ components:
           title: publisher
           type: string
         type:
-          $ref: '#/components/schemas/yorkie.v1.DocEventType'
+          $ref: "#/components/schemas/yorkie.v1.DocEventType"
           additionalProperties: false
           description: ""
           title: type
@@ -324,14 +325,14 @@ components:
     yorkie.v1.DocEventType:
       description: ""
       enum:
-      - - DOC_EVENT_TYPE_DOCUMENT_CHANGED
-        - 0
-        - DOC_EVENT_TYPE_DOCUMENT_WATCHED
-        - 1
-        - DOC_EVENT_TYPE_DOCUMENT_UNWATCHED
-        - 2
-        - DOC_EVENT_TYPE_DOCUMENT_BROADCAST
-        - 3
+        - - DOC_EVENT_TYPE_DOCUMENT_CHANGED
+          - 0
+          - DOC_EVENT_TYPE_DOCUMENT_WATCHED
+          - 1
+          - DOC_EVENT_TYPE_DOCUMENT_UNWATCHED
+          - 2
+          - DOC_EVENT_TYPE_DOCUMENT_BROADCAST
+          - 3
       title: DocEventType
       type: string
     yorkie.v1.DocumentSummary:
@@ -339,13 +340,13 @@ components:
       description: ""
       properties:
         accessedAt:
-          $ref: '#/components/schemas/google.protobuf.Timestamp'
+          $ref: "#/components/schemas/google.protobuf.Timestamp"
           additionalProperties: false
           description: ""
           title: accessed_at
           type: object
         createdAt:
-          $ref: '#/components/schemas/google.protobuf.Timestamp'
+          $ref: "#/components/schemas/google.protobuf.Timestamp"
           additionalProperties: false
           description: ""
           title: created_at
@@ -366,7 +367,7 @@ components:
           title: snapshot
           type: string
         updatedAt:
-          $ref: '#/components/schemas/google.protobuf.Timestamp'
+          $ref: "#/components/schemas/google.protobuf.Timestamp"
           additionalProperties: false
           description: ""
           title: updated_at
@@ -378,37 +379,37 @@ components:
       description: ""
       properties:
         counter:
-          $ref: '#/components/schemas/yorkie.v1.JSONElement.Counter'
+          $ref: "#/components/schemas/yorkie.v1.JSONElement.Counter"
           additionalProperties: false
           description: ""
           title: counter
           type: object
         jsonArray:
-          $ref: '#/components/schemas/yorkie.v1.JSONElement.JSONArray'
+          $ref: "#/components/schemas/yorkie.v1.JSONElement.JSONArray"
           additionalProperties: false
           description: ""
           title: json_array
           type: object
         jsonObject:
-          $ref: '#/components/schemas/yorkie.v1.JSONElement.JSONObject'
+          $ref: "#/components/schemas/yorkie.v1.JSONElement.JSONObject"
           additionalProperties: false
           description: ""
           title: json_object
           type: object
         primitive:
-          $ref: '#/components/schemas/yorkie.v1.JSONElement.Primitive'
+          $ref: "#/components/schemas/yorkie.v1.JSONElement.Primitive"
           additionalProperties: false
           description: ""
           title: primitive
           type: object
         text:
-          $ref: '#/components/schemas/yorkie.v1.JSONElement.Text'
+          $ref: "#/components/schemas/yorkie.v1.JSONElement.Text"
           additionalProperties: false
           description: ""
           title: text
           type: object
         tree:
-          $ref: '#/components/schemas/yorkie.v1.JSONElement.Tree'
+          $ref: "#/components/schemas/yorkie.v1.JSONElement.Tree"
           additionalProperties: false
           description: ""
           title: tree
@@ -420,25 +421,25 @@ components:
       description: ""
       properties:
         createdAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: created_at
           type: object
         movedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: moved_at
           type: object
         removedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: removed_at
           type: object
         type:
-          $ref: '#/components/schemas/yorkie.v1.ValueType'
+          $ref: "#/components/schemas/yorkie.v1.ValueType"
           additionalProperties: false
           description: ""
           title: type
@@ -455,13 +456,13 @@ components:
       description: ""
       properties:
         createdAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: created_at
           type: object
         movedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: moved_at
@@ -470,12 +471,12 @@ components:
           additionalProperties: false
           description: ""
           items:
-            $ref: '#/components/schemas/yorkie.v1.RGANode'
+            $ref: "#/components/schemas/yorkie.v1.RGANode"
             type: object
           title: nodes
           type: array
         removedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: removed_at
@@ -487,13 +488,13 @@ components:
       description: ""
       properties:
         createdAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: created_at
           type: object
         movedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: moved_at
@@ -502,12 +503,12 @@ components:
           additionalProperties: false
           description: ""
           items:
-            $ref: '#/components/schemas/yorkie.v1.RHTNode'
+            $ref: "#/components/schemas/yorkie.v1.RHTNode"
             type: object
           title: nodes
           type: array
         removedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: removed_at
@@ -519,25 +520,25 @@ components:
       description: ""
       properties:
         createdAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: created_at
           type: object
         movedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: moved_at
           type: object
         removedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: removed_at
           type: object
         type:
-          $ref: '#/components/schemas/yorkie.v1.ValueType'
+          $ref: "#/components/schemas/yorkie.v1.ValueType"
           additionalProperties: false
           description: ""
           title: type
@@ -554,13 +555,13 @@ components:
       description: ""
       properties:
         createdAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: created_at
           type: object
         movedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: moved_at
@@ -569,12 +570,12 @@ components:
           additionalProperties: false
           description: ""
           items:
-            $ref: '#/components/schemas/yorkie.v1.TextNode'
+            $ref: "#/components/schemas/yorkie.v1.TextNode"
             type: object
           title: nodes
           type: array
         removedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: removed_at
@@ -586,13 +587,13 @@ components:
       description: ""
       properties:
         createdAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: created_at
           type: object
         movedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: moved_at
@@ -601,12 +602,12 @@ components:
           additionalProperties: false
           description: ""
           items:
-            $ref: '#/components/schemas/yorkie.v1.TreeNode'
+            $ref: "#/components/schemas/yorkie.v1.TreeNode"
             type: object
           title: nodes
           type: array
         removedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: removed_at
@@ -618,25 +619,25 @@ components:
       description: ""
       properties:
         createdAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: created_at
           type: object
         movedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: moved_at
           type: object
         removedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: removed_at
           type: object
         type:
-          $ref: '#/components/schemas/yorkie.v1.ValueType'
+          $ref: "#/components/schemas/yorkie.v1.ValueType"
           additionalProperties: false
           description: ""
           title: type
@@ -658,7 +659,7 @@ components:
           title: is_removed
           type: boolean
         updatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: updated_at
@@ -675,61 +676,61 @@ components:
       description: ""
       properties:
         add:
-          $ref: '#/components/schemas/yorkie.v1.Operation.Add'
+          $ref: "#/components/schemas/yorkie.v1.Operation.Add"
           additionalProperties: false
           description: ""
           title: add
           type: object
         edit:
-          $ref: '#/components/schemas/yorkie.v1.Operation.Edit'
+          $ref: "#/components/schemas/yorkie.v1.Operation.Edit"
           additionalProperties: false
           description: ""
           title: edit
           type: object
         increase:
-          $ref: '#/components/schemas/yorkie.v1.Operation.Increase'
+          $ref: "#/components/schemas/yorkie.v1.Operation.Increase"
           additionalProperties: false
           description: ""
           title: increase
           type: object
         move:
-          $ref: '#/components/schemas/yorkie.v1.Operation.Move'
+          $ref: "#/components/schemas/yorkie.v1.Operation.Move"
           additionalProperties: false
           description: ""
           title: move
           type: object
         remove:
-          $ref: '#/components/schemas/yorkie.v1.Operation.Remove'
+          $ref: "#/components/schemas/yorkie.v1.Operation.Remove"
           additionalProperties: false
           description: ""
           title: remove
           type: object
         select:
-          $ref: '#/components/schemas/yorkie.v1.Operation.Select'
+          $ref: "#/components/schemas/yorkie.v1.Operation.Select"
           additionalProperties: false
           description: ""
           title: select
           type: object
         set:
-          $ref: '#/components/schemas/yorkie.v1.Operation.Set'
+          $ref: "#/components/schemas/yorkie.v1.Operation.Set"
           additionalProperties: false
           description: ""
           title: set
           type: object
         style:
-          $ref: '#/components/schemas/yorkie.v1.Operation.Style'
+          $ref: "#/components/schemas/yorkie.v1.Operation.Style"
           additionalProperties: false
           description: ""
           title: style
           type: object
         treeEdit:
-          $ref: '#/components/schemas/yorkie.v1.Operation.TreeEdit'
+          $ref: "#/components/schemas/yorkie.v1.Operation.TreeEdit"
           additionalProperties: false
           description: ""
           title: tree_edit
           type: object
         treeStyle:
-          $ref: '#/components/schemas/yorkie.v1.Operation.TreeStyle'
+          $ref: "#/components/schemas/yorkie.v1.Operation.TreeStyle"
           additionalProperties: false
           description: ""
           title: tree_style
@@ -741,25 +742,25 @@ components:
       description: ""
       properties:
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
           type: object
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
           type: object
         prevCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: prev_created_at
           type: object
         value:
-          $ref: '#/components/schemas/yorkie.v1.JSONElementSimple'
+          $ref: "#/components/schemas/yorkie.v1.JSONElementSimple"
           additionalProperties: false
           description: ""
           title: value
@@ -786,25 +787,25 @@ components:
           title: created_at_map_by_actor
           type: object
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
           type: object
         from:
-          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          $ref: "#/components/schemas/yorkie.v1.TextNodePos"
           additionalProperties: false
           description: ""
           title: from
           type: object
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
           type: object
         to:
-          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          $ref: "#/components/schemas/yorkie.v1.TextNodePos"
           additionalProperties: false
           description: ""
           title: to
@@ -837,7 +838,7 @@ components:
           title: key
           type: string
         value:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: value
@@ -849,19 +850,19 @@ components:
       description: ""
       properties:
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
           type: object
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
           type: object
         value:
-          $ref: '#/components/schemas/yorkie.v1.JSONElementSimple'
+          $ref: "#/components/schemas/yorkie.v1.JSONElementSimple"
           additionalProperties: false
           description: ""
           title: value
@@ -873,25 +874,25 @@ components:
       description: ""
       properties:
         createdAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: created_at
           type: object
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
           type: object
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
           type: object
         prevCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: prev_created_at
@@ -903,19 +904,19 @@ components:
       description: ""
       properties:
         createdAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: created_at
           type: object
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
           type: object
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
@@ -931,25 +932,25 @@ components:
          compatibility purposes.
       properties:
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
           type: object
         from:
-          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          $ref: "#/components/schemas/yorkie.v1.TextNodePos"
           additionalProperties: false
           description: ""
           title: from
           type: object
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
           type: object
         to:
-          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          $ref: "#/components/schemas/yorkie.v1.TextNodePos"
           additionalProperties: false
           description: ""
           title: to
@@ -961,7 +962,7 @@ components:
       description: ""
       properties:
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
@@ -972,13 +973,13 @@ components:
           title: key
           type: string
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
           type: object
         value:
-          $ref: '#/components/schemas/yorkie.v1.JSONElementSimple'
+          $ref: "#/components/schemas/yorkie.v1.JSONElementSimple"
           additionalProperties: false
           description: ""
           title: value
@@ -1000,25 +1001,25 @@ components:
           title: created_at_map_by_actor
           type: object
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
           type: object
         from:
-          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          $ref: "#/components/schemas/yorkie.v1.TextNodePos"
           additionalProperties: false
           description: ""
           title: from
           type: object
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
           type: object
         to:
-          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          $ref: "#/components/schemas/yorkie.v1.TextNodePos"
           additionalProperties: false
           description: ""
           title: to
@@ -1051,7 +1052,7 @@ components:
           title: key
           type: string
         value:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: value
@@ -1066,7 +1067,7 @@ components:
           additionalProperties: false
           description: ""
           items:
-            $ref: '#/components/schemas/yorkie.v1.TreeNodes'
+            $ref: "#/components/schemas/yorkie.v1.TreeNodes"
             type: object
           title: contents
           type: array
@@ -1076,19 +1077,19 @@ components:
           title: created_at_map_by_actor
           type: object
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
           type: object
         from:
-          $ref: '#/components/schemas/yorkie.v1.TreePos'
+          $ref: "#/components/schemas/yorkie.v1.TreePos"
           additionalProperties: false
           description: ""
           title: from
           type: object
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
@@ -1099,7 +1100,7 @@ components:
           title: split_level
           type: integer
         to:
-          $ref: '#/components/schemas/yorkie.v1.TreePos'
+          $ref: "#/components/schemas/yorkie.v1.TreePos"
           additionalProperties: false
           description: ""
           title: to
@@ -1116,7 +1117,7 @@ components:
           title: key
           type: string
         value:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: value
@@ -1145,25 +1146,25 @@ components:
           title: created_at_map_by_actor
           type: object
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
           type: object
         from:
-          $ref: '#/components/schemas/yorkie.v1.TreePos'
+          $ref: "#/components/schemas/yorkie.v1.TreePos"
           additionalProperties: false
           description: ""
           title: from
           type: object
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
           type: object
         to:
-          $ref: '#/components/schemas/yorkie.v1.TreePos'
+          $ref: "#/components/schemas/yorkie.v1.TreePos"
           additionalProperties: false
           description: ""
           title: to
@@ -1196,7 +1197,7 @@ components:
           title: key
           type: string
         value:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: value
@@ -1235,13 +1236,13 @@ components:
       description: ""
       properties:
         presence:
-          $ref: '#/components/schemas/yorkie.v1.Presence'
+          $ref: "#/components/schemas/yorkie.v1.Presence"
           additionalProperties: false
           description: ""
           title: presence
           type: object
         type:
-          $ref: '#/components/schemas/yorkie.v1.PresenceChange.ChangeType'
+          $ref: "#/components/schemas/yorkie.v1.PresenceChange.ChangeType"
           additionalProperties: false
           description: ""
           title: type
@@ -1250,14 +1251,14 @@ components:
     yorkie.v1.PresenceChange.ChangeType:
       description: ""
       enum:
-      - - CHANGE_TYPE_UNSPECIFIED
-        - 0
-        - CHANGE_TYPE_PUT
-        - 1
-        - CHANGE_TYPE_DELETE
-        - 2
-        - CHANGE_TYPE_CLEAR
-        - 3
+        - - CHANGE_TYPE_UNSPECIFIED
+          - 0
+          - CHANGE_TYPE_PUT
+          - 1
+          - CHANGE_TYPE_DELETE
+          - 2
+          - CHANGE_TYPE_CLEAR
+          - 3
       title: ChangeType
       type: string
     yorkie.v1.Project:
@@ -1282,7 +1283,7 @@ components:
           title: client_deactivate_threshold
           type: string
         createdAt:
-          $ref: '#/components/schemas/google.protobuf.Timestamp'
+          $ref: "#/components/schemas/google.protobuf.Timestamp"
           additionalProperties: false
           description: ""
           title: created_at
@@ -1308,7 +1309,7 @@ components:
           title: secret_key
           type: string
         updatedAt:
-          $ref: '#/components/schemas/google.protobuf.Timestamp'
+          $ref: "#/components/schemas/google.protobuf.Timestamp"
           additionalProperties: false
           description: ""
           title: updated_at
@@ -1320,13 +1321,13 @@ components:
       description: ""
       properties:
         element:
-          $ref: '#/components/schemas/yorkie.v1.JSONElement'
+          $ref: "#/components/schemas/yorkie.v1.JSONElement"
           additionalProperties: false
           description: ""
           title: element
           type: object
         next:
-          $ref: '#/components/schemas/yorkie.v1.RGANode'
+          $ref: "#/components/schemas/yorkie.v1.RGANode"
           additionalProperties: false
           description: ""
           title: next
@@ -1338,7 +1339,7 @@ components:
       description: ""
       properties:
         element:
-          $ref: '#/components/schemas/yorkie.v1.JSONElement'
+          $ref: "#/components/schemas/yorkie.v1.JSONElement"
           additionalProperties: false
           description: ""
           title: element
@@ -1363,7 +1364,7 @@ components:
           title: presences
           type: object
         root:
-          $ref: '#/components/schemas/yorkie.v1.JSONElement'
+          $ref: "#/components/schemas/yorkie.v1.JSONElement"
           additionalProperties: false
           description: ""
           title: root
@@ -1380,7 +1381,7 @@ components:
           title: key
           type: string
         value:
-          $ref: '#/components/schemas/yorkie.v1.Presence'
+          $ref: "#/components/schemas/yorkie.v1.Presence"
           additionalProperties: false
           description: ""
           title: value
@@ -1397,19 +1398,19 @@ components:
           title: attributes
           type: object
         id:
-          $ref: '#/components/schemas/yorkie.v1.TextNodeID'
+          $ref: "#/components/schemas/yorkie.v1.TextNodeID"
           additionalProperties: false
           description: ""
           title: id
           type: object
         insPrevId:
-          $ref: '#/components/schemas/yorkie.v1.TextNodeID'
+          $ref: "#/components/schemas/yorkie.v1.TextNodeID"
           additionalProperties: false
           description: ""
           title: ins_prev_id
           type: object
         removedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: removed_at
@@ -1431,7 +1432,7 @@ components:
           title: key
           type: string
         value:
-          $ref: '#/components/schemas/yorkie.v1.NodeAttr'
+          $ref: "#/components/schemas/yorkie.v1.NodeAttr"
           additionalProperties: false
           description: ""
           title: value
@@ -1443,7 +1444,7 @@ components:
       description: ""
       properties:
         createdAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: created_at
@@ -1460,7 +1461,7 @@ components:
       description: ""
       properties:
         createdAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: created_at
@@ -1496,8 +1497,8 @@ components:
           additionalProperties: false
           description: ""
           oneOf:
-          - type: string
-          - type: number
+            - type: string
+            - type: number
           title: lamport
       title: TimeTicket
       type: object
@@ -1516,25 +1517,25 @@ components:
           title: depth
           type: integer
         id:
-          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          $ref: "#/components/schemas/yorkie.v1.TreeNodeID"
           additionalProperties: false
           description: ""
           title: id
           type: object
         insNextId:
-          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          $ref: "#/components/schemas/yorkie.v1.TreeNodeID"
           additionalProperties: false
           description: ""
           title: ins_next_id
           type: object
         insPrevId:
-          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          $ref: "#/components/schemas/yorkie.v1.TreeNodeID"
           additionalProperties: false
           description: ""
           title: ins_prev_id
           type: object
         removedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: removed_at
@@ -1561,7 +1562,7 @@ components:
           title: key
           type: string
         value:
-          $ref: '#/components/schemas/yorkie.v1.NodeAttr'
+          $ref: "#/components/schemas/yorkie.v1.NodeAttr"
           additionalProperties: false
           description: ""
           title: value
@@ -1573,7 +1574,7 @@ components:
       description: ""
       properties:
         createdAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: created_at
@@ -1593,7 +1594,7 @@ components:
           additionalProperties: false
           description: ""
           items:
-            $ref: '#/components/schemas/yorkie.v1.TreeNode'
+            $ref: "#/components/schemas/yorkie.v1.TreeNode"
             type: object
           title: content
           type: array
@@ -1604,13 +1605,13 @@ components:
       description: ""
       properties:
         leftSiblingId:
-          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          $ref: "#/components/schemas/yorkie.v1.TreeNodeID"
           additionalProperties: false
           description: ""
           title: left_sibling_id
           type: object
         parentId:
-          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          $ref: "#/components/schemas/yorkie.v1.TreeNodeID"
           additionalProperties: false
           description: ""
           title: parent_id
@@ -1622,25 +1623,25 @@ components:
       description: ""
       properties:
         authWebhookMethods:
-          $ref: '#/components/schemas/yorkie.v1.UpdatableProjectFields.AuthWebhookMethods'
+          $ref: "#/components/schemas/yorkie.v1.UpdatableProjectFields.AuthWebhookMethods"
           additionalProperties: false
           description: ""
           title: auth_webhook_methods
           type: object
         authWebhookUrl:
-          $ref: '#/components/schemas/google.protobuf.StringValue'
+          $ref: "#/components/schemas/google.protobuf.StringValue"
           additionalProperties: false
           description: ""
           title: auth_webhook_url
           type: object
         clientDeactivateThreshold:
-          $ref: '#/components/schemas/google.protobuf.StringValue'
+          $ref: "#/components/schemas/google.protobuf.StringValue"
           additionalProperties: false
           description: ""
           title: client_deactivate_threshold
           type: object
         name:
-          $ref: '#/components/schemas/google.protobuf.StringValue'
+          $ref: "#/components/schemas/google.protobuf.StringValue"
           additionalProperties: false
           description: ""
           title: name
@@ -1665,7 +1666,7 @@ components:
       description: ""
       properties:
         createdAt:
-          $ref: '#/components/schemas/google.protobuf.Timestamp'
+          $ref: "#/components/schemas/google.protobuf.Timestamp"
           additionalProperties: false
           description: ""
           title: created_at
@@ -1685,34 +1686,34 @@ components:
     yorkie.v1.ValueType:
       description: ""
       enum:
-      - - VALUE_TYPE_NULL
-        - 0
-        - VALUE_TYPE_BOOLEAN
-        - 1
-        - VALUE_TYPE_INTEGER
-        - 2
-        - VALUE_TYPE_LONG
-        - 3
-        - VALUE_TYPE_DOUBLE
-        - 4
-        - VALUE_TYPE_STRING
-        - 5
-        - VALUE_TYPE_BYTES
-        - 6
-        - VALUE_TYPE_DATE
-        - 7
-        - VALUE_TYPE_JSON_OBJECT
-        - 8
-        - VALUE_TYPE_JSON_ARRAY
-        - 9
-        - VALUE_TYPE_TEXT
-        - 10
-        - VALUE_TYPE_INTEGER_CNT
-        - 11
-        - VALUE_TYPE_LONG_CNT
-        - 12
-        - VALUE_TYPE_TREE
-        - 13
+        - - VALUE_TYPE_NULL
+          - 0
+          - VALUE_TYPE_BOOLEAN
+          - 1
+          - VALUE_TYPE_INTEGER
+          - 2
+          - VALUE_TYPE_LONG
+          - 3
+          - VALUE_TYPE_DOUBLE
+          - 4
+          - VALUE_TYPE_STRING
+          - 5
+          - VALUE_TYPE_BYTES
+          - 6
+          - VALUE_TYPE_DATE
+          - 7
+          - VALUE_TYPE_JSON_OBJECT
+          - 8
+          - VALUE_TYPE_JSON_ARRAY
+          - 9
+          - VALUE_TYPE_TEXT
+          - 10
+          - VALUE_TYPE_INTEGER_CNT
+          - 11
+          - VALUE_TYPE_LONG_CNT
+          - 12
+          - VALUE_TYPE_TREE
+          - 13
       title: ValueType
       type: string
   securitySchemes:
@@ -1721,4 +1722,4 @@ components:
       name: Authorization
       type: apiKey
 security:
-- ApiKeyAuth: []
+  - ApiKeyAuth: []

--- a/api/docs/yorkie/v1/yorkie.openapi.yaml
+++ b/api/docs/yorkie/v1/yorkie.openapi.yaml
@@ -1,175 +1,176 @@
 openapi: 3.1.0
 info:
-  description: Yorkie is an open source document store for building collaborative
+  description:
+    Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.4.27
+  version: v0.4.28
 servers:
-- description: Production server
-  url: https://api.yorkie.dev
-- description: Local server
-  url: http://localhost:8080
+  - description: Production server
+    url: https://api.yorkie.dev
+  - description: Local server
+    url: http://localhost:8080
 paths:
   /yorkie.v1.YorkieService/ActivateClient:
     post:
       description: ""
       requestBody:
-        $ref: '#/components/requestBodies/yorkie.v1.YorkieService.ActivateClient.yorkie.v1.ActivateClientRequest'
+        $ref: "#/components/requestBodies/yorkie.v1.YorkieService.ActivateClient.yorkie.v1.ActivateClientRequest"
       responses:
         "200":
-          $ref: '#/components/responses/yorkie.v1.YorkieService.ActivateClient.yorkie.v1.ActivateClientResponse'
+          $ref: "#/components/responses/yorkie.v1.YorkieService.ActivateClient.yorkie.v1.ActivateClientResponse"
         default:
-          $ref: '#/components/responses/connect.error'
+          $ref: "#/components/responses/connect.error"
       tags:
-      - yorkie.v1.YorkieService
+        - yorkie.v1.YorkieService
   /yorkie.v1.YorkieService/AttachDocument:
     post:
       description: ""
       requestBody:
-        $ref: '#/components/requestBodies/yorkie.v1.YorkieService.AttachDocument.yorkie.v1.AttachDocumentRequest'
+        $ref: "#/components/requestBodies/yorkie.v1.YorkieService.AttachDocument.yorkie.v1.AttachDocumentRequest"
       responses:
         "200":
-          $ref: '#/components/responses/yorkie.v1.YorkieService.AttachDocument.yorkie.v1.AttachDocumentResponse'
+          $ref: "#/components/responses/yorkie.v1.YorkieService.AttachDocument.yorkie.v1.AttachDocumentResponse"
         default:
-          $ref: '#/components/responses/connect.error'
+          $ref: "#/components/responses/connect.error"
       tags:
-      - yorkie.v1.YorkieService
+        - yorkie.v1.YorkieService
   /yorkie.v1.YorkieService/Broadcast:
     post:
       description: ""
       requestBody:
-        $ref: '#/components/requestBodies/yorkie.v1.YorkieService.Broadcast.yorkie.v1.BroadcastRequest'
+        $ref: "#/components/requestBodies/yorkie.v1.YorkieService.Broadcast.yorkie.v1.BroadcastRequest"
       responses:
         "200":
-          $ref: '#/components/responses/yorkie.v1.YorkieService.Broadcast.yorkie.v1.BroadcastResponse'
+          $ref: "#/components/responses/yorkie.v1.YorkieService.Broadcast.yorkie.v1.BroadcastResponse"
         default:
-          $ref: '#/components/responses/connect.error'
+          $ref: "#/components/responses/connect.error"
       tags:
-      - yorkie.v1.YorkieService
+        - yorkie.v1.YorkieService
   /yorkie.v1.YorkieService/DeactivateClient:
     post:
       description: ""
       requestBody:
-        $ref: '#/components/requestBodies/yorkie.v1.YorkieService.DeactivateClient.yorkie.v1.DeactivateClientRequest'
+        $ref: "#/components/requestBodies/yorkie.v1.YorkieService.DeactivateClient.yorkie.v1.DeactivateClientRequest"
       responses:
         "200":
-          $ref: '#/components/responses/yorkie.v1.YorkieService.DeactivateClient.yorkie.v1.DeactivateClientResponse'
+          $ref: "#/components/responses/yorkie.v1.YorkieService.DeactivateClient.yorkie.v1.DeactivateClientResponse"
         default:
-          $ref: '#/components/responses/connect.error'
+          $ref: "#/components/responses/connect.error"
       tags:
-      - yorkie.v1.YorkieService
+        - yorkie.v1.YorkieService
   /yorkie.v1.YorkieService/DetachDocument:
     post:
       description: ""
       requestBody:
-        $ref: '#/components/requestBodies/yorkie.v1.YorkieService.DetachDocument.yorkie.v1.DetachDocumentRequest'
+        $ref: "#/components/requestBodies/yorkie.v1.YorkieService.DetachDocument.yorkie.v1.DetachDocumentRequest"
       responses:
         "200":
-          $ref: '#/components/responses/yorkie.v1.YorkieService.DetachDocument.yorkie.v1.DetachDocumentResponse'
+          $ref: "#/components/responses/yorkie.v1.YorkieService.DetachDocument.yorkie.v1.DetachDocumentResponse"
         default:
-          $ref: '#/components/responses/connect.error'
+          $ref: "#/components/responses/connect.error"
       tags:
-      - yorkie.v1.YorkieService
+        - yorkie.v1.YorkieService
   /yorkie.v1.YorkieService/PushPullChanges:
     post:
       description: ""
       requestBody:
-        $ref: '#/components/requestBodies/yorkie.v1.YorkieService.PushPullChanges.yorkie.v1.PushPullChangesRequest'
+        $ref: "#/components/requestBodies/yorkie.v1.YorkieService.PushPullChanges.yorkie.v1.PushPullChangesRequest"
       responses:
         "200":
-          $ref: '#/components/responses/yorkie.v1.YorkieService.PushPullChanges.yorkie.v1.PushPullChangesResponse'
+          $ref: "#/components/responses/yorkie.v1.YorkieService.PushPullChanges.yorkie.v1.PushPullChangesResponse"
         default:
-          $ref: '#/components/responses/connect.error'
+          $ref: "#/components/responses/connect.error"
       tags:
-      - yorkie.v1.YorkieService
+        - yorkie.v1.YorkieService
   /yorkie.v1.YorkieService/RemoveDocument:
     post:
       description: ""
       requestBody:
-        $ref: '#/components/requestBodies/yorkie.v1.YorkieService.RemoveDocument.yorkie.v1.RemoveDocumentRequest'
+        $ref: "#/components/requestBodies/yorkie.v1.YorkieService.RemoveDocument.yorkie.v1.RemoveDocumentRequest"
       responses:
         "200":
-          $ref: '#/components/responses/yorkie.v1.YorkieService.RemoveDocument.yorkie.v1.RemoveDocumentResponse'
+          $ref: "#/components/responses/yorkie.v1.YorkieService.RemoveDocument.yorkie.v1.RemoveDocumentResponse"
         default:
-          $ref: '#/components/responses/connect.error'
+          $ref: "#/components/responses/connect.error"
       tags:
-      - yorkie.v1.YorkieService
+        - yorkie.v1.YorkieService
   /yorkie.v1.YorkieService/WatchDocument:
     post:
       description: ""
       requestBody:
-        $ref: '#/components/requestBodies/yorkie.v1.YorkieService.WatchDocument.yorkie.v1.WatchDocumentRequest'
+        $ref: "#/components/requestBodies/yorkie.v1.YorkieService.WatchDocument.yorkie.v1.WatchDocumentRequest"
       responses:
         "200":
-          $ref: '#/components/responses/yorkie.v1.YorkieService.WatchDocument.yorkie.v1.WatchDocumentResponse'
+          $ref: "#/components/responses/yorkie.v1.YorkieService.WatchDocument.yorkie.v1.WatchDocumentResponse"
         default:
-          $ref: '#/components/responses/connect.error'
+          $ref: "#/components/responses/connect.error"
       tags:
-      - yorkie.v1.YorkieService
+        - yorkie.v1.YorkieService
 components:
   requestBodies:
     yorkie.v1.YorkieService.ActivateClient.yorkie.v1.ActivateClientRequest:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.ActivateClientRequest'
+            $ref: "#/components/schemas/yorkie.v1.ActivateClientRequest"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.ActivateClientRequest'
+            $ref: "#/components/schemas/yorkie.v1.ActivateClientRequest"
       required: true
     yorkie.v1.YorkieService.AttachDocument.yorkie.v1.AttachDocumentRequest:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.AttachDocumentRequest'
+            $ref: "#/components/schemas/yorkie.v1.AttachDocumentRequest"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.AttachDocumentRequest'
+            $ref: "#/components/schemas/yorkie.v1.AttachDocumentRequest"
       required: true
     yorkie.v1.YorkieService.Broadcast.yorkie.v1.BroadcastRequest:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.BroadcastRequest'
+            $ref: "#/components/schemas/yorkie.v1.BroadcastRequest"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.BroadcastRequest'
+            $ref: "#/components/schemas/yorkie.v1.BroadcastRequest"
       required: true
     yorkie.v1.YorkieService.DeactivateClient.yorkie.v1.DeactivateClientRequest:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.DeactivateClientRequest'
+            $ref: "#/components/schemas/yorkie.v1.DeactivateClientRequest"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.DeactivateClientRequest'
+            $ref: "#/components/schemas/yorkie.v1.DeactivateClientRequest"
       required: true
     yorkie.v1.YorkieService.DetachDocument.yorkie.v1.DetachDocumentRequest:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.DetachDocumentRequest'
+            $ref: "#/components/schemas/yorkie.v1.DetachDocumentRequest"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.DetachDocumentRequest'
+            $ref: "#/components/schemas/yorkie.v1.DetachDocumentRequest"
       required: true
     yorkie.v1.YorkieService.PushPullChanges.yorkie.v1.PushPullChangesRequest:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.PushPullChangesRequest'
+            $ref: "#/components/schemas/yorkie.v1.PushPullChangesRequest"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.PushPullChangesRequest'
+            $ref: "#/components/schemas/yorkie.v1.PushPullChangesRequest"
       required: true
     yorkie.v1.YorkieService.RemoveDocument.yorkie.v1.RemoveDocumentRequest:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.RemoveDocumentRequest'
+            $ref: "#/components/schemas/yorkie.v1.RemoveDocumentRequest"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.RemoveDocumentRequest'
+            $ref: "#/components/schemas/yorkie.v1.RemoveDocumentRequest"
       required: true
     yorkie.v1.YorkieService.WatchDocument.yorkie.v1.WatchDocumentRequest:
       content: {}
@@ -179,100 +180,100 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/connect.error'
+            $ref: "#/components/schemas/connect.error"
         application/proto:
           schema:
-            $ref: '#/components/schemas/connect.error'
+            $ref: "#/components/schemas/connect.error"
       description: ""
     yorkie.v1.YorkieService.ActivateClient.yorkie.v1.ActivateClientResponse:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.ActivateClientResponse'
+            $ref: "#/components/schemas/yorkie.v1.ActivateClientResponse"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.ActivateClientResponse'
+            $ref: "#/components/schemas/yorkie.v1.ActivateClientResponse"
       description: ""
     yorkie.v1.YorkieService.AttachDocument.yorkie.v1.AttachDocumentResponse:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.AttachDocumentResponse'
+            $ref: "#/components/schemas/yorkie.v1.AttachDocumentResponse"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.AttachDocumentResponse'
+            $ref: "#/components/schemas/yorkie.v1.AttachDocumentResponse"
       description: ""
     yorkie.v1.YorkieService.Broadcast.yorkie.v1.BroadcastResponse:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.BroadcastResponse'
+            $ref: "#/components/schemas/yorkie.v1.BroadcastResponse"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.BroadcastResponse'
+            $ref: "#/components/schemas/yorkie.v1.BroadcastResponse"
       description: ""
     yorkie.v1.YorkieService.DeactivateClient.yorkie.v1.DeactivateClientResponse:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.DeactivateClientResponse'
+            $ref: "#/components/schemas/yorkie.v1.DeactivateClientResponse"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.DeactivateClientResponse'
+            $ref: "#/components/schemas/yorkie.v1.DeactivateClientResponse"
       description: ""
     yorkie.v1.YorkieService.DetachDocument.yorkie.v1.DetachDocumentResponse:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.DetachDocumentResponse'
+            $ref: "#/components/schemas/yorkie.v1.DetachDocumentResponse"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.DetachDocumentResponse'
+            $ref: "#/components/schemas/yorkie.v1.DetachDocumentResponse"
       description: ""
     yorkie.v1.YorkieService.PushPullChanges.yorkie.v1.PushPullChangesResponse:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.PushPullChangesResponse'
+            $ref: "#/components/schemas/yorkie.v1.PushPullChangesResponse"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.PushPullChangesResponse'
+            $ref: "#/components/schemas/yorkie.v1.PushPullChangesResponse"
       description: ""
     yorkie.v1.YorkieService.RemoveDocument.yorkie.v1.RemoveDocumentResponse:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.RemoveDocumentResponse'
+            $ref: "#/components/schemas/yorkie.v1.RemoveDocumentResponse"
         application/proto:
           schema:
-            $ref: '#/components/schemas/yorkie.v1.RemoveDocumentResponse'
+            $ref: "#/components/schemas/yorkie.v1.RemoveDocumentResponse"
       description: ""
     yorkie.v1.YorkieService.WatchDocument.yorkie.v1.WatchDocumentResponse:
       description: ""
   schemas:
     connect.error:
       additionalProperties: false
-      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
+      description: "Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation"
       properties:
         code:
           enum:
-          - CodeCanceled
-          - CodeUnknown
-          - CodeInvalidArgument
-          - CodeDeadlineExceeded
-          - CodeNotFound
-          - CodeAlreadyExists
-          - CodePermissionDenied
-          - CodeResourceExhausted
-          - CodeFailedPrecondition
-          - CodeAborted
-          - CodeOutOfRange
-          - CodeInternal
-          - CodeUnavailable
-          - CodeDataLoss
-          - CodeUnauthenticated
+            - CodeCanceled
+            - CodeUnknown
+            - CodeInvalidArgument
+            - CodeDeadlineExceeded
+            - CodeNotFound
+            - CodeAlreadyExists
+            - CodePermissionDenied
+            - CodeResourceExhausted
+            - CodeFailedPrecondition
+            - CodeAborted
+            - CodeOutOfRange
+            - CodeInternal
+            - CodeUnavailable
+            - CodeDataLoss
+            - CodeUnauthenticated
           examples:
-          - CodeNotFound
+            - CodeNotFound
           type: string
         message:
           type: string
@@ -305,7 +306,7 @@ components:
       description: ""
       properties:
         changePack:
-          $ref: '#/components/schemas/yorkie.v1.ChangePack'
+          $ref: "#/components/schemas/yorkie.v1.ChangePack"
           additionalProperties: false
           description: ""
           title: change_pack
@@ -322,7 +323,7 @@ components:
       description: ""
       properties:
         changePack:
-          $ref: '#/components/schemas/yorkie.v1.ChangePack'
+          $ref: "#/components/schemas/yorkie.v1.ChangePack"
           additionalProperties: false
           description: ""
           title: change_pack
@@ -371,7 +372,7 @@ components:
       description: ""
       properties:
         id:
-          $ref: '#/components/schemas/yorkie.v1.ChangeID'
+          $ref: "#/components/schemas/yorkie.v1.ChangeID"
           additionalProperties: false
           description: ""
           title: id
@@ -385,12 +386,12 @@ components:
           additionalProperties: false
           description: ""
           items:
-            $ref: '#/components/schemas/yorkie.v1.Operation'
+            $ref: "#/components/schemas/yorkie.v1.Operation"
             type: object
           title: operations
           type: array
         presenceChange:
-          $ref: '#/components/schemas/yorkie.v1.PresenceChange'
+          $ref: "#/components/schemas/yorkie.v1.PresenceChange"
           additionalProperties: false
           description: ""
           title: presence_change
@@ -416,15 +417,15 @@ components:
           additionalProperties: false
           description: ""
           oneOf:
-          - type: string
-          - type: number
+            - type: string
+            - type: number
           title: lamport
         serverSeq:
           additionalProperties: false
           description: ""
           oneOf:
-          - type: string
-          - type: number
+            - type: string
+            - type: number
           title: server_seq
       title: ChangeID
       type: object
@@ -438,12 +439,12 @@ components:
           additionalProperties: false
           description: ""
           items:
-            $ref: '#/components/schemas/yorkie.v1.Change'
+            $ref: "#/components/schemas/yorkie.v1.Change"
             type: object
           title: changes
           type: array
         checkpoint:
-          $ref: '#/components/schemas/yorkie.v1.Checkpoint'
+          $ref: "#/components/schemas/yorkie.v1.Checkpoint"
           additionalProperties: false
           description: ""
           title: checkpoint
@@ -459,7 +460,7 @@ components:
           title: is_removed
           type: boolean
         minSyncedTicket:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: min_synced_ticket
@@ -485,8 +486,8 @@ components:
           additionalProperties: false
           description: ""
           oneOf:
-          - type: string
-          - type: number
+            - type: string
+            - type: number
           title: server_seq
       title: Checkpoint
       type: object
@@ -511,7 +512,7 @@ components:
       description: ""
       properties:
         changePack:
-          $ref: '#/components/schemas/yorkie.v1.ChangePack'
+          $ref: "#/components/schemas/yorkie.v1.ChangePack"
           additionalProperties: false
           description: ""
           title: change_pack
@@ -538,7 +539,7 @@ components:
       description: ""
       properties:
         changePack:
-          $ref: '#/components/schemas/yorkie.v1.ChangePack'
+          $ref: "#/components/schemas/yorkie.v1.ChangePack"
           additionalProperties: false
           description: ""
           title: change_pack
@@ -550,7 +551,7 @@ components:
       description: ""
       properties:
         body:
-          $ref: '#/components/schemas/yorkie.v1.DocEventBody'
+          $ref: "#/components/schemas/yorkie.v1.DocEventBody"
           additionalProperties: false
           description: ""
           title: body
@@ -561,7 +562,7 @@ components:
           title: publisher
           type: string
         type:
-          $ref: '#/components/schemas/yorkie.v1.DocEventType'
+          $ref: "#/components/schemas/yorkie.v1.DocEventType"
           additionalProperties: false
           description: ""
           title: type
@@ -587,14 +588,14 @@ components:
     yorkie.v1.DocEventType:
       description: ""
       enum:
-      - - DOC_EVENT_TYPE_DOCUMENT_CHANGED
-        - 0
-        - DOC_EVENT_TYPE_DOCUMENT_WATCHED
-        - 1
-        - DOC_EVENT_TYPE_DOCUMENT_UNWATCHED
-        - 2
-        - DOC_EVENT_TYPE_DOCUMENT_BROADCAST
-        - 3
+        - - DOC_EVENT_TYPE_DOCUMENT_CHANGED
+          - 0
+          - DOC_EVENT_TYPE_DOCUMENT_WATCHED
+          - 1
+          - DOC_EVENT_TYPE_DOCUMENT_UNWATCHED
+          - 2
+          - DOC_EVENT_TYPE_DOCUMENT_BROADCAST
+          - 3
       title: DocEventType
       type: string
     yorkie.v1.JSONElementSimple:
@@ -602,25 +603,25 @@ components:
       description: ""
       properties:
         createdAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: created_at
           type: object
         movedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: moved_at
           type: object
         removedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: removed_at
           type: object
         type:
-          $ref: '#/components/schemas/yorkie.v1.ValueType'
+          $ref: "#/components/schemas/yorkie.v1.ValueType"
           additionalProperties: false
           description: ""
           title: type
@@ -642,7 +643,7 @@ components:
           title: is_removed
           type: boolean
         updatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: updated_at
@@ -659,61 +660,61 @@ components:
       description: ""
       properties:
         add:
-          $ref: '#/components/schemas/yorkie.v1.Operation.Add'
+          $ref: "#/components/schemas/yorkie.v1.Operation.Add"
           additionalProperties: false
           description: ""
           title: add
           type: object
         edit:
-          $ref: '#/components/schemas/yorkie.v1.Operation.Edit'
+          $ref: "#/components/schemas/yorkie.v1.Operation.Edit"
           additionalProperties: false
           description: ""
           title: edit
           type: object
         increase:
-          $ref: '#/components/schemas/yorkie.v1.Operation.Increase'
+          $ref: "#/components/schemas/yorkie.v1.Operation.Increase"
           additionalProperties: false
           description: ""
           title: increase
           type: object
         move:
-          $ref: '#/components/schemas/yorkie.v1.Operation.Move'
+          $ref: "#/components/schemas/yorkie.v1.Operation.Move"
           additionalProperties: false
           description: ""
           title: move
           type: object
         remove:
-          $ref: '#/components/schemas/yorkie.v1.Operation.Remove'
+          $ref: "#/components/schemas/yorkie.v1.Operation.Remove"
           additionalProperties: false
           description: ""
           title: remove
           type: object
         select:
-          $ref: '#/components/schemas/yorkie.v1.Operation.Select'
+          $ref: "#/components/schemas/yorkie.v1.Operation.Select"
           additionalProperties: false
           description: ""
           title: select
           type: object
         set:
-          $ref: '#/components/schemas/yorkie.v1.Operation.Set'
+          $ref: "#/components/schemas/yorkie.v1.Operation.Set"
           additionalProperties: false
           description: ""
           title: set
           type: object
         style:
-          $ref: '#/components/schemas/yorkie.v1.Operation.Style'
+          $ref: "#/components/schemas/yorkie.v1.Operation.Style"
           additionalProperties: false
           description: ""
           title: style
           type: object
         treeEdit:
-          $ref: '#/components/schemas/yorkie.v1.Operation.TreeEdit'
+          $ref: "#/components/schemas/yorkie.v1.Operation.TreeEdit"
           additionalProperties: false
           description: ""
           title: tree_edit
           type: object
         treeStyle:
-          $ref: '#/components/schemas/yorkie.v1.Operation.TreeStyle'
+          $ref: "#/components/schemas/yorkie.v1.Operation.TreeStyle"
           additionalProperties: false
           description: ""
           title: tree_style
@@ -725,25 +726,25 @@ components:
       description: ""
       properties:
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
           type: object
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
           type: object
         prevCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: prev_created_at
           type: object
         value:
-          $ref: '#/components/schemas/yorkie.v1.JSONElementSimple'
+          $ref: "#/components/schemas/yorkie.v1.JSONElementSimple"
           additionalProperties: false
           description: ""
           title: value
@@ -770,25 +771,25 @@ components:
           title: created_at_map_by_actor
           type: object
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
           type: object
         from:
-          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          $ref: "#/components/schemas/yorkie.v1.TextNodePos"
           additionalProperties: false
           description: ""
           title: from
           type: object
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
           type: object
         to:
-          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          $ref: "#/components/schemas/yorkie.v1.TextNodePos"
           additionalProperties: false
           description: ""
           title: to
@@ -821,7 +822,7 @@ components:
           title: key
           type: string
         value:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: value
@@ -833,19 +834,19 @@ components:
       description: ""
       properties:
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
           type: object
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
           type: object
         value:
-          $ref: '#/components/schemas/yorkie.v1.JSONElementSimple'
+          $ref: "#/components/schemas/yorkie.v1.JSONElementSimple"
           additionalProperties: false
           description: ""
           title: value
@@ -857,25 +858,25 @@ components:
       description: ""
       properties:
         createdAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: created_at
           type: object
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
           type: object
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
           type: object
         prevCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: prev_created_at
@@ -887,19 +888,19 @@ components:
       description: ""
       properties:
         createdAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: created_at
           type: object
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
           type: object
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
@@ -915,25 +916,25 @@ components:
          compatibility purposes.
       properties:
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
           type: object
         from:
-          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          $ref: "#/components/schemas/yorkie.v1.TextNodePos"
           additionalProperties: false
           description: ""
           title: from
           type: object
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
           type: object
         to:
-          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          $ref: "#/components/schemas/yorkie.v1.TextNodePos"
           additionalProperties: false
           description: ""
           title: to
@@ -945,7 +946,7 @@ components:
       description: ""
       properties:
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
@@ -956,13 +957,13 @@ components:
           title: key
           type: string
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
           type: object
         value:
-          $ref: '#/components/schemas/yorkie.v1.JSONElementSimple'
+          $ref: "#/components/schemas/yorkie.v1.JSONElementSimple"
           additionalProperties: false
           description: ""
           title: value
@@ -984,25 +985,25 @@ components:
           title: created_at_map_by_actor
           type: object
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
           type: object
         from:
-          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          $ref: "#/components/schemas/yorkie.v1.TextNodePos"
           additionalProperties: false
           description: ""
           title: from
           type: object
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
           type: object
         to:
-          $ref: '#/components/schemas/yorkie.v1.TextNodePos'
+          $ref: "#/components/schemas/yorkie.v1.TextNodePos"
           additionalProperties: false
           description: ""
           title: to
@@ -1035,7 +1036,7 @@ components:
           title: key
           type: string
         value:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: value
@@ -1050,7 +1051,7 @@ components:
           additionalProperties: false
           description: ""
           items:
-            $ref: '#/components/schemas/yorkie.v1.TreeNodes'
+            $ref: "#/components/schemas/yorkie.v1.TreeNodes"
             type: object
           title: contents
           type: array
@@ -1060,19 +1061,19 @@ components:
           title: created_at_map_by_actor
           type: object
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
           type: object
         from:
-          $ref: '#/components/schemas/yorkie.v1.TreePos'
+          $ref: "#/components/schemas/yorkie.v1.TreePos"
           additionalProperties: false
           description: ""
           title: from
           type: object
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
@@ -1083,7 +1084,7 @@ components:
           title: split_level
           type: integer
         to:
-          $ref: '#/components/schemas/yorkie.v1.TreePos'
+          $ref: "#/components/schemas/yorkie.v1.TreePos"
           additionalProperties: false
           description: ""
           title: to
@@ -1100,7 +1101,7 @@ components:
           title: key
           type: string
         value:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: value
@@ -1129,25 +1130,25 @@ components:
           title: created_at_map_by_actor
           type: object
         executedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: executed_at
           type: object
         from:
-          $ref: '#/components/schemas/yorkie.v1.TreePos'
+          $ref: "#/components/schemas/yorkie.v1.TreePos"
           additionalProperties: false
           description: ""
           title: from
           type: object
         parentCreatedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: parent_created_at
           type: object
         to:
-          $ref: '#/components/schemas/yorkie.v1.TreePos'
+          $ref: "#/components/schemas/yorkie.v1.TreePos"
           additionalProperties: false
           description: ""
           title: to
@@ -1180,7 +1181,7 @@ components:
           title: key
           type: string
         value:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: value
@@ -1219,13 +1220,13 @@ components:
       description: ""
       properties:
         presence:
-          $ref: '#/components/schemas/yorkie.v1.Presence'
+          $ref: "#/components/schemas/yorkie.v1.Presence"
           additionalProperties: false
           description: ""
           title: presence
           type: object
         type:
-          $ref: '#/components/schemas/yorkie.v1.PresenceChange.ChangeType'
+          $ref: "#/components/schemas/yorkie.v1.PresenceChange.ChangeType"
           additionalProperties: false
           description: ""
           title: type
@@ -1234,14 +1235,14 @@ components:
     yorkie.v1.PresenceChange.ChangeType:
       description: ""
       enum:
-      - - CHANGE_TYPE_UNSPECIFIED
-        - 0
-        - CHANGE_TYPE_PUT
-        - 1
-        - CHANGE_TYPE_DELETE
-        - 2
-        - CHANGE_TYPE_CLEAR
-        - 3
+        - - CHANGE_TYPE_UNSPECIFIED
+          - 0
+          - CHANGE_TYPE_PUT
+          - 1
+          - CHANGE_TYPE_DELETE
+          - 2
+          - CHANGE_TYPE_CLEAR
+          - 3
       title: ChangeType
       type: string
     yorkie.v1.PushPullChangesRequest:
@@ -1249,7 +1250,7 @@ components:
       description: ""
       properties:
         changePack:
-          $ref: '#/components/schemas/yorkie.v1.ChangePack'
+          $ref: "#/components/schemas/yorkie.v1.ChangePack"
           additionalProperties: false
           description: ""
           title: change_pack
@@ -1276,7 +1277,7 @@ components:
       description: ""
       properties:
         changePack:
-          $ref: '#/components/schemas/yorkie.v1.ChangePack'
+          $ref: "#/components/schemas/yorkie.v1.ChangePack"
           additionalProperties: false
           description: ""
           title: change_pack
@@ -1288,7 +1289,7 @@ components:
       description: ""
       properties:
         changePack:
-          $ref: '#/components/schemas/yorkie.v1.ChangePack'
+          $ref: "#/components/schemas/yorkie.v1.ChangePack"
           additionalProperties: false
           description: ""
           title: change_pack
@@ -1310,7 +1311,7 @@ components:
       description: ""
       properties:
         changePack:
-          $ref: '#/components/schemas/yorkie.v1.ChangePack'
+          $ref: "#/components/schemas/yorkie.v1.ChangePack"
           additionalProperties: false
           description: ""
           title: change_pack
@@ -1322,7 +1323,7 @@ components:
       description: ""
       properties:
         createdAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: created_at
@@ -1358,8 +1359,8 @@ components:
           additionalProperties: false
           description: ""
           oneOf:
-          - type: string
-          - type: number
+            - type: string
+            - type: number
           title: lamport
       title: TimeTicket
       type: object
@@ -1378,25 +1379,25 @@ components:
           title: depth
           type: integer
         id:
-          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          $ref: "#/components/schemas/yorkie.v1.TreeNodeID"
           additionalProperties: false
           description: ""
           title: id
           type: object
         insNextId:
-          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          $ref: "#/components/schemas/yorkie.v1.TreeNodeID"
           additionalProperties: false
           description: ""
           title: ins_next_id
           type: object
         insPrevId:
-          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          $ref: "#/components/schemas/yorkie.v1.TreeNodeID"
           additionalProperties: false
           description: ""
           title: ins_prev_id
           type: object
         removedAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: removed_at
@@ -1423,7 +1424,7 @@ components:
           title: key
           type: string
         value:
-          $ref: '#/components/schemas/yorkie.v1.NodeAttr'
+          $ref: "#/components/schemas/yorkie.v1.NodeAttr"
           additionalProperties: false
           description: ""
           title: value
@@ -1435,7 +1436,7 @@ components:
       description: ""
       properties:
         createdAt:
-          $ref: '#/components/schemas/yorkie.v1.TimeTicket'
+          $ref: "#/components/schemas/yorkie.v1.TimeTicket"
           additionalProperties: false
           description: ""
           title: created_at
@@ -1455,7 +1456,7 @@ components:
           additionalProperties: false
           description: ""
           items:
-            $ref: '#/components/schemas/yorkie.v1.TreeNode'
+            $ref: "#/components/schemas/yorkie.v1.TreeNode"
             type: object
           title: content
           type: array
@@ -1466,13 +1467,13 @@ components:
       description: ""
       properties:
         leftSiblingId:
-          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          $ref: "#/components/schemas/yorkie.v1.TreeNodeID"
           additionalProperties: false
           description: ""
           title: left_sibling_id
           type: object
         parentId:
-          $ref: '#/components/schemas/yorkie.v1.TreeNodeID'
+          $ref: "#/components/schemas/yorkie.v1.TreeNodeID"
           additionalProperties: false
           description: ""
           title: parent_id
@@ -1482,34 +1483,34 @@ components:
     yorkie.v1.ValueType:
       description: ""
       enum:
-      - - VALUE_TYPE_NULL
-        - 0
-        - VALUE_TYPE_BOOLEAN
-        - 1
-        - VALUE_TYPE_INTEGER
-        - 2
-        - VALUE_TYPE_LONG
-        - 3
-        - VALUE_TYPE_DOUBLE
-        - 4
-        - VALUE_TYPE_STRING
-        - 5
-        - VALUE_TYPE_BYTES
-        - 6
-        - VALUE_TYPE_DATE
-        - 7
-        - VALUE_TYPE_JSON_OBJECT
-        - 8
-        - VALUE_TYPE_JSON_ARRAY
-        - 9
-        - VALUE_TYPE_TEXT
-        - 10
-        - VALUE_TYPE_INTEGER_CNT
-        - 11
-        - VALUE_TYPE_LONG_CNT
-        - 12
-        - VALUE_TYPE_TREE
-        - 13
+        - - VALUE_TYPE_NULL
+          - 0
+          - VALUE_TYPE_BOOLEAN
+          - 1
+          - VALUE_TYPE_INTEGER
+          - 2
+          - VALUE_TYPE_LONG
+          - 3
+          - VALUE_TYPE_DOUBLE
+          - 4
+          - VALUE_TYPE_STRING
+          - 5
+          - VALUE_TYPE_BYTES
+          - 6
+          - VALUE_TYPE_DATE
+          - 7
+          - VALUE_TYPE_JSON_OBJECT
+          - 8
+          - VALUE_TYPE_JSON_ARRAY
+          - 9
+          - VALUE_TYPE_TEXT
+          - 10
+          - VALUE_TYPE_INTEGER_CNT
+          - 11
+          - VALUE_TYPE_LONG_CNT
+          - 12
+          - VALUE_TYPE_TREE
+          - 13
       title: ValueType
       type: string
     yorkie.v1.WatchDocumentRequest:
@@ -1533,13 +1534,13 @@ components:
       description: ""
       properties:
         event:
-          $ref: '#/components/schemas/yorkie.v1.DocEvent'
+          $ref: "#/components/schemas/yorkie.v1.DocEvent"
           additionalProperties: false
           description: ""
           title: event
           type: object
         initialization:
-          $ref: '#/components/schemas/yorkie.v1.WatchDocumentResponse.Initialization'
+          $ref: "#/components/schemas/yorkie.v1.WatchDocumentResponse.Initialization"
           additionalProperties: false
           description: ""
           title: initialization
@@ -1565,7 +1566,7 @@ components:
       name: Authorization
       type: apiKey
 security:
-- ApiKeyAuth: []
+  - ApiKeyAuth: []
 tags:
-- description: Yorkie is a service that provides a API for SDKs.
-  name: yorkie.v1.YorkieService
+  - description: Yorkie is a service that provides a API for SDKs.
+    name: yorkie.v1.YorkieService

--- a/build/charts/yorkie-cluster/Chart.yaml
+++ b/build/charts/yorkie-cluster/Chart.yaml
@@ -11,8 +11,8 @@ maintainers:
 
 sources:
   - https://github.com/yorkie-team/yorkie
-version: 0.4.27
-appVersion: "0.4.27"
+version: 0.4.28
+appVersion: "0.4.28"
 kubeVersion: ">=1.23.0-0"
 
 keywords:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Update CHANGELOG.md for v0.4.28

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced housekeeping capabilities with new tasks added.
	- Bulk retrieval functionality introduced in the GetDocuments API.
	- Performance improvements for creating `crdt.TreeNode` instances.
  
- **Bug Fixes**
	- Improved logic for the `updated_at` timestamp to update only during actual changes.

- **Version Updates**
	- Incremented version from `0.4.27` to `0.4.28` across various documentation and configuration files, indicating overall enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->