### PR TITLE
Add HMAC Signing Support for Webhook Client Security

### DIFF
--- a/pkg/webhook/client.go
+++ b/pkg/webhook/client.go
@@ -20,6 +20,9 @@ package webhook
 import (
 	"bytes"
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -51,6 +54,8 @@ type Options struct {
 
 	MaxRetries      uint64
 	MaxWaitInterval time.Duration
+
+	HMACKey string
 }
 
 // Client is a client for the webhook.
@@ -87,12 +92,7 @@ func (c *Client[Req, Res]) Send(ctx context.Context, req Req) (*Res, int, error)
 
 	var res Res
 	status, err := c.withExponentialBackoff(ctx, func() (int, error) {
-		// TODO(hackerwins, window9u): We should consider using HMAC to sign the request.
-		resp, err := http.Post(
-			c.url,
-			"application/json",
-			bytes.NewBuffer(body),
-		)
+		resp, err := c.post("application/json", body)
 		if err != nil {
 			return 0, fmt.Errorf("post to webhook: %w", err)
 		}
@@ -124,6 +124,33 @@ func (c *Client[Req, Res]) Send(ctx context.Context, req Req) (*Res, int, error)
 	}
 
 	return &res, status, nil
+}
+
+// post sends an HTTP POST request with HMAC-SHA256 signature headers.
+// If key is empty, post sends an HTTP POST without signature.
+func (c *Client[Req, Res]) post(contentType string, body []byte) (*http.Response, error) {
+	req, err := http.NewRequest("POST", c.url, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", contentType)
+	if c.options.HMACKey != "" {
+		mac := hmac.New(sha256.New, []byte(c.options.HMACKey))
+		if _, err := mac.Write(body); err != nil {
+			return nil, fmt.Errorf("failed to write HMAC body: %w", err)
+		}
+		signature := mac.Sum(nil)
+		signatureHex := hex.EncodeToString(signature) // Convert to hex string
+		req.Header.Set("X-Signature-256", fmt.Sprintf("sha256=%s", signatureHex))
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP POST request failed: %w", err) // Wrapped with context
+	}
+
+	return resp, nil
 }
 
 func (c *Client[Req, Res]) withExponentialBackoff(ctx context.Context, webhookFn func() (int, error)) (int, error) {

--- a/pkg/webhook/client.go
+++ b/pkg/webhook/client.go
@@ -131,14 +131,14 @@ func (c *Client[Req, Res]) Send(ctx context.Context, req Req) (*Res, int, error)
 func (c *Client[Req, Res]) post(contentType string, body []byte) (*http.Response, error) {
 	req, err := http.NewRequest("POST", c.url, bytes.NewBuffer(body))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+		return nil, fmt.Errorf("create HTTP request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", contentType)
 	if c.options.HMACKey != "" {
 		mac := hmac.New(sha256.New, []byte(c.options.HMACKey))
 		if _, err := mac.Write(body); err != nil {
-			return nil, fmt.Errorf("failed to write HMAC body: %w", err)
+			return nil, fmt.Errorf("write HMAC body: %w", err)
 		}
 		signature := mac.Sum(nil)
 		signatureHex := hex.EncodeToString(signature) // Convert to hex string
@@ -147,7 +147,7 @@ func (c *Client[Req, Res]) post(contentType string, body []byte) (*http.Response
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("HTTP POST request failed: %w", err) // Wrapped with context
+		return nil, fmt.Errorf("send to %s: %w", c.url, err) // Wrapped with context
 	}
 
 	return resp, nil

--- a/pkg/webhook/client_test.go
+++ b/pkg/webhook/client_test.go
@@ -36,7 +36,7 @@ func verifySignature(signatureHeader, secret string, body []byte) error {
 	mac.Write(body)
 	expectedSig := hex.EncodeToString(mac.Sum(nil))
 	expectedSigHeader := fmt.Sprintf("sha256=%s", expectedSig)
-	if signatureHeader != expectedSigHeader {
+	if !hmac.Equal([]byte(signatureHeader), []byte(expectedSigHeader)) {
 		return errors.New("signature validation failed")
 	}
 

--- a/pkg/webhook/client_test.go
+++ b/pkg/webhook/client_test.go
@@ -1,0 +1,115 @@
+package webhook_test
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/pkg/cache"
+	"github.com/yorkie-team/yorkie/pkg/types"
+	"github.com/yorkie-team/yorkie/pkg/webhook"
+)
+
+// testRequest is a simple request type for demonstration.
+type testRequest struct {
+	Name string `json:"name"`
+}
+
+// testResponse is a simple response type for demonstration.
+type testResponse struct {
+	Greeting string `json:"greeting"`
+}
+
+func verifySignature(signatureHeader, secret string, body []byte) error {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	expectedSig := hex.EncodeToString(mac.Sum(nil))
+	expectedSigHeader := fmt.Sprintf("sha256=%s", expectedSig)
+	if signatureHeader != expectedSigHeader {
+		return errors.New("signature validation failed")
+	}
+
+	return nil
+}
+
+func TestHMAC(t *testing.T) {
+	const secretKey = "my-secret-key"
+	const wrongKey = "wrong-key"
+	reqData := testRequest{Name: "HMAC Tester"}
+	resData := testResponse{Greeting: "HMAC OK"}
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		signatureHeader := r.Header.Get("X-Signature-256")
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		if err := verifySignature(signatureHeader, secretKey, bodyBytes); err != nil {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		assert.NoError(t, json.NewEncoder(w).Encode(resData))
+	}))
+	defer testServer.Close()
+
+	t.Run("webhook client with valid HMAC key test", func(t *testing.T) {
+		testCache, err := cache.NewLRUExpireCache[string, types.Pair[int, *testResponse]](100)
+		assert.NoError(t, err)
+
+		client := webhook.NewClient[testRequest, testResponse](
+			testServer.URL,
+			testCache,
+			webhook.Options{
+				CacheKeyPrefix:  "testPrefix-hmac",
+				CacheTTL:        5 * time.Second,
+				MaxRetries:      0,
+				MaxWaitInterval: 200 * time.Millisecond,
+				HMACKey:         secretKey,
+			},
+		)
+
+		ctx := context.Background()
+		resp, statusCode, err := client.Send(ctx, reqData)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, statusCode)
+		assert.NotNil(t, resp)
+		assert.Equal(t, resData.Greeting, resp.Greeting)
+	})
+
+	t.Run("webhook client with invalid HMAC key test", func(t *testing.T) {
+		testCache, err := cache.NewLRUExpireCache[string, types.Pair[int, *testResponse]](100)
+		assert.NoError(t, err)
+
+		client := webhook.NewClient[testRequest, testResponse](
+			testServer.URL,
+			testCache,
+			webhook.Options{
+				CacheKeyPrefix:  "testPrefix-hmac",
+				CacheTTL:        5 * time.Second,
+				MaxRetries:      0,
+				MaxWaitInterval: 200 * time.Millisecond,
+				HMACKey:         wrongKey,
+			},
+		)
+
+		ctx := context.Background()
+		resp, statusCode, err := client.Send(ctx, reqData)
+		assert.Error(t, err)
+		assert.Equal(t, http.StatusForbidden, statusCode)
+		assert.Nil(t, resp)
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- This PR introduce HMAC signing for requests in webhook client
- If an HMAC key is set in the client's options, it will be used for signing the webhook requests.
- The signature will be inserted into the request header as `X-Signature-256`.


**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:
- I referenced how GitHub's `X-Hub-Signature` works while working on this PR.

**Does this PR introduce a user-facing change?**:


```release-note

```

**Additional documentation**:

- This HMAC implementation uses the SHA-256 algorithm.
- The request body will be signed using this algorithm.
- I've also included test code demonstrating how the client verifies the signature, as shown below:

```go
func verifySignature(signatureHeader, secret string, body []byte) error {
	mac := hmac.New(sha256.New, []byte(secret))
	mac.Write(body)
	expectedSig := hex.EncodeToString(mac.Sum(nil))
	expectedSigHeader := fmt.Sprintf("sha256=%s", expectedSig)
	if signatureHeader != expectedSigHeader {
		return errors.New("signature validation failed")
	}
	return nil
}
```

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced webhook request security with HMAC-SHA256 signing.
	- Enabled configurable HMAC key support for request validation.

- **Tests**
	- Introduced comprehensive unit tests to validate HMAC signature functionality, covering various scenarios including valid, invalid, and missing HMAC keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->