### PR TITLE
Add support for building arm64 binaries on macOS

### DIFF
--- a/build/build-binaries.sh
+++ b/build/build-binaries.sh
@@ -22,6 +22,10 @@ function main {
     export GOOS=${os}
     TARGET_ARCHS=("amd64")
 
+    if [ "${GOOS}" == "darwin" ]; then
+      TARGET_ARCHS+=("arm64")
+    fi
+
     if [ "${GOOS}" == "windows" ]; then
       ext=".exe"
     fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add support for building arm64 binaries on macOS

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced support for macOS by enabling arm64 architecture during binary builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->