### PR TITLE
Replaced gRPC dependency with ConnectRpc

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,8 +31,6 @@ linters-settings:
   wrapcheck:
     ignoreSigRegexps:
       - github.com/yorkie-team/yorkie # Ignore all methods in internal package
-      - google.golang.org/grpc/status # Ignore all methods in grpc/status package
-      - google.golang.org/grpc/internal/status # Ignore all methods in grpc/internal/status package
       - context.Context # Ignore all methods in context package
 
 issues:

--- a/cmd/yorkie/project/create.go
+++ b/cmd/yorkie/project/create.go
@@ -22,10 +22,10 @@ import (
 	"errors"
 	"fmt"
 
+	"connectrpc.com/connect"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
-	"google.golang.org/grpc/status"
 	"gopkg.in/yaml.v3"
 
 	"github.com/yorkie-team/yorkie/admin"
@@ -61,13 +61,21 @@ func newCreateCommand() *cobra.Command {
 			ctx := context.Background()
 			project, err := cli.CreateProject(ctx, name)
 			if err != nil {
-				// TODO(chacha912): consider creating the error details type to remove the dependency on gRPC.
-				st := status.Convert(err)
-				for _, detail := range st.Details() {
-					switch t := detail.(type) {
-					case *errdetails.BadRequest:
-						for _, violation := range t.GetFieldViolations() {
-							cmd.Printf("Invalid Fields: The %q field was wrong: %s\n", violation.GetField(), violation.GetDescription())
+				var connErr *connect.Error
+				if errors.As(err, &connErr) {
+					for _, detail := range connErr.Details() {
+						value, err := detail.Value()
+						if err != nil {
+							continue
+						}
+
+						badReq, ok := value.(*errdetails.BadRequest)
+						if !ok {
+							continue
+						}
+
+						for _, violation := range badReq.GetFieldViolations() {
+							cmd.Printf("Invalid Field: %q - %s\n", violation.GetField(), violation.GetDescription())
 						}
 					}
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Replaced gRPC dependency in create.go with ConnectRPC.
Originally `status.Convert()` method is from gRPC module, so i replaced it with connectrpc method. This will cover errors for creating new project through cli.

**Which issue(s) this PR fixes**:
Fixes #940 


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: no

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [ ] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [ ] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced error reporting for the project creation process, providing clearer, more direct feedback on invalid inputs.
	- Improved error handling during the project update process, offering more precise messages for invalid fields.
	- Streamlined error handling by transitioning from gRPC-specific methods to a more generalized approach using the `connect` package.
- **Chores**
	- Updated linter configuration to include checks for wrapping issues in gRPC-related methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->