### PR TITLE
Fix mongo db client to use GridFS API on 16MB exceed file

### DIFF
--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -1070,56 +1070,49 @@ func (c *Client) CreateSnapshotInfo(
 	docRefKey types.DocRefKey,
 	doc *document.InternalDocument,
 ) error {
-	// 스냅샷 생성
 	snapshot, err := converter.SnapshotToBytes(doc.RootObject(), doc.AllPresences())
 	if err != nil {
 		return err
 	}
 
-	// 16MB 이상이면 GridFS에 저장
 	const maxSnapshotSize = 16 * 1024 * 1024 // 16MB
 	if len(snapshot) > maxSnapshotSize {
 		log.Println("16MB over!!!")
 
 		db := c.client.Database(c.config.YorkieDatabase)
 
-		// GridFS 버킷 생성
-		bucket, err := gridfs.NewBucket(db) // MongoDB의 c.db는 데이터베이스 객체
+		// create GridFS bucket
+		bucket, err := gridfs.NewBucket(db)
 		if err != nil {
 			return fmt.Errorf("failed to create GridFS bucket: %w", err)
 		}
 
-		// GridFS에 파일 업로드
 		uploadStream, err := bucket.OpenUploadStream(fmt.Sprintf("%s_snapshot", docRefKey.DocID))
 		if err != nil {
 			return fmt.Errorf("failed to open GridFS upload stream: %w", err)
 		}
 		defer uploadStream.Close()
 
-		// 스냅샷 데이터를 GridFS에 저장
 		_, err = uploadStream.Write(snapshot)
 		if err != nil {
 			return fmt.Errorf("failed to write to GridFS: %w", err)
 		}
 
-		// 파일의 ID (GridFS에서 파일을 식별하는 ObjectId)
 		fileID := uploadStream.FileID
 
-		// GridFS에 저장된 파일 ID를 사용하여 문서 삽입
 		if _, err := c.collection(ColSnapshots).InsertOne(ctx, bson.M{
 			"project_id":       docRefKey.ProjectID,
 			"doc_id":           docRefKey.DocID,
 			"server_seq":       doc.Checkpoint().ServerSeq,
 			"lamport":          doc.Lamport(),
 			"version_vector":   doc.VersionVector(),
-			"snapshot_file_id": fileID, // GridFS 파일 ID
+			"snapshot_file_id": fileID, // GridFS file ID
 			"created_at":       gotime.Now(),
 		}); err != nil {
 			return fmt.Errorf("insert snapshot info: %w", err)
 		}
 
 	} else {
-		// 스냅샷이 16MB 이하일 경우 일반적인 컬렉션에 삽입
 		if _, err := c.collection(ColSnapshots).InsertOne(ctx, bson.M{
 			"project_id":     docRefKey.ProjectID,
 			"doc_id":         docRefKey.DocID,

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"strings"
 	gotime "time"
 
@@ -45,7 +44,8 @@ import (
 
 const (
 	// StatusKey is the key of the status field.
-	StatusKey = "status"
+	StatusKey           = "status"
+	BSONMaxSnapshotSize = 16 * 1024 * 1024 // 16MB
 )
 
 // Client is a client that connects to Mongo DB and reads or saves Yorkie data.
@@ -1075,10 +1075,7 @@ func (c *Client) CreateSnapshotInfo(
 		return err
 	}
 
-	const maxSnapshotSize = 16 * 1024 * 1024 // 16MB
-	if len(snapshot) > maxSnapshotSize {
-		log.Println("16MB over!!!")
-
+	if len(snapshot) > BSONMaxSnapshotSize {
 		db := c.client.Database(c.config.YorkieDatabase)
 
 		// create GridFS bucket

--- a/server/backend/database/testcases/testcases.go
+++ b/server/backend/database/testcases/testcases.go
@@ -1620,7 +1620,7 @@ func AssertKeys(t *testing.T, expectedKeys []key.Key, infos []*database.DocInfo)
 	assert.EqualValues(t, expectedKeys, keys)
 }
 
-func CreateLargeSnapshotTest(t *testing.T, db database.Database, projectID types.ID) {
+func RunCreateLargeSnapshotTest(t *testing.T, db database.Database, projectID types.ID) {
 	t.Run("store and validate large snapshot test", func(t *testing.T) {
 		ctx := context.Background()
 		docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
@@ -1633,9 +1633,9 @@ func CreateLargeSnapshotTest(t *testing.T, db database.Database, projectID types
 		doc := document.New(docKey)
 		doc.SetActor(actorID)
 
-		largeData := make([]byte, 16*1024*1024+1) // 16MB + 1 byte
+		largeData := make([]byte, 16*1024*1024+1)
 		for i := range largeData {
-			largeData[i] = byte('A' + (i % 26)) // A-Z 반복
+			largeData[i] = byte('A' + (i % 26))
 		}
 
 		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
@@ -1645,7 +1645,6 @@ func CreateLargeSnapshotTest(t *testing.T, db database.Database, projectID types
 
 		docRefKey := docInfo.RefKey()
 
-		// 스냅샷 생성 및 오류 확인
 		err := db.CreateSnapshotInfo(ctx, docRefKey, doc.InternalDocument())
 		assert.NoError(t, err)
 	})

--- a/test/complex/mongo_client_test.go
+++ b/test/complex/mongo_client_test.go
@@ -171,4 +171,8 @@ func TestClientWithShardedDB(t *testing.T) {
 		assert.Equal(t, docInfo1.Key, result.Key)
 		assert.Equal(t, docInfo1.ID, result.ID)
 	})
+
+	t.Run("CreateLargeSnapshotTest test", func(t *testing.T) {
+		testcases.CreateLargeSnapshotTest(t, cli, dummyProjectID)
+	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Modified to create a snapshot of files larger than 16MB and upload them to MongoDB using GridFS.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #267 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [ ] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [ ] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced snapshot handling for large documents, allowing uploads to GridFS when size exceeds 16MB.
	- Improved error handling and logging for snapshot creation processes.

- **Tests**
	- Introduced new test functions to validate the handling of large snapshots in the database, ensuring error-free processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->