### PR TITLE
Set replicaCount for standalone controller

### DIFF
--- a/build/charts/yorkie-analytics/values.yaml
+++ b/build/charts/yorkie-analytics/values.yaml
@@ -51,6 +51,8 @@ kube-starrocks:
         type: LoadBalancer
 
 kafka:
+  controller:
+    replicaCount: 1
   kraft:
     clusterId: yorkie-analytics
   listeners:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Set replicaCount for standalone controller

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new configuration option that allows you to set the number of Kafka controller replicas, with a default value of 1. This enhancement provides greater flexibility when deploying and scaling Kafka services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->