### PR TITLE
Provide global output flag for all cli commands

### DIFF
--- a/cmd/yorkie/commands.go
+++ b/cmd/yorkie/commands.go
@@ -68,7 +68,7 @@ func init() {
 // validateOutputOpts validates the output options.
 func validateOutputOpts() error {
 	output := viper.GetString("output")
-	if output != "" && output != "yaml" && output != "json" {
+	if output != DefaultOutput && output != YamlOutput && output != JSONOutput {
 		return errors.New(`--output must be 'yaml' or 'json'`)
 	}
 	return nil

--- a/cmd/yorkie/commands.go
+++ b/cmd/yorkie/commands.go
@@ -55,4 +55,7 @@ func init() {
 
 	rootCmd.PersistentFlags().String("rpc-addr", "localhost:8080", "Address of the rpc server")
 	_ = viper.BindPFlag("rpcAddr", rootCmd.PersistentFlags().Lookup("rpc-addr"))
+
+	rootCmd.PersistentFlags().StringP("output", "o", "", "One of 'yaml' or 'json'.")
+	_ = viper.BindPFlag("output", rootCmd.PersistentFlags().Lookup("output"))
 }

--- a/cmd/yorkie/commands.go
+++ b/cmd/yorkie/commands.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path"
 
@@ -58,4 +59,17 @@ func init() {
 
 	rootCmd.PersistentFlags().StringP("output", "o", "", "One of 'yaml' or 'json'.")
 	_ = viper.BindPFlag("output", rootCmd.PersistentFlags().Lookup("output"))
+
+	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		return validateOutputOpts()
+	}
+}
+
+// validateOutputOpts validates the output options.
+func validateOutputOpts() error {
+	output := viper.GetString("output")
+	if output != "" && output != "yaml" && output != "json" {
+		return errors.New(`--output must be 'yaml' or 'json'`)
+	}
+	return nil
 }

--- a/cmd/yorkie/context/list.go
+++ b/cmd/yorkie/context/list.go
@@ -115,6 +115,7 @@ func printContexts(cmd *cobra.Command, outputFormat string, contexts []Info) err
 	default:
 		return errors.New("unknown output format")
 	}
+
 	return nil
 }
 

--- a/cmd/yorkie/context/list.go
+++ b/cmd/yorkie/context/list.go
@@ -28,7 +28,7 @@ import (
 	"github.com/yorkie-team/yorkie/cmd/yorkie/config"
 )
 
