### PR TITLE
Fix transaction in UpdateAndFindMinSyncedVersionVector

### DIFF
--- a/server/backend/database/database.go
+++ b/server/backend/database/database.go
@@ -271,9 +271,9 @@ type Database interface {
 		serverSeq int64,
 	) (*time.Ticket, error)
 
-	// UpdateAndFindMinSyncedVersionVectorAfterPushPull updates the given serverSeq of the given client
+	// UpdateAndFindMinSyncedVersionVector updates the given serverSeq of the given client
 	// and returns the SyncedVersionVector of the document.
-	UpdateAndFindMinSyncedVersionVectorAfterPushPull(
+	UpdateAndFindMinSyncedVersionVector(
 		ctx context.Context,
 		clientInfo *ClientInfo,
 		docRefKey types.DocRefKey,

--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -1312,9 +1312,9 @@ func (d *DB) UpdateVersionVector(
 	return nil
 }
 
-// UpdateAndFindMinSyncedVersionVectorAfterPushPull updates the given serverSeq of the given client
+// UpdateAndFindMinSyncedVersionVector updates the given serverSeq of the given client
 // and returns the SyncedVersionVector of the document.
-func (d *DB) UpdateAndFindMinSyncedVersionVectorAfterPushPull(
+func (d *DB) UpdateAndFindMinSyncedVersionVector(
 	ctx context.Context,
 	clientInfo *database.ClientInfo,
 	docRefKey types.DocRefKey,
@@ -1338,7 +1338,7 @@ func (d *DB) UpdateAndFindMinSyncedVersionVectorAfterPushPull(
 	}
 
 	// 02. Find all version vectors of the given document from DB.
-	txn := d.db.Txn(true)
+	txn := d.db.Txn(false)
 	defer txn.Abort()
 	iterator, err := txn.Get(tblVersionVectors, "doc_id", docRefKey.DocID.String())
 	if err != nil {

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -1197,8 +1197,8 @@ func (c *Client) UpdateAndFindMinSyncedTicket(
 	), nil
 }
 
-// UpdateAndFindMinSyncedVersionVectorAfterPushPull returns min synced version vector
-func (c *Client) UpdateAndFindMinSyncedVersionVectorAfterPushPull(
+// UpdateAndFindMinSyncedVersionVector returns min synced version vector
+func (c *Client) UpdateAndFindMinSyncedVersionVector(
 	ctx context.Context,
 	clientInfo *database.ClientInfo,
 	docRefKey types.DocRefKey,

--- a/server/packs/packs.go
+++ b/server/packs/packs.go
@@ -132,7 +132,7 @@ func PushPull(
 	// 05. update and find min synced version vector for garbage collection.
 	// NOTE(hackerwins): Since the client could not receive the response, the
 	// requested seq(reqPack) is stored instead of the response seq(resPack).
-	minSyncedVersionVector, err := be.DB.UpdateAndFindMinSyncedVersionVectorAfterPushPull(
+	minSyncedVersionVector, err := be.DB.UpdateAndFindMinSyncedVersionVector(
 		ctx,
 		clientInfo,
 		docRefKey,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix transaction in UpdateAndFindMinSyncedVersionVector

This commit resolves an issue where the PushPull operation does not function correctly when using the Memory DB. `UpdateAndFindMinSyncedVersionVector` was previously set to start in `write mode`, which causes it to simply read documents. However, inside this function, it calls `UpdateVersionVector`, which attempts to start in write mode again, resulting in a deadlock scenario where the transaction cannot be acquired, causing an infinite wait.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced transaction handling for fetching version vectors, improving database interaction.
	- Updated logic to compute the minimum version vector while filtering out detached clients.

- **Bug Fixes**
	- Refined method to ensure accurate computation of the minimum synced version vector after push-pull operations.

- **Documentation**
	- Minor adjustments made to comments for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->