### PR TITLE
Add CLI for migration

### DIFF
--- a/cmd/yorkie/migration.go
+++ b/cmd/yorkie/migration.go
@@ -19,13 +19,13 @@ package main
 import (
 	"context"
 	"fmt"
-	"go.mongodb.org/mongo-driver/bson"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 
@@ -41,43 +41,58 @@ var (
 	batchSize    int
 )
 
-var migrationMap = map[string]func(ctx context.Context, db *mongo.Client, databaseName string, batchSize int) error{
+// migrationMap is a map of migration functions for each version.
+var migrationMap = map[string]func(ctx context.Context, db *mongo.Client, dbName string, batchSize int) error{
 	"v0.6.0": v060.RunMigration,
 }
 
-func runMigration(ctx context.Context, db *mongo.Client, version string, databaseName string, batchSize int) error {
-	if migrationFunc, exists := migrationMap[version]; exists {
-		err := migrationFunc(ctx, db, databaseName, batchSize)
-		if err != nil {
-			return err
-		}
-	} else {
-		fmt.Printf("No migration found for version: %s\n", version)
+// runMigration runs the migration for the given version.
+func runMigration(ctx context.Context, db *mongo.Client, version string, dbName string, batchSize int) error {
+	migrationFunc, exists := migrationMap[version]
+	if !exists {
+		fmt.Printf("migration not found for version: %s\n", version)
+		return nil
+	}
+
+	if err := migrationFunc(ctx, db, dbName, batchSize); err != nil {
+		return err
 	}
 
 	return nil
 }
 
+// filterDirectories filters directories that are between the given versions.
 func filterDirectories(dirPath, from, to string) ([]string, error) {
 	var validDirs []string
 	files, err := os.ReadDir(dirPath)
 	if err != nil {
-		return nil, fmt.Errorf("no such directory %s: %w", dirPath, err) // 에러 래핑
+		return nil, fmt.Errorf("no such directory %s: %w", dirPath, err)
 	}
 
 	for _, file := range files {
-		if file.IsDir() && strings.HasPrefix(file.Name(), "v") {
-			version := file.Name()
-			cmpFrom, _ := compareVersions(version, from)
-			cmpTo, _ := compareVersions(version, to)
-			if cmpFrom >= 0 && cmpTo <= 0 {
-				validDirs = append(validDirs, version)
-			}
+		if !file.IsDir() || !strings.HasPrefix(file.Name(), "v") {
+			continue
+		}
+
+		version := file.Name()
+		cmpFrom, err := compareVersions(version, from)
+		if err != nil {
+			return nil, err
+		}
+
+		cmpTo, err := compareVersions(version, to)
+		if err != nil {
+			return nil, err
+		}
+
+		if cmpFrom >= 0 && cmpTo <= 0 {
+			validDirs = append(validDirs, version)
 		}
 	}
 	return validDirs, nil
 }
 
+// parseVersion parses the version string into an array of integers.
 func parseVersion(version string) ([]int, error) {
 	version = strings.TrimPrefix(version, "v")
 	parts := strings.Split(version, ".")
@@ -88,11 +103,14 @@ func parseVersion(version string) ([]int, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid version format: %s", version)
 		}
+
 		result[i] = num
 	}
 
 	return result, nil
 }
+
+// compareVersions compares two version strings.
 func compareVersions(v1, v2 string) (int, error) {
 	parsedV1, err := parseVersion(v1)
 	if err != nil {
@@ -131,6 +149,7 @@ func newMigrationCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+
 			if result == 1 {
 				return fmt.Errorf("to version must be larger then from version: %s %s", from, to)
 			}
@@ -175,10 +194,9 @@ func newMigrationCmd() *cobra.Command {
 			}
 
 			for _, dir := range validDirs {
-				fmt.Printf("Running migration for directory: %s\n", dir)
-				err := runMigration(ctx, client, dir, databaseName, batchSize)
+				fmt.Printf("running migration for directory: %s\n", dir)
 
-				if err != nil {
+				if err := runMigration(ctx, client, dir, databaseName, batchSize); err != nil {
 					return fmt.Errorf("migration failed: %w\n", err)
 				}
 			}

--- a/cmd/yorkie/migration.go
+++ b/cmd/yorkie/migration.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/yorkie-team/yorkie/cmd/yorkie/config"
 	v060 "github.com/yorkie-team/yorkie/migrations/v0.6.0"
+	yorkiemongo "github.com/yorkie-team/yorkie/server/backend/database/mongo"
 )
 
 var (
@@ -146,7 +147,10 @@ func newMigrationCmd() *cobra.Command {
 			ctx := context.Background()
 			client, err := mongo.Connect(
 				ctx,
-				options.Client().ApplyURI(mongoConnectionURI),
+				options.Client().
+					ApplyURI(mongoConnectionURI).
+					SetRegistry(yorkiemongo.NewRegistryBuilder().Build()),
+
 			)
 			if err != nil {
 				return fmt.Errorf("connect to mongo: %w", err)

--- a/migrations/v0.6.0/add-version-vector.go
+++ b/migrations/v0.6.0/add-version-vector.go
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package v060 provides migration for v0.6.0
+package v060
+
+import (
+	"fmt"
+)
+
+// RunMigration runs migrations for package version
+func RunMigration() {
+
+	fmt.Println("돌돌돌아간다.")
+}

--- a/migrations/v0.6.0/add-version-vector.go
+++ b/migrations/v0.6.0/add-version-vector.go
@@ -19,6 +19,7 @@ package v060
 import (
 	"context"
 	"fmt"
+	"math"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -26,6 +27,39 @@ import (
 	"github.com/yorkie-team/yorkie/pkg/document/time"
 	"github.com/yorkie-team/yorkie/server/backend/database"
 )
+
+func validateAddVersionVector(ctx context.Context, db *mongo.Client, databaseName string) error {
+	collection := db.Database(databaseName).Collection("changes")
+
+	cursor, err := collection.Find(ctx, bson.M{})
+	if err != nil {
+		return err
+	}
+
+	for cursor.Next(ctx) {
+		var info database.ChangeInfo
+		if err := cursor.Decode(&info); err != nil {
+			return fmt.Errorf("decode change info: %w", err)
+		}
+
+		versionVector := info.VersionVector
+		actors, err := versionVector.Keys()
+		if err != nil {
+			return err
+		}
+		lamport := info.Lamport
+
+		if len(actors) > 1 {
+			return fmt.Errorf("found %d actor in version vector", len(actors))
+		}
+
+		if versionVector.VersionOf(actors[0]) != lamport {
+			return fmt.Errorf("wrong lamport in version vector")
+		}
+	}
+
+	return nil
+}
 
 func processMigrationBatch(
 	ctx context.Context,
@@ -62,8 +96,13 @@ func processMigrationBatch(
 }
 
 // AddVersionVector runs migrations for add version vector
-func AddVersionVector(ctx context.Context, db *mongo.Client, batchSize int) error {
-	collection := db.Database("yorkie-meta").Collection("changes")
+func AddVersionVector(ctx context.Context, db *mongo.Client, databaseName string, batchSize int) error {
+	collection := db.Database(databaseName).Collection("changes")
+	totalCount, err := collection.CountDocuments(ctx, bson.M{})
+	if err != nil {
+		return err
+	}
+	batchCount := 1
 
 	cursor, err := collection.Find(ctx, bson.M{})
 	if err != nil {
@@ -85,7 +124,12 @@ func AddVersionVector(ctx context.Context, db *mongo.Client, batchSize int) erro
 				return err
 			}
 
+			percentage := (float64(batchSize*batchCount) / float64(totalCount)) * 100
+			rounded := math.Round(percentage)
+			fmt.Printf("%s.changes migration %0.f%% completed \n", databaseName, rounded)
+
 			infos = infos[:0]
+			batchCount++
 		}
 	}
 
@@ -94,6 +138,13 @@ func AddVersionVector(ctx context.Context, db *mongo.Client, batchSize int) erro
 			return fmt.Errorf("process final batch: %w", err)
 		}
 	}
+
+	err = validateAddVersionVector(ctx, db, databaseName)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("add version vector completed")
 
 	return nil
 }

--- a/migrations/v0.6.0/drop-snapshots.go
+++ b/migrations/v0.6.0/drop-snapshots.go
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v060
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// DropSnapshots runs migrations for drop snapshots collection
+func DropSnapshots(ctx context.Context, db *mongo.Client) error {
+	collection := db.Database("yorkie-meta").Collection("snapshots")
+
+	if err := collection.Drop(ctx); err != nil {
+		return fmt.Errorf("drop collection: %w", err)
+	}
+
+	return nil
+}

--- a/migrations/v0.6.0/drop-snapshots.go
+++ b/migrations/v0.6.0/drop-snapshots.go
@@ -19,11 +19,13 @@ package v060
 import (
 	"context"
 	"fmt"
+	"log"
+
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
-	"log"
 )
 
+// validateDropSnapshot validates if the snapshots collection is dropped successfully.
 func validateDropSnapshot(ctx context.Context, db *mongo.Client, databaseName string) error {
 	collections, err := db.Database(databaseName).ListCollectionNames(ctx, bson.D{})
 	if err != nil {
@@ -45,7 +47,7 @@ func validateDropSnapshot(ctx context.Context, db *mongo.Client, databaseName st
 	return nil
 }
 
-// DropSnapshots runs migrations for drop snapshots collection
+// DropSnapshots runs the migration of dropping snapshots collection.
 func DropSnapshots(ctx context.Context, db *mongo.Client, databaseName string) error {
 	collection := db.Database(databaseName).Collection("snapshots")
 

--- a/migrations/v0.6.0/main.go
+++ b/migrations/v0.6.0/main.go
@@ -19,19 +19,22 @@ package v060
 
 import (
 	"context"
+	"fmt"
 
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
 // RunMigration runs migrations for v0.6.0
-func RunMigration(ctx context.Context, db *mongo.Client, batchSize int) error {
-	if err := AddVersionVector(ctx, db, batchSize); err != nil {
+func RunMigration(ctx context.Context, db *mongo.Client, databaseName string, batchSize int) error {
+	if err := AddVersionVector(ctx, db, databaseName, batchSize); err != nil {
 		return err
 	}
 
-	if err := DropSnapshots(ctx, db); err != nil {
+	if err := DropSnapshots(ctx, db, databaseName); err != nil {
 		return err
 	}
+
+	fmt.Println("v0.6.0 migration completed")
 
 	return nil
 }

--- a/migrations/v0.6.0/main.go
+++ b/migrations/v0.6.0/main.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package v060 provides migration for v0.6.0
+package v060
+
+import (
+	"context"
+
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// RunMigration runs migrations for v0.6.0
+func RunMigration(ctx context.Context, db *mongo.Client, batchSize int) error {
+	if err := AddVersionVector(ctx, db, batchSize); err != nil {
+		return err
+	}
+
+	if err := DropSnapshots(ctx, db); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Define semi-auto migration architecture and add migration scripts for add version vector.

**Process**
```
1. make new version directory in migrations
2. add migration script files.
3. add version into migrationMap in /cmd/migration.go
```
**Usage example** 
```
$ ./yorkie migration --from v0.5.1 --to v0.6.0 --mongo-connection-uri mongodb://localhost:27017 --batch-size 10000 --database-name yorkie-meta
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
