### PR TITLE
Prevent duplicate DocChangedEvents in batch processing

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -624,6 +624,10 @@ func handleResponse(
 			return &WatchResponse{Type: DocumentChanged}, nil
 		case events.DocWatchedEvent:
 			doc.AddOnlineClient(cli.String())
+
+			// NOTE(hackerwins): If the presence does not exist, it means that
+			// PushPull is not received before watching. In that case, the 'watched'
+			// event is ignored here, and it will be triggered by PushPull.
 			if doc.Presence(cli.String()) == nil {
 				return nil, nil
 			}
@@ -637,6 +641,10 @@ func handleResponse(
 		case events.DocUnwatchedEvent:
 			p := doc.Presence(cli.String())
 			doc.RemoveOnlineClient(cli.String())
+
+			// NOTE(hackerwins): If the presence does not exist, it means that
+			// PushPull is already received before unwatching. In that case, the
+			// 'unwatched' event is ignored here, and it was triggered by PushPull.
 			if p == nil {
 				return nil, nil
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Prevent duplicate DocChangedEvents in batch processing

If the queue contains multiple DocChangedEvents from the same publisher,  
only two events are processed. This happens when a client attaches or  
detaches a document, as the order of Changed and Watch/Unwatch events is  
not guaranteed.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced document event processing by filtering out duplicate triggers during batch operations. These changes ensure that document updates are reported accurately and efficiently, reducing redundant notifications and streamlining the update flow. These internal improvements optimize system performance and further enhance the overall user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->