### PR TITLE
Preserve Detached Client's Lamport in Version Vector

### DIFF
--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -221,17 +221,7 @@ func (d *Document) ApplyChangePack(pack *change.Pack) error {
 		d.GarbageCollect(pack.VersionVector)
 	}
 
-	// 05. Remove detached client's lamport from version vector if it exists
-	if pack.VersionVector != nil && !hasSnapshot {
-		actorIDs, err := pack.VersionVector.Keys()
-		if err != nil {
-			return err
-		}
-
-		d.doc.changeID = d.doc.changeID.SetVersionVector(d.doc.changeID.VersionVector().Filter(actorIDs))
-	}
-
-	// 06. Update the status.
+	// 05. Update the status.
 	if pack.IsRemoved {
 		d.SetStatus(StatusRemoved)
 	}

--- a/pkg/document/internal_document.go
+++ b/pkg/document/internal_document.go
@@ -188,16 +188,6 @@ func (d *InternalDocument) ApplyChangePack(pack *change.Pack, disableGC bool) er
 		}
 	}
 
-	// 04. Remove detached client's lamport from version vector if it exists
-	if pack.VersionVector != nil && !hasSnapshot {
-		actorIDs, err := pack.VersionVector.Keys()
-		if err != nil {
-			return err
-		}
-
-		d.changeID = d.changeID.SetVersionVector(d.changeID.VersionVector().Filter(actorIDs))
-	}
-
 	return nil
 }
 

