### PR TITLE
Add minLamport for proper GC of deactivated clients

### DIFF
--- a/pkg/document/time/version_vector.go
+++ b/pkg/document/time/version_vector.go
@@ -18,6 +18,7 @@ package time
 
 import (
 	"bytes"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -114,7 +115,15 @@ func (v VersionVector) AfterOrEqual(other VersionVector) bool {
 
 // EqualToOrAfter returns whether this VersionVector's every field is equal or after than given ticket.
 func (v VersionVector) EqualToOrAfter(other *Ticket) bool {
-	return v[other.actorID.bytes] >= other.lamport
+	clientLamport, ok := v[other.actorID.bytes]
+
+	if !ok {
+		minLamport := v.MinLamport()
+
+		return minLamport > other.lamport
+	}
+
+	return clientLamport >= other.lamport
 }
 
 // Min returns new vv consists of every min value in each column.
@@ -167,7 +176,20 @@ func (v VersionVector) Max(other VersionVector) VersionVector {
 	return maxVV
 }
 
-// MaxLamport returns new vv consists of every max value in each column.
+// MinLamport returns min lamport value in version vector.
+func (v VersionVector) MinLamport() int64 {
+	var minLamport int64 = math.MaxInt64
+
+	for _, value := range v {
+		if value < minLamport {
+			minLamport = value
+		}
+	}
+
+	return minLamport
+}
+
+// MaxLamport returns max lamport value in version vector.
 func (v VersionVector) MaxLamport() int64 {
 	var maxLamport int64 = -1
 

--- a/test/integration/gc_test.go
+++ b/test/integration/gc_test.go
@@ -1136,4 +1136,64 @@ func TestGarbageCollection(t *testing.T) {
 			assert.Equal(t, 2, d2.GarbageLen())
 		}
 	})
+
+	t.Run("gc targeting nodes made by deactivated client", func(t *testing.T) {
+		ctx := context.Background()
+		d1 := document.New(helper.TestDocKey(t))
+		assert.NoError(t, c1.Attach(ctx, d1))
+		// d2.vv =[c1:1], minvv =[c1:1], db.vv {c1: [c1:1]}
+		assert.Equal(t, checkVV(d1.VersionVector(), versionOf(d1.ActorID(), 1)), true)
+
+		d2 := document.New(helper.TestDocKey(t))
+		assert.NoError(t, c2.Attach(ctx, d2))
+		// d2.vv =[c1:1, c2:1], minvv =[c1:0, c2:0], db.vv {c1: [c1:1], c2: [c2:1]}
+		assert.Equal(t, checkVV(d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 2)), true)
+
+		err := d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewText("text").Edit(0, 0, "a").Edit(1, 1, "b").Edit(2, 2, "c")
+			return nil
+		}, "sets text")
+		//d1.vv = [c1:2]
+		assert.Equal(t, checkVV(d1.VersionVector(), versionOf(d1.ActorID(), 2)), true)
+		assert.NoError(t, err)
+
+		assert.NoError(t, c1.Sync(ctx))
+		// d1.vv =[c1:3, c2:1], minvv =[c1:0, c2:0], db.vv {c1: [c1:2], c2: [c2:1]}
+		assert.Equal(t, checkVV(d1.VersionVector(), versionOf(d1.ActorID(), 3), versionOf(d2.ActorID(), 1)), true)
+
+		assert.NoError(t, c2.Sync(ctx))
+		// d2.vv =[c1:2, c2:3], minvv =[c1:0, c2:0], db.vv {c1: [c1:2], c2: [c1:1, c2:2]}
+		assert.Equal(t, checkVV(d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 3)), true)
+
+		err = d2.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(2, 2, "c")
+			return nil
+		}, "insert c")
+		//d2.vv =[c1:2, c2:4]
+		assert.Equal(t, checkVV(d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 4)), true)
+		assert.NoError(t, err)
+
+		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(1, 3, "")
+			return nil
+		}, "delete bd")
+		//d1.vv = [c1:4, c2:1]
+		assert.Equal(t, checkVV(d1.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 1)), true)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, d1.GarbageLen())
+		assert.Equal(t, 0, d2.GarbageLen())
+
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c1.Deactivate(ctx))
+
+		assert.Equal(t, d2.GarbageLen(), 2)
+		assert.Equal(t, len(d2.VersionVector()), 2)
+
+		// TODO(JOOHOJANG): remove below comments after https://github.com/yorkie-team/yorkie/issues/1058 resolved
+		// Due to https://github.com/yorkie-team/yorkie/issues/1058, removing deactivated client's version vector is not working properly now.
+		// assert.NoError(t, c2.Sync(ctx))
+		// assert.Equal(t, d2.GarbageLen(), 0)
+		// assert.Equal(t, len(d2.VersionVector()), 1)
+	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is same as https://github.com/yorkie-team/yorkie-js-sdk/pull/926

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to compute the minimum Lamport value in the version vector.
	- Updated version comparison logic to handle cases where an actor's version is absent.

- **Bug Fixes**
	- Enhanced garbage collection behavior for documents updated by deactivated clients.

- **Tests**
	- Added a test case to verify garbage collection functionality when a client is deactivated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->