### PR TITLE
Fix panic in pubsub by deleting subs in callback

### DIFF
--- a/server/backend/sync/memory/pubsub.go
+++ b/server/backend/sync/memory/pubsub.go
@@ -145,12 +145,14 @@ func (m *PubSub) Unsubscribe(
 	if subs, ok := m.subscriptionsMap.Get(docKey); ok {
 		subs.Delete(sub.ID())
 
-		if subs.Len() == 0 {
-			m.subscriptionsMap.Delete(docKey, func(subs *Subscriptions, exists bool) bool {
-				subs.Close()
-				return exists
-			})
-		}
+		m.subscriptionsMap.Delete(docKey, func(subs *Subscriptions, exists bool) bool {
+			if !exists || 0 < subs.Len() {
+				return false
+			}
+
+			subs.Close()
+			return true
+		})
 	}
 
 	if logging.Enabled(zap.DebugLevel) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix panic in pubsub by deleting subs in callback

This PR addresses a panic error that occurred after [the introduction of a concurrency map in the pubsub](https://github.com/yorkie-team/yorkie/pull/1051) by modifying the deletion process of subscriptions. Now, instead of causing a panic, `subs` are deleted within the callback to ensure thread safety and prevent race conditions.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved logic for managing subscription deletions, ensuring active subscriptions are not prematurely removed.

- **Chores**
	- Maintained existing debug logging for the unsubscribe process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->