--- a/pkg/document/time/version_vector.go
+++ b/pkg/document/time/version_vector.go
@@ -18,7 +18,6 @@ package time
 
 import (
 	"bytes"
-	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -118,9 +117,7 @@ func (v VersionVector) EqualToOrAfter(other *Ticket) bool {
 	clientLamport, ok := v[other.actorID.bytes]
 
 	if !ok {
-		minLamport := v.MinLamport()
-
-		return minLamport > other.lamport
+		return false
 	}
 
 	return clientLamport >= other.lamport
@@ -174,19 +171,6 @@ func (v VersionVector) Max(other VersionVector) VersionVector {
 	}
 
 	return maxVV
-}
-
-// MinLamport returns min lamport value in version vector.
-func (v VersionVector) MinLamport() int64 {
-	var minLamport int64 = math.MaxInt64
-
-	for _, value := range v {
-		if value < minLamport {
-			minLamport = value
-		}
-	}
-
-	return minLamport
 }
 
 // MaxLamport returns max lamport value in version vector.

--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -1347,24 +1347,9 @@ func (d *DB) UpdateAndFindMinSyncedVersionVector(
 	docRefKey types.DocRefKey,
 	versionVector time.VersionVector,
 ) (time.VersionVector, error) {
-	// 01. Prepare attachedActorIDs including the current client.
-	// If some clients are detached, we should remove them from the min version vector.
-	// For this, we use attachedActorIDs to filter the min version vector.
-	var attachedActorIDs []*time.ActorID
-	attached, err := clientInfo.IsAttached(docRefKey.DocID)
-	if err != nil {
-		return nil, err
-	}
+	// TODO(JOOHOJANG): we have to consider removing detached client's lamport from min version vector
 
-	if attached {
-		actorID, err := clientInfo.ID.ToActorID()
-		if err != nil {
-			return nil, err
-		}
-		attachedActorIDs = append(attachedActorIDs, actorID)
-	}
-
-	// 02. Find all version vectors of the given document from DB.
+	// 01. Find all version vectors of the given document from DB.
 	txn := d.db.Txn(false)
 	defer txn.Abort()
 	iterator, err := txn.Get(tblVersionVectors, "doc_id", docRefKey.DocID.String())
@@ -1372,21 +1357,15 @@ func (d *DB) UpdateAndFindMinSyncedVersionVector(
 		return nil, fmt.Errorf("find all version vectors: %w", err)
 	}
 
-	// 03. Compute min version vector.
+	// 02. Compute min version vector.
 	var minVersionVector time.VersionVector
 
-	// 03-1. Compute min version vector of other clients and collect attachedActorIDs.
+	// 02-1. Compute min version vector of other clients and collect attachedActorIDs.
 	for raw := iterator.Next(); raw != nil; raw = iterator.Next() {
 		vvi := raw.(*database.VersionVectorInfo)
 		if clientInfo.ID == vvi.ClientID {
 			continue
 		}
-
-		actorID, err := vvi.ClientID.ToActorID()
-		if err != nil {
-			return nil, err
-		}
-		attachedActorIDs = append(attachedActorIDs, actorID)
 
 		if minVersionVector == nil {
 			minVersionVector = vvi.VersionVector
@@ -1399,11 +1378,10 @@ func (d *DB) UpdateAndFindMinSyncedVersionVector(
 		minVersionVector = versionVector
 	}
 
-	// 03-2. Compute min version vector with current client's version vector and filter detached clients.
+	// 02-2. Compute min version vector with current client's version vector\
 	minVersionVector = minVersionVector.Min(versionVector)
-	minVersionVector = minVersionVector.Filter(attachedActorIDs)
 
-	// 04. Update current client's version vector. If the client is detached, remove it.
+	// 03. Update current client's version vector. If the client is detached, remove it.
 	// This is only for the current client and does not affect the version vector of other clients.
 	if err = d.UpdateVersionVector(ctx, clientInfo, docRefKey, versionVector); err != nil {
 		return nil, err

--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -1347,7 +1347,8 @@ func (d *DB) UpdateAndFindMinSyncedVersionVector(
 	docRefKey types.DocRefKey,
 	versionVector time.VersionVector,
 ) (time.VersionVector, error) {
-	// TODO(JOOHOJANG): we have to consider removing detached client's lamport from min version vector
+	// TODO(JOOHOJANG): We have to consider removing detached client's lamport
+	// from min version vector.
 
 	// 01. Find all version vectors of the given document from DB.
 	txn := d.db.Txn(false)
@@ -1378,7 +1379,7 @@ func (d *DB) UpdateAndFindMinSyncedVersionVector(
 		minVersionVector = versionVector
 	}
 
-	// 02-2. Compute min version vector with current client's version vector\
+	// 02-2. Compute min version vector with current client's version vector.
 	minVersionVector = minVersionVector.Min(versionVector)
 
 	// 03. Update current client's version vector. If the client is detached, remove it.

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -1235,7 +1235,8 @@ func (c *Client) UpdateAndFindMinSyncedVersionVector(
 	docRefKey types.DocRefKey,
 	versionVector time.VersionVector,
 ) (time.VersionVector, error) {
-	// TODO(JOOHOJANG): we have to consider removing detached client's lamport from min version vector
+	// TODO(JOOHOJANG): We have to consider removing detached client's lamport
+	// from min version vector.
 	var versionVectorInfos []database.VersionVectorInfo
 
 	// 01. Find all version vectors of the given document from DB.
@@ -1271,7 +1272,7 @@ func (c *Client) UpdateAndFindMinSyncedVersionVector(
 		minVersionVector = versionVector
 	}
 
-	// 02-2. Compute min version vector with current client's version vector
+	// 02-2. Compute min version vector with current client's version vector.
 	minVersionVector = minVersionVector.Min(versionVector)
 
 	// 03. Update current client's version vector. If the client is detached, remove it.

--- a/test/integration/gc_test.go
+++ b/test/integration/gc_test.go
@@ -442,8 +442,9 @@ func TestGarbageCollection(t *testing.T) {
 
 		assert.NoError(t, c1.Sync(ctx))
 		// remove c2 lamport from d1.vv after GC
-		// d1.vv = [c1:5], minvv = [c1:4], db.vv {c1: [c1:4]}
-		assert.Equal(t, true, checkVV(d1.VersionVector(), versionOf(d1.ActorID(), 5)))
+		// d1.vv = [c1:5, c2:4], minvv = [c1:4, c2:4], db.vv {c1: [c1:4]}
+		// TODO(JOOHOJANG): we have to consider removing detached client's lamport from version vector
+		assert.Equal(t, true, checkVV(d1.VersionVector(), versionOf(d1.ActorID(), 5), versionOf(d2.ActorID(), 4)))
 		assert.Equal(t, 0, d1.GarbageLen())
 		assert.Equal(t, 6, d2.GarbageLen())
 	})
@@ -1190,6 +1191,7 @@ func TestGarbageCollection(t *testing.T) {
 
 		assert.NoError(t, c2.Sync(ctx))
 		assert.Equal(t, 0, d2.GarbageLen())
-		assert.Equal(t, 1, len(d2.VersionVector()))
+		// TODO(JOOHOJANG): we have to consider removing detached client's lamport from version vector
+		assert.Equal(t, 2, len(d2.VersionVector()))
 	})
 }

--- a/test/integration/gc_test.go
+++ b/test/integration/gc_test.go
@@ -1194,4 +1194,110 @@ func TestGarbageCollection(t *testing.T) {
 		// TODO(JOOHOJANG): we have to consider removing detached client's lamport from version vector
 		assert.Equal(t, 2, len(d2.VersionVector()))
 	})
+
+	t.Run("detach gc test", func(t *testing.T) {
+		clients := activeClients(t, 3)
+		c1, c2, c3 := clients[0], clients[1], clients[2]
+		defer deactivateAndCloseClients(t, clients)
+		ctx := context.Background()
+		d1 := document.New(helper.TestDocKey(t))
+		d2 := document.New(helper.TestDocKey(t))
+		d3 := document.New(helper.TestDocKey(t))
+
+		assert.NoError(t, c1.Attach(ctx, d1))
+		assert.NoError(t, c2.Attach(ctx, d2))
+		assert.NoError(t, c3.Attach(ctx, d3))
+		assert.NoError(t, c3.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c1.Sync(ctx))
+
+		assert.Equal(t, true, checkVV(d1.VersionVector(), versionOf(d1.ActorID(), 3), versionOf(d2.ActorID(), 1), versionOf(d3.ActorID(), 1)))
+		assert.Equal(t, true, checkVV(d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 3), versionOf(d3.ActorID(), 1)))
+		assert.Equal(t, true, checkVV(d3.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 1), versionOf(d3.ActorID(), 3)))
+
+		err := d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewText("text").Edit(0, 0, "a").Edit(1, 1, "b").Edit(2, 2, "c")
+			return nil
+		}, "insert abc")
+		assert.NoError(t, err)
+
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c3.Sync(ctx))
+		assert.NoError(t, c3.Sync(ctx))
+
+		assert.Equal(t, true, checkVV(d1.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 1), versionOf(d3.ActorID(), 1)))
+		assert.Equal(t, true, checkVV(d2.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 5), versionOf(d3.ActorID(), 1)))
+		assert.Equal(t, true, checkVV(d3.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 1), versionOf(d3.ActorID(), 5)))
+
+		err = d3.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(1, 3, "") // delete bc
+			return nil
+		}, "delete bc")
+		assert.NoError(t, err)
+		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(0, 0, "1") // 1abc
+			return nil
+		}, "insert 1")
+		assert.NoError(t, err)
+		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(0, 0, "2") // 21abc
+			return nil
+		}, "insert 2")
+		assert.NoError(t, err)
+		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(0, 0, "3") // 321abc
+			return nil
+		}, "insert 3")
+		assert.NoError(t, err)
+		err = d2.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(3, 3, "x") // abcx
+			return nil
+		}, "insert x")
+		assert.NoError(t, err)
+		err = d2.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(4, 4, "y") // abcxy
+			return nil
+		}, "insert x")
+		assert.NoError(t, err)
+
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c1.Sync(ctx))
+
+		assert.Equal(t, `{"text":[{"val":"3"},{"val":"2"},{"val":"1"},{"val":"a"},{"val":"b"},{"val":"c"},{"val":"x"},{"val":"y"}]}`, d1.Marshal())
+		assert.Equal(t, `{"text":[{"val":"3"},{"val":"2"},{"val":"1"},{"val":"a"},{"val":"b"},{"val":"c"},{"val":"x"},{"val":"y"}]}`, d2.Marshal())
+		assert.Equal(t, true, checkVV(d1.VersionVector(), versionOf(d1.ActorID(), 9), versionOf(d2.ActorID(), 7), versionOf(d3.ActorID(), 1)))
+		assert.Equal(t, true, checkVV(d2.VersionVector(), versionOf(d1.ActorID(), 7), versionOf(d2.ActorID(), 10), versionOf(d3.ActorID(), 1)))
+		assert.Equal(t, true, checkVV(d3.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 1), versionOf(d3.ActorID(), 6)))
+
+		assert.NoError(t, c3.Detach(ctx, d3))
+		err = d2.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(5, 5, "z") // 321abzcxy
+			return nil
+		}, "insert y")
+		assert.NoError(t, err)
+		assert.NoError(t, c1.Sync(ctx))
+
+		assert.Equal(t, 2, d1.GarbageLen())
+		assert.NoError(t, c1.Sync(ctx))
+		assert.Equal(t, 2, d1.GarbageLen())
+
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c1.Sync(ctx))
+		// TODO(JOOHOJANG): we have to consider removing detached client's lamport from version vector
+		assert.Equal(t, true, checkVV(d1.VersionVector(), versionOf(d1.ActorID(), 12), versionOf(d2.ActorID(), 11), versionOf(d3.ActorID(), 7)))
+		assert.Equal(t, true, checkVV(d2.VersionVector(), versionOf(d1.ActorID(), 7), versionOf(d2.ActorID(), 13), versionOf(d3.ActorID(), 7)))
+		assert.Equal(t, `{"text":[{"val":"3"},{"val":"2"},{"val":"1"},{"val":"a"},{"val":"z"},{"val":"x"},{"val":"y"}]}`, d1.Marshal())
+		assert.Equal(t, `{"text":[{"val":"3"},{"val":"2"},{"val":"1"},{"val":"a"},{"val":"z"},{"val":"x"},{"val":"y"}]}`, d2.Marshal())
+		assert.Equal(t, 2, d1.GarbageLen())
+		assert.Equal(t, 2, d2.GarbageLen())
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c1.Sync(ctx))
+		assert.Equal(t, 0, d1.GarbageLen())
+		assert.Equal(t, 0, d2.GarbageLen())
+	})
 }

