### PR TITLE
Implement `InitialRoot` option for Document attachment

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -349,12 +349,14 @@ func (c *Client) Attach(ctx context.Context, doc *document.Document, options ...
 
 	if opts.InitialRoot != nil {
 		if !doc.HasElement() {
-			err = doc.Update(func(root *json.Object, p *presence.Presence) error {
+			if err = doc.Update(func(root *json.Object, p *presence.Presence) error {
 				for k, v := range opts.InitialRoot {
 					root.SetDynamicValue(k, v)
 				}
 				return nil
-			})
+			}); err != nil {
+				return err
+			}
 		} else {
 			return ErrDocumentExists
 		}

--- a/client/client.go
+++ b/client/client.go
@@ -344,16 +344,17 @@ func (c *Client) Attach(ctx context.Context, doc *document.Document, options ...
 		}
 	}
 
-	if opts.InitialRoot != nil {
-		if err = doc.Update(func(root *json.Object, p *presence.Presence) error {
-			for k, v := range opts.InitialRoot {
+	if err = doc.Update(func(root *json.Object, p *presence.Presence) error {
+		for k, v := range opts.InitialRoot {
+			if root.Get(k) == nil {
 				root.SetDynamicValue(k, v)
 			}
-			return nil
-		}); err != nil {
-			return err
 		}
+		return nil
+	}); err != nil {
+		return err
 	}
+
 	return nil
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -63,6 +63,9 @@ var (
 	// this client.
 	ErrDocumentNotAttached = errors.New("document is not attached")
 
+	// ErrDocumentExists occurs when use initialRoot Option but document already exists.
+	ErrDocumentExists = errors.New("document already exists in server")
+
 	// ErrDocumentNotDetached occurs when the given document is not detached from
 	// this client.
 	ErrDocumentNotDetached = errors.New("document is not detached")
@@ -344,6 +347,18 @@ func (c *Client) Attach(ctx context.Context, doc *document.Document, options ...
 		}
 	}
 
+	if opts.InitialRoot != nil {
+		if !doc.HasElement() {
+			err = doc.Update(func(root *json.Object, p *presence.Presence) error {
+				for k, v := range opts.InitialRoot {
+					root.SetDynamicValue(k, v)
+				}
+				return nil
+			})
+		} else {
+			return ErrDocumentExists
+		}
+	}
 	return nil
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -63,9 +63,6 @@ var (
 	// this client.
 	ErrDocumentNotAttached = errors.New("document is not attached")
 
-	// ErrDocumentExists occurs when use initialRoot Option but document already exists.
-	ErrDocumentExists = errors.New("document already exists in server")
-
 	// ErrDocumentNotDetached occurs when the given document is not detached from
 	// this client.
 	ErrDocumentNotDetached = errors.New("document is not detached")
@@ -348,17 +345,13 @@ func (c *Client) Attach(ctx context.Context, doc *document.Document, options ...
 	}
 
 	if opts.InitialRoot != nil {
-		if !doc.HasElement() {
-			if err = doc.Update(func(root *json.Object, p *presence.Presence) error {
-				for k, v := range opts.InitialRoot {
-					root.SetDynamicValue(k, v)
-				}
-				return nil
-			}); err != nil {
-				return err
+		if err = doc.Update(func(root *json.Object, p *presence.Presence) error {
+			for k, v := range opts.InitialRoot {
+				root.SetDynamicValue(k, v)
 			}
-		} else {
-			return ErrDocumentExists
+			return nil
+		}); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/client/options.go
+++ b/client/options.go
@@ -102,8 +102,9 @@ func WithPresence(presence innerpresence.Presence) AttachOption {
 	return func(o *AttachOptions) { o.Presence = presence }
 }
 
-// WithInitialRoot sets the initial root of the document.
-// If the document already exists before attachment, this initial root will not be applied.
+// WithInitialRoot sets the initial root of the document. Values in the initial
+// root will be discarded if the key already exists in the document. If some
+// keys are not in the document, they will be added.
 func WithInitialRoot(root map[string]any) AttachOption {
 	return func(o *AttachOptions) {
 		o.InitialRoot = root

--- a/client/options.go
+++ b/client/options.go
@@ -92,13 +92,22 @@ type AttachOption func(*AttachOptions)
 // AttachOptions configures how we set up the document.
 type AttachOptions struct {
 	// Presence is the presence of the client.
-	Presence innerpresence.Presence
-	IsManual bool
+	Presence    innerpresence.Presence
+	InitialRoot map[string]any
+	IsManual    bool
 }
 
 // WithPresence configures the presence of the client.
 func WithPresence(presence innerpresence.Presence) AttachOption {
 	return func(o *AttachOptions) { o.Presence = presence }
+}
+
+// WithInitialRoot sets the initial root of the document.
+// If the document already exists before attachment, this initial root will not be applied.
+func WithInitialRoot(root map[string]any) AttachOption {
+	return func(o *AttachOptions) {
+		o.InitialRoot = root
+	}
 }
 
 // WithManualSync configures the manual sync of the client.

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -267,11 +267,6 @@ func (d *Document) HasLocalChanges() bool {
 	return d.doc.HasLocalChanges()
 }
 
-// HasElement returns whether this document has any elements or not.
-func (d *Document) HasElement() bool {
-	return d.doc.Root().ElementMapLen() > 1 || d.GarbageLen() > 0
-}
-
 // Marshal returns the JSON encoding of this document.
 func (d *Document) Marshal() string {
 	return d.doc.Marshal()

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -267,6 +267,11 @@ func (d *Document) HasLocalChanges() bool {
 	return d.doc.HasLocalChanges()
 }
 
+// HasElement returns whether this document has any elements or not.
+func (d *Document) HasElement() bool {
+	return d.doc.Root().ElementMapLen() > 1 || d.GarbageLen() > 0
+}
+
 // Marshal returns the JSON encoding of this document.
 func (d *Document) Marshal() string {
 	return d.doc.Marshal()

--- a/pkg/document/json/object.go
+++ b/pkg/document/json/object.go
@@ -43,6 +43,13 @@ func NewObject(ctx *change.Context, root *crdt.Object) *Object {
 	}
 }
 
+// SetDynamicValue sets a dynamic value for the given key.
+func (p *Object) SetDynamicValue(k string, v any) {
+	p.setInternal(k, func(ticket *time.Ticket) crdt.Element {
+		return toElement(p.context, buildCRDTElement(p.context, v, ticket, newBuildState()))
+	})
+}
+
 // SetNewObject sets a new Object for the given key.
 func (p *Object) SetNewObject(k string, v ...any) *Object {
 	value := p.setInternal(k, func(ticket *time.Ticket) crdt.Element {

--- a/test/integration/document_test.go
+++ b/test/integration/document_test.go
@@ -881,7 +881,7 @@ func TestDocumentWithInitialRoot(t *testing.T) {
 
 		// 02. attach with initialRoot and fails because document has elements
 		doc2 := document.New(helper.TestDocKey(t))
-		assert.ErrorIs(t, client.ErrDocumentExists, c2.Attach(ctx, doc2, client.WithInitialRoot(map[string]any{
+		assert.Error(t, c2.Attach(ctx, doc2, client.WithInitialRoot(map[string]any{
 			"counter": json.NewCounter(2, crdt.LongCnt),
 			"content": map[string]any{
 				"x": 2,
@@ -900,7 +900,7 @@ func TestDocumentWithInitialRoot(t *testing.T) {
 
 		// 03. attach with initialRoot and fails because document has no elements but garbage
 		doc3 := document.New(helper.TestDocKey(t))
-		assert.ErrorIs(t, client.ErrDocumentExists, c3.Attach(ctx, doc3, client.WithInitialRoot(map[string]any{
+		assert.Error(t, c3.Attach(ctx, doc3, client.WithInitialRoot(map[string]any{
 			"counter": json.NewCounter(3, crdt.LongCnt),
 			"content": map[string]any{
 				"x": 3,


### PR DESCRIPTION
**What this PR does / why we need it**: 

This PR introduces an `initialRoot` option when users attach a Document. The goal is to set initial values for editing documents with a predefined structure. Rather than checking if the document is in its initial state or empty, this feature checks if the document has been set up with initial values for editing, and if not, it applies them.

**Implementation details**:
- The `attach` function in the client now accepts an `initialRoot` option.
- `initialRoot` can be partially applied. For each element in `initialRoot`:
    - If the key already exists in the Document, that element will be discarded.
    - If the key doesn't exist, the element will be applied.
- In this implementation, `initialRoot` is not sent to the server during `Attach`. It is applied locally to the Document after pushpull during `Attach`.

**How to use the initialRoot option**: 
When attaching a document, you can use the `initialRoot` option. Here's a comparison of the old and new approaches:

Before (without `initialRoot`):
```go
doc := document.New("doc_key")
client1.Attach(ctx, doc)
doc.Update(func(root *json.Object, p *presence.Presence) error {  
    if root.GetCounter("k")!=nil{  
       root.GetCounter("k").Increase(1)  
    }else{  
       root.SetNewCounter("k", crdt.LongCnt, 0).Increase(1)  
    }  
    return nil  
})
```

After (with `initialRoot`):
```go
doc := document.New("doc_key")
client1.Attach(ctx, doc, client.WithInitialRoot(map[string]any{
    "k": json.NewCounter(0, crdt.LongCnt),  
}))
doc.Update(func(root *json.Object, p *presence.Presence) error {  
    root.GetCounter("k").Increase(1)  
    return nil  
})
```

In this case:
- If a counter for "k" already exists, setting it to 0 is discarded.
- If a counter for "k" doesn't exist, it's initialized with 0.
- Users don't need to worry about overwriting existing valid counters.

**Note**: 
- This function doesn't perform type checking to ensure "k" is a counter. Yorkie recommends using the same type for the same key to maintain consistency.
- Currently, when documents are created simultaneously, one user's document may overwrite another's due to LWW (Last Write Wins). To see an example of this case, please refer `concurrent attach with InitialRoot test case`


**Which issue(s) this PR fixes**:

Addresses #669

**Special notes for your reviewer**:
1. This implementation uses a key-based criterion to determine whether to apply the `initialRoot`.
2. It works for both new and existing documents, preventing accidental overwriting of content.

**Does this PR introduce a user-facing change?**:
```
Users can use an initialRoot option when attaching documents.
```

**Additional documentation**:

**Future plans** (as discussed):

1. Consider creating the Document instance in the `attach` method in future work.
2. Implement offline editing features.

**Checklist**:
* [x] Added relevant tests
* [x] Didn't break existing functionality

<details>
  <summary>Previous discussion</summary>
  <div>
  This PR introduces an "InitialRoot" option when users attach a Document. The goal is to allow initialization under specific conditions. Two approaches are considered:

  1. Apply InitialRoot only when the Document is first created
  2. Apply InitialRoot when the Document is empty

  Here's how each option works:
  1. Apply InitialRoot only when Document is first created:
     * Determined by checking if the Checkpoint's Serverseq is 1.
     * Guarantees InitialRoot is only applied to newly created Documents.
     * Drawback: Won't apply InitialRoot to existing but empty Documents.
  2. Apply InitialRoot when Document is empty:
     * Determined by checking if the Document has no elements and no garbage elements.
     * Allows applying InitialRoot to any empty Document, regardless of creation time.
     * Concern: Potential unintended behavior in concurrent scenarios.

  Current Implementation:
  - Option 2 is currently implemented.
  - Option 1 is being considered as potentially more predictable and safer in concurrent scenarios.

  Implementation Details:
  - Client's Attach function checks Document state after attachment.
  - InitialRoot is applied to Local Document but not immediately pushed.

  Notes for Reviewer:
  1. Consider which option is more appropriate.
  2. Evaluate trade-offs between options:
     - Option 1: More predictable, safer in concurrent scenarios, can't initialize existing empty Documents.
     - Option 2: More flexible, can initialize any empty Document, potentially risky in concurrent scenarios.
  3. If Option 1 is chosen, implementation will be updated.
  </div>
</details>