### PR TITLE
Add metric for WatchDocument streams

### DIFF
--- a/server/profiling/prometheus/metrics.go
+++ b/server/profiling/prometheus/metrics.go
@@ -54,6 +54,8 @@ type Metrics struct {
 	serverVersion        *prometheus.GaugeVec
 	serverHandledCounter *prometheus.CounterVec
 
+	backgroundGoroutinesTotal *prometheus.GaugeVec
+
 	pushPullResponseSeconds         prometheus.Histogram
 	pushPullReceivedChangesTotal    prometheus.Counter
 	pushPullSentChangesTotal        prometheus.Counter
@@ -62,12 +64,10 @@ type Metrics struct {
 	pushPullSnapshotDurationSeconds prometheus.Histogram
 	pushPullSnapshotBytesTotal      prometheus.Counter
 
-	backgroundGoroutinesTotal *prometheus.GaugeVec
+	watchDocumentConnectionTotal   *prometheus.GaugeVec
+	watchDocumentPayloadBytesTotal *prometheus.GaugeVec
 
-	watchDocumentConnectionTotal *prometheus.GaugeVec
-
-	userAgentTotal                      *prometheus.CounterVec
-	watchDocumentEventPayloadBytesTotal *prometheus.GaugeVec
+	userAgentTotal *prometheus.CounterVec
 }
 
 // NewMetrics creates a new instance of Metrics.

--- a/server/profiling/prometheus/metrics.go
+++ b/server/profiling/prometheus/metrics.go
@@ -64,7 +64,10 @@ type Metrics struct {
 
 	backgroundGoroutinesTotal *prometheus.GaugeVec
 
-	userAgentTotal *prometheus.CounterVec
+	watchDocumentConnectionTotal *prometheus.GaugeVec
+
+	userAgentTotal                      *prometheus.CounterVec
+	watchDocumentEventPayloadBytesTotal *prometheus.GaugeVec
 }
 
 // NewMetrics creates a new instance of Metrics.
@@ -143,6 +146,15 @@ func NewMetrics() (*Metrics, error) {
 			Name:      "goroutines_total",
 			Help:      "The total number of goroutines attached by a particular background task.",
 		}, []string{taskTypeLabel}),
+		watchDocumentConnectionTotal: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: "stream",
+			Name:      "watch_document_stream_connection_total",
+			Help:      "The total number of document watch stream connection.",
+		}, []string{
+			projectIDLabel,
+			projectNameLabel,
+		}),
 		userAgentTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: "user_agent",
@@ -254,6 +266,22 @@ func (m *Metrics) AddBackgroundGoroutines(taskType string) {
 func (m *Metrics) RemoveBackgroundGoroutines(taskType string) {
 	m.backgroundGoroutinesTotal.With(prometheus.Labels{
 		taskTypeLabel: taskType,
+	}).Dec()
+}
+
+// AddWatchDocumentConnection adds the number of document watch stream connection.
+func (m *Metrics) AddWatchDocumentConnection(project *types.Project) {
+	m.watchDocumentConnectionTotal.With(prometheus.Labels{
+		projectIDLabel:   project.ID.String(),
+		projectNameLabel: project.Name,
+	}).Inc()
+}
+
+// RemoveWatchDocumentConnection removes the number of document watch stream connection.
+func (m *Metrics) RemoveWatchDocumentConnection(project *types.Project) {
+	m.watchDocumentConnectionTotal.With(prometheus.Labels{
+		projectIDLabel:   project.ID.String(),
+		projectNameLabel: project.Name,
 	}).Dec()
 }
 

--- a/server/profiling/prometheus/metrics.go
+++ b/server/profiling/prometheus/metrics.go
@@ -154,6 +154,7 @@ func NewMetrics() (*Metrics, error) {
 		}, []string{
 			projectIDLabel,
 			projectNameLabel,
+			hostnameLabel,
 		}),
 		userAgentTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Namespace: namespace,
@@ -270,18 +271,20 @@ func (m *Metrics) RemoveBackgroundGoroutines(taskType string) {
 }
 
 // AddWatchDocumentConnection adds the number of document watch stream connection.
-func (m *Metrics) AddWatchDocumentConnection(project *types.Project) {
+func (m *Metrics) AddWatchDocumentConnection(hostname string, project *types.Project) {
 	m.watchDocumentConnectionTotal.With(prometheus.Labels{
 		projectIDLabel:   project.ID.String(),
 		projectNameLabel: project.Name,
+		hostnameLabel:    hostname,
 	}).Inc()
 }
 
 // RemoveWatchDocumentConnection removes the number of document watch stream connection.
-func (m *Metrics) RemoveWatchDocumentConnection(project *types.Project) {
+func (m *Metrics) RemoveWatchDocumentConnection(hostname string, project *types.Project) {
 	m.watchDocumentConnectionTotal.With(prometheus.Labels{
 		projectIDLabel:   project.ID.String(),
 		projectNameLabel: project.Name,
+		hostnameLabel:    hostname,
 	}).Dec()
 }
 

--- a/server/rpc/yorkie_server.go
+++ b/server/rpc/yorkie_server.go
@@ -430,12 +430,12 @@ func (s *yorkieServer) WatchDocument(
 		logging.From(ctx).Error(err)
 		return err
 	}
-	s.backend.Metrics.AddWatchDocumentConnection(project)
+	s.backend.Metrics.AddWatchDocumentConnection(s.backend.Config.Hostname, project)
 	defer func() {
 		if err := s.unwatchDoc(subscription, docRefKey); err != nil {
 			logging.From(ctx).Error(err)
 		} else {
-			s.backend.Metrics.RemoveWatchDocumentConnection(project)
+			s.backend.Metrics.RemoveWatchDocumentConnection(s.backend.Config.Hostname, project)
 		}
 	}()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Added count of watch document connection Metrics.
- count is increased when client watch document
- count is decreased when client unwatch document

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Address https://github.com/yorkie-team/yorkie/issues/984

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new metric for tracking document watch stream connections, enhancing monitoring capabilities.
	- Added methods to manage document watch connection counts.

- **Bug Fixes**
	- Improved error handling in the document watching process to ensure accurate metrics tracking for document connections.

These changes enhance the overall reliability and monitoring of document watch streams in the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->