### PR TITLE
Add missing MongoDB sharding configuration for version vectors

### DIFF
--- a/build/charts/yorkie-cluster/charts/yorkie-mongodb/values.yaml
+++ b/build/charts/yorkie-cluster/charts/yorkie-mongodb/values.yaml
@@ -57,6 +57,11 @@ sharded:
           - name: doc_id
             method: "1"
         unique: false
+      - collectionName: versionvectors
+        shardKeys:
+          - name: doc_id
+            method: "1"
+        unique: false
 
 # Configuration for manual dmongodb sharded stack
 mongodb-sharded:

--- a/build/docker/sharding/scripts/init-mongos1.js
+++ b/build/docker/sharding/scripts/init-mongos1.js
@@ -1,39 +1,46 @@
-sh.addShard("shard-rs-1/shard1-1:27017")
-sh.addShard("shard-rs-2/shard2-1:27017")
+sh.addShard("shard-rs-1/shard1-1:27017");
+sh.addShard("shard-rs-2/shard2-1:27017");
 
 function findAnotherShard(shard) {
-    if (shard == "shard-rs-1") {
-        return "shard-rs-2"
-    } else {
-        return "shard-rs-1"
-    }
+  if (shard == "shard-rs-1") {
+    return "shard-rs-2";
+  } else {
+    return "shard-rs-1";
+  }
 }
 
 function shardOfChunk(minKeyOfChunk) {
-    return db.getSiblingDB("config").chunks.findOne({ min: { project_id: minKeyOfChunk } }).shard
+  return db
+    .getSiblingDB("config")
+    .chunks.findOne({ min: { project_id: minKeyOfChunk } }).shard;
 }
 
 // Shard the database for the mongo client test
-const mongoClientDB = "test-yorkie-meta-mongo-client"
-sh.enableSharding(mongoClientDB)
-sh.shardCollection(mongoClientDB + ".clients", { project_id: 1 })
-sh.shardCollection(mongoClientDB + ".documents", { project_id: 1 })
-sh.shardCollection(mongoClientDB + ".changes", { doc_id: 1 })
-sh.shardCollection(mongoClientDB + ".snapshots", { doc_id: 1 })
-sh.shardCollection(mongoClientDB + ".syncedseqs", { doc_id: 1 })
+const mongoClientDB = "test-yorkie-meta-mongo-client";
+sh.enableSharding(mongoClientDB);
+sh.shardCollection(mongoClientDB + ".clients", { project_id: 1 });
+sh.shardCollection(mongoClientDB + ".documents", { project_id: 1 });
+sh.shardCollection(mongoClientDB + ".changes", { doc_id: 1 });
+sh.shardCollection(mongoClientDB + ".snapshots", { doc_id: 1 });
+sh.shardCollection(mongoClientDB + ".syncedseqs", { doc_id: 1 });
+sh.shardCollection(mongoClientDB + ".versionvectors", { doc_id: 1 });
 
 // Split the inital range at `splitPoint` to allow doc_ids duplicate in different shards.
-const splitPoint = ObjectId("500000000000000000000000")
-sh.splitAt(mongoClientDB + ".documents", { project_id: splitPoint })
+const splitPoint = ObjectId("500000000000000000000000");
+sh.splitAt(mongoClientDB + ".documents", { project_id: splitPoint });
 // Move the chunk to another shard.
-db.adminCommand({ moveChunk: mongoClientDB + ".documents", find: { project_id: splitPoint }, to: findAnotherShard(shardOfChunk(splitPoint)) })
+db.adminCommand({
+  moveChunk: mongoClientDB + ".documents",
+  find: { project_id: splitPoint },
+  to: findAnotherShard(shardOfChunk(splitPoint)),
+});
 
 // Shard the database for the server test
-const serverDB = "test-yorkie-meta-server"
-sh.enableSharding(serverDB)
-sh.shardCollection(serverDB + ".clients", { project_id: 1 })
-sh.shardCollection(serverDB + ".documents", { project_id: 1 })
-sh.shardCollection(serverDB + ".changes", { doc_id: 1 })
-sh.shardCollection(serverDB + ".snapshots", { doc_id: 1 })
-sh.shardCollection(serverDB + ".syncedseqs", { doc_id: 1 })
-
+const serverDB = "test-yorkie-meta-server";
+sh.enableSharding(serverDB);
+sh.shardCollection(serverDB + ".clients", { project_id: 1 });
+sh.shardCollection(serverDB + ".documents", { project_id: 1 });
+sh.shardCollection(serverDB + ".changes", { doc_id: 1 });
+sh.shardCollection(serverDB + ".snapshots", { doc_id: 1 });
+sh.shardCollection(serverDB + ".syncedseqs", { doc_id: 1 });
+sh.shardCollection(serverDB + ".versionvectors", { doc_id: 1 });

--- a/server/backend/database/mongo/indexes.go
+++ b/server/backend/database/mongo/indexes.go
@@ -174,8 +174,8 @@ var collectionInfos = []collectionInfo{
 		name: ColVersionVectors,
 		indexes: []mongo.IndexModel{{
 			Keys: bsonx.Doc{
+				{Key: "doc_id", Value: bsonx.Int32(1)}, // shard key
 				{Key: "project_id", Value: bsonx.Int32(1)},
-				{Key: "doc_id", Value: bsonx.Int32(1)},
 				{Key: "client_id", Value: bsonx.Int32(1)},
 			},
 			Options: options.Index().SetUnique(true),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR adds the missing MongoDB sharding configuration for the version vectors collection introduced in PR #1047, as well as updates the related documentation to reflect these changes.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Address https://github.com/yorkie-team/yorkie/issues/723

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new collection named `versionvectors` with sharding capabilities in the MongoDB configuration.
	- Added sharding operations for the `versionvectors` collection in the initialization script.

- **Documentation**
	- Updated the MongoDB sharding documentation to include details about the new `versionvectors` collection and its sharding strategy.

- **Bug Fixes**
	- Improved readability and consistency in the sharding initialization script through syntax enhancements.

- **Refactor**
	- Adjusted the indexing strategy for the `ColVersionVectors` collection to prioritize the `doc_id` key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->