-type Info struct {
+type contextInfo struct {
 	Current  string `json:"current" yaml:"current"`
 	RPCAddr  string `json:"rpc_addr" yaml:"rpc_addr"`
 	Insecure string `json:"insecure" yaml:"insecure"`
@@ -51,7 +51,7 @@ func newListCommand() *cobra.Command {
 				return err
 			}
 
-			contexts := make([]Info, 0, len(conf.Auths))
+			contexts := make([]ContextInfo, 0, len(conf.Auths))
 			for rpcAddr, auth := range conf.Auths {
 				current := ""
 				if rpcAddr == viper.GetString("rpcAddr") {
@@ -68,7 +68,7 @@ func newListCommand() *cobra.Command {
 					ellipsisToken = auth.Token[:10] + "..." + auth.Token[len(auth.Token)-10:]
 				}
 
-				contexts = append(contexts, Info{
+				contexts = append(contexts, contextInfo{
 					Current:  current,
 					RPCAddr:  rpcAddr,
 					Insecure: insecure,
@@ -85,7 +85,7 @@ func newListCommand() *cobra.Command {
 	}
 }
 
-func printContexts(cmd *cobra.Command, outputFormat string, contexts []Info) error {
+func printContexts(cmd *cobra.Command, outputFormat string, contexts []contextInfo) error {
 	switch outputFormat {
 	case "":
 		tw := table.NewWriter()

--- a/cmd/yorkie/context/list.go
+++ b/cmd/yorkie/context/list.go
@@ -19,9 +19,8 @@ package context
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
-	"github.com/jedib0t/go-pretty/v6/table"
 
+	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
@@ -100,7 +99,7 @@ func printContexts(cmd *cobra.Command, outputFormat string, contexts []Info) err
 		for _, ctx := range contexts {
 			tw.AppendRow(table.Row{ctx.Current, ctx.RPCAddr, ctx.Insecure, ctx.Token})
 		}
-		fmt.Println(tw.Render())
+		cmd.Println(tw.Render())
 	case "json":
 		marshalled, err := json.MarshalIndent(contexts, "", "  ")
 		if err != nil {
@@ -112,7 +111,7 @@ func printContexts(cmd *cobra.Command, outputFormat string, contexts []Info) err
 		if err != nil {
 			return errors.New("marshal YAML")
 		}
-		fmt.Println(string(marshalled))
+		cmd.Println(string(marshalled))
 	default:
 		return errors.New("unknown output format")
 	}

--- a/cmd/yorkie/context/list.go
+++ b/cmd/yorkie/context/list.go
@@ -18,7 +18,7 @@ package context
 
 import (
 	"encoding/json"
-	"errors"
+	"fmt"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
@@ -81,8 +81,8 @@ func newListCommand() *cobra.Command {
 	}
 }
 
-func printContexts(cmd *cobra.Command, outputFormat string, contexts []contextInfo) error {
-	switch outputFormat {
+func printContexts(cmd *cobra.Command, output string, contexts []contextInfo) error {
+	switch output {
 	case "":
 		tw := table.NewWriter()
 		tw.Style().Options.DrawBorder = false
@@ -99,17 +99,17 @@ func printContexts(cmd *cobra.Command, outputFormat string, contexts []contextIn
 	case "json":
 		marshalled, err := json.MarshalIndent(contexts, "", "  ")
 		if err != nil {
-			return errors.New("marshal JSON")
+			return fmt.Errorf("failed to marshal JSON: %w", err)
 		}
 		cmd.Println(string(marshalled))
 	case "yaml":
 		marshalled, err := yaml.Marshal(contexts)
 		if err != nil {
-			return errors.New("marshal YAML")
+			return fmt.Errorf("failed to marshal YAML: %w", err)
 		}
 		cmd.Println(string(marshalled))
 	default:
-		return errors.New("unknown output format")
+		return fmt.Errorf("unknown output format: %s", output)
 	}
 
 	return nil

--- a/cmd/yorkie/context/list.go
+++ b/cmd/yorkie/context/list.go
@@ -46,12 +46,7 @@ func newListCommand() *cobra.Command {
 				return err
 			}
 
-			output := viper.GetString("output")
-			if err := validateOutputOpts(output); err != nil {
-				return err
-			}
-
-			contexts := make([]ContextInfo, 0, len(conf.Auths))
+			contexts := make([]contextInfo, 0, len(conf.Auths))
 			for rpcAddr, auth := range conf.Auths {
 				current := ""
 				if rpcAddr == viper.GetString("rpcAddr") {
@@ -76,6 +71,7 @@ func newListCommand() *cobra.Command {
 				})
 			}
 
+			output := viper.GetString("output")
 			if err := printContexts(cmd, output, contexts); err != nil {
 				return err
 			}
@@ -116,13 +112,6 @@ func printContexts(cmd *cobra.Command, outputFormat string, contexts []contextIn
 		return errors.New("unknown output format")
 	}
 
-	return nil
-}
-
-func validateOutputOpts(output string) error {
-	if output != "" && output != "yaml" && output != "json" {
-		return errors.New(`--output must be 'yaml' or 'json'`)
-	}
 	return nil
 }
 

--- a/cmd/yorkie/document/list.go
+++ b/cmd/yorkie/document/list.go
@@ -50,11 +50,6 @@ func newListCommand() *cobra.Command {
 			}
 			projectName := args[0]
 
-			output := viper.GetString("output")
-			if err := validateOutputOpts(output); err != nil {
-				return err
-			}
-
 			rpcAddr := viper.GetString("rpcAddr")
 			auth, err := config.LoadAuth(rpcAddr)
 			if err != nil {
@@ -76,6 +71,7 @@ func newListCommand() *cobra.Command {
 				return err
 			}
 
+			output := viper.GetString("output")
 			if err := printDocuments(cmd, output, documents); err != nil {
 				return err
 			}
@@ -129,13 +125,6 @@ func printDocuments(cmd *cobra.Command, outputFormat string, documents []*types.
 		return errors.New("unknown output format")
 	}
 
-	return nil
-}
-
-func validateOutputOpts(output string) error {
-	if output != "" && output != "yaml" && output != "json" {
-		return errors.New(`--output must be 'yaml' or 'json'`)
-	}
 	return nil
 }
 

--- a/cmd/yorkie/document/list.go
+++ b/cmd/yorkie/document/list.go
@@ -87,18 +87,6 @@ func newListCommand() *cobra.Command {
 
 func printDocuments(cmd *cobra.Command, outputFormat string, documents []*types.DocumentSummary) error {
 	switch outputFormat {
-	case "json":
-		jsonOutput, err := json.MarshalIndent(documents, "", "  ")
-		if err != nil {
-			return errors.New("marshal JSON")
-		}
-		cmd.Println(string(jsonOutput))
-	case "yaml":
-		yamlOutput, err := yaml.Marshal(documents)
-		if err != nil {
-			return errors.New("marshal YAML")
-		}
-		cmd.Println(string(yamlOutput))
 	case "":
 		tw := table.NewWriter()
 		tw.Style().Options.DrawBorder = false
@@ -125,6 +113,18 @@ func printDocuments(cmd *cobra.Command, outputFormat string, documents []*types.
 			})
 		}
 		cmd.Printf("%s\n", tw.Render())
+	case "json":
+		jsonOutput, err := json.MarshalIndent(documents, "", "  ")
+		if err != nil {
+			return errors.New("marshal JSON")
+		}
+		cmd.Println(string(jsonOutput))
+	case "yaml":
+		yamlOutput, err := yaml.Marshal(documents)
+		if err != nil {
+			return errors.New("marshal YAML")
+		}
+		cmd.Println(string(yamlOutput))
 	default:
 		return errors.New("unknown output format")
 	}

--- a/cmd/yorkie/document/list.go
+++ b/cmd/yorkie/document/list.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/jedib0t/go-pretty/v6/table"
@@ -81,8 +82,8 @@ func newListCommand() *cobra.Command {
 	}
 }
 
-func printDocuments(cmd *cobra.Command, outputFormat string, documents []*types.DocumentSummary) error {
-	switch outputFormat {
+func printDocuments(cmd *cobra.Command, output string, documents []*types.DocumentSummary) error {
+	switch output {
 	case "":
 		tw := table.NewWriter()
 		tw.Style().Options.DrawBorder = false
@@ -112,17 +113,17 @@ func printDocuments(cmd *cobra.Command, outputFormat string, documents []*types.
 	case "json":
 		jsonOutput, err := json.MarshalIndent(documents, "", "  ")
 		if err != nil {
-			return errors.New("marshal JSON")
+			return fmt.Errorf("failed to marshal JSON: %w", err)
 		}
 		cmd.Println(string(jsonOutput))
 	case "yaml":
 		yamlOutput, err := yaml.Marshal(documents)
 		if err != nil {
-			return errors.New("marshal YAML")
+			return fmt.Errorf("failed to marshal YAML: %w", err)
 		}
 		cmd.Println(string(yamlOutput))
 	default:
-		return errors.New("unknown output format")
+		return fmt.Errorf("unknown output format: %s", output)
 	}
 
 	return nil

--- a/cmd/yorkie/history.go
+++ b/cmd/yorkie/history.go
@@ -91,18 +91,6 @@ func newHistoryCmd() *cobra.Command {
 
 func printHistories(cmd *cobra.Command, output string, changes []*types.ChangeSummary) error {
 	switch output {
-	case "json":
-		jsonOutput, err := json.MarshalIndent(changes, "", "  ")
-		if err != nil {
-			return errors.New("marshal JSON")
-		}
-		cmd.Println(string(jsonOutput))
-	case "yaml":
-		yamlOutput, err := yaml.Marshal(changes)
-		if err != nil {
-			return errors.New("marshal YAML")
-		}
-		cmd.Println(string(yamlOutput))
 	case "":
 		tw := table.NewWriter()
 		tw.Style().Options.DrawBorder = false
@@ -123,6 +111,18 @@ func printHistories(cmd *cobra.Command, output string, changes []*types.ChangeSu
 			})
 		}
 		cmd.Printf("%s\n", tw.Render())
+	case "json":
+		jsonOutput, err := json.MarshalIndent(changes, "", "  ")
+		if err != nil {
+			return errors.New("marshal JSON")
+		}
+		cmd.Println(string(jsonOutput))
+	case "yaml":
+		yamlOutput, err := yaml.Marshal(changes)
+		if err != nil {
+			return errors.New("marshal YAML")
+		}
+		cmd.Println(string(yamlOutput))
 	default:
 		return errors.New("unknown output format")
 	}

--- a/cmd/yorkie/history.go
+++ b/cmd/yorkie/history.go
@@ -86,7 +86,7 @@ func newHistoryCmd() *cobra.Command {
 
 func printHistories(cmd *cobra.Command, output string, changes []*types.ChangeSummary) error {
 	switch output {
-	case "":
+	case DefaultOutput:
 		tw := table.NewWriter()
 		tw.Style().Options.DrawBorder = false
 		tw.Style().Options.SeparateColumns = false
@@ -106,13 +106,13 @@ func printHistories(cmd *cobra.Command, output string, changes []*types.ChangeSu
 			})
 		}
 		cmd.Printf("%s\n", tw.Render())
-	case "json":
+	case JSONOutput:
 		jsonOutput, err := json.MarshalIndent(changes, "", "  ")
 		if err != nil {
 			return errors.New("marshal JSON")
 		}
 		cmd.Println(string(jsonOutput))
-	case "yaml":
+	case YamlOutput:
 		yamlOutput, err := yaml.Marshal(changes)
 		if err != nil {
 			return errors.New("marshal YAML")

--- a/cmd/yorkie/history.go
+++ b/cmd/yorkie/history.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
@@ -109,17 +110,17 @@ func printHistories(cmd *cobra.Command, output string, changes []*types.ChangeSu
 	case JSONOutput:
 		jsonOutput, err := json.MarshalIndent(changes, "", "  ")
 		if err != nil {
-			return errors.New("marshal JSON")
+			return fmt.Errorf("failed to marshal JSON: %w", err)
 		}
 		cmd.Println(string(jsonOutput))
 	case YamlOutput:
 		yamlOutput, err := yaml.Marshal(changes)
 		if err != nil {
-			return errors.New("marshal YAML")
+			return fmt.Errorf("failed to marshal YAML: %w", err)
 		}
 		cmd.Println(string(yamlOutput))
 	default:
-		return errors.New("unknown output format")
+		return fmt.Errorf("unknown output format: %s", output)
 	}
 
 	return nil

--- a/cmd/yorkie/history.go
+++ b/cmd/yorkie/history.go
@@ -47,12 +47,6 @@ func newHistoryCmd() *cobra.Command {
 			if len(args) != 2 {
 				return errors.New("project name and document key are required")
 			}
-
-			output = viper.GetString("output")
-			if err := validateOutputOpts(); err != nil {
-				return err
-			}
-
 			rpcAddr := viper.GetString("rpcAddr")
 			auth, err := config.LoadAuth(rpcAddr)
 			if err != nil {
@@ -80,6 +74,7 @@ func newHistoryCmd() *cobra.Command {
 				return err
 			}
 
+			output := viper.GetString("output")
 			if err := printHistories(cmd, output, changes); err != nil {
 				return err
 			}

--- a/cmd/yorkie/output.go
+++ b/cmd/yorkie/output.go
@@ -1,0 +1,7 @@
+package main
+
+const (
+	DefaultOutput = ""     // DefaultOutput is for table format
+	YamlOutput    = "yaml" // YamlOutput is for yaml format
+	JSONOutput    = "json" // JSONOutput is for json format
+)

--- a/cmd/yorkie/project/create.go
+++ b/cmd/yorkie/project/create.go
@@ -92,7 +92,7 @@ func printCreateProjectInfo(cmd *cobra.Command, outputFormat string, project *ty
 	case "json", "":
 		encoded, err := json.Marshal(project)
 		if err != nil {
-			return errors.New("marshal project: %w")
+			return errors.New("marshal JSON")
 		}
 		cmd.Println(string(encoded))
 	case "yaml":
@@ -104,6 +104,7 @@ func printCreateProjectInfo(cmd *cobra.Command, outputFormat string, project *ty
 	default:
 		return errors.New("unknown output format")
 	}
+
 	return nil
 }
 

--- a/cmd/yorkie/project/create.go
+++ b/cmd/yorkie/project/create.go
@@ -20,15 +20,15 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/yorkie-team/yorkie/api/types"
-	"gopkg.in/yaml.v3"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/status"
+	"gopkg.in/yaml.v3"
 
 	"github.com/yorkie-team/yorkie/admin"
+	"github.com/yorkie-team/yorkie/api/types"
 	"github.com/yorkie-team/yorkie/cmd/yorkie/config"
 )
 

--- a/cmd/yorkie/project/create.go
+++ b/cmd/yorkie/project/create.go
@@ -44,11 +44,6 @@ func newCreateCommand() *cobra.Command {
 			}
 			name := args[0]
 
-			output := viper.GetString("output")
-			if err := validateOutputOpts(output); err != nil {
-				return err
-			}
-
 			rpcAddr := viper.GetString("rpcAddr")
 			auth, err := config.LoadAuth(rpcAddr)
 			if err != nil {
@@ -78,6 +73,7 @@ func newCreateCommand() *cobra.Command {
 				return err
 			}
 
+			output := viper.GetString("output")
 			if err := printCreateProjectInfo(cmd, output, project); err != nil {
 				return err
 			}
@@ -87,8 +83,8 @@ func newCreateCommand() *cobra.Command {
 	}
 }
 
-func printCreateProjectInfo(cmd *cobra.Command, outputFormat string, project *types.Project) error {
-	switch outputFormat {
+func printCreateProjectInfo(cmd *cobra.Command, output string, project *types.Project) error {
+	switch output {
 	case "json", "":
 		encoded, err := json.Marshal(project)
 		if err != nil {
@@ -105,13 +101,6 @@ func printCreateProjectInfo(cmd *cobra.Command, outputFormat string, project *ty
 		return errors.New("unknown output format")
 	}
 
-	return nil
-}
-
-func validateOutputOpts(output string) error {
-	if output != "" && output != "yaml" && output != "json" {
-		return errors.New(`--output must be 'yaml' or 'json'`)
-	}
 	return nil
 }
 

--- a/cmd/yorkie/project/create.go
+++ b/cmd/yorkie/project/create.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -88,17 +89,17 @@ func printCreateProjectInfo(cmd *cobra.Command, output string, project *types.Pr
 	case JSONOutput, DefaultOutput:
 		encoded, err := json.Marshal(project)
 		if err != nil {
-			return errors.New("marshal JSON")
+			return fmt.Errorf("failed to marshal JSON: %w", err)
 		}
 		cmd.Println(string(encoded))
 	case YamlOutput:
 		marshalled, err := yaml.Marshal(project)
 		if err != nil {
-			return errors.New("marshal YAML")
+			return fmt.Errorf("failed to marshal YAML: %w", err)
 		}
 		cmd.Println(string(marshalled))
 	default:
-		return errors.New("unknown output format")
+		return fmt.Errorf("unknown output format: %s", output)
 	}
 
 	return nil

--- a/cmd/yorkie/project/create.go
+++ b/cmd/yorkie/project/create.go
@@ -85,13 +85,13 @@ func newCreateCommand() *cobra.Command {
 
 func printCreateProjectInfo(cmd *cobra.Command, output string, project *types.Project) error {
 	switch output {
-	case "json", "":
+	case JSONOutput, DefaultOutput:
 		encoded, err := json.Marshal(project)
 		if err != nil {
 			return errors.New("marshal JSON")
 		}
 		cmd.Println(string(encoded))
-	case "yaml":
+	case YamlOutput:
 		marshalled, err := yaml.Marshal(project)
 		if err != nil {
 			return errors.New("marshal YAML")

--- a/cmd/yorkie/project/list.go
+++ b/cmd/yorkie/project/list.go
@@ -41,11 +41,6 @@ func newListCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rpcAddr := viper.GetString("rpcAddr")
 
-			output := viper.GetString("output")
-			if err := validateOutputOpts(output); err != nil {
-				return err
-			}
-
 			auth, err := config.LoadAuth(rpcAddr)
 			if err != nil {
 				return err
@@ -65,9 +60,8 @@ func newListCommand() *cobra.Command {
 				return err
 			}
 
-			outputFormat := viper.GetString("output")
-
-			err2 := printProjects(cmd, outputFormat, projects)
+			output := viper.GetString("output")
+			err2 := printProjects(cmd, output, projects)
 			if err2 != nil {
 				return err2
 			}
@@ -77,8 +71,8 @@ func newListCommand() *cobra.Command {
 	}
 }
 
-func printProjects(cmd *cobra.Command, outputFormat string, projects []*types.Project) error {
-	switch outputFormat {
+func printProjects(cmd *cobra.Command, output string, projects []*types.Project) error {
+	switch output {
 	case "":
 		tw := table.NewWriter()
 		tw.Style().Options.DrawBorder = false

--- a/cmd/yorkie/project/list.go
+++ b/cmd/yorkie/project/list.go
@@ -20,15 +20,15 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/yorkie-team/yorkie/api/types"
-	"gopkg.in/yaml.v3"
 	"time"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
 
 	"github.com/yorkie-team/yorkie/admin"
+	"github.com/yorkie-team/yorkie/api/types"
 	"github.com/yorkie-team/yorkie/cmd/yorkie/config"
 	"github.com/yorkie-team/yorkie/pkg/units"
 )

--- a/cmd/yorkie/project/list.go
+++ b/cmd/yorkie/project/list.go
@@ -79,18 +79,6 @@ func newListCommand() *cobra.Command {
 
 func printProjects(cmd *cobra.Command, outputFormat string, projects []*types.Project) error {
 	switch outputFormat {
-	case "json":
-		jsonOutput, err := json.MarshalIndent(projects, "", "  ")
-		if err != nil {
-			return errors.New("error marshaling to JSON: %w")
-		}
-		cmd.Println(string(jsonOutput))
-	case "yaml":
-		yamlOutput, err := yaml.Marshal(projects)
-		if err != nil {
-			return errors.New("error marshaling to YAML: %w")
-		}
-		cmd.Println(string(yamlOutput))
 	case "":
 		tw := table.NewWriter()
 		tw.Style().Options.DrawBorder = false
@@ -119,6 +107,18 @@ func printProjects(cmd *cobra.Command, outputFormat string, projects []*types.Pr
 			})
 		}
 		cmd.Println(tw.Render())
+	case "json":
+		jsonOutput, err := json.MarshalIndent(projects, "", "  ")
+		if err != nil {
+			return errors.New("marshal JSON")
+		}
+		cmd.Println(string(jsonOutput))
+	case "yaml":
+		yamlOutput, err := yaml.Marshal(projects)
+		if err != nil {
+			return errors.New("marshal YAML")
+		}
+		cmd.Println(string(yamlOutput))
 	default:
 		return errors.New("unknown output format")
 	}

--- a/cmd/yorkie/project/list.go
+++ b/cmd/yorkie/project/list.go
@@ -19,7 +19,7 @@ package project
 import (
 	"context"
 	"encoding/json"
-	"errors"
+	"fmt"
 	"time"
 
 	"github.com/jedib0t/go-pretty/v6/table"
@@ -104,17 +104,17 @@ func printProjects(cmd *cobra.Command, output string, projects []*types.Project)
 	case JSONOutput:
 		jsonOutput, err := json.MarshalIndent(projects, "", "  ")
 		if err != nil {
-			return errors.New("marshal JSON")
+			return fmt.Errorf("failed to marshal JSON: %w", err)
 		}
 		cmd.Println(string(jsonOutput))
 	case YamlOutput:
 		yamlOutput, err := yaml.Marshal(projects)
 		if err != nil {
-			return errors.New("marshal YAML")
+			return fmt.Errorf("failed to marshal YAML: %w", err)
 		}
 		cmd.Println(string(yamlOutput))
 	default:
-		return errors.New("unknown output format")
+		return fmt.Errorf("unknown output format: %s", output)
 	}
 
 	return nil

--- a/cmd/yorkie/project/list.go
+++ b/cmd/yorkie/project/list.go
@@ -73,7 +73,7 @@ func newListCommand() *cobra.Command {
 
 func printProjects(cmd *cobra.Command, output string, projects []*types.Project) error {
 	switch output {
-	case "":
+	case DefaultOutput:
 		tw := table.NewWriter()
 		tw.Style().Options.DrawBorder = false
 		tw.Style().Options.SeparateColumns = false
@@ -101,13 +101,13 @@ func printProjects(cmd *cobra.Command, output string, projects []*types.Project)
 			})
 		}
 		cmd.Println(tw.Render())
-	case "json":
+	case JSONOutput:
 		jsonOutput, err := json.MarshalIndent(projects, "", "  ")
 		if err != nil {
 			return errors.New("marshal JSON")
 		}
 		cmd.Println(string(jsonOutput))
-	case "yaml":
+	case YamlOutput:
 		yamlOutput, err := yaml.Marshal(projects)
 		if err != nil {
 			return errors.New("marshal YAML")

--- a/cmd/yorkie/project/project.go
+++ b/cmd/yorkie/project/project.go
@@ -26,3 +26,9 @@ var (
 		Short: "Manage projects",
 	}
 )
+
+const (
+	DefaultOutput = ""     // DefaultOutput is for table format
+	YamlOutput    = "yaml" // YamlOutput is for yaml format
+	JSONOutput    = "json" // JSONOutput is for json format
+)

--- a/cmd/yorkie/project/update.go
+++ b/cmd/yorkie/project/update.go
@@ -139,6 +139,7 @@ func printUpdateProjectInfo(cmd *cobra.Command, outputFormat string, project *ty
 	default:
 		return errors.New("unknown output format")
 	}
+
 	return nil
 }
 

--- a/cmd/yorkie/project/update.go
+++ b/cmd/yorkie/project/update.go
@@ -50,11 +50,6 @@ func newUpdateCommand() *cobra.Command {
 			}
 			name := args[0]
 
-			output := viper.GetString("output")
-			if err := validateOutputOpts(output); err != nil {
-				return err
-			}
-
 			rpcAddr := viper.GetString("rpcAddr")
 			auth, err := config.LoadAuth(rpcAddr)
 			if err != nil {
@@ -113,6 +108,7 @@ func newUpdateCommand() *cobra.Command {
 				return err
 			}
 
+			output := viper.GetString("output")
 			if err := printUpdateProjectInfo(cmd, output, updated); err != nil {
 				return err
 			}
@@ -122,8 +118,8 @@ func newUpdateCommand() *cobra.Command {
 	}
 }
 
-func printUpdateProjectInfo(cmd *cobra.Command, outputFormat string, project *types.Project) error {
-	switch outputFormat {
+func printUpdateProjectInfo(cmd *cobra.Command, output string, project *types.Project) error {
+	switch output {
 	case "json", "":
 		encoded, err := json.Marshal(project)
 		if err != nil {

--- a/cmd/yorkie/project/update.go
+++ b/cmd/yorkie/project/update.go
@@ -20,12 +20,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"gopkg.in/yaml.v3"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/status"
+	"gopkg.in/yaml.v3"
 
 	"github.com/yorkie-team/yorkie/admin"
 	"github.com/yorkie-team/yorkie/api/types"

--- a/cmd/yorkie/project/update.go
+++ b/cmd/yorkie/project/update.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -123,17 +124,17 @@ func printUpdateProjectInfo(cmd *cobra.Command, output string, project *types.Pr
 	case JSONOutput, DefaultOutput:
 		encoded, err := json.Marshal(project)
 		if err != nil {
-			return errors.New("marshal JSON")
+			return fmt.Errorf("failed to marshal JSON: %w", err)
 		}
 		cmd.Println(string(encoded))
 	case YamlOutput:
 		encoded, err := yaml.Marshal(project)
 		if err != nil {
-			return errors.New("marshal YAML")
+			return fmt.Errorf("failed to marshal YAML: %w", err)
 		}
 		cmd.Println(string(encoded))
 	default:
-		return errors.New("unknown output format")
+		return fmt.Errorf("unknown output format: %s", output)
 	}
 
 	return nil

--- a/cmd/yorkie/project/update.go
+++ b/cmd/yorkie/project/update.go
@@ -120,13 +120,13 @@ func newUpdateCommand() *cobra.Command {
 
 func printUpdateProjectInfo(cmd *cobra.Command, output string, project *types.Project) error {
 	switch output {
-	case "json", "":
+	case JSONOutput, DefaultOutput:
 		encoded, err := json.Marshal(project)
 		if err != nil {
 			return errors.New("marshal JSON")
 		}
 		cmd.Println(string(encoded))
-	case "yaml":
+	case YamlOutput:
 		encoded, err := yaml.Marshal(project)
 		if err != nil {
 			return errors.New("marshal YAML")

--- a/cmd/yorkie/version.go
+++ b/cmd/yorkie/version.go
@@ -44,6 +44,7 @@ func newVersionCmd() *cobra.Command {
 		Short:   "Print the version number of Yorkie",
 		PreRunE: config.Preload,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			output = viper.GetString("output")
 			if err := validateOutputOpts(); err != nil {
 				return err
 			}
@@ -164,17 +165,6 @@ func init() {
 		"client",
 		clientOnly,
 		"Shows client version only (no server required).",
-	)
-
-	// TODO(hackerwins): Output format should be configurable globally.
-	// So, we need to move this to the root command like `--rpc-addr` and
-	// apply it to all subcommands that print output.
-	cmd.Flags().StringVarP(
-		&output,
-		"output",
-		"o",
-		output,
-		"One of 'yaml' or 'json'.",
 	)
 
 	rootCmd.AddCommand(cmd)

--- a/cmd/yorkie/version.go
+++ b/cmd/yorkie/version.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"runtime"
 
 	"connectrpc.com/connect"
@@ -53,7 +54,7 @@ func newVersionCmd() *cobra.Command {
 				info.ServerVersion, serverErr = fetchServerVersion()
 			}
 
-			output = viper.GetString("output")
+			output := viper.GetString("output")
 			if err := printVersionInfo(cmd, output, &info); err != nil {
 				return err
 			}
@@ -128,17 +129,17 @@ func printVersionInfo(cmd *cobra.Command, output string, versionInfo *types.Vers
 	case YamlOutput:
 		marshalled, err := yaml.Marshal(versionInfo)
 		if err != nil {
-			return errors.New("marshal YAML")
+			return fmt.Errorf("failed to marshal YAML: %w", err)
 		}
 		cmd.Println(string(marshalled))
 	case JSONOutput:
 		marshalled, err := json.MarshalIndent(versionInfo, "", "  ")
 		if err != nil {
-			return errors.New("marshal JSON")
+			return fmt.Errorf("failed to marshal JSON: %w", err)
 		}
 		cmd.Println(string(marshalled))
 	default:
-		return errors.New("unknown output format")
+		return fmt.Errorf("unknown output format: %s", output)
 	}
 
 	return nil

--- a/cmd/yorkie/version.go
+++ b/cmd/yorkie/version.go
@@ -44,11 +44,6 @@ func newVersionCmd() *cobra.Command {
 		Short:   "Print the version number of Yorkie",
 		PreRunE: config.Preload,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			output = viper.GetString("output")
-			if err := validateOutputOpts(); err != nil {
-				return err
-			}
-
 			info := types.VersionInfo{
 				ClientVersion: clientVersion(),
 			}
@@ -58,6 +53,7 @@ func newVersionCmd() *cobra.Command {
 				info.ServerVersion, serverErr = fetchServerVersion()
 			}
 
+			output = viper.GetString("output")
 			if err := printVersionInfo(cmd, output, &info); err != nil {
 				return err
 			}
@@ -143,15 +139,6 @@ func printVersionInfo(cmd *cobra.Command, output string, versionInfo *types.Vers
 		cmd.Println(string(marshalled))
 	default:
 		return errors.New("unknown output format")
-	}
-
-	return nil
-}
-
-// validateOutputOpts validates the output options.
-func validateOutputOpts() error {
-	if output != "" && output != "yaml" && output != "json" {
-		return errors.New(`--output must be 'yaml' or 'json'`)
 	}
 
 	return nil

--- a/cmd/yorkie/version.go
+++ b/cmd/yorkie/version.go
@@ -116,7 +116,7 @@ func printServerError(cmd *cobra.Command, err error) {
 
 func printVersionInfo(cmd *cobra.Command, output string, versionInfo *types.VersionInfo) error {
 	switch output {
-	case "":
+	case DefaultOutput:
 		cmd.Printf("Yorkie Client: %s\n", versionInfo.ClientVersion.YorkieVersion)
 		cmd.Printf("Go: %s\n", versionInfo.ClientVersion.GoVersion)
 		cmd.Printf("Build Date: %s\n", versionInfo.ClientVersion.BuildDate)
@@ -125,13 +125,13 @@ func printVersionInfo(cmd *cobra.Command, output string, versionInfo *types.Vers
 			cmd.Printf("Go: %s\n", versionInfo.ServerVersion.GoVersion)
 			cmd.Printf("Build Date: %s\n", versionInfo.ServerVersion.BuildDate)
 		}
-	case "yaml":
+	case YamlOutput:
 		marshalled, err := yaml.Marshal(versionInfo)
 		if err != nil {
 			return errors.New("marshal YAML")
 		}
 		cmd.Println(string(marshalled))
-	case "json":
+	case JSONOutput:
 		marshalled, err := json.MarshalIndent(versionInfo, "", "  ")
 		if err != nil {
 			return errors.New("marshal JSON")


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Provide a consistent and convenient way for users to set the output format for all CLI commands
Add `json` and `yaml` data format as options of output flag, changed it to globally.
Validation for options that are input by user was also changed as globally. ebbf4f04d797420bfbb0cf95693b311e0cc01b35

Following prior work, implemented output format for each commands below
- `context ls`
- `project create`
- `project ls`
- `project update`
- `document ls`
- `history ls`



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #955 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a command-line flag for output format selection (JSON or YAML).
	- Added functions to centralize output formatting for contexts, documents, project information, and history changes.
  
- **Bug Fixes**
	- Enhanced error handling for unknown output formats and marshaling failures.

- **Refactor**
	- Streamlined output handling processes across various commands for better organization and flexibility.
	- Standardized output format constants for improved consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->