### PR TITLE
Update docker compose command to V2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       run: make build
 
     - name: Stack
-      run: docker-compose -f build/docker/docker-compose.yml up --build -d
+      run: docker compose -f build/docker/docker-compose.yml up --build -d
 
     - name: Test
       run: go test -tags integration -race -coverprofile=coverage.txt -covermode=atomic -v ./...
@@ -77,7 +77,7 @@ jobs:
       run: make tools
 
     - name: Stack
-      run: docker-compose -f build/docker/docker-compose.yml up --build -d
+      run: docker compose -f build/docker/docker-compose.yml up --build -d
 
     - name: Bench
       run: make bench

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ make build		# executable: ./bin/yorkie
 You can set testing environment via Docker Compose. It is needed because integration tests require local applications like MongoDB.
 
 ```sh
-docker-compose -f build/docker/docker-compose.yml up --build -d
+docker compose -f build/docker/docker-compose.yml up --build -d
 make test
 ```
 

--- a/build/docker/README.md
+++ b/build/docker/README.md
@@ -5,14 +5,14 @@ running multi-container Docker applications. We use Docker Compose to run the
 applications needed during Yorkie development.
 
 When developing Yorkie, we can easily run the required dependant applications
-through `docker-compose` command.
+through `docker compose` command.
 
 ```bash
-# Run docker-compose up and Compose starts and runs apps.
-docker-compose -f docker/docker-compose.yml up --build -d
+# Run docker compose up and Compose starts and runs apps.
+docker compose -f docker/docker-compose.yml up --build -d
 
 # Shut down the apps
-docker-compose -f docker/docker-compose.yml down
+docker compose -f docker/docker-compose.yml down
 ```
 
 The docker-compose files we use are as follows:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR modified the docker-compose command, which was deprecated in compose v1, to the docker compose command in accordance with compose v2.

This also resolves the failure of CI workflow due to Docker Compose V1 being deprecated on the runner's ubuntu image by https://github.com/actions/runner-images/pull/10368

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #949

Related content
https://docs.docker.com/compose/migrate/

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [v] Added relevant tests or not required
- [v] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated CI workflow to use the newer `docker compose` command, enhancing compatibility and simplifying command usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->