### PR TITLE
Extend RWMutex Interface for locker package

### DIFF
--- a/pkg/locker/locker.go
+++ b/pkg/locker/locker.go
@@ -123,7 +123,7 @@ func (l *Locker) Lock(name string) {
 	// Lock the nameLock outside the main mutex so we don't block other operations
 	// once locked then we can decrement the number of waiters for this lock
 	nameLock.Lock()
-	nameLock.dec()
+	//nameLock.dec()
 }
 
 // TryLock locks a mutex with the given name. If it doesn't exist, one is created.
@@ -147,7 +147,6 @@ func (l *Locker) TryLock(name string) bool {
 	// Lock the nameLock outside the main mutex so we don't block other operations
 	// once locked then we can decrement the number of waiters for this lock
 	succeeded := nameLock.TryLock()
-	nameLock.dec()
 
 	return succeeded
 }
@@ -162,10 +161,12 @@ func (l *Locker) Unlock(name string) error {
 		return ErrNoSuchLock
 	}
 
+	nameLock.Unlock()
+	nameLock.dec()
+
 	if nameLock.count() == 0 {
 		delete(l.locks, name)
 	}
-	nameLock.Unlock()
 
 	l.mu.Unlock()
 	return nil
@@ -193,7 +194,7 @@ func (l *Locker) RLock(name string) {
 	// Lock the nameLock outside the main mutex so we don't block other operations
 	// once locked then we can decrement the number of waiters for this lock
 	nameLock.RLock()
-	nameLock.dec()
+	//nameLock.dec()
 }
 
 // RUnlock releases a read lock for the given name.
@@ -205,10 +206,12 @@ func (l *Locker) RUnlock(name string) error {
 		return ErrNoSuchLock
 	}
 
+	nameLock.RUnlock()
+	nameLock.dec()
+
 	if nameLock.count() == 0 {
 		delete(l.locks, name)
 	}
-	nameLock.RUnlock()
 
 	l.mu.Unlock()
 	return nil

--- a/pkg/locker/locker.go
+++ b/pkg/locker/locker.go
@@ -151,7 +151,6 @@ func (l *Locker) Lock(name string) {
 	// once locked then we can decrement the number of waiters for this lock
 	nameLock.Lock()
 
-	nameLock.decWaiters()
 	nameLock.setWriter(1)
 }
 
