### PR TITLE
Add HTTP health check handler for server health monitoring

### DIFF
--- a/server/rpc/health/health.go
+++ b/server/rpc/health/health.go
@@ -29,8 +29,8 @@ type CheckResponse struct {
 	Status string `json:"status"`
 }
 
-// NewHTTPHealthCheckHandler creates a new HTTP handler for health checks.
-func NewHTTPHealthCheckHandler(checker grpchealth.Checker) (string, http.Handler) {
+// NewHTTPHandler creates a new HTTP handler for health checks.
+func NewHTTPHandler(checker grpchealth.Checker) (string, http.Handler) {
 	const serviceName = "/healthz/"
 	check := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {

--- a/server/rpc/health/health.go
+++ b/server/rpc/health/health.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package health uses http GET to provide a health check for the server.
+package health
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"connectrpc.com/grpchealth"
+)
+
+// HealthCheckResponse represents the response structure for health checks.
+type HealthCheckResponse struct {
+	Status string `json:"status"`
+}
+
+// NewHTTPHealthCheckHandler creates a new HTTP handler for health checks.
+func NewHTTPHealthCheckHandler(checker grpchealth.Checker) (string, http.Handler) {
+	const serviceName = "/healthz/"
+	check := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var checkRequest grpchealth.CheckRequest
+		service := r.URL.Query().Get("service")
+		if service != "" {
+			checkRequest.Service = service
+		}
+		checkResponse, err := checker.Check(r.Context(), &checkRequest)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		resp, err := json.Marshal(HealthCheckResponse{checkResponse.Status.String()})
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write(resp); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	})
+	return serviceName, check
+}

--- a/server/rpc/health/health.go
+++ b/server/rpc/health/health.go
@@ -24,8 +24,8 @@ import (
 	"connectrpc.com/grpchealth"
 )
 
-// HealthCheckResponse represents the response structure for health checks.
-type HealthCheckResponse struct {
+// CheckResponse represents the response structure for health checks.
+type CheckResponse struct {
 	Status string `json:"status"`
 }
 
@@ -47,7 +47,7 @@ func NewHTTPHealthCheckHandler(checker grpchealth.Checker) (string, http.Handler
 			http.Error(w, err.Error(), http.StatusNotFound)
 			return
 		}
-		resp, err := json.Marshal(HealthCheckResponse{checkResponse.Status.String()})
+		resp, err := json.Marshal(CheckResponse{checkResponse.Status.String()})
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/server/rpc/httphealth/httphealth.go
+++ b/server/rpc/httphealth/httphealth.go
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-// Package health uses http GET to provide a health check for the server.
-package health
+// Package httphealth uses http GET to provide a health check for the server.
+package httphealth
 
 import (
 	"encoding/json"
@@ -29,8 +29,8 @@ type CheckResponse struct {
 	Status string `json:"status"`
 }
 
-// NewHTTPHandler creates a new HTTP handler for health checks.
-func NewHTTPHandler(checker grpchealth.Checker) (string, http.Handler) {
+// NewHandler creates a new HTTP handler for health checks.
+func NewHandler(checker grpchealth.Checker) (string, http.Handler) {
 	const serviceName = "/healthz/"
 	check := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {

--- a/server/rpc/server.go
+++ b/server/rpc/server.go
@@ -74,7 +74,7 @@ func NewServer(conf *Config, be *backend.Backend) (*Server, error) {
 	mux.Handle(v1connect.NewYorkieServiceHandler(newYorkieServer(yorkieServiceCtx, be), opts...))
 	mux.Handle(v1connect.NewAdminServiceHandler(newAdminServer(be, tokenManager), opts...))
 	mux.Handle(grpchealth.NewHandler(healthChecker))
-	mux.Handle(health.NewHTTPHealthCheckHandler(healthChecker))
+	mux.Handle(health.NewHTTPHandler(healthChecker))
 	// TODO(hackerwins): We need to provide proper http server configuration.
 	return &Server{
 		conf: conf,

--- a/server/rpc/server.go
+++ b/server/rpc/server.go
@@ -36,7 +36,7 @@ import (
 	"github.com/yorkie-team/yorkie/server/backend"
 	"github.com/yorkie-team/yorkie/server/logging"
 	"github.com/yorkie-team/yorkie/server/rpc/auth"
-	"github.com/yorkie-team/yorkie/server/rpc/health"
+	"github.com/yorkie-team/yorkie/server/rpc/httphealth"
 	"github.com/yorkie-team/yorkie/server/rpc/interceptors"
 )
 
@@ -74,7 +74,7 @@ func NewServer(conf *Config, be *backend.Backend) (*Server, error) {
 	mux.Handle(v1connect.NewYorkieServiceHandler(newYorkieServer(yorkieServiceCtx, be), opts...))
 	mux.Handle(v1connect.NewAdminServiceHandler(newAdminServer(be, tokenManager), opts...))
 	mux.Handle(grpchealth.NewHandler(healthChecker))
-	mux.Handle(health.NewHTTPHandler(healthChecker))
+	mux.Handle(httphealth.NewHandler(healthChecker))
 	// TODO(hackerwins): We need to provide proper http server configuration.
 	return &Server{
 		conf: conf,

--- a/test/integration/health_test.go
+++ b/test/integration/health_test.go
@@ -27,7 +27,7 @@ import (
 	"connectrpc.com/grpchealth"
 	"github.com/stretchr/testify/assert"
 	"github.com/yorkie-team/yorkie/api/yorkie/v1/v1connect"
-	"github.com/yorkie-team/yorkie/server/rpc/health"
+	"github.com/yorkie-team/yorkie/server/rpc/httphealth"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
@@ -88,7 +88,7 @@ func TestHTTPHealthCheck(t *testing.T) {
 		}()
 		assert.Equal(t, resp.StatusCode, http.StatusOK)
 
-		var healthResp health.CheckResponse
+		var healthResp httphealth.CheckResponse
 		err = json.NewDecoder(resp.Body).Decode(&healthResp)
 		assert.NoError(t, err)
 		assert.Equal(t, healthResp.Status, grpchealth.StatusServing.String())
@@ -106,7 +106,7 @@ func TestHTTPHealthCheck(t *testing.T) {
 			}()
 			assert.Equal(t, resp.StatusCode, http.StatusOK)
 
-			var healthResp health.CheckResponse
+			var healthResp httphealth.CheckResponse
 			err = json.NewDecoder(resp.Body).Decode(&healthResp)
 			assert.NoError(t, err)
 			assert.Equal(t, healthResp.Status, grpchealth.StatusServing.String())

--- a/test/integration/health_test.go
+++ b/test/integration/health_test.go
@@ -26,6 +26,7 @@ import (
 
 	"connectrpc.com/grpchealth"
 	"github.com/stretchr/testify/assert"
+	"github.com/yorkie-team/yorkie/api/yorkie/v1/v1connect"
 	"github.com/yorkie-team/yorkie/server/rpc/health"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -49,6 +50,81 @@ func TestRPCHealthCheck(t *testing.T) {
 	assert.Equal(t, resp.Status, healthpb.HealthCheckResponse_SERVING)
 }
 
+func TestRPCHealthCheckYorkie(t *testing.T) {
+	// use gRPC health check for Yorkie
+	conn, err := grpc.Dial(
+		defaultServer.RPCAddr(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, conn.Close())
+	}()
+
+	cli := healthpb.NewHealthClient(conn)
+	resp, err := cli.Check(context.Background(), &healthpb.HealthCheckRequest{
+		Service: v1connect.YorkieServiceName,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, resp.Status, healthpb.HealthCheckResponse_SERVING)
+}
+
+func TestRPCHealthCheckAdmin(t *testing.T) {
+	// use gRPC health check for Admin
+	conn, err := grpc.Dial(
+		defaultServer.RPCAddr(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, conn.Close())
+	}()
+
+	cli := healthpb.NewHealthClient(conn)
+	resp, err := cli.Check(context.Background(), &healthpb.HealthCheckRequest{
+		Service: v1connect.AdminServiceName,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, resp.Status, healthpb.HealthCheckResponse_SERVING)
+}
+
+func TestRPCHealthCheckHealthService(t *testing.T) {
+	// use gRPC health check for health service
+	conn, err := grpc.Dial(
+		defaultServer.RPCAddr(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, conn.Close())
+	}()
+
+	cli := healthpb.NewHealthClient(conn)
+	resp, err := cli.Check(context.Background(), &healthpb.HealthCheckRequest{
+		Service: grpchealth.HealthV1ServiceName,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, resp.Status, healthpb.HealthCheckResponse_SERVING)
+}
+
+func TestRPCHealthCheckUnknownService(t *testing.T) {
+	// use gRPC health check for unknown service
+	conn, err := grpc.Dial(
+		defaultServer.RPCAddr(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, conn.Close())
+	}()
+
+	cli := healthpb.NewHealthClient(conn)
+	_, err = cli.Check(context.Background(), &healthpb.HealthCheckRequest{
+		Service: "unknown",
+	})
+	assert.Error(t, err)
+}
+
 func TestHTTPHealthCheck(t *testing.T) {
 	// use HTTP health check
 	resp, err := http.Get("http://" + defaultServer.RPCAddr() + "/healthz/")
@@ -62,4 +138,59 @@ func TestHTTPHealthCheck(t *testing.T) {
 	err = json.NewDecoder(resp.Body).Decode(&healthResp)
 	assert.NoError(t, err)
 	assert.Equal(t, healthResp.Status, grpchealth.StatusServing.String())
+}
+
+func TestHTTPHealthCheckYorkie(t *testing.T) {
+	// use HTTP health check for Yorkie
+	resp, err := http.Get("http://" + defaultServer.RPCAddr() + "/healthz/?service=" + v1connect.YorkieServiceName)
+	defer func() {
+		assert.NoError(t, resp.Body.Close())
+	}()
+	assert.NoError(t, err)
+	assert.Equal(t, resp.StatusCode, 200)
+
+	var healthResp health.CheckResponse
+	err = json.NewDecoder(resp.Body).Decode(&healthResp)
+	assert.NoError(t, err)
+	assert.Equal(t, healthResp.Status, grpchealth.StatusServing.String())
+}
+
+func TestHTTPHealthCheckAdmin(t *testing.T) {
+	// use HTTP health check for Admin
+	resp, err := http.Get("http://" + defaultServer.RPCAddr() + "/healthz/?service=" + v1connect.AdminServiceName)
+	defer func() {
+		assert.NoError(t, resp.Body.Close())
+	}()
+	assert.NoError(t, err)
+	assert.Equal(t, resp.StatusCode, 200)
+
+	var healthResp health.CheckResponse
+	err = json.NewDecoder(resp.Body).Decode(&healthResp)
+	assert.NoError(t, err)
+	assert.Equal(t, healthResp.Status, grpchealth.StatusServing.String())
+}
+
+func TestHTTPHealthCheckHealthService(t *testing.T) {
+	// use HTTP health check for health service
+	resp, err := http.Get("http://" + defaultServer.RPCAddr() + "/healthz/?service=" + grpchealth.HealthV1ServiceName)
+	defer func() {
+		assert.NoError(t, resp.Body.Close())
+	}()
+	assert.NoError(t, err)
+	assert.Equal(t, resp.StatusCode, 200)
+
+	var healthResp health.CheckResponse
+	err = json.NewDecoder(resp.Body).Decode(&healthResp)
+	assert.NoError(t, err)
+	assert.Equal(t, healthResp.Status, grpchealth.StatusServing.String())
+}
+
+func TestHTTPHealthCheckUnknownService(t *testing.T) {
+	// use HTTP health check for unknown service
+	resp, err := http.Get("http://" + defaultServer.RPCAddr() + "/healthz/?service=unknown")
+	defer func() {
+		assert.NoError(t, resp.Body.Close())
+	}()
+	assert.NoError(t, err)
+	assert.Equal(t, resp.StatusCode, 404)
 }

--- a/test/integration/health_test.go
+++ b/test/integration/health_test.go
@@ -58,7 +58,7 @@ func TestHTTPHealthCheck(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, resp.StatusCode, 200)
 
-	var healthResp health.HealthCheckResponse
+	var healthResp health.CheckResponse
 	err = json.NewDecoder(resp.Body).Decode(&healthResp)
 	assert.NoError(t, err)
 	assert.Equal(t, healthResp.Status, grpchealth.StatusServing.String())

--- a/test/integration/health_test.go
+++ b/test/integration/health_test.go
@@ -33,8 +33,13 @@ import (
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
+var services = []string{
+	grpchealth.HealthV1ServiceName,
+	v1connect.YorkieServiceName,
+	v1connect.AdminServiceName,
+}
+
 func TestRPCHealthCheck(t *testing.T) {
-	// use gRPC health check
 	conn, err := grpc.Dial(
 		defaultServer.RPCAddr(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -43,140 +48,78 @@ func TestRPCHealthCheck(t *testing.T) {
 	defer func() {
 		assert.NoError(t, conn.Close())
 	}()
-
 	cli := healthpb.NewHealthClient(conn)
-	resp, err := cli.Check(context.Background(), &healthpb.HealthCheckRequest{})
-	assert.NoError(t, err)
-	assert.Equal(t, resp.Status, healthpb.HealthCheckResponse_SERVING)
 
-	// use gRPC health check for unknown service
-	_, err = cli.Check(context.Background(), &healthpb.HealthCheckRequest{
-		Service: "unknown",
+	// check default service
+	t.Run("Service: default", func(t *testing.T) {
+		resp, err := cli.Check(context.Background(), &healthpb.HealthCheckRequest{})
+		assert.NoError(t, err)
+		assert.Equal(t, resp.Status, healthpb.HealthCheckResponse_SERVING)
 	})
-	assert.Error(t, err)
-}
 
-func TestRPCHealthCheckYorkie(t *testing.T) {
-	// use gRPC health check for Yorkie
-	conn, err := grpc.Dial(
-		defaultServer.RPCAddr(),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
-	assert.NoError(t, err)
-	defer func() {
-		assert.NoError(t, conn.Close())
-	}()
+	// check all services
+	for _, s := range services {
+		service := s
+		t.Run("Service: "+service, func(t *testing.T) {
+			resp, err := cli.Check(context.Background(), &healthpb.HealthCheckRequest{
+				Service: service,
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, resp.Status, healthpb.HealthCheckResponse_SERVING)
+		})
+	}
 
-	cli := healthpb.NewHealthClient(conn)
-	resp, err := cli.Check(context.Background(), &healthpb.HealthCheckRequest{
-		Service: v1connect.YorkieServiceName,
+	// check unknown service
+	t.Run("Service: unknown", func(t *testing.T) {
+		_, err := cli.Check(context.Background(), &healthpb.HealthCheckRequest{
+			Service: "unknown",
+		})
+		assert.Error(t, err)
 	})
-	assert.NoError(t, err)
-	assert.Equal(t, resp.Status, healthpb.HealthCheckResponse_SERVING)
-}
-
-func TestRPCHealthCheckAdmin(t *testing.T) {
-	// use gRPC health check for Admin
-	conn, err := grpc.Dial(
-		defaultServer.RPCAddr(),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
-	assert.NoError(t, err)
-	defer func() {
-		assert.NoError(t, conn.Close())
-	}()
-
-	cli := healthpb.NewHealthClient(conn)
-	resp, err := cli.Check(context.Background(), &healthpb.HealthCheckRequest{
-		Service: v1connect.AdminServiceName,
-	})
-	assert.NoError(t, err)
-	assert.Equal(t, resp.Status, healthpb.HealthCheckResponse_SERVING)
-}
-
-func TestRPCHealthCheckHealthService(t *testing.T) {
-	// use gRPC health check for health service
-	conn, err := grpc.Dial(
-		defaultServer.RPCAddr(),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
-	assert.NoError(t, err)
-	defer func() {
-		assert.NoError(t, conn.Close())
-	}()
-
-	cli := healthpb.NewHealthClient(conn)
-	resp, err := cli.Check(context.Background(), &healthpb.HealthCheckRequest{
-		Service: grpchealth.HealthV1ServiceName,
-	})
-	assert.NoError(t, err)
-	assert.Equal(t, resp.Status, healthpb.HealthCheckResponse_SERVING)
 }
 
 func TestHTTPHealthCheck(t *testing.T) {
-	// use HTTP health check
-	resp, err := http.Get("http://" + defaultServer.RPCAddr() + "/healthz/")
-	defer func() {
-		assert.NoError(t, resp.Body.Close())
-	}()
-	assert.NoError(t, err)
-	assert.Equal(t, resp.StatusCode, 200)
+	// check default service
+	t.Run("Service: default", func(t *testing.T) {
+		resp, err := http.Get("http://" + defaultServer.RPCAddr() + "/healthz/")
+		assert.NoError(t, err)
+		defer func() {
+			assert.NoError(t, resp.Body.Close())
+		}()
+		assert.Equal(t, resp.StatusCode, http.StatusOK)
 
-	var healthResp health.CheckResponse
-	err = json.NewDecoder(resp.Body).Decode(&healthResp)
-	assert.NoError(t, err)
-	assert.Equal(t, healthResp.Status, grpchealth.StatusServing.String())
+		var healthResp health.CheckResponse
+		err = json.NewDecoder(resp.Body).Decode(&healthResp)
+		assert.NoError(t, err)
+		assert.Equal(t, healthResp.Status, grpchealth.StatusServing.String())
+	})
 
-	// use HTTP health check for unknown service
-	resp, err = http.Get("http://" + defaultServer.RPCAddr() + "/healthz/?service=unknown")
-	defer func() {
-		assert.NoError(t, resp.Body.Close())
-	}()
-	assert.NoError(t, err)
-	assert.Equal(t, resp.StatusCode, 404)
-}
+	// check all services
+	for _, s := range services {
+		service := s
+		t.Run("Service: "+service, func(t *testing.T) {
+			url := "http://" + defaultServer.RPCAddr() + "/healthz/?service=" + service
+			resp, err := http.Get(url)
+			assert.NoError(t, err)
+			defer func() {
+				assert.NoError(t, resp.Body.Close())
+			}()
+			assert.Equal(t, resp.StatusCode, http.StatusOK)
 
-func TestHTTPHealthCheckYorkie(t *testing.T) {
-	// use HTTP health check for Yorkie
-	resp, err := http.Get("http://" + defaultServer.RPCAddr() + "/healthz/?service=" + v1connect.YorkieServiceName)
-	defer func() {
-		assert.NoError(t, resp.Body.Close())
-	}()
-	assert.NoError(t, err)
-	assert.Equal(t, resp.StatusCode, 200)
+			var healthResp health.CheckResponse
+			err = json.NewDecoder(resp.Body).Decode(&healthResp)
+			assert.NoError(t, err)
+			assert.Equal(t, healthResp.Status, grpchealth.StatusServing.String())
+		})
+	}
 
-	var healthResp health.CheckResponse
-	err = json.NewDecoder(resp.Body).Decode(&healthResp)
-	assert.NoError(t, err)
-	assert.Equal(t, healthResp.Status, grpchealth.StatusServing.String())
-}
-
-func TestHTTPHealthCheckAdmin(t *testing.T) {
-	// use HTTP health check for Admin
-	resp, err := http.Get("http://" + defaultServer.RPCAddr() + "/healthz/?service=" + v1connect.AdminServiceName)
-	defer func() {
-		assert.NoError(t, resp.Body.Close())
-	}()
-	assert.NoError(t, err)
-	assert.Equal(t, resp.StatusCode, 200)
-
-	var healthResp health.CheckResponse
-	err = json.NewDecoder(resp.Body).Decode(&healthResp)
-	assert.NoError(t, err)
-	assert.Equal(t, healthResp.Status, grpchealth.StatusServing.String())
-}
-
-func TestHTTPHealthCheckHealthService(t *testing.T) {
-	// use HTTP health check for health service
-	resp, err := http.Get("http://" + defaultServer.RPCAddr() + "/healthz/?service=" + grpchealth.HealthV1ServiceName)
-	defer func() {
-		assert.NoError(t, resp.Body.Close())
-	}()
-	assert.NoError(t, err)
-	assert.Equal(t, resp.StatusCode, 200)
-
-	var healthResp health.CheckResponse
-	err = json.NewDecoder(resp.Body).Decode(&healthResp)
-	assert.NoError(t, err)
-	assert.Equal(t, healthResp.Status, grpchealth.StatusServing.String())
+	// check unknown service
+	t.Run("Service: unknown", func(t *testing.T) {
+		resp, err := http.Get("http://" + defaultServer.RPCAddr() + "/healthz/?service=unknown")
+		assert.NoError(t, err)
+		defer func() {
+			assert.NoError(t, resp.Body.Close())
+		}()
+		assert.Equal(t, resp.StatusCode, http.StatusNotFound)
+	})
 }


### PR DESCRIPTION
Added a handler to allow health checks to be performed with plain HTTP GET requests, rather than health checks using rpc.

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
In issue #832 , we needed a health check via HTTP GET or HEAD method because of NCP's load balancer.
The existing [grpchealth](https://github.com/connectrpc/grpchealth-go) could not satisfy this, so we implemented a separate handler.
This allows us to check the health of a specific service via the path `/healthz/` and the health of a specific service via the query `service=<serviceName>`.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #832 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced health check functionality, allowing clients to verify the server's status via HTTP GET requests.
  - Added an HTTP handler for health checks, enhancing service reliability and monitoring.

- **Bug Fixes**
  - Improved error handling for unsupported request methods.

- **Tests**
  - Renamed existing health check test for clarity.
  - Added multiple new tests for both gRPC and HTTP health checks to ensure comprehensive coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->