### PR TITLE
Replace maxCreatedAtMap with version vector for causal-concurrent operations

### DIFF
--- a/api/converter/from_bytes.go
+++ b/api/converter/from_bytes.go
@@ -334,7 +334,7 @@ func fromTextNode(
 		if err != nil {
 			return nil, err
 		}
-		textNode.Remove(removedAt, time.MaxLamport)
+		textNode.Remove(removedAt, time.MaxTicket, time.MaxLamport)
 	}
 	return textNode, nil
 }

--- a/api/converter/from_bytes.go
+++ b/api/converter/from_bytes.go
@@ -334,7 +334,7 @@ func fromTextNode(
 		if err != nil {
 			return nil, err
 		}
-		textNode.Remove(removedAt, time.MaxTicket)
+		textNode.Remove(removedAt, time.MaxLamport)
 	}
 	return textNode, nil
 }

--- a/pkg/document/change/change.go
+++ b/pkg/document/change/change.go
@@ -54,7 +54,7 @@ func New(id ID, message string, operations []operations.Operation, p *innerprese
 // Execute applies this change to the given JSON root.
 func (c *Change) Execute(root *crdt.Root, presences *innerpresence.Map) error {
 	for _, op := range c.operations {
-		if err := op.Execute(root); err != nil {
+		if err := op.Execute(root, operations.WithVersionVector(c.ID().versionVector)); err != nil {
 			return err
 		}
 	}

--- a/pkg/document/change/change.go
+++ b/pkg/document/change/change.go
@@ -52,10 +52,17 @@ func New(id ID, message string, operations []operations.Operation, p *innerprese
 }
 
 // Execute applies this change to the given JSON root.
-func (c *Change) Execute(root *crdt.Root, presences *innerpresence.Map) error {
+func (c *Change) Execute(root *crdt.Root, presences *innerpresence.Map, opSource string) error {
 	for _, op := range c.operations {
-		if err := op.Execute(root, operations.WithVersionVector(c.ID().versionVector)); err != nil {
-			return err
+		// TODO(chacha912): Remove opSource after testing.
+		if opSource == "remote" {
+			if err := op.Execute(root, operations.WithVersionVector(c.ID().versionVector)); err != nil {
+				return err
+			}
+		} else {
+			if err := op.Execute(root); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/document/change/change.go
+++ b/pkg/document/change/change.go
@@ -54,7 +54,7 @@ func New(id ID, message string, operations []operations.Operation, p *innerprese
 // Execute applies this change to the given JSON root.
 func (c *Change) Execute(root *crdt.Root, presences *innerpresence.Map) error {
 	for _, op := range c.operations {
-		if err := op.Execute(root, operations.WithVersionVector(c.ID().versionVector)); err != nil {
+		if err := op.Execute(root, c.ID().versionVector); err != nil {
 			return err
 		}
 	}

--- a/pkg/document/crdt/rga_tree_split.go
+++ b/pkg/document/crdt/rga_tree_split.go
@@ -271,8 +271,8 @@ func (s *RGATreeSplitNode[V]) Remove(removedAt *time.Ticket, clientLamportAtChan
 }
 
 // canStyle checks if node is able to set style.
-func (s *RGATreeSplitNode[V]) canStyle(editedAt *time.Ticket, maxCreatedAt *time.Ticket) bool {
-	return !s.createdAt().After(maxCreatedAt) &&
+func (s *RGATreeSplitNode[V]) canStyle(editedAt *time.Ticket, clientLamportAtChange int64) bool {
+	return (s.createdAt().Lamport() <= clientLamportAtChange) &&
 		(s.removedAt == nil || editedAt.After(s.removedAt))
 }
 

--- a/pkg/document/crdt/rga_tree_split.go
+++ b/pkg/document/crdt/rga_tree_split.go
@@ -258,10 +258,18 @@ func (s *RGATreeSplitNode[V]) toTestString() string {
 
 // Remove removes this node if it created before the time of deletion are
 // deleted. It only marks the deleted time (tombstone).
-func (s *RGATreeSplitNode[V]) Remove(removedAt *time.Ticket, clientLamportAtChange int64) bool {
+func (s *RGATreeSplitNode[V]) Remove(removedAt *time.Ticket,
+	maxCreatedAt *time.Ticket, clientLamportAtChange int64) bool {
 	justRemoved := s.removedAt == nil
 
-	if (s.createdAt().Lamport() <= clientLamportAtChange) &&
+	var nodeExisted bool
+	if maxCreatedAt == nil {
+		nodeExisted = s.createdAt().Lamport() <= clientLamportAtChange
+	} else {
+		nodeExisted = !s.createdAt().After(maxCreatedAt)
+	}
+
+	if nodeExisted &&
 		(s.removedAt == nil || removedAt.After(s.removedAt)) {
 		s.removedAt = removedAt
 		return justRemoved
@@ -271,8 +279,16 @@ func (s *RGATreeSplitNode[V]) Remove(removedAt *time.Ticket, clientLamportAtChan
 }
 
 // canStyle checks if node is able to set style.
-func (s *RGATreeSplitNode[V]) canStyle(editedAt *time.Ticket, clientLamportAtChange int64) bool {
-	return (s.createdAt().Lamport() <= clientLamportAtChange) &&
+func (s *RGATreeSplitNode[V]) canStyle(editedAt *time.Ticket,
+	maxCreatedAt *time.Ticket, clientLamportAtChange int64) bool {
+	var nodeExisted bool
+	if maxCreatedAt == nil {
+		nodeExisted = s.createdAt().Lamport() <= clientLamportAtChange
+	} else {
+		nodeExisted = !s.createdAt().After(maxCreatedAt)
+	}
+
+	return nodeExisted &&
 		(s.removedAt == nil || editedAt.After(s.removedAt))
 }
 
@@ -505,7 +521,7 @@ func (s *RGATreeSplit[V]) findBetween(from, to *RGATreeSplitNode[V]) []*RGATreeS
 
 func (s *RGATreeSplit[V]) deleteNodes(
 	candidates []*RGATreeSplitNode[V],
-	_ map[string]*time.Ticket,
+	maxCreatedAtMapByActor map[string]*time.Ticket,
 	editedAt *time.Ticket,
 	versionVector time.VersionVector,
 ) (map[string]*time.Ticket, map[string]*RGATreeSplitNode[V]) {
@@ -524,25 +540,33 @@ func (s *RGATreeSplit[V]) deleteNodes(
 	nodesToKeep = append(nodesToKeep, leftEdge)
 
 	for _, node := range candidates {
-		actorID := node.createdAt().ActorID()
 		actorIDHex := node.createdAt().ActorIDHex()
+		actorID := node.createdAt().ActorID()
 
+		var maxCreatedAt *time.Ticket
 		var clientLamportAtChange int64
-		if versionVector == nil {
+		if versionVector == nil && maxCreatedAtMapByActor == nil {
+			// Local edit - use version vector comparison
 			clientLamportAtChange = time.MaxLamport
-		} else {
+		} else if versionVector != nil {
 			lamport, ok := versionVector.Get(actorID)
 			if ok {
 				clientLamportAtChange = lamport
 			} else {
 				clientLamportAtChange = 0
 			}
+		} else {
+			createdAt, ok := maxCreatedAtMapByActor[actorIDHex]
+			if ok {
+				maxCreatedAt = createdAt
+			} else {
+				maxCreatedAt = time.InitialTicket
+			}
 		}
 
-		// TODO(chacha912): We should migrate db to add maxCreatedAt to change vv for existing changes.
-		// Since we've modified all changes to use vv instead of maxCreatedAt (assuming we've tested this),
-		// we need to verify this migration with tests.
-		if node.Remove(editedAt, clientLamportAtChange) {
+		// TODO(chacha912): maxCreatedAt can be removed after all legacy Changes
+		// (without version vector) are migrated to new Changes with version vector.
+		if node.Remove(editedAt, maxCreatedAt, clientLamportAtChange) {
 			maxCreatedAt := createdAtMapByActor[actorIDHex]
 			createdAt := node.id.createdAt
 			if maxCreatedAt == nil || createdAt.After(maxCreatedAt) {

--- a/pkg/document/crdt/root_test.go
+++ b/pkg/document/crdt/root_test.go
@@ -65,28 +65,28 @@ func TestRoot(t *testing.T) {
 		text := crdt.NewText(crdt.NewRGATreeSplit(crdt.InitialTextNode()), ctx.IssueTimeTicket())
 
 		fromPos, toPos, _ := text.CreateRange(0, 0)
-		_, _, pairs, err := text.Edit(fromPos, toPos, nil, "Hello World", nil, ctx.IssueTimeTicket())
+		_, _, pairs, err := text.Edit(fromPos, toPos, nil, "Hello World", nil, ctx.IssueTimeTicket(), nil)
 		assert.NoError(t, err)
 		registerGCPairs(root, pairs)
 		assert.Equal(t, "Hello World", text.String())
 		assert.Equal(t, 0, root.GarbageLen())
 
 		fromPos, toPos, _ = text.CreateRange(5, 10)
-		_, _, pairs, err = text.Edit(fromPos, toPos, nil, "Yorkie", nil, ctx.IssueTimeTicket())
+		_, _, pairs, err = text.Edit(fromPos, toPos, nil, "Yorkie", nil, ctx.IssueTimeTicket(), nil)
 		assert.NoError(t, err)
 		registerGCPairs(root, pairs)
 		assert.Equal(t, "HelloYorkied", text.String())
 		assert.Equal(t, 1, root.GarbageLen())
 
 		fromPos, toPos, _ = text.CreateRange(0, 5)
-		_, _, pairs, err = text.Edit(fromPos, toPos, nil, "", nil, ctx.IssueTimeTicket())
+		_, _, pairs, err = text.Edit(fromPos, toPos, nil, "", nil, ctx.IssueTimeTicket(), nil)
 		assert.NoError(t, err)
 		registerGCPairs(root, pairs)
 		assert.Equal(t, "Yorkied", text.String())
 		assert.Equal(t, 2, root.GarbageLen())
 
 		fromPos, toPos, _ = text.CreateRange(6, 7)
-		_, _, pairs, err = text.Edit(fromPos, toPos, nil, "", nil, ctx.IssueTimeTicket())
+		_, _, pairs, err = text.Edit(fromPos, toPos, nil, "", nil, ctx.IssueTimeTicket(), nil)
 		assert.NoError(t, err)
 		registerGCPairs(root, pairs)
 		assert.Equal(t, "Yorkie", text.String())
@@ -125,7 +125,7 @@ func TestRoot(t *testing.T) {
 
 		for _, tc := range steps {
 			fromPos, toPos, _ := text.CreateRange(tc.from, tc.to)
-			_, _, pairs, err := text.Edit(fromPos, toPos, nil, tc.content, nil, ctx.IssueTimeTicket())
+			_, _, pairs, err := text.Edit(fromPos, toPos, nil, tc.content, nil, ctx.IssueTimeTicket(), nil)
 			assert.NoError(t, err)
 			registerGCPairs(root, pairs)
 			assert.Equal(t, tc.want, text.String())
@@ -157,7 +157,7 @@ func TestRoot(t *testing.T) {
 
 		for _, tc := range steps {
 			fromPos, toPos, _ := text.CreateRange(tc.from, tc.to)
-			_, _, pairs, err := text.Edit(fromPos, toPos, nil, tc.content, nil, ctx.IssueTimeTicket())
+			_, _, pairs, err := text.Edit(fromPos, toPos, nil, tc.content, nil, ctx.IssueTimeTicket(), nil)
 			assert.NoError(t, err)
 			registerGCPairs(root, pairs)
 			assert.Equal(t, tc.want, text.String())
@@ -176,21 +176,21 @@ func TestRoot(t *testing.T) {
 		text := crdt.NewText(crdt.NewRGATreeSplit(crdt.InitialTextNode()), ctx.IssueTimeTicket())
 
 		fromPos, toPos, _ := text.CreateRange(0, 0)
-		_, _, pairs, err := text.Edit(fromPos, toPos, nil, "Hello World", nil, ctx.IssueTimeTicket())
+		_, _, pairs, err := text.Edit(fromPos, toPos, nil, "Hello World", nil, ctx.IssueTimeTicket(), nil)
 		assert.NoError(t, err)
 		registerGCPairs(root, pairs)
 		assert.Equal(t, `[{"val":"Hello World"}]`, text.Marshal())
 		assert.Equal(t, 0, root.GarbageLen())
 
 		fromPos, toPos, _ = text.CreateRange(6, 11)
-		_, _, pairs, err = text.Edit(fromPos, toPos, nil, "Yorkie", nil, ctx.IssueTimeTicket())
+		_, _, pairs, err = text.Edit(fromPos, toPos, nil, "Yorkie", nil, ctx.IssueTimeTicket(), nil)
 		assert.NoError(t, err)
 		registerGCPairs(root, pairs)
 		assert.Equal(t, `[{"val":"Hello "},{"val":"Yorkie"}]`, text.Marshal())
 		assert.Equal(t, 1, root.GarbageLen())
 
 		fromPos, toPos, _ = text.CreateRange(0, 6)
-		_, _, pairs, err = text.Edit(fromPos, toPos, nil, "", nil, ctx.IssueTimeTicket())
+		_, _, pairs, err = text.Edit(fromPos, toPos, nil, "", nil, ctx.IssueTimeTicket(), nil)
 		assert.NoError(t, err)
 		registerGCPairs(root, pairs)
 		assert.Equal(t, `[{"val":"Yorkie"}]`, text.Marshal())

--- a/pkg/document/crdt/text.go
+++ b/pkg/document/crdt/text.go
@@ -273,6 +273,7 @@ func (t *Text) Edit(
 	content string,
 	attributes map[string]string,
 	executedAt *time.Ticket,
+	versionVector time.VersionVector,
 ) (*RGATreeSplitNodePos, map[string]*time.Ticket, []GCPair, error) {
 	val := NewTextValue(content, NewRHT())
 	for key, value := range attributes {
@@ -285,6 +286,7 @@ func (t *Text) Edit(
 		maxCreatedAtMapByActor,
 		val,
 		executedAt,
+		versionVector,
 	)
 }
 

--- a/pkg/document/crdt/text_test.go
+++ b/pkg/document/crdt/text_test.go
@@ -80,7 +80,7 @@ func TestText(t *testing.T) {
 		assert.Equal(t, `[{"val":"Hello "},{"val":"Yorkie"}]`, text.Marshal())
 
 		fromPos, toPos, _ = text.CreateRange(0, 1)
-		_, _, err = text.Style(fromPos, toPos, nil, map[string]string{"b": "1"}, ctx.IssueTimeTicket())
+		_, _, err = text.Style(fromPos, toPos, nil, map[string]string{"b": "1"}, ctx.IssueTimeTicket(), nil)
 		assert.NoError(t, err)
 		assert.Equal(
 			t,

--- a/pkg/document/crdt/text_test.go
+++ b/pkg/document/crdt/text_test.go
@@ -32,12 +32,12 @@ func TestText(t *testing.T) {
 		text := crdt.NewText(crdt.NewRGATreeSplit(crdt.InitialTextNode()), ctx.IssueTimeTicket())
 
 		fromPos, toPos, _ := text.CreateRange(0, 0)
-		_, _, _, err := text.Edit(fromPos, toPos, nil, "Hello World", nil, ctx.IssueTimeTicket())
+		_, _, _, err := text.Edit(fromPos, toPos, nil, "Hello World", nil, ctx.IssueTimeTicket(), nil)
 		assert.NoError(t, err)
 		assert.Equal(t, `[{"val":"Hello World"}]`, text.Marshal())
 
 		fromPos, toPos, _ = text.CreateRange(6, 11)
-		_, _, _, err = text.Edit(fromPos, toPos, nil, "Yorkie", nil, ctx.IssueTimeTicket())
+		_, _, _, err = text.Edit(fromPos, toPos, nil, "Yorkie", nil, ctx.IssueTimeTicket(), nil)
 		assert.NoError(t, err)
 		assert.Equal(t, `[{"val":"Hello "},{"val":"Yorkie"}]`, text.Marshal())
 	})
@@ -70,12 +70,12 @@ func TestText(t *testing.T) {
 		text := crdt.NewText(crdt.NewRGATreeSplit(crdt.InitialTextNode()), ctx.IssueTimeTicket())
 
 		fromPos, toPos, _ := text.CreateRange(0, 0)
-		_, _, _, err := text.Edit(fromPos, toPos, nil, "Hello World", nil, ctx.IssueTimeTicket())
+		_, _, _, err := text.Edit(fromPos, toPos, nil, "Hello World", nil, ctx.IssueTimeTicket(), nil)
 		assert.NoError(t, err)
 		assert.Equal(t, `[{"val":"Hello World"}]`, text.Marshal())
 
 		fromPos, toPos, _ = text.CreateRange(6, 11)
-		_, _, _, err = text.Edit(fromPos, toPos, nil, "Yorkie", nil, ctx.IssueTimeTicket())
+		_, _, _, err = text.Edit(fromPos, toPos, nil, "Yorkie", nil, ctx.IssueTimeTicket(), nil)
 		assert.NoError(t, err)
 		assert.Equal(t, `[{"val":"Hello "},{"val":"Yorkie"}]`, text.Marshal())
 

--- a/pkg/document/crdt/tree_test.go
+++ b/pkg/document/crdt/tree_test.go
@@ -405,28 +405,28 @@ func TestTreeEdit(t *testing.T) {
 		assert.Equal(t, "<root><p>ab</p><p>cd</p></root>", tree.ToXML())
 
 		// style attributes with opening tag
-		_, _, err = tree.StyleByIndex(0, 1, map[string]string{"weight": "bold"}, helper.TimeT(ctx), nil)
+		_, _, err = tree.StyleByIndex(0, 1, map[string]string{"weight": "bold"}, helper.TimeT(ctx), nil, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, `<root><p weight="bold">ab</p><p>cd</p></root>`, tree.ToXML())
 
 		// style attributes with closing tag
-		_, _, err = tree.StyleByIndex(3, 4, map[string]string{"color": "red"}, helper.TimeT(ctx), nil)
+		_, _, err = tree.StyleByIndex(3, 4, map[string]string{"color": "red"}, helper.TimeT(ctx), nil, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, `<root><p color="red" weight="bold">ab</p><p>cd</p></root>`, tree.ToXML())
 
 		// style attributes with the whole
-		_, _, err = tree.StyleByIndex(0, 4, map[string]string{"size": "small"}, helper.TimeT(ctx), nil)
+		_, _, err = tree.StyleByIndex(0, 4, map[string]string{"size": "small"}, helper.TimeT(ctx), nil, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, `<root><p color="red" size="small" weight="bold">ab</p><p>cd</p></root>`, tree.ToXML())
 
 		// 02. style attributes to elements.
-		_, _, err = tree.StyleByIndex(0, 5, map[string]string{"style": "italic"}, helper.TimeT(ctx), nil)
+		_, _, err = tree.StyleByIndex(0, 5, map[string]string{"style": "italic"}, helper.TimeT(ctx), nil, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, `<root><p color="red" size="small" style="italic" weight="bold">ab</p>`+
 			`<p style="italic">cd</p></root>`, tree.ToXML())
 
 		// 03. Ignore styling attributes to text nodes.
-		_, _, err = tree.StyleByIndex(1, 3, map[string]string{"bold": "true"}, helper.TimeT(ctx), nil)
+		_, _, err = tree.StyleByIndex(1, 3, map[string]string{"bold": "true"}, helper.TimeT(ctx), nil, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, `<root><p color="red" size="small" style="italic" weight="bold">ab</p>`+
 			`<p style="italic">cd</p></root>`, tree.ToXML())

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -170,7 +170,7 @@ func (d *Document) Update(
 
 	if ctx.HasChange() {
 		c := ctx.ToChange()
-		if err := c.Execute(d.doc.root, d.doc.presences); err != nil {
+		if err := c.Execute(d.doc.root, d.doc.presences, "local"); err != nil {
 			return err
 		}
 
@@ -245,7 +245,7 @@ func (d *Document) applyChanges(changes []*change.Change) error {
 	}
 
 	for _, c := range changes {
-		if err := c.Execute(d.cloneRoot, d.clonePresences); err != nil {
+		if err := c.Execute(d.cloneRoot, d.clonePresences, "remote"); err != nil {
 			return err
 		}
 	}

--- a/pkg/document/internal_document.go
+++ b/pkg/document/internal_document.go
@@ -326,7 +326,7 @@ func (d *InternalDocument) ApplyChanges(changes ...*change.Change) ([]DocEvent, 
 			}
 		}
 
-		if err := c.Execute(d.root, d.presences); err != nil {
+		if err := c.Execute(d.root, d.presences, "remote"); err != nil {
 			return nil, err
 		}
 

--- a/pkg/document/json/text.go
+++ b/pkg/document/json/text.go
@@ -120,6 +120,7 @@ func (p *Text) Style(from, to int, attributes map[string]string) *Text {
 		nil,
 		attributes,
 		ticket,
+		nil,
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/document/json/text.go
+++ b/pkg/document/json/text.go
@@ -80,6 +80,7 @@ func (p *Text) Edit(
 		content,
 		attrs,
 		ticket,
+		nil,
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/document/json/tree.go
+++ b/pkg/document/json/tree.go
@@ -221,7 +221,7 @@ func (t *Tree) Style(fromIdx, toIdx int, attributes map[string]string) bool {
 	}
 
 	ticket := t.context.IssueTimeTicket()
-	maxCreationMapByActor, pairs, err := t.Tree.Style(fromPos, toPos, attributes, ticket, nil)
+	maxCreationMapByActor, pairs, err := t.Tree.Style(fromPos, toPos, attributes, ticket, nil, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -262,7 +262,7 @@ func (t *Tree) RemoveStyle(fromIdx, toIdx int, attributesToRemove []string) bool
 	}
 
 	ticket := t.context.IssueTimeTicket()
-	maxCreationMapByActor, pairs, err := t.Tree.RemoveStyle(fromPos, toPos, attributesToRemove, ticket, nil)
+	maxCreationMapByActor, pairs, err := t.Tree.RemoveStyle(fromPos, toPos, attributesToRemove, ticket, nil, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -353,6 +353,7 @@ func (t *Tree) edit(fromPos, toPos *crdt.TreePos, contents []*TreeNode, splitLev
 		splitLevel,
 		ticket,
 		t.context.IssueTimeTicket,
+		nil,
 		nil,
 	)
 	if err != nil {

--- a/pkg/document/operations/add.go
+++ b/pkg/document/operations/add.go
@@ -52,7 +52,7 @@ func NewAdd(
 }
 
 // Execute executes this operation on the given document(`root`).
-func (o *Add) Execute(root *crdt.Root, _ ...Option) error {
+func (o *Add) Execute(root *crdt.Root, _ time.VersionVector) error {
 	parent := root.FindByCreatedAt(o.parentCreatedAt)
 
 	obj, ok := parent.(*crdt.Array)

--- a/pkg/document/operations/add.go
+++ b/pkg/document/operations/add.go
@@ -52,7 +52,7 @@ func NewAdd(
 }
 
 // Execute executes this operation on the given document(`root`).
-func (o *Add) Execute(root *crdt.Root) error {
+func (o *Add) Execute(root *crdt.Root, _ ...Option) error {
 	parent := root.FindByCreatedAt(o.parentCreatedAt)
 
 	obj, ok := parent.(*crdt.Array)

--- a/pkg/document/operations/array_set.go
+++ b/pkg/document/operations/array_set.go
@@ -52,7 +52,7 @@ func NewArraySet(
 }
 
 // Execute executes this operation on the given document(`root`).
-func (o *ArraySet) Execute(root *crdt.Root) error {
+func (o *ArraySet) Execute(root *crdt.Root, _ ...Option) error {
 	parent := root.FindByCreatedAt(o.parentCreatedAt)
 
 	obj, ok := parent.(*crdt.Array)

--- a/pkg/document/operations/array_set.go
+++ b/pkg/document/operations/array_set.go
@@ -52,9 +52,8 @@ func NewArraySet(
 }
 
 // Execute executes this operation on the given document(`root`).
-func (o *ArraySet) Execute(root *crdt.Root, _ ...Option) error {
+func (o *ArraySet) Execute(root *crdt.Root, _ time.VersionVector) error {
 	parent := root.FindByCreatedAt(o.parentCreatedAt)
-
 	obj, ok := parent.(*crdt.Array)
 	if !ok {
 		return ErrNotApplicableDataType

--- a/pkg/document/operations/edit.go
+++ b/pkg/document/operations/edit.go
@@ -70,12 +70,18 @@ func NewEdit(
 }
 
 // Execute executes this operation on the given document(`root`).
-func (e *Edit) Execute(root *crdt.Root) error {
+func (e *Edit) Execute(root *crdt.Root, opts ...Option) error {
+	options := &ExecuteOption{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
 	parent := root.FindByCreatedAt(e.parentCreatedAt)
 
 	switch obj := parent.(type) {
 	case *crdt.Text:
-		_, _, pairs, err := obj.Edit(e.from, e.to, e.maxCreatedAtMapByActor, e.content, e.attributes, e.executedAt)
+		_, _, pairs, err := obj.Edit(e.from, e.to, e.maxCreatedAtMapByActor,
+			e.content, e.attributes, e.executedAt, options.VersionVector)
 		if err != nil {
 			return err
 		}

--- a/pkg/document/operations/edit.go
+++ b/pkg/document/operations/edit.go
@@ -70,18 +70,13 @@ func NewEdit(
 }
 
 // Execute executes this operation on the given document(`root`).
-func (e *Edit) Execute(root *crdt.Root, opts ...Option) error {
-	options := &ExecuteOption{}
-	for _, opt := range opts {
-		opt(options)
-	}
-
+func (e *Edit) Execute(root *crdt.Root, versionVector time.VersionVector) error {
 	parent := root.FindByCreatedAt(e.parentCreatedAt)
 
 	switch obj := parent.(type) {
 	case *crdt.Text:
 		_, _, pairs, err := obj.Edit(e.from, e.to, e.maxCreatedAtMapByActor,
-			e.content, e.attributes, e.executedAt, options.VersionVector)
+			e.content, e.attributes, e.executedAt, versionVector)
 		if err != nil {
 			return err
 		}

--- a/pkg/document/operations/increase.go
+++ b/pkg/document/operations/increase.go
@@ -43,7 +43,7 @@ func NewIncrease(
 }
 
 // Execute executes this operation on the given document(`root`).
-func (o *Increase) Execute(root *crdt.Root, _ ...Option) error {
+func (o *Increase) Execute(root *crdt.Root, _ time.VersionVector) error {
 	parent := root.FindByCreatedAt(o.parentCreatedAt)
 	cnt, ok := parent.(*crdt.Counter)
 	if !ok {

--- a/pkg/document/operations/increase.go
+++ b/pkg/document/operations/increase.go
@@ -43,7 +43,7 @@ func NewIncrease(
 }
 
 // Execute executes this operation on the given document(`root`).
-func (o *Increase) Execute(root *crdt.Root) error {
+func (o *Increase) Execute(root *crdt.Root, _ ...Option) error {
 	parent := root.FindByCreatedAt(o.parentCreatedAt)
 	cnt, ok := parent.(*crdt.Counter)
 	if !ok {

--- a/pkg/document/operations/move.go
+++ b/pkg/document/operations/move.go
@@ -52,7 +52,7 @@ func NewMove(
 }
 
 // Execute executes this operation on the given document(`root`).
-func (o *Move) Execute(root *crdt.Root, _ ...Option) error {
+func (o *Move) Execute(root *crdt.Root, _ time.VersionVector) error {
 	parent := root.FindByCreatedAt(o.parentCreatedAt)
 
 	obj, ok := parent.(*crdt.Array)

--- a/pkg/document/operations/move.go
+++ b/pkg/document/operations/move.go
@@ -52,7 +52,7 @@ func NewMove(
 }
 
 // Execute executes this operation on the given document(`root`).
-func (o *Move) Execute(root *crdt.Root) error {
+func (o *Move) Execute(root *crdt.Root, _ ...Option) error {
 	parent := root.FindByCreatedAt(o.parentCreatedAt)
 
 	obj, ok := parent.(*crdt.Array)

--- a/pkg/document/operations/operation.go
+++ b/pkg/document/operations/operation.go
@@ -31,26 +31,10 @@ var (
 	ErrNotApplicableDataType = errors.New("not applicable datatype")
 )
 
-// ExecuteOption contains options for executing operations.
-type ExecuteOption struct {
-	// VersionVector represents the version vector at the time of operation creation.
-	VersionVector time.VersionVector
-}
-
-// Option is a function type that configures ExecuteOption.
-type Option func(*ExecuteOption)
-
-// WithVersionVector returns an Option that sets the version vector for the operation.
-func WithVersionVector(versionVector time.VersionVector) Option {
-	return func(option *ExecuteOption) {
-		option.VersionVector = versionVector
-	}
-}
-
 // Operation represents an operation to be executed on a document.
 type Operation interface {
 	// Execute executes this operation on the given document(`root`).
-	Execute(root *crdt.Root, opts ...Option) error
+	Execute(root *crdt.Root, versionVector time.VersionVector) error
 
 	// ExecutedAt returns execution time of this operation.
 	ExecutedAt() *time.Ticket

--- a/pkg/document/operations/operation.go
+++ b/pkg/document/operations/operation.go
@@ -31,10 +31,26 @@ var (
 	ErrNotApplicableDataType = errors.New("not applicable datatype")
 )
 
+// ExecuteOption contains options for executing operations.
+type ExecuteOption struct {
+	// VersionVector represents the version vector at the time of operation creation.
+	VersionVector time.VersionVector
+}
+
+// Option is a function type that configures ExecuteOption.
+type Option func(*ExecuteOption)
+
+// WithVersionVector returns an Option that sets the version vector for the operation.
+func WithVersionVector(versionVector time.VersionVector) Option {
+	return func(option *ExecuteOption) {
+		option.VersionVector = versionVector
+	}
+}
+
 // Operation represents an operation to be executed on a document.
 type Operation interface {
 	// Execute executes this operation on the given document(`root`).
-	Execute(root *crdt.Root) error
+	Execute(root *crdt.Root, opts ...Option) error
 
 	// ExecutedAt returns execution time of this operation.
 	ExecutedAt() *time.Ticket

--- a/pkg/document/operations/remove.go
+++ b/pkg/document/operations/remove.go
@@ -48,7 +48,7 @@ func NewRemove(
 }
 
 // Execute executes this operation on the given document(`root`).
-func (o *Remove) Execute(root *crdt.Root) error {
+func (o *Remove) Execute(root *crdt.Root, _ ...Option) error {
 	parentElem := root.FindByCreatedAt(o.parentCreatedAt)
 
 	switch parent := parentElem.(type) {

--- a/pkg/document/operations/remove.go
+++ b/pkg/document/operations/remove.go
@@ -48,7 +48,7 @@ func NewRemove(
 }
 
 // Execute executes this operation on the given document(`root`).
-func (o *Remove) Execute(root *crdt.Root, _ ...Option) error {
+func (o *Remove) Execute(root *crdt.Root, _ time.VersionVector) error {
 	parentElem := root.FindByCreatedAt(o.parentCreatedAt)
 
 	switch parent := parentElem.(type) {

--- a/pkg/document/operations/set.go
+++ b/pkg/document/operations/set.go
@@ -53,7 +53,7 @@ func NewSet(
 }
 
 // Execute executes this operation on the given document(`root`).
-func (o *Set) Execute(root *crdt.Root, _ ...Option) error {
+func (o *Set) Execute(root *crdt.Root, _ time.VersionVector) error {
 	parent := root.FindByCreatedAt(o.parentCreatedAt)
 
 	obj, ok := parent.(*crdt.Object)

--- a/pkg/document/operations/set.go
+++ b/pkg/document/operations/set.go
@@ -53,7 +53,7 @@ func NewSet(
 }
 
 // Execute executes this operation on the given document(`root`).
-func (o *Set) Execute(root *crdt.Root) error {
+func (o *Set) Execute(root *crdt.Root, _ ...Option) error {
 	parent := root.FindByCreatedAt(o.parentCreatedAt)
 
 	obj, ok := parent.(*crdt.Object)

--- a/pkg/document/operations/style.go
+++ b/pkg/document/operations/style.go
@@ -63,14 +63,19 @@ func NewStyle(
 }
 
 // Execute executes this operation on the given document(`root`).
-func (e *Style) Execute(root *crdt.Root, _ ...Option) error {
+func (e *Style) Execute(root *crdt.Root, opts ...Option) error {
+	options := &ExecuteOption{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
 	parent := root.FindByCreatedAt(e.parentCreatedAt)
 	obj, ok := parent.(*crdt.Text)
 	if !ok {
 		return ErrNotApplicableDataType
 	}
 
-	_, pairs, err := obj.Style(e.from, e.to, e.maxCreatedAtMapByActor, e.attributes, e.executedAt)
+	_, pairs, err := obj.Style(e.from, e.to, e.maxCreatedAtMapByActor, e.attributes, e.executedAt, options.VersionVector)
 	if err != nil {
 		return err
 	}

--- a/pkg/document/operations/style.go
+++ b/pkg/document/operations/style.go
@@ -63,19 +63,14 @@ func NewStyle(
 }
 
 // Execute executes this operation on the given document(`root`).
-func (e *Style) Execute(root *crdt.Root, opts ...Option) error {
-	options := &ExecuteOption{}
-	for _, opt := range opts {
-		opt(options)
-	}
-
+func (e *Style) Execute(root *crdt.Root, versionVector time.VersionVector) error {
 	parent := root.FindByCreatedAt(e.parentCreatedAt)
 	obj, ok := parent.(*crdt.Text)
 	if !ok {
 		return ErrNotApplicableDataType
 	}
 
-	_, pairs, err := obj.Style(e.from, e.to, e.maxCreatedAtMapByActor, e.attributes, e.executedAt, options.VersionVector)
+	_, pairs, err := obj.Style(e.from, e.to, e.maxCreatedAtMapByActor, e.attributes, e.executedAt, versionVector)
 	if err != nil {
 		return err
 	}

--- a/pkg/document/operations/style.go
+++ b/pkg/document/operations/style.go
@@ -63,7 +63,7 @@ func NewStyle(
 }
 
 // Execute executes this operation on the given document(`root`).
-func (e *Style) Execute(root *crdt.Root) error {
+func (e *Style) Execute(root *crdt.Root, _ ...Option) error {
 	parent := root.FindByCreatedAt(e.parentCreatedAt)
 	obj, ok := parent.(*crdt.Text)
 	if !ok {

--- a/pkg/document/operations/tree_edit.go
+++ b/pkg/document/operations/tree_edit.go
@@ -69,7 +69,12 @@ func NewTreeEdit(
 }
 
 // Execute executes this operation on the given `CRDTRoot`.
-func (e *TreeEdit) Execute(root *crdt.Root, _ ...Option) error {
+func (e *TreeEdit) Execute(root *crdt.Root, opts ...Option) error {
+	options := &ExecuteOption{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
 	parent := root.FindByCreatedAt(e.parentCreatedAt)
 
 	switch obj := parent.(type) {
@@ -117,6 +122,7 @@ func (e *TreeEdit) Execute(root *crdt.Root, _ ...Option) error {
 				}
 			}(),
 			e.maxCreatedAtMapByActor,
+			options.VersionVector,
 		)
 		if err != nil {
 			return err

--- a/pkg/document/operations/tree_edit.go
+++ b/pkg/document/operations/tree_edit.go
@@ -69,12 +69,7 @@ func NewTreeEdit(
 }
 
 // Execute executes this operation on the given `CRDTRoot`.
-func (e *TreeEdit) Execute(root *crdt.Root, opts ...Option) error {
-	options := &ExecuteOption{}
-	for _, opt := range opts {
-		opt(options)
-	}
-
+func (e *TreeEdit) Execute(root *crdt.Root, versionVector time.VersionVector) error {
 	parent := root.FindByCreatedAt(e.parentCreatedAt)
 
 	switch obj := parent.(type) {
@@ -122,7 +117,7 @@ func (e *TreeEdit) Execute(root *crdt.Root, opts ...Option) error {
 				}
 			}(),
 			e.maxCreatedAtMapByActor,
-			options.VersionVector,
+			versionVector,
 		)
 		if err != nil {
 			return err

--- a/pkg/document/operations/tree_edit.go
+++ b/pkg/document/operations/tree_edit.go
@@ -69,7 +69,7 @@ func NewTreeEdit(
 }
 
 // Execute executes this operation on the given `CRDTRoot`.
-func (e *TreeEdit) Execute(root *crdt.Root) error {
+func (e *TreeEdit) Execute(root *crdt.Root, _ ...Option) error {
 	parent := root.FindByCreatedAt(e.parentCreatedAt)
 
 	switch obj := parent.(type) {

--- a/pkg/document/operations/tree_style.go
+++ b/pkg/document/operations/tree_style.go
@@ -87,7 +87,7 @@ func NewTreeStyleRemove(
 }
 
 // Execute executes this operation on the given `CRDTRoot`.
-func (e *TreeStyle) Execute(root *crdt.Root) error {
+func (e *TreeStyle) Execute(root *crdt.Root, _ ...Option) error {
 	parent := root.FindByCreatedAt(e.parentCreatedAt)
 	obj, ok := parent.(*crdt.Tree)
 	if !ok {

--- a/pkg/document/operations/tree_style.go
+++ b/pkg/document/operations/tree_style.go
@@ -87,12 +87,7 @@ func NewTreeStyleRemove(
 }
 
 // Execute executes this operation on the given `CRDTRoot`.
-func (e *TreeStyle) Execute(root *crdt.Root, opts ...Option) error {
-	options := &ExecuteOption{}
-	for _, opt := range opts {
-		opt(options)
-	}
-
+func (e *TreeStyle) Execute(root *crdt.Root, versionVector time.VersionVector) error {
 	parent := root.FindByCreatedAt(e.parentCreatedAt)
 	obj, ok := parent.(*crdt.Tree)
 	if !ok {
@@ -102,13 +97,13 @@ func (e *TreeStyle) Execute(root *crdt.Root, opts ...Option) error {
 	var pairs []crdt.GCPair
 	var err error
 	if len(e.attributes) > 0 {
-		_, pairs, err = obj.Style(e.from, e.to, e.attributes, e.executedAt, e.maxCreatedAtMapByActor, options.VersionVector)
+		_, pairs, err = obj.Style(e.from, e.to, e.attributes, e.executedAt, e.maxCreatedAtMapByActor, versionVector)
 		if err != nil {
 			return err
 		}
 	} else {
 		_, pairs, err = obj.RemoveStyle(e.from, e.to, e.attributesToRemove, e.executedAt,
-			e.maxCreatedAtMapByActor, options.VersionVector)
+			e.maxCreatedAtMapByActor, versionVector)
 		if err != nil {
 			return err
 		}

--- a/pkg/document/operations/tree_style.go
+++ b/pkg/document/operations/tree_style.go
@@ -87,7 +87,12 @@ func NewTreeStyleRemove(
 }
 
 // Execute executes this operation on the given `CRDTRoot`.
-func (e *TreeStyle) Execute(root *crdt.Root, _ ...Option) error {
+func (e *TreeStyle) Execute(root *crdt.Root, opts ...Option) error {
+	options := &ExecuteOption{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
 	parent := root.FindByCreatedAt(e.parentCreatedAt)
 	obj, ok := parent.(*crdt.Tree)
 	if !ok {
@@ -97,12 +102,13 @@ func (e *TreeStyle) Execute(root *crdt.Root, _ ...Option) error {
 	var pairs []crdt.GCPair
 	var err error
 	if len(e.attributes) > 0 {
-		_, pairs, err = obj.Style(e.from, e.to, e.attributes, e.executedAt, e.maxCreatedAtMapByActor)
+		_, pairs, err = obj.Style(e.from, e.to, e.attributes, e.executedAt, e.maxCreatedAtMapByActor, options.VersionVector)
 		if err != nil {
 			return err
 		}
 	} else {
-		_, pairs, err = obj.RemoveStyle(e.from, e.to, e.attributesToRemove, e.executedAt, e.maxCreatedAtMapByActor)
+		_, pairs, err = obj.RemoveStyle(e.from, e.to, e.attributesToRemove, e.executedAt,
+			e.maxCreatedAtMapByActor, options.VersionVector)
 		if err != nil {
 			return err
 		}

--- a/pkg/document/time/version_vector.go
+++ b/pkg/document/time/version_vector.go
@@ -36,6 +36,13 @@ func NewVersionVector() VersionVector {
 	return make(VersionVector)
 }
 
+// Get gets the version of the given actor.
+// Returns the version and whether the actor exists in the vector.
+func (v VersionVector) Get(id *ActorID) (int64, bool) {
+	version, exists := v[id.bytes]
+	return version, exists
+}
+
 // Set sets the given actor's version to the given value.
 func (v VersionVector) Set(id *ActorID, i int64) {
 	v[id.bytes] = i

--- a/test/integration/gc_test.go
+++ b/test/integration/gc_test.go
@@ -1192,4 +1192,148 @@ func TestGarbageCollection(t *testing.T) {
 		assert.Equal(t, 0, d2.GarbageLen())
 		assert.Equal(t, 1, len(d2.VersionVector()))
 	})
+
+	t.Run("attach > pushpull > detach lifecycle version vector test (run gc at last client detaches document)", func(t *testing.T) {
+		clients := activeClients(t, 2)
+		c1, c2 := clients[0], clients[1]
+		defer deactivateAndCloseClients(t, clients)
+
+		ctx := context.Background()
+		d1 := document.New(helper.TestDocKey(t))
+		assert.NoError(t, c1.Attach(ctx, d1))
+		// d2.vv =[c1:1], minvv =[c1:1], db.vv {c1: [c1:1]}
+		assert.Equal(t, true, checkVV(d1.VersionVector(), versionOf(d1.ActorID(), 1)))
+
+		d2 := document.New(helper.TestDocKey(t))
+		assert.NoError(t, c2.Attach(ctx, d2))
+		// d2.vv =[c1:1, c2:2], minvv =[c1:0, c2:0], db.vv {c1: [c1:1], c2: [c2:1]}
+		assert.Equal(t, true, checkVV(d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 2)))
+
+		err := d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewText("text").Edit(0, 0, "a").Edit(1, 1, "b").Edit(2, 2, "c")
+			return nil
+		}, "sets text")
+		// d1/vv = [c1:2]
+		assert.Equal(t, true, checkVV(d1.VersionVector(), versionOf(d1.ActorID(), 2)))
+		assert.NoError(t, err)
+
+		assert.NoError(t, c1.Sync(ctx))
+		// d1.vv = [c1:3, c2:1], minvv = [c1:0, c2:0], db.vv {c1: [c1:2], c2: [c2:1]}
+		assert.Equal(t, true, checkVV(d1.VersionVector(), versionOf(d1.ActorID(), 3), versionOf(d2.ActorID(), 1)))
+
+		assert.NoError(t, c2.Sync(ctx))
+		// d2.vv = [c1:2, c2:3], minvv = [c1:1, c2:0], db.vv {c1: [c1:2], c2: [c1:1, c2:2]}
+		assert.Equal(t, true, checkVV(d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 3)))
+
+		err = d2.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(2, 2, "c")
+			return nil
+		}, "insert c")
+		//d2.vv = [c1:2, c2:4]
+		assert.Equal(t, true, checkVV(d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 4)))
+		assert.NoError(t, err)
+
+		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(1, 3, "")
+			return nil
+		}, "delete bc")
+		//d1.vv = [c1:4, c2:1]
+		assert.Equal(t, true, checkVV(d1.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 1)))
+		assert.NoError(t, err)
+		assert.Equal(t, 2, d1.GarbageLen())
+		assert.Equal(t, 0, d2.GarbageLen())
+
+		assert.NoError(t, c1.Sync(ctx))
+		assert.Equal(t, true, checkVV(d1.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 1)))
+
+		assert.NoError(t, c2.Sync(ctx))
+		assert.Equal(t, true, checkVV(d2.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 5)))
+
+		assert.Equal(t, 2, d1.GarbageLen())
+		assert.Equal(t, 2, d2.GarbageLen())
+
+		err = d2.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(2, 2, "1")
+			return nil
+		}, "insert c")
+		assert.Equal(t, true, checkVV(d2.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 6)))
+		assert.NoError(t, err)
+
+		assert.NoError(t, c2.Sync(ctx))
+		assert.Equal(t, true, checkVV(d2.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 6)))
+
+		assert.Equal(t, 2, d1.GarbageLen())
+		assert.Equal(t, 0, d2.GarbageLen())
+
+		assert.NoError(t, c1.Sync(ctx))
+		assert.Equal(t, true, checkVV(d1.VersionVector(), versionOf(d1.ActorID(), 7), versionOf(d2.ActorID(), 6)))
+
+		assert.NoError(t, c1.Detach(ctx, d1))
+
+		assert.NoError(t, c2.Sync(ctx))
+		assert.Equal(t, true, checkVV(d2.VersionVector(), versionOf(d2.ActorID(), 9)))
+		assert.Equal(t, `{"text":[{"val":"a"},{"val":"c"},{"val":"1"}]}`, d2.Marshal())
+
+		err = d2.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(0, 3, "")
+			return nil
+		}, "delete all")
+		assert.NoError(t, err)
+		assert.Equal(t, true, checkVV(d2.VersionVector(), versionOf(d2.ActorID(), 10)))
+		assert.Equal(t, `{"text":[]}`, d2.Marshal())
+
+		assert.Equal(t, 3, d2.GarbageLen())
+		assert.NoError(t, c2.Detach(ctx, d2))
+		assert.Equal(t, 0, d2.GarbageLen())
+	})
+
+	t.Run("detached client node deletion test", func(t *testing.T) {
+		t.Skip("remove this after implementing node deletion")
+		clients := activeClients(t, 3)
+		c1, c2, c3 := clients[0], clients[1], clients[2]
+		defer deactivateAndCloseClients(t, clients)
+		ctx := context.Background()
+		d1 := document.New(helper.TestDocKey(t))
+		d2 := document.New(helper.TestDocKey(t))
+		d3 := document.New(helper.TestDocKey(t))
+
+		assert.NoError(t, c1.Attach(ctx, d1))
+		assert.NoError(t, c2.Attach(ctx, d2))
+		assert.NoError(t, c3.Attach(ctx, d3))
+
+		err := d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewText("text").Edit(0, 0, "a") // a
+			return nil
+		}, "insert abc")
+		assert.NoError(t, err)
+
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c3.Sync(ctx))
+
+		err = d3.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(0, 0, "1") // 1a
+			return nil
+		})
+		assert.NoError(t, err)
+
+		assert.NoError(t, c3.Sync(ctx))
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+
+		assert.NoError(t, c3.Detach(ctx, d3))
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+
+		err = d2.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(0, 1, "x") // xa
+			return nil
+		}, "delete 123 and insert x")
+		assert.NoError(t, err)
+
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c1.Sync(ctx))
+		assert.Equal(t, `{"text":[{"val":"x"},{"val":"a"}]}`, d2.Marshal())
+		assert.Equal(t, `{"text":[{"val":"x"},{"val":"a"}]}`, d1.Marshal()) // "x1a": cannot delete 1
+	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR replaces the usage of `MaxCreatedAtMapByActor` with `version vector` for operations that handle causal and concurrent relationships. (`Text.Edit`, `Text.Style`, `Tree.Edit`, and `Tree.Style`)

The introduction of version vector allows us to track which client's Lamport time existed when a change was created. For example, during delete operations, we compare the Lamport time of the deleted character's creation with the Lamport time from the version vector to maintain proper concurrency handling.

As shown in the diagram, when checking if a node should be removed, we compare:
- Node's createdAt (e.g., `6@A`)  
- Client's Lamport time at change creation (e.g., `2@A`)

![image](https://github.com/user-attachments/assets/6beead19-86e5-4669-bd94-d2aef4aa1b05)


**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Related #723 #1047

**Special notes for your reviewer**:

There are two issues with replacing maxCreatedAt with VV (Version Vector):

1. Since the information of detached clients is removed from VV, the client's lamport value is set to 0 at that point. When a client's lamport value is not present in VV, we need to be able to distinguish between two cases: whether we haven't received the client's changes yet, or whether the client has been detached.

![image](https://github.com/user-attachments/assets/896f3d16-7d04-4881-94a0-6fe1b8cf8145)

[Resolved] Modified to retain client information in change VV even after detachment, ensuring all client states remain traceable. (#1090)

2. Considering backward compatibility, since the version vectors for previous changes are not accurate (when performing DB migration, only the lamport of the change actor ID was added), we cannot use the lamport values obtained from there. Therefore, to maintain backward compatibility, we need to keep maxCreatedAt.

[Resolved] Since the version vectors in existing data are uncertain, we can proceed after removing all this information. If a change has no version vector, maxCreatedAt will be used; otherwise, we use the version vector to verify nodeExisted.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced new methods for managing version vectors.
	- Added tests for document lifecycle and garbage collection interactions.

- **Bug Fixes**
	- Enhanced handling of node deletion and styling based on updated parameters.

- **Documentation**
	- Updated method signatures to reflect new parameters and structures.

- **Refactor**
	- Streamlined method signatures across various operations to include options for enhanced flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->