### PR TITLE
Fix Helm Release with Updating Chart Lock

### DIFF
--- a/build/charts/yorkie-cluster/Chart.lock
+++ b/build/charts/yorkie-cluster/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: yorkie-mongodb
   repository: ""
   version: 0.4.13
-digest: sha256:0c702d4ee264c8cbc9a8959d0290c12679e013ccd7a979fcbf81a8c03519b220
-generated: "2024-10-19T15:27:57.253314+09:00"
+digest: sha256:de02be0ff7ab619effa0be7ca151150552eef1098b4866a8648abcc90ca8e401
+generated: "2024-10-19T23:13:22.777257+09:00"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix Helm release action failure by updating `Chart.lock` file.
This was due to the lock file (Chart.lock) was out of sync with the dependencies file (Chart.yaml).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [Include yorkie-mongodb to yorkie-cluster Helm Chart (#1031)](https://github.com/yorkie-team/yorkie/actions/runs/11415855524)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
