### PR TITLE
Refactor webhook method configuration and add CLI commands

### DIFF
--- a/api/types/project.go
+++ b/api/types/project.go
@@ -62,7 +62,7 @@ func (p *Project) RequireAuth(method Method) bool {
 	}
 
 	if len(p.AuthWebhookMethods) == 0 {
-		return true
+		return false
 	}
 
 	for _, m := range p.AuthWebhookMethods {

--- a/api/types/project_test.go
+++ b/api/types/project_test.go
@@ -35,13 +35,13 @@ func TestProjectInfo(t *testing.T) {
 		assert.True(t, info.RequireAuth(types.ActivateClient))
 		assert.False(t, info.RequireAuth(types.DetachDocument))
 
-		// 2. Allow all
+		// 2. No method specified
 		info2 := &types.Project{
 			AuthWebhookURL:     validWebhookURL,
 			AuthWebhookMethods: []string{},
 		}
-		assert.True(t, info2.RequireAuth(types.ActivateClient))
-		assert.True(t, info2.RequireAuth(types.DetachDocument))
+		assert.False(t, info2.RequireAuth(types.ActivateClient))
+		assert.False(t, info2.RequireAuth(types.DetachDocument))
 
 		// 3. Empty webhook URL
 		info3 := &types.Project{

--- a/test/integration/auth_webhook_test.go
+++ b/test/integration/auth_webhook_test.go
@@ -41,6 +41,17 @@ import (
 	"github.com/yorkie-team/yorkie/test/helper"
 )
 
+var allWebhookMethods = &[]string{
+	string(types.ActivateClient),
+	string(types.DeactivateClient),
+	string(types.AttachDocument),
+	string(types.DetachDocument),
+	string(types.RemoveDocument),
+	string(types.PushPull),
+	string(types.WatchDocuments),
+	string(types.Broadcast),
+}
+
 func newAuthServer(t *testing.T) (*httptest.Server, string) {
 	token := xid.New().String()
 
@@ -110,7 +121,8 @@ func TestProjectAuthWebhook(t *testing.T) {
 			ctx,
 			project.ID.String(),
 			&types.UpdatableProjectFields{
-				AuthWebhookURL: &project.AuthWebhookURL,
+				AuthWebhookURL:     &project.AuthWebhookURL,
+				AuthWebhookMethods: allWebhookMethods,
 			},
 		)
 		assert.NoError(t, err)
@@ -140,7 +152,8 @@ func TestProjectAuthWebhook(t *testing.T) {
 			ctx,
 			project.ID.String(),
 			&types.UpdatableProjectFields{
-				AuthWebhookURL: &project.AuthWebhookURL,
+				AuthWebhookURL:     &project.AuthWebhookURL,
+				AuthWebhookMethods: allWebhookMethods,
 			},
 		)
 		assert.NoError(t, err)
@@ -179,7 +192,8 @@ func TestProjectAuthWebhook(t *testing.T) {
 			ctx,
 			project.ID.String(),
 			&types.UpdatableProjectFields{
-				AuthWebhookURL: &project.AuthWebhookURL,
+				AuthWebhookURL:     &project.AuthWebhookURL,
+				AuthWebhookMethods: allWebhookMethods,
 			},
 		)
 		assert.NoError(t, err)
@@ -278,7 +292,8 @@ func TestAuthWebhookErrorHandling(t *testing.T) {
 			ctx,
 			project.ID.String(),
 			&types.UpdatableProjectFields{
-				AuthWebhookURL: &project.AuthWebhookURL,
+				AuthWebhookURL:     &project.AuthWebhookURL,
+				AuthWebhookMethods: allWebhookMethods,
 			},
 		)
 		assert.NoError(t, err)
@@ -318,7 +333,8 @@ func TestAuthWebhookErrorHandling(t *testing.T) {
 			ctx,
 			project.ID.String(),
 			&types.UpdatableProjectFields{
-				AuthWebhookURL: &project.AuthWebhookURL,
+				AuthWebhookURL:     &project.AuthWebhookURL,
+				AuthWebhookMethods: allWebhookMethods,
 			},
 		)
 		assert.NoError(t, err)
@@ -346,7 +362,8 @@ func TestAuthWebhookErrorHandling(t *testing.T) {
 			ctx,
 			project.ID.String(),
 			&types.UpdatableProjectFields{
-				AuthWebhookURL: &project.AuthWebhookURL,
+				AuthWebhookURL:     &project.AuthWebhookURL,
+				AuthWebhookMethods: allWebhookMethods,
 			},
 		)
 		assert.NoError(t, err)
@@ -375,7 +392,8 @@ func TestAuthWebhookErrorHandling(t *testing.T) {
 			ctx,
 			project.ID.String(),
 			&types.UpdatableProjectFields{
-				AuthWebhookURL: &project.AuthWebhookURL,
+				AuthWebhookURL:     &project.AuthWebhookURL,
+				AuthWebhookMethods: allWebhookMethods,
 			},
 		)
 		assert.NoError(t, err)
@@ -434,7 +452,8 @@ func TestAuthWebhookCache(t *testing.T) {
 			ctx,
 			project.ID.String(),
 			&types.UpdatableProjectFields{
-				AuthWebhookURL: &project.AuthWebhookURL,
+				AuthWebhookURL:     &project.AuthWebhookURL,
+				AuthWebhookMethods: allWebhookMethods,
 			},
 		)
 		assert.NoError(t, err)
@@ -511,7 +530,8 @@ func TestAuthWebhookCache(t *testing.T) {
 			ctx,
 			project.ID.String(),
 			&types.UpdatableProjectFields{
-				AuthWebhookURL: &project.AuthWebhookURL,
+				AuthWebhookURL:     &project.AuthWebhookURL,
+				AuthWebhookMethods: allWebhookMethods,
 			},
 		)
 		assert.NoError(t, err)
@@ -574,7 +594,8 @@ func TestAuthWebhookCache(t *testing.T) {
 			ctx,
 			project.ID.String(),
 			&types.UpdatableProjectFields{
-				AuthWebhookURL: &project.AuthWebhookURL,
+				AuthWebhookURL:     &project.AuthWebhookURL,
+				AuthWebhookMethods: allWebhookMethods,
 			},
 		)
 		assert.NoError(t, err)
@@ -622,7 +643,8 @@ func TestAuthWebhookNewToken(t *testing.T) {
 			ctx,
 			project.ID.String(),
 			&types.UpdatableProjectFields{
-				AuthWebhookURL: &project.AuthWebhookURL,
+				AuthWebhookURL:     &project.AuthWebhookURL,
+				AuthWebhookMethods: allWebhookMethods,
 			},
 		)
 		assert.NoError(t, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Change webhook behavior to require explicit method configuration
- Previously: Webhooks triggered for all methods when none specified
- Now: Webhooks only trigger for explicitly configured methods
- This makes the behavior more intuitive and gives users better control

2. Add CLI commands for managing webhook methods
- Implement commands to add/remove webhook methods
- Support for single method, multiple methods, and ALL methods
- Remove operations are always processed before add operations

```bash
# Add a single method
bin/yorkie project update project-name --auth-webhook-method-add PushPull

# Remove a method
bin/yorkie project update project-name --auth-webhook-method-rm PushPull

# Add ALL methods
bin/yorkie project update project-name --auth-webhook-method-add ALL

# Remove ALL methods
bin/yorkie project update project-name --auth-webhook-method-rm ALL

# Add multiple methods
bin/yorkie project update project-name \
  --auth-webhook-method-add ActivateClient \
  --auth-webhook-method-add PushPull \
  --auth-webhook-method-add WatchDocuments
```

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Related https://github.com/yorkie-team/dashboard/issues/175#issuecomment-2484881931

**Special notes for your reviewer**:

- CLI design follows Docker CLI patterns
  - Option format inspired by [`docker service update`](https://docs.docker.com/reference/cli/docker/service/update/)
  - Use of `ALL` keyword: [ref](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-specific-capabilities-needed-by-a-container)
- Uses `StringArrayVar` instead of `StringSliceVar` for method flags: https://github.com/spf13/cobra/issues/661
  - Requires explicit `--auth-webhook-method-add` for each method
  - More verbose but clearer than comma-separated values

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

![image](https://github.com/user-attachments/assets/bb75889a-a3d4-4119-9a1e-e394ba1b887c)


```
$ bin/yorkie project update project-name --help
Update a project

Usage:
  yorkie project update [name] [flags]

Examples:
yorkie project update name [options]

Flags:
      --auth-webhook-method-add stringArray   authorization-webhook methods to add ('ALL' for all methods)
      --auth-webhook-method-rm stringArray    authorization-webhook methods to remove ('ALL' for all methods)
      --auth-webhook-url string               authorization-webhook update url
      --client-deactivate-threshold string    client deactivate threshold for housekeeping
  -h, --help                                  help for update
      --name string                           new project name

Global Flags:
  -o, --output string     One of 'yaml' or 'json'.
      --rpc-addr string   Address of the rpc server (default "localhost:8080")
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced project update functionality with new options for managing authorization webhook methods.
	- Introduced flexible management of authorization methods during project updates, allowing addition and removal of methods.

- **Bug Fixes**
	- Adjusted behavior of authorization requirement logic to not require authentication when no methods are specified.

- **Tests**
	- Updated test cases to reflect changes in authorization webhook methods, ensuring accurate validation of new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->