### PR TITLE
Set `updated_at` with `created_at` when creating Document

### DIFF
--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -746,6 +746,7 @@ func (d *DB) FindDocInfoByKeyAndOwner(
 			Owner:      clientRefKey.ClientID,
 			ServerSeq:  0,
 			CreatedAt:  now,
+			UpdatedAt:  now,
 			AccessedAt: now,
 		}
 		if err := txn.Insert(tblDocuments, info); err != nil {

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -741,7 +741,7 @@ func (c *Client) FindDocInfoByKeyAndOwner(
 				"created_at": now,
 				"updated_at": now,
 			},
-		})
+		}, options.FindOneAndUpdate().SetReturnDocument(options.After))
 	} else {
 		result = c.collection(ColDocuments).FindOne(ctx, filter)
 		if result.Err() == mongo.ErrNoDocuments {

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -739,6 +739,7 @@ func (c *Client) FindDocInfoByKeyAndOwner(
 				"owner":      clientRefKey.ClientID,
 				"server_seq": 0,
 				"created_at": now,
+				"updated_at": now,
 			},
 		})
 	} else {

--- a/server/backend/database/testcases/testcases.go
+++ b/server/backend/database/testcases/testcases.go
@@ -948,6 +948,9 @@ func RunCreateChangeInfosTest(t *testing.T, db database.Database, projectID type
 		// 01. Create a client and a document then attach the document to the client.
 		clientInfo, _ := db.ActivateClient(ctx, projectID, t.Name())
 		docInfo1, _ := db.FindDocInfoByKeyAndOwner(ctx, clientInfo.RefKey(), docKey, true)
+		assert.Equal(t, docInfo1.Owner, clientInfo.ID)
+		assert.NotEqual(t, gotime.Date(1, gotime.January, 1, 0, 0, 0, 0, gotime.UTC), docInfo1.UpdatedAt)
+		assert.Equal(t, docInfo1.CreatedAt, docInfo1.UpdatedAt)
 		docRefKey := docInfo1.RefKey()
 		assert.NoError(t, clientInfo.AttachDocument(docRefKey.DocID, false))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo1))
@@ -957,7 +960,7 @@ func RunCreateChangeInfosTest(t *testing.T, db database.Database, projectID type
 		doc := document.New(key.Key(t.Name()))
 		doc.SetActor(actorID)
 
-		// 02. update document only presence
+		// 02. Update document only presence
 		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
 			p.Set("key", "val")
 			return nil
@@ -968,7 +971,7 @@ func RunCreateChangeInfosTest(t *testing.T, db database.Database, projectID type
 		docInfo2, _ := db.FindDocInfoByKeyAndOwner(ctx, clientInfo.RefKey(), docKey, true)
 		assert.Equal(t, updatedAt, docInfo2.UpdatedAt)
 
-		// 03. update document presence and operation
+		// 03. Update document presence and operation
 		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
 			p.Set("key", "val")
 			root.SetNewArray("array")


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

This PR ensures that when a new `Document` is created and attached, the `updated_at` field is initialized with the `created_at` timestamp. 

Before the commit [b494fa2d](https://github.com/yorkie-team/yorkie/commit/b494fa2d02c17e229ad3fc5cebaa7ea33231077a), the `updated_at` field was correctly set during the attachment process through a `pushpull` operation that included presence. However, after this commit, the `updated_at` field is no longer updated when the document is attached, leading to inconsistencies.


Fixes #968

**Special notes for your reviewer**:

The underlying issue stems from the `FindDocInfoByKeyAndOwner` function, which returned a `DocInfo` object without setting the "owner", "server_seq", "created_at", and "updated_at" fields, leading to zero values being assigned. While this functionality is acceptable within the specific context where only `project_id` and `id` are required, it creates issues when the `AttachDocument` function relies on these values. It currently works around this issue since `server_seq` has a zero value of 0. 

However, I believe we should return `DocInfo` with the updated "owner", "server_seq", "created_at", "updated_at" fields to maintain consistency and improve clarity.



**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an `UpdatedAt` field for improved tracking of document update times.
	- Enhanced document update functionality to return the latest version post-update.

- **Bug Fixes**
	- Improved test assertions to ensure document ownership and timestamp accuracy.

- **Documentation**
	- Updated comments for improved readability in test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->