### PR TITLE
Remove `jstype=string` from resources.proto

### DIFF
--- a/api/yorkie/v1/resources.proto
+++ b/api/yorkie/v1/resources.proto
@@ -57,8 +57,8 @@ message Change {
 
 message ChangeID {
   uint32 client_seq = 1;
-  int64 server_seq = 2 [jstype = JS_STRING];
-  int64 lamport = 3 [jstype = JS_STRING];
+  int64 server_seq = 2; 
+  int64 lamport = 3;
   bytes actor_id = 4;
 }
 
@@ -332,7 +332,7 @@ message Presence {
 }
 
 message Checkpoint {
-  int64 server_seq = 1 [jstype = JS_STRING];
+  int64 server_seq = 1; 
   uint32 client_seq = 2;
 }
 
@@ -343,7 +343,7 @@ message TextNodePos {
 }
 
 message TimeTicket {
-  int64 lamport = 1 [jstype = JS_STRING];
+  int64 lamport = 1;
   uint32 delimiter = 2;
   bytes actor_id = 3;
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Removes ```jstype=string``` notation from resources.proto file since javascript supports Bigint from ES2020
One of the two PRs addressing this issue, the other PR is for the js-sdk repository replacing Long with BigInt.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
One of the two PRs that should Fix #1023

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Streamlined data representation for `ChangeID`, `Checkpoint`, and `TimeTicket` messages by reverting certain fields to numeric types, enhancing compatibility and performance.
  
These changes improve the overall efficiency of data handling within the application without altering existing functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->