### PR TITLE
Fix FindDocInfosByKeys when keys is empty

### DIFF
--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -770,7 +770,7 @@ func (c *Client) FindDocInfosByKeys(
 	docKeys []key.Key,
 ) ([]*database.DocInfo, error) {
 	if len(docKeys) == 0 {
-		return []*database.DocInfo{}, nil
+		return nil, nil
 	}
 	filter := bson.M{
 		"project_id": projectID,

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -769,6 +769,9 @@ func (c *Client) FindDocInfosByKeys(
 	projectID types.ID,
 	docKeys []key.Key,
 ) ([]*database.DocInfo, error) {
+	if len(docKeys) == 0 {
+		return []*database.DocInfo{}, nil
+	}
 	filter := bson.M{
 		"project_id": projectID,
 		"key": bson.M{

--- a/server/backend/database/testcases/testcases.go
+++ b/server/backend/database/testcases/testcases.go
@@ -127,6 +127,27 @@ func RunFindDocInfosByKeysTest(
 		assert.Len(t, infos, len(docKeys))
 	})
 
+	t.Run("find docInfos by empty key slice test", func(t *testing.T) {
+		ctx := context.Background()
+		clientInfo, err := db.ActivateClient(ctx, projectID, t.Name())
+		assert.NoError(t, err)
+
+		// 01. Create documents
+		docKeys := []key.Key{
+			"test", "test$3", "test123", "test$0",
+			"search$test", "abcde", "test abc",
+		}
+		for _, docKey := range docKeys {
+			_, err := db.FindDocInfoByKeyAndOwner(ctx, clientInfo.RefKey(), docKey, true)
+			assert.NoError(t, err)
+		}
+
+		// 02. Find documents
+		infos, err := db.FindDocInfosByKeys(ctx, projectID, []key.Key{})
+		assert.NoError(t, err)
+		assert.Len(t, infos, 0)
+	})
+
 	t.Run("find docInfos by keys where some keys are not found test", func(t *testing.T) {
 		ctx := context.Background()
 		clientInfo, err := db.ActivateClient(ctx, projectID, t.Name())


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix the mongodb query keys slice to return an empty slice if it is empty.

Currently, FindDocInfosByKeys throws a query error when passing an empty slice of keys.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #943 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved robustness of the document retrieval process by preventing unnecessary database queries when no document keys are provided, resulting in a more efficient and responsive application.
- **Tests**
	- Added a new test case to ensure the function correctly handles scenarios where an empty slice of keys is provided, enhancing the reliability of the document retrieval functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->