### PR TITLE
Handle panic during conversion to connectCode

### DIFF
--- a/server/rpc/connecthelper/status.go
+++ b/server/rpc/connecthelper/status.go
@@ -151,9 +151,10 @@ func errorToConnectError(err error) (*connect.Error, bool) {
 		cause = errors.Unwrap(cause)
 	}
 
+	// NOTE(hackerwins): This prevents panic when the cause is an unhashable
+	// error.
 	var connectCode connect.Code
 	var ok bool
-
 	defer func() {
 		if r := recover(); r != nil {
 			ok = false
@@ -161,7 +162,6 @@ func errorToConnectError(err error) (*connect.Error, bool) {
 	}()
 
 	connectCode, ok = errorToConnectCode[cause]
-
 	if !ok {
 		return nil, false
 	}

--- a/server/rpc/connecthelper/status.go
+++ b/server/rpc/connecthelper/status.go
@@ -151,7 +151,17 @@ func errorToConnectError(err error) (*connect.Error, bool) {
 		cause = errors.Unwrap(cause)
 	}
 
-	connectCode, ok := errorToConnectCode[cause]
+	var connectCode connect.Code
+	var ok bool
+
+	defer func() {
+		if r := recover(); r != nil {
+			ok = false
+		}
+	}()
+
+	connectCode, ok = errorToConnectCode[cause]
+
 	if !ok {
 		return nil, false
 	}

--- a/server/rpc/connecthelper/status_test.go
+++ b/server/rpc/connecthelper/status_test.go
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connecthelper
+
+import (
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/mongo"
+
+	"github.com/yorkie-team/yorkie/api/converter"
+)
+
+func TestStatus(t *testing.T) {
+	t.Run("errorToConnectCode test", func(t *testing.T) {
+		status, ok := errorToConnectError(converter.ErrPackRequired)
+		assert.True(t, ok)
+		assert.Equal(t, status.Code(), connect.CodeInvalidArgument)
+
+		status, ok = errorToConnectError(mongo.CommandError{})
+		assert.False(t, ok)
+		assert.Nil(t, status)
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

If an unhashable error is given, the error cannot be converted to a connecteError with a map, causing a panic and shutting down the server.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #944 

**Special notes for your reviewer**:

Would it be a good idea to log errors in recover?

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved error handling in the connection status function to enhance resilience against runtime errors.
	- Implemented panic recovery to prevent unexpected failures during execution.
- **Tests**
	- Introduced a test suite for the connection helper functions, ensuring robust error handling through various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->