### PR TITLE
Add nginx-ingress-controller option

### DIFF
--- a/build/charts/yorkie-cluster/templates/istio/ingress.yaml
+++ b/build/charts/yorkie-cluster/templates/istio/ingress.yaml
@@ -1,7 +1,11 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  {{ if .Values.ingress.nginx.enabled }}
+  name: ingress-nginx
+  {{ else }}
   name: {{ .Values.yorkie.name }}
+  {{ end }}
   namespace: {{ .Values.yorkie.namespace }}
   {{ if .Values.ingress.awsAlb.enabled }}
   annotations:
@@ -27,14 +31,18 @@ metadata:
     # If the health check fails, NCP ALB will not route the traffic to the service
     alb.ingress.kubernetes.io/healthcheck-path: /healthz
   {{ end }}
+  {{ if .Values.ingress.nginx.enabled }}
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    kubernetes.io/ingress.class: "nginx"
+  {{ end }}
 spec:
   ingressClassName: {{ .Values.ingress.ingressClassName }}
   rules:
     {{ if .Values.ingress.hosts.enabled }}
     - host: {{ .Values.ingress.hosts.apiHost }}
       http:
-    {{ end }}
-    {{ if not .Values.ingress.hosts.enabled }}
+    {{ else }}
     - http:
     {{ end }}
         paths:

--- a/build/charts/yorkie-cluster/values.yaml
+++ b/build/charts/yorkie-cluster/values.yaml
@@ -60,6 +60,9 @@ ingress:
     enabled: false
     certNo: 1234
 
+  nginx:
+    enabled: false
+
 # Configuration for ratelimit
 ratelimit:
   enabled: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Previously, our AWS-based setup only supported ALB ingresses via the
alb-ingress-controller. This change enables the use of Nginx ingress
controller as an alternative, particularly beneficial for self-hosted
clusters. Users can now choose between ALB and Nginx when configuring
ingresses, providing more flexibility in ingress management.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced conditional logic for Ingress resource configuration based on the enabled state of ingress controllers.
	- Added a new `nginx` configuration block in the ingress settings.
	- Updated rate limit configuration with a new `name` field.

- **Bug Fixes**
	- Ensured backend service configuration remains intact when ingress hosts are enabled or not.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->