--- a/test/integration/gc_test.go
+++ b/test/integration/gc_test.go
@@ -443,7 +443,8 @@ func TestGarbageCollection(t *testing.T) {
 		assert.NoError(t, c1.Sync(ctx))
 		// remove c2 lamport from d1.vv after GC
 		// d1.vv = [c1:5, c2:4], minvv = [c1:4, c2:4], db.vv {c1: [c1:4]}
-		// TODO(JOOHOJANG): we have to consider removing detached client's lamport from version vector
+		// TODO(JOOHOJANG): We have to consider removing detached client's lamport
+		// from version vector.
 		assert.Equal(t, true, checkVV(d1.VersionVector(), versionOf(d1.ActorID(), 5), versionOf(d2.ActorID(), 4)))
 		assert.Equal(t, 0, d1.GarbageLen())
 		assert.Equal(t, 6, d2.GarbageLen())
@@ -1191,7 +1192,8 @@ func TestGarbageCollection(t *testing.T) {
 
 		assert.NoError(t, c2.Sync(ctx))
 		assert.Equal(t, 0, d2.GarbageLen())
-		// TODO(JOOHOJANG): we have to consider removing detached client's lamport from version vector
+		// TODO(JOOHOJANG): We have to consider removing detached client's lamport
+		// from version vector.
 		assert.Equal(t, 2, len(d2.VersionVector()))
 	})
 
@@ -1288,7 +1290,8 @@ func TestGarbageCollection(t *testing.T) {
 
 		assert.NoError(t, c2.Sync(ctx))
 		assert.NoError(t, c1.Sync(ctx))
-		// TODO(JOOHOJANG): we have to consider removing detached client's lamport from version vector
+		// TODO(JOOHOJANG): We have to consider removing detached client's lamport
+		// from version vector.
 		assert.Equal(t, true, checkVV(d1.VersionVector(), versionOf(d1.ActorID(), 12), versionOf(d2.ActorID(), 11), versionOf(d3.ActorID(), 7)))
 		assert.Equal(t, true, checkVV(d2.VersionVector(), versionOf(d1.ActorID(), 7), versionOf(d2.ActorID(), 13), versionOf(d3.ActorID(), 7)))
 		assert.Equal(t, `{"text":[{"val":"3"},{"val":"2"},{"val":"1"},{"val":"a"},{"val":"z"},{"val":"x"},{"val":"y"}]}`, d1.Marshal())


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Since we found GC error in https://github.com/yorkie-team/yorkie/issues/1089.
We decided to leave detached client's lamport in every version vector(local document and min version vector) for now and look for a solution later.

I modified following items
- Local document version vector filtering 
- Min version vector filtering
- Using minLamport when run GC
- GC design document

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://github.com/yorkie-team/yorkie/issues/1089

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced documentation on garbage collection, clarifying its implementation and the role of version vectors.
  - Added new test cases for garbage collection behavior, particularly concerning detached clients.

- **Bug Fixes**
  - Streamlined logic for handling version vectors related to detached clients in various methods.

- **Documentation**
  - Updated and clarified the garbage collection document, including detailed explanations and examples.

- **Tests**
  - Improved garbage collection tests with new scenarios and refined assertions to ensure accurate behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->