### PR TITLE
Add enabled condition for yorkie-mongodb subchart

### DIFF
--- a/build/charts/yorkie-cluster/Chart.yaml
+++ b/build/charts/yorkie-cluster/Chart.yaml
@@ -18,7 +18,7 @@ kubeVersion: ">=1.23.0-0"
 dependencies:
   - name: yorkie-mongodb
     version: 0.4.13
-    condition: yorkie-mongodb.auto
+    condition: yorkie-mongodb.enabled
 
 keywords:
   - yorkie

--- a/build/charts/yorkie-cluster/Chart.yaml
+++ b/build/charts/yorkie-cluster/Chart.yaml
@@ -18,6 +18,7 @@ kubeVersion: ">=1.23.0-0"
 dependencies:
   - name: yorkie-mongodb
     version: 0.4.13
+    condition: yorkie-mongodb.auto
 
 keywords:
   - yorkie

--- a/build/charts/yorkie-cluster/values.yaml
+++ b/build/charts/yorkie-cluster/values.yaml
@@ -86,3 +86,4 @@ yorkie-mongodb:
     storageClass: standard
   sharded:
     enabled: true
+  auto: true

--- a/build/charts/yorkie-cluster/values.yaml
+++ b/build/charts/yorkie-cluster/values.yaml
@@ -86,4 +86,4 @@ yorkie-mongodb:
     storageClass: standard
   sharded:
     enabled: true
-  auto: true
+  enabled: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add capability to conditionally install MongoDB subchart in yorkie-cluster
by adding enabled flag. This allows users to skip MongoDB installation
when using external database.

- Add enabled condition in values.yaml
- Update chart documentation

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