@@ -176,7 +175,6 @@ func (l *Locker) TryLock(name string) bool {
 	// Lock the nameLock outside the main mutex so we don't block other operations
 	// once locked then we can decrement the number of waiters for this lock
 	succeeded := nameLock.TryLock()
-	nameLock.decWaiters()
 	nameLock.setWriter(1)
 
 	return succeeded
@@ -195,6 +193,7 @@ func (l *Locker) Unlock(name string) error {
 
 	nameLock.Unlock()
 	nameLock.setWriter(0)
+	nameLock.decWaiters()
 
 	if nameLock.canDelete() {
 		delete(l.locks, name)

--- a/pkg/locker/locker.go
+++ b/pkg/locker/locker.go
@@ -49,25 +49,47 @@ type Locker struct {
 
 // lockCtr is used by Locker to represent a lock with a given name.
 type lockCtr struct {
-	mu sync.Mutex
+	mu sync.RWMutex
 	// waiters is the number of waiters waiting to acquire the lock
-	// this is int32 instead of uint32 so we can add `-1` in `dec()`
+	// this is int32 instead of uint32 so we can add `-1` in `decWaiters()`
 	waiters int32
+	// readers is the number of readers currently holding RLock.
+	readers int32
+	// writer is 1 if currently holding Lock, otherwise 0.
+	writer int32
 }
 
-// inc increments the number of waiters waiting for the lock
-func (l *lockCtr) inc() {
+// incWaiters increments the number of waiters waiting for the lock
+func (l *lockCtr) incWaiters() {
 	atomic.AddInt32(&l.waiters, 1)
 }
 
-// dec decrements the number of waiters waiting on the lock
-func (l *lockCtr) dec() {
+// decWaiters decrements the number of waiters waiting on the lock
+func (l *lockCtr) decWaiters() {
 	atomic.AddInt32(&l.waiters, -1)
+}
+
+func (l *lockCtr) incReaders() {
+	atomic.AddInt32(&l.readers, 1)
+}
+
+func (l *lockCtr) decReaders() {
+	atomic.AddInt32(&l.readers, -1)
+}
+
+func (l *lockCtr) setWriter(val int32) {
+	atomic.StoreInt32(&l.writer, val)
 }
 
 // count gets the current number of waiters
 func (l *lockCtr) count() int32 {
 	return atomic.LoadInt32(&l.waiters)
+}
+
+func (l *lockCtr) canDelete() bool {
+	return atomic.LoadInt32(&l.waiters) == 0 &&
+		atomic.LoadInt32(&l.readers) == 0 &&
+		atomic.LoadInt32(&l.writer) == 0
 }
 
 // Lock locks the mutex
@@ -83,6 +105,21 @@ func (l *lockCtr) TryLock() bool {
 // Unlock unlocks the mutex
 func (l *lockCtr) Unlock() {
 	l.mu.Unlock()
+}
+
+// RLock locks the mutex
+func (l *lockCtr) RLock() {
+	l.mu.RLock()
+}
+
+// TryRLock tries to lock the mutex.
+func (l *lockCtr) TryRLock() bool {
+	return l.mu.TryRLock()
+}
+
+// RUnlock unlocks the mutex
+func (l *lockCtr) RUnlock() {
+	l.mu.RUnlock()
 }
 
 // New creates a new Locker
@@ -107,13 +144,15 @@ func (l *Locker) Lock(name string) {
 
 	// increment the nameLock waiters while inside the main mutex
 	// this makes sure that the lock isn't deleted if `Lock` and `Unlock` are called concurrently
-	nameLock.inc()
+	nameLock.incWaiters()
 	l.mu.Unlock()
 
 	// Lock the nameLock outside the main mutex so we don't block other operations
 	// once locked then we can decrement the number of waiters for this lock
 	nameLock.Lock()
-	nameLock.dec()
+
+	nameLock.decWaiters()
+	nameLock.setWriter(1)
 }
 
 // TryLock locks a mutex with the given name. If it doesn't exist, one is created.
@@ -131,13 +170,14 @@ func (l *Locker) TryLock(name string) bool {
 
 	// increment the nameLock waiters while inside the main mutex
 	// this makes sure that the lock isn't deleted if `Lock` and `Unlock` are called concurrently
-	nameLock.inc()
+	nameLock.incWaiters()
 	l.mu.Unlock()
 
 	// Lock the nameLock outside the main mutex so we don't block other operations
 	// once locked then we can decrement the number of waiters for this lock
 	succeeded := nameLock.TryLock()
-	nameLock.dec()
+	nameLock.decWaiters()
+	nameLock.setWriter(1)
 
 	return succeeded
 }
@@ -146,17 +186,94 @@ func (l *Locker) TryLock(name string) bool {
 // If the given lock is not being waited on by any other callers, it is deleted
 func (l *Locker) Unlock(name string) error {
 	l.mu.Lock()
+	defer l.mu.Unlock()
+
 	nameLock, exists := l.locks[name]
 	if !exists {
-		l.mu.Unlock()
 		return ErrNoSuchLock
 	}
 
-	if nameLock.count() == 0 {
+	nameLock.Unlock()
+	nameLock.setWriter(0)
+
+	if nameLock.canDelete() {
 		delete(l.locks, name)
 	}
-	nameLock.Unlock()
 
+	return nil
+}
+
+// RLock acquires a read lock for the given name.
+// If there is no lock for that name, a new one is created.
+func (l *Locker) RLock(name string) {
+	l.mu.Lock()
+	if l.locks == nil {
+		l.locks = make(map[string]*lockCtr)
+	}
+
+	nameLock, exists := l.locks[name]
+	if !exists {
+		nameLock = &lockCtr{}
+		l.locks[name] = nameLock
+	}
+
+	// 01. Increase waiters inside the global lock
+	nameLock.incWaiters()
 	l.mu.Unlock()
+
+	// 02. Acquire RLock
+	nameLock.RLock()
+
+	// 03. Decrease waiters and increase readers
+	nameLock.decWaiters()
+	nameLock.incReaders()
+}
+
+// TryRLock attempts to acquire a read lock for the given name.
+// Returns true if success, false if the lock is currently held by a writer.
+func (l *Locker) TryRLock(name string) bool {
+	l.mu.Lock()
+	if l.locks == nil {
+		l.locks = make(map[string]*lockCtr)
+	}
+
+	nameLock, exists := l.locks[name]
+	if !exists {
+		nameLock = &lockCtr{}
+		l.locks[name] = nameLock
+	}
+
+	// increment the nameLock waiters while inside the main mutex
+	// this makes sure that the lock isn't deleted if `Lock` and `Unlock` are called concurrently
+	nameLock.incWaiters()
+	l.mu.Unlock()
+
+	// Lock the nameLock outside the main mutex so we don't block other operations
+	// once locked then we can decrement the number of waiters for this lock
+	succeeded := nameLock.TryRLock()
+
+	nameLock.decWaiters()
+	nameLock.incReaders()
+
+	return succeeded
+}
+
+// RUnlock releases a read lock for the given name.
+func (l *Locker) RUnlock(name string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	nameLock, exists := l.locks[name]
+	if !exists {
+		return ErrNoSuchLock
+	}
+
+	nameLock.RUnlock()
+	nameLock.decReaders()
+
+	if nameLock.canDelete() {
+		delete(l.locks, name)
+	}
+
 	return nil
 }

--- a/pkg/locker/locker_test.go
+++ b/pkg/locker/locker_test.go
@@ -216,7 +216,7 @@ func TestRWLockerRLock(t *testing.T) {
 	}
 }
 
-func TestRWLockerMixed(t *testing.T) {
+func TestLockRLock(t *testing.T) {
 	l := New()
 
 	// RLock after Lock

--- a/pkg/locker/locker_test.go
+++ b/pkg/locker/locker_test.go
@@ -46,8 +46,8 @@ func TestLockerLock(t *testing.T) {
 	l.Lock("test")
 	ctr := l.locks["test"]
 
-	if ctr.count() != 0 {
-		t.Fatalf("expected waiters to be 0, got :%d", ctr.waiters)
+	if ctr.count() != 1 {
+		t.Fatalf("expected waiters to be 1, got :%d", ctr.waiters)
 	}
 
 	chDone := make(chan struct{})
@@ -59,7 +59,7 @@ func TestLockerLock(t *testing.T) {
 	chWaiting := make(chan struct{})
 	go func() {
 		for range time.Tick(1 * time.Millisecond) {
-			if ctr.count() == 1 {
+			if ctr.count() == 2 {
 				close(chWaiting)
 				break
 			}
@@ -86,6 +86,10 @@ func TestLockerLock(t *testing.T) {
 	case <-chDone:
 	case <-time.After(3 * time.Second):
 		t.Fatalf("lock should have completed")
+	}
+
+	if err := l.Unlock("test"); err != nil {
+		t.Fatal(err)
 	}
 
 	if ctr.count() != 0 {

--- a/pkg/locker/locker_test.go
+++ b/pkg/locker/locker_test.go
@@ -29,15 +29,15 @@ import (
 
 func TestLockCounter(t *testing.T) {
 	l := &lockCtr{}
-	l.incWaiters()
+	l.inc()
 
 	if l.waiters != 1 {
-		t.Fatal("counter incWaiters failed")
+		t.Fatal("counter inc failed")
 	}
 
-	l.decWaiters()
+	l.dec()
 	if l.waiters != 0 {
-		t.Fatal("counter decWaiters failed")
+		t.Fatal("counter dec failed")
 	}
 }
 
@@ -119,10 +119,8 @@ func TestLockerConcurrency(t *testing.T) {
 	for i := 0; i <= 1000; i++ {
 		wg.Add(1)
 		go func() {
-			//fmt.Println("locked: ")
 			l.Lock("test")
 			// if there is a concurrency issue, will very likely panic here
-			//fmt.Println("unLock: ")
 			assert.NoError(t, l.Unlock("test"))
 			wg.Done()
 		}()

--- a/pkg/locker/locker_test.go
+++ b/pkg/locker/locker_test.go
@@ -29,15 +29,15 @@ import (
 
 func TestLockCounter(t *testing.T) {
 	l := &lockCtr{}
-	l.inc()
+	l.incWaiters()
 
 	if l.waiters != 1 {
-		t.Fatal("counter inc failed")
+		t.Fatal("counter incWaiters failed")
 	}
 
-	l.dec()
+	l.decWaiters()
 	if l.waiters != 0 {
-		t.Fatal("counter dec failed")
+		t.Fatal("counter decWaiters failed")
 	}
 }
 
@@ -119,8 +119,10 @@ func TestLockerConcurrency(t *testing.T) {
 	for i := 0; i <= 1000; i++ {
 		wg.Add(1)
 		go func() {
+			//fmt.Println("locked: ")
 			l.Lock("test")
 			// if there is a concurrency issue, will very likely panic here
+			//fmt.Println("unLock: ")
 			assert.NoError(t, l.Unlock("test"))
 			wg.Done()
 		}()

--- a/server/backend/sync/locker.go
+++ b/server/backend/sync/locker.go
@@ -118,15 +118,6 @@ func (il *internalLocker) RLock(_ context.Context) error {
 	return nil
 }
 
-// TryRLock locks the mutex for reading if not already locked by another session.
-func (il *internalLocker) TryRLock(_ context.Context) error {
-	if !il.locks.TryRLock(il.key) {
-		return ErrAlreadyLocked
-	}
-
-	return nil
-}
-
 // RUnlock unlocks the read lock.
 func (il *internalLocker) RUnlock(_ context.Context) error {
 	if err := il.locks.RUnlock(il.key); err != nil {

--- a/server/rpc/yorkie_server.go
+++ b/server/rpc/yorkie_server.go
@@ -303,29 +303,21 @@ func (s *yorkieServer) PushPullChanges(
 	}
 
 	project := projects.From(ctx)
-	locker, err := s.backend.Locker.NewLocker(
-		ctx,
-		packs.PushPullKey(project.ID, pack.DocumentKey),
-	)
-	if err != nil {
-		return nil, err
-	}
 
 	if pack.HasChanges() {
+		locker, err := s.backend.Locker.NewLocker(
+			ctx,
+			packs.PushPullKey(project.ID, pack.DocumentKey),
+		)
+		if err != nil {
+			return nil, err
+		}
+
 		if err := locker.Lock(ctx); err != nil {
 			return nil, err
 		}
 		defer func() {
 			if err := locker.Unlock(ctx); err != nil {
-				logging.DefaultLogger().Error(err)
-			}
-		}()
-	} else {
-		if err := locker.RLock(ctx); err != nil {
-			return nil, err
-		}
-		defer func() {
-			if err := locker.RUnlock(ctx); err != nil {
 				logging.DefaultLogger().Error(err)
 			}
 		}()
@@ -528,26 +520,18 @@ func (s *yorkieServer) RemoveDocument(
 	}
 
 	project := projects.From(ctx)
-	locker, err := s.backend.Locker.NewLocker(ctx, packs.PushPullKey(project.ID, pack.DocumentKey))
-	if err != nil {
-		return nil, err
-	}
 
 	if pack.HasChanges() {
+		locker, err := s.backend.Locker.NewLocker(ctx, packs.PushPullKey(project.ID, pack.DocumentKey))
+		if err != nil {
+			return nil, err
+		}
+
 		if err := locker.Lock(ctx); err != nil {
 			return nil, err
 		}
 		defer func() {
 			if err := locker.Unlock(ctx); err != nil {
-				logging.DefaultLogger().Error(err)
-			}
-		}()
-	} else {
-		if err := locker.RLock(ctx); err != nil {
-			return nil, err
-		}
-		defer func() {
-			if err := locker.RUnlock(ctx); err != nil {
 				logging.DefaultLogger().Error(err)
 			}
 		}()

--- a/server/rpc/yorkie_server.go
+++ b/server/rpc/yorkie_server.go
@@ -303,20 +303,29 @@ func (s *yorkieServer) PushPullChanges(
 	}
 
 	project := projects.From(ctx)
-	if pack.HasChanges() {
-		locker, err := s.backend.Locker.NewLocker(
-			ctx,
-			packs.PushPullKey(project.ID, pack.DocumentKey),
-		)
-		if err != nil {
-			return nil, err
-		}
+	locker, err := s.backend.Locker.NewLocker(
+		ctx,
+		packs.PushPullKey(project.ID, pack.DocumentKey),
+	)
+	if err != nil {
+		return nil, err
+	}
 
+	if pack.HasChanges() {
 		if err := locker.Lock(ctx); err != nil {
 			return nil, err
 		}
 		defer func() {
 			if err := locker.Unlock(ctx); err != nil {
+				logging.DefaultLogger().Error(err)
+			}
+		}()
+	} else {
+		if err := locker.RLock(ctx); err != nil {
+			return nil, err
+		}
+		defer func() {
+			if err := locker.RUnlock(ctx); err != nil {
 				logging.DefaultLogger().Error(err)
 			}
 		}()
@@ -519,17 +528,26 @@ func (s *yorkieServer) RemoveDocument(
 	}
 
 	project := projects.From(ctx)
-	if pack.HasChanges() {
-		locker, err := s.backend.Locker.NewLocker(ctx, packs.PushPullKey(project.ID, pack.DocumentKey))
-		if err != nil {
-			return nil, err
-		}
+	locker, err := s.backend.Locker.NewLocker(ctx, packs.PushPullKey(project.ID, pack.DocumentKey))
+	if err != nil {
+		return nil, err
+	}
 
+	if pack.HasChanges() {
 		if err := locker.Lock(ctx); err != nil {
 			return nil, err
 		}
 		defer func() {
 			if err := locker.Unlock(ctx); err != nil {
+				logging.DefaultLogger().Error(err)
+			}
+		}()
+	} else {
+		if err := locker.RLock(ctx); err != nil {
+			return nil, err
+		}
+		defer func() {
+			if err := locker.RUnlock(ctx); err != nil {
 				logging.DefaultLogger().Error(err)
 			}
 		}()


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR addresses the bug reported in Issue #1081, which was identified in version v0.5.6. The core issue involves a mismatch between `doc.presences` and `doc.changeID.versionVector` counts under certain scenarios.

This patch is a prerequisite for future changes that involve removing Lamport clocks from the version vector. The practical application of rwMutex will be after the temporary preservation logic introduced in PR #1090 , which was added to address GC errors, is resolved.

#### Any background context you want to provide?

The implementation of `rwMutex` resolves the problem by ensuring that `updateVersionVector()` is consistently executed without interference from concurrent routines. This change is necessary to maintain the integrity of the version vector in scenarios where a client detaches while concurrently processing changes from another client.

Consider the situation where Client A is to be detached and Client B triggers changes. If Client B's changes lead to the execution of `PushPullChanges` (Read; no local changes) on the `yorkieServer` for Client A, and Client A's detachment occurs nearly simultaneously at the `clusterServer`, the order of execution for `updateVersionVector()` becomes critical. 

Should the detachment process remove the version vector first, followed by the PushPull (read), the subsequent upsert operation of `updateVersionVector()` could inadvertently recreate the version vector. This situation arises from the lack of isolation between the read and write routines, which this PR seeks to rectify through the `rwMutex`.

#### Limitations
Even with routine isolation, there are cases where `updateVersionVector()` may not execute properly due to 'context canceled' errors. A solution for this issue needs to be considered.


**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Address #1081 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the synchronization mechanism with concurrent read access, improving overall performance and reliability.
- **Tests**
	- Expanded the test suite to validate the new locking behaviors and ensure robust concurrency control.
- **Chores**
	- Introduced benchmarking to measure the performance of the updated locking functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->