### PR TITLE
Update CHANGELOG.md for v0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and Yorkie adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## [0.5.6] - 2024-11-22
+
+### Added
+
+- Add migration script to detach documents from deactivated clients by @raararaara in https://github.com/yorkie-team/yorkie/pull/1062
+
+### Changed
+
+- Upate garbage collection algorithm design by @JOOHOJANG in https://github.com/yorkie-team/yorkie/pull/1061
+- Convert `presence change` from string to binary by @chacha912 in https://github.com/yorkie-team/yorkie/pull/1069
+
+### Fixed
+
+- Add minLamport for proper GC of deactivated clients by @JOOHOJANG in https://github.com/yorkie-team/yorkie/pull/1060
+- Optimize document detachment in Cluster Server by @raararaara in https://github.com/yorkie-team/yorkie/pull/1055
+- Fix version vector cleanup during client deactivation by @raararaara in https://github.com/yorkie-team/yorkie/pull/1068
+- Correct ReverseLowerBound behavior in MemDB by setting unique index by @chacha912 in https://github.com/yorkie-team/yorkie/pull/1074
+- Update presence_change migration for JSON to Protobuf conversion by @chacha912 in https://github.com/yorkie-team/yorkie/pull/1075
+
 ## [0.5.5] - 2024-11-07
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-YORKIE_VERSION := 0.5.5
+YORKIE_VERSION := 0.5.6
 
 GO_PROJECT = github.com/yorkie-team/yorkie
 

--- a/api/docs/yorkie.base.yaml
+++ b/api/docs/yorkie.base.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Yorkie
   description: "Yorkie is an open source document store for building collaborative editing applications."
-  version: v0.5.5
+  version: v0.5.6
 servers:
   - url: https://api.yorkie.dev
     description: Production server

--- a/api/docs/yorkie/v1/admin.openapi.yaml
+++ b/api/docs/yorkie/v1/admin.openapi.yaml
@@ -4,7 +4,7 @@ info:
     Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.5.5
+  version: v0.5.6
 servers:
   - description: Production server
     url: https://api.yorkie.dev

--- a/api/docs/yorkie/v1/cluster.openapi.yaml
+++ b/api/docs/yorkie/v1/cluster.openapi.yaml
@@ -4,7 +4,7 @@ info:
     Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.5.5
+  version: v0.5.6
 servers:
   - description: Production server
     url: https://api.yorkie.dev

--- a/api/docs/yorkie/v1/resources.openapi.yaml
+++ b/api/docs/yorkie/v1/resources.openapi.yaml
@@ -4,7 +4,7 @@ info:
     Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.5.5
+  version: v0.5.6
 servers:
   - description: Production server
     url: https://api.yorkie.dev

--- a/api/docs/yorkie/v1/yorkie.openapi.yaml
+++ b/api/docs/yorkie/v1/yorkie.openapi.yaml
@@ -4,7 +4,7 @@ info:
     Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.5.5
+  version: v0.5.6
 servers:
   - description: Production server
     url: https://api.yorkie.dev

--- a/build/charts/yorkie-cluster/Chart.yaml
+++ b/build/charts/yorkie-cluster/Chart.yaml
@@ -11,8 +11,8 @@ maintainers:
 
 sources:
   - https://github.com/yorkie-team/yorkie
-version: 0.5.5
-appVersion: "0.5.5"
+version: 0.5.6
+appVersion: "0.5.6"
 kubeVersion: ">=1.23.0-0"
 
 dependencies:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Update CHANGELOG.md for v0.5.6

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes for Version 0.5.6

- **New Features**
  - Introduced a migration script to detach documents from deactivated clients.

- **Bug Fixes**
  - Implemented a minimum Lamport timestamp for garbage collection of deactivated clients.
  - Optimized document detachment in the Cluster Server.
  - Corrected the version vector cleanup process during client deactivation.
  - Fixed the behavior of the ReverseLowerBound function in MemDB.

- **Documentation**
  - Updated version numbers across the API documentation and Helm chart to reflect the new version 0.5.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->