### PR TITLE
Optimize document detachment in Cluster Server

### DIFF
--- a/server/backend/database/database.go
+++ b/server/backend/database/database.go
@@ -224,6 +224,7 @@ type Database interface {
 		ctx context.Context,
 		docRefKey types.DocRefKey,
 		actorID types.ID,
+		serverSeq int64,
 	) (*ChangeInfo, error)
 
 	// FindChangesBetweenServerSeqs returns the changes between two server sequences.

--- a/server/backend/database/database.go
+++ b/server/backend/database/database.go
@@ -219,6 +219,13 @@ type Database interface {
 		docRefKey types.DocRefKey,
 	) error
 
+	// FindChangeInfoByServerSeq returns the change by the given server sequence.
+	FindChangeInfoByServerSeq(
+		ctx context.Context,
+		docRefKey types.DocRefKey,
+		serverSeq int64,
+	) (*ChangeInfo, error)
+
 	// FindChangesBetweenServerSeqs returns the changes between two server sequences.
 	FindChangesBetweenServerSeqs(
 		ctx context.Context,

--- a/server/backend/database/database.go
+++ b/server/backend/database/database.go
@@ -226,13 +226,6 @@ type Database interface {
 		actorID types.ID,
 	) (*ChangeInfo, error)
 
-	// FindChangeInfoByServerSeq returns the change by the given server sequence.
-	FindChangeInfoByServerSeq(
-		ctx context.Context,
-		docRefKey types.DocRefKey,
-		serverSeq int64,
-	) (*ChangeInfo, error)
-
 	// FindChangesBetweenServerSeqs returns the changes between two server sequences.
 	FindChangesBetweenServerSeqs(
 		ctx context.Context,

--- a/server/backend/database/database.go
+++ b/server/backend/database/database.go
@@ -219,6 +219,13 @@ type Database interface {
 		docRefKey types.DocRefKey,
 	) error
 
+	// FindLatestChangeInfoByActor returns the latest change created by given actorID.
+	FindLatestChangeInfoByActor(
+		ctx context.Context,
+		docRefKey types.DocRefKey,
+		actorID types.ID,
+	) (*ChangeInfo, error)
+
 	// FindChangeInfoByServerSeq returns the change by the given server sequence.
 	FindChangeInfoByServerSeq(
 		ctx context.Context,

--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -1012,6 +1012,15 @@ func (d *DB) PurgeStaleChanges(
 	return nil
 }
 
+// FindLatestChangeInfoByActor returns the latest change created by given actorID.
+func (d *DB) FindLatestChangeInfoByActor(
+	_ context.Context,
+	_ types.DocRefKey,
+	_ types.ID,
+) (*database.ChangeInfo, error) {
+	return nil, nil
+}
+
 // FindChangeInfoByServerSeq returns the change by the given server sequence.
 func (d *DB) FindChangeInfoByServerSeq(
 	_ context.Context,

--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -1017,15 +1017,17 @@ func (d *DB) FindLatestChangeInfoByActor(
 	_ context.Context,
 	docRefKey types.DocRefKey,
 	actorID types.ID,
+	serverSeq int64,
 ) (*database.ChangeInfo, error) {
 	txn := d.db.Txn(false)
 	defer txn.Abort()
 
-	iterator, err := txn.GetReverse(
+	iterator, err := txn.ReverseLowerBound(
 		tblChanges,
-		"doc_id_actor_id",
+		"doc_id_actor_id_server_seq",
 		docRefKey.DocID.String(),
 		actorID.String(),
+		serverSeq,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("fetch changes of %s: %w", actorID, err)

--- a/server/backend/database/memory/database_test.go
+++ b/server/backend/database/memory/database_test.go
@@ -64,6 +64,10 @@ func TestDB(t *testing.T) {
 		testcases.RunFindChangeInfosBetweenServerSeqsTest(t, db, projectID)
 	})
 
+	t.Run("RunFindLatestChangeInfoTest test", func(t *testing.T) {
+		testcases.RunFindLatestChangeInfoTest(t, db, projectID)
+	})
+
 	t.Run("RunFindClosestSnapshotInfo test", func(t *testing.T) {
 		testcases.RunFindClosestSnapshotInfoTest(t, db, projectID)
 	})

--- a/server/backend/database/memory/indexes.go
+++ b/server/backend/database/memory/indexes.go
@@ -167,6 +167,15 @@ var schema = &memdb.DBSchema{
 						},
 					},
 				},
+				"doc_id_actor_id": {
+					Name: "doc_id_actor_id",
+					Indexer: &memdb.CompoundIndex{
+						Indexes: []memdb.Indexer{
+							&memdb.StringFieldIndex{Field: "DocID"},
+							&memdb.StringFieldIndex{Field: "ActorID"},
+						},
+					},
+				},
 			},
 		},
 		tblSnapshots: {

--- a/server/backend/database/memory/indexes.go
+++ b/server/backend/database/memory/indexes.go
@@ -167,12 +167,13 @@ var schema = &memdb.DBSchema{
 						},
 					},
 				},
-				"doc_id_actor_id": {
-					Name: "doc_id_actor_id",
+				"doc_id_actor_id_server_seq": {
+					Name: "doc_id_actor_id_server_seq",
 					Indexer: &memdb.CompoundIndex{
 						Indexes: []memdb.Indexer{
 							&memdb.StringFieldIndex{Field: "DocID"},
 							&memdb.StringFieldIndex{Field: "ActorID"},
+							&memdb.IntFieldIndex{Field: "ServerSeq"},
 						},
 					},
 				},

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -982,14 +982,20 @@ func (c *Client) FindLatestChangeInfoByActor(
 	ctx context.Context,
 	docRefKey types.DocRefKey,
 	actorID types.ID,
+	serverSeq int64,
 ) (*database.ChangeInfo, error) {
+	option := options.FindOne().SetSort(bson.M{
+		"server_seq": -1,
+	})
+
 	result := c.collection(ColChanges).FindOne(ctx, bson.M{
 		"project_id": docRefKey.ProjectID,
 		"doc_id":     docRefKey.DocID,
 		"actor_id":   actorID,
-	}, options.FindOne().SetSort(bson.M{
-		"lamport": -1,
-	}))
+		"server_seq": bson.M{
+			"$lte": serverSeq,
+		},
+	}, option)
 
 	changeInfo := &database.ChangeInfo{}
 	if result.Err() == mongo.ErrNoDocuments {

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -1006,33 +1006,6 @@ func (c *Client) FindLatestChangeInfoByActor(
 	return changeInfo, nil
 }
 
-// FindChangeInfoByServerSeq returns the change by the given server sequence.
-func (c *Client) FindChangeInfoByServerSeq(
-	ctx context.Context,
-	docRefKey types.DocRefKey,
-	serverSeq int64,
-) (*database.ChangeInfo, error) {
-	result := c.collection(ColChanges).FindOne(ctx, bson.M{
-		"project_id": docRefKey.ProjectID,
-		"doc_id":     docRefKey.DocID,
-		"server_seq": serverSeq,
-	})
-
-	changeInfo := &database.ChangeInfo{}
-	if result.Err() == mongo.ErrNoDocuments {
-		return changeInfo, nil
-	}
-	if result.Err() != nil {
-		return nil, fmt.Errorf("find change: %w", result.Err())
-	}
-
-	if err := result.Decode(changeInfo); err != nil {
-		return nil, fmt.Errorf("decode change: %w", err)
-	}
-
-	return changeInfo, nil
-}
-
 // FindChangesBetweenServerSeqs returns the changes between two server sequences.
 func (c *Client) FindChangesBetweenServerSeqs(
 	ctx context.Context,

--- a/server/backend/database/mongo/client_test.go
+++ b/server/backend/database/mongo/client_test.go
@@ -80,6 +80,10 @@ func TestClient(t *testing.T) {
 		testcases.RunFindChangeInfosBetweenServerSeqsTest(t, cli, dummyProjectID)
 	})
 
+	t.Run("RunFindLatestChangeInfoTest test", func(t *testing.T) {
+		testcases.RunFindLatestChangeInfoTest(t, cli, dummyProjectID)
+	})
+
 	t.Run("RunFindClosestSnapshotInfo test", func(t *testing.T) {
 		testcases.RunFindClosestSnapshotInfoTest(t, cli, dummyProjectID)
 	})

--- a/server/backend/database/mongo/indexes.go
+++ b/server/backend/database/mongo/indexes.go
@@ -124,15 +124,10 @@ var collectionInfos = []collectionInfo{
 			Keys: bsonx.Doc{
 				{Key: "doc_id", Value: bsonx.Int32(1)}, // shard key
 				{Key: "project_id", Value: bsonx.Int32(1)},
+				{Key: "actor_id", Value: bsonx.Int32(1)},
 				{Key: "server_seq", Value: bsonx.Int32(1)},
 			},
 			Options: options.Index().SetUnique(true),
-		}, {
-			Keys: bsonx.Doc{
-				{Key: "doc_id", Value: bsonx.Int32(1)}, // shard key
-				{Key: "project_id", Value: bsonx.Int32(1)},
-				{Key: "actor_id", Value: bsonx.Int32(1)},
-			},
 		}},
 	}, {
 		name: ColSnapshots,

--- a/server/backend/database/mongo/indexes.go
+++ b/server/backend/database/mongo/indexes.go
@@ -124,6 +124,13 @@ var collectionInfos = []collectionInfo{
 			Keys: bsonx.Doc{
 				{Key: "doc_id", Value: bsonx.Int32(1)}, // shard key
 				{Key: "project_id", Value: bsonx.Int32(1)},
+				{Key: "server_seq", Value: bsonx.Int32(1)},
+			},
+			Options: options.Index().SetUnique(true),
+		}, {
+			Keys: bsonx.Doc{
+				{Key: "doc_id", Value: bsonx.Int32(1)}, // shard key
+				{Key: "project_id", Value: bsonx.Int32(1)},
 				{Key: "actor_id", Value: bsonx.Int32(1)},
 				{Key: "server_seq", Value: bsonx.Int32(1)},
 			},

--- a/server/backend/database/mongo/indexes.go
+++ b/server/backend/database/mongo/indexes.go
@@ -127,6 +127,12 @@ var collectionInfos = []collectionInfo{
 				{Key: "server_seq", Value: bsonx.Int32(1)},
 			},
 			Options: options.Index().SetUnique(true),
+		}, {
+			Keys: bsonx.Doc{
+				{Key: "doc_id", Value: bsonx.Int32(1)}, // shard key
+				{Key: "project_id", Value: bsonx.Int32(1)},
+				{Key: "actor_id", Value: bsonx.Int32(1)},
+			},
 		}},
 	}, {
 		name: ColSnapshots,

--- a/server/backend/database/testcases/testcases.go
+++ b/server/backend/database/testcases/testcases.go
@@ -572,14 +572,24 @@ func RunFindLatestChangeInfoTest(t *testing.T,
 		)
 		assert.NoError(t, err)
 
-		// 02. Find latest changeInfo
+		// 02-1. Find all changes
+		changes, err := db.FindChangesBetweenServerSeqs(ctx, docRefKey, 1, 10)
+		assert.NoError(t, err)
+		maxLamport := int64(0)
+		for _, ch := range changes {
+			if maxLamport < ch.ID().Lamport() {
+				maxLamport = ch.ID().Lamport()
+			}
+		}
+		// 02-2. Find latest changeInfo and compare results.
 		latestChangeInfo, err := db.FindLatestChangeInfoByActor(
 			ctx,
 			docRefKey,
 			types.ID(actorID.String()),
+			10,
 		)
 		assert.NoError(t, err)
-		assert.Equal(t, latestChangeInfo.Lamport, int64(6))
+		assert.Equal(t, maxLamport, latestChangeInfo.Lamport)
 	})
 }
 

--- a/server/rpc/cluster_server.go
+++ b/server/rpc/cluster_server.go
@@ -96,12 +96,17 @@ func (s *clusterServer) DetachDocument(
 
 	// 01. Create changePack with presence clear change
 	cp := clientInfo.Checkpoint(summary.ID)
-	latestChange, err := s.backend.DB.FindLatestChangeInfoByActor(ctx, docRefKey, types.ID(req.Msg.ClientId))
+	latestChangeInfo, err := s.backend.DB.FindLatestChangeInfoByActor(
+		ctx,
+		docRefKey,
+		types.ID(req.Msg.ClientId),
+		cp.ServerSeq,
+	)
 	if err != nil {
 		return nil, err
 	}
 	changeCtx := change.NewContext(
-		change.NewID(cp.ClientSeq, cp.ServerSeq, latestChange.Lamport, actorID, latestChange.VersionVector).Next(),
+		change.NewID(cp.ClientSeq, cp.ServerSeq, latestChangeInfo.Lamport, actorID, latestChangeInfo.VersionVector).Next(),
 		"",
 		nil,
 	)

--- a/server/rpc/cluster_server.go
+++ b/server/rpc/cluster_server.go
@@ -100,13 +100,8 @@ func (s *clusterServer) DetachDocument(
 	if err != nil {
 		return nil, err
 	}
-	maxLamport := latestChange.Lamport
-	if cp.ServerSeq > maxLamport {
-		maxLamport = cp.ServerSeq
-	}
-	latestChange.VersionVector.Set(actorID, maxLamport)
 	changeCtx := change.NewContext(
-		change.NewID(cp.ClientSeq, cp.ServerSeq, maxLamport, actorID, latestChange.VersionVector).Next(),
+		change.NewID(cp.ClientSeq, cp.ServerSeq, latestChange.Lamport, actorID, latestChange.VersionVector).Next(),
 		"",
 		nil,
 	)
@@ -125,7 +120,7 @@ func (s *clusterServer) DetachDocument(
 		docInfo,
 		pack,
 		packs.PushPullOptions{
-			Mode:   types.SyncModePushPull,
+			Mode:   types.SyncModePushOnly,
 			Status: document.StatusDetached,
 		},
 	); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
This PR optimizes the document detach operation through the Cluster Server. As mentioned in #1039 , improvements during the client deactivation process highlighted several areas for enhancement, particularly the part that generates the presence clear event, which was the most time-consuming.

Previously, the process involved building the document corresponding to the client's checkpoint to create changes. This approach was time-intensive due to the overhead of document construction. To address this, we have introduced logic to generate changes directly, bypassing the document build phase.

The changes that are generated will be considered as the latest change created immediately after the targeted client (or actor) has its `latestChangeInfo`.
To quickly obtain the `latestChangeInfo` for a specific actor, the index of the change collection has been added, with fields `{ doc_id, project_id, actor_id, server_seq }`.

By implementing these changes, we have observed significant improvements: the execution time for documents that previously took about 150ms for detachment has been reduced to an average of 30ms.

#### Any background context you want to provide?
1. Background: The optimization covered in this PR is based on the contents of PR https://github.com/yorkie-team/yorkie/pull/1036, which covers the overall flow of client deactivation, and issue #1039 , which covers points that may become bottlenecks in the process.

2. Limitation: It’s important to note that the Lamport timestamp and version vector for the created change will differ from the actual Lamport timestamp and version vector associated with the client’s document, which could lead to potential issues, further discussed in another issue.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Addresses #1039 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [ ] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a method to retrieve the latest change information by actor ID for improved tracking of document changes.
	- Added new indexes to enhance query efficiency for change retrieval.

- **Bug Fixes**
	- Optimized the document detachment process in the cluster server for better performance.

- **Tests**
	- Expanded test coverage with new test cases for validating the retrieval of the latest change information.

These updates enhance the overall functionality and performance of the application, particularly in tracking changes and managing document states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->