### PR TITLE
Update garbage collection related TCs

### DIFF
--- a/test/integration/gc_test.go
+++ b/test/integration/gc_test.go
@@ -46,9 +46,6 @@ func assertVectorEquality(t *testing.T, actual time.VersionVector, versions ...v
 		expected.Set(version.actorID, version.lamport)
 	}
 
-	// NOTE(hackerwins): After remove logical clocks from presence only changes,
-	// the version vector is not equal to the expected version vector.
-	// So we need to update the expected version vector to match the actual version vector.
 	assert.Equal(t, expected.Marshal(), actual.Marshal())
 }
 

--- a/test/integration/gc_test.go
+++ b/test/integration/gc_test.go
@@ -106,13 +106,13 @@ func TestGarbageCollection(t *testing.T) {
 		assert.Equal(t, 4, d2.GarbageLen())
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv = [c1: 1, c2:3], minvv = [c1: 2, c2:0], db.vv = {c1: [c1:2], c2: [c1:1, c2:2]}
+		// d2.vv = [c1: 1, c2:3], minvv = [c1: 0, c2:0], db.vv = {c1: [c1:1], c2: [c1:1, c2:2]}
 		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 3))
 		assert.Equal(t, 0, d1.GarbageLen())
 		assert.Equal(t, 4, d2.GarbageLen())
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv = [c1: 5, c2:4], minvv = [c1: 2, c2:1], db.vv = {c1: [c1:3, c2:1], c2: [c1:2, c2:4]}
+		// d1.vv = [c1: 4, c2:3], minvv = [c1: 2, c2:1], db.vv = {c1: [c1:3, c2:1], c2: [c1:1, c2:2]}
 		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 3))
 		assert.Equal(t, 4, d1.GarbageLen())
 		assert.Equal(t, 4, d2.GarbageLen())
@@ -124,17 +124,17 @@ func TestGarbageCollection(t *testing.T) {
 		assert.Equal(t, 4, d2.GarbageLen())
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv = [c1: 5, c2:4], minvv = [c1: 2, c2:4], db.vv = {c1: [c1:5, c2:4], c2: [c1:2, c2:4]}
+		// d1.vv = [c1: 4, c2:3], minvv = [c1: 2, c2:1], db.vv = {c1: [c1:4, c2:3], c2: [c1:2, c2:4]}
 		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 3))
 		// node removedAt = 4@c2, minVV[c2] = 4 meet GC condition
 		assert.Equal(t, 0, d1.GarbageLen())
 		assert.Equal(t, 4, d2.GarbageLen())
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv = [c1: 2, c2:4], minvv = [c1: 2, c2:4], db.vv = {c1: [c1:5 c2:4], c2: [c1:2, c2:4]}
+		// d2.vv = [c1: 1, c2:3], minvv = [c1: 2, c2:2], db.vv = {c1: [c1:4 c2:3], c2: [c1:1, c2:3]}
 		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 3))
 		assert.Equal(t, 0, d1.GarbageLen())
-		// node removedAt = 4@c2, minVV[c2] = 4 meet GC condition
+		// node removedAt = 3@c2, minVV[c2] = 3 meet GC condition
 		assert.Equal(t, 0, d2.GarbageLen())
 	})
 
@@ -142,12 +142,12 @@ func TestGarbageCollection(t *testing.T) {
 		ctx := context.Background()
 		d1 := document.New(helper.TestDocKey(t))
 		assert.NoError(t, c1.Attach(ctx, d1))
-		// d1.vv = [c1:1], minvv = [c1:1], db.vv {c1: [c1:1]}
+		// d1.vv = [], minvv = [], db.vv {}
 		assertVectorEquality(t, d1.VersionVector())
 
 		d2 := document.New(helper.TestDocKey(t))
 		assert.NoError(t, c2.Attach(ctx, d2))
-		// d2.vv = [c2:2], minvv = [c1: 0, c2:0], db.vv = {c1: [c1:1], c2: [c2:1]}
+		// d2.vv = [], minvv = [], db.vv = {}
 		assertVectorEquality(t, d2.VersionVector())
 
 		assert.NoError(t,
@@ -159,17 +159,17 @@ func TestGarbageCollection(t *testing.T) {
 				return nil
 			}, "sets test and richText"),
 		)
-		// d1.vv = [c1:2]
+		// d1.vv = [c1:1]
 		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
 		assert.Equal(t, 0, d1.GarbageLen())
 		assert.Equal(t, 0, d2.GarbageLen())
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv = [c1:3], minvv = [c1:0, c2:0], db.vv = {c1: [c1:2], c2: [c2:1]}
+		// d1.vv = [c1:1], minvv = [c1:1], db.vv = {c1: [c1:1]}
 		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv = [c1:2, c2:3], minvv = [c1:1, c2:0], db.vv = {c1: [c1:2], c2: [c1:1 c2:2]}
+		// d2.vv = [c1:1, c2:2], minvv = [c1:0, c2:0], db.vv = {c1: [c1:1], c2: [c2:1]}
 		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 2))
 
 		assert.NoError(t,
@@ -182,41 +182,41 @@ func TestGarbageCollection(t *testing.T) {
 				return nil
 			}, "edit text type elements"),
 		)
-		// d2.vv = [c1:2, c2:4]
+		// d2.vv = [c1:1, c2:3]
 		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 3))
 		assert.Equal(t, 0, d1.GarbageLen())
 		assert.Equal(t, 3, d2.GarbageLen())
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv = [c1:2, c2:4], minvv = [c1:2, c2:0], db.vv = {c1: [c1:2], c2: [c1:2 c2:4]}
+		// d2.vv = [c1:1, c2:3], minvv = [c1:1, c2:0], db.vv = {c1: [c1:1], c2: [c1:1 c2:2]}
 		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 3))
 		assert.Equal(t, 0, d1.GarbageLen())
 		assert.Equal(t, 3, d2.GarbageLen())
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv = [c1:5, c2:4], minvv = [c1:2, c2:1], db.vv = {c1: [c1:3, c2:1], c2: [c1:2 c2:4]}
+		// d1.vv = [c1:4, c2:3], minvv = [c1:1, c2:1], db.vv = {c1: [c1:1], c2: [c1:1 c2:3]}
 		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 3))
 		assert.Equal(t, 3, d1.GarbageLen())
 		assert.Equal(t, 3, d2.GarbageLen())
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv = [c1:2, c2:4], minvv = [c1:2, c2:0], db.vv = {c1: [c1:3, c2:1], c2: [c1:2 c2:4]}
+		// d2.vv = [c1:1, c2:3], minvv = [c1:2, c2:0], db.vv = {c1: [c1:3, c2:1], c2: [c1:2 c2:4]}
 		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 3))
 		assert.Equal(t, 3, d1.GarbageLen())
 		assert.Equal(t, 3, d2.GarbageLen())
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv = [c1:5, c2:4], minvv = [c1:2, c2:4], db.vv = {c1: [c1:5, c2:4], c2: [c1:2 c2:4]}
+		// d1.vv = [c1:4, c2:3], minvv = [c1:1, c2:1], db.vv = {c1: [c1:3, c2:1], c2: [c1:2 c2:4]}
 		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 3))
 		// node removedAt = 4@c2, minVV[c2] = 4 meet GC condition
 		assert.Equal(t, 0, d1.GarbageLen())
 		assert.Equal(t, 3, d2.GarbageLen())
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv = [c1:2, c2:4], minvv = [c1:2, c2:4], db.vv = {c1: [c1:5, c2:4], c2: [c1:2 c2:4]}
+		// d2.vv = [c1:1, c2:3], minvv = [c1:2, c2:3], db.vv = {c1: [c1:4, c2:3], c2: [c1:2 c2:4]}
 		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 3))
 		assert.Equal(t, 0, d1.GarbageLen())
-		// node removedAt = 4@c2, minVV[c2] = 4 meet GC condition
+		// node removedAt = 3@c2, minVV[c2] = 3 meet GC condition
 		assert.Equal(t, 0, d2.GarbageLen())
 	})
 
@@ -295,13 +295,13 @@ func TestGarbageCollection(t *testing.T) {
 		ctx := context.Background()
 		d1 := document.New(helper.TestDocKey(t))
 		assert.NoError(t, c1.Attach(ctx, d1))
-		// d1.vv = [c1:1], minvv = [c1:1], db.vv {c1: [c1:1]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
+		// d1.vv = [], minvv = [], db.vv {}
+		assertVectorEquality(t, d1.VersionVector())
 
 		d2 := document.New(helper.TestDocKey(t))
 		assert.NoError(t, c2.Attach(ctx, d2))
-		// d2.vv = [c2:2], minvv = [c1:0, c2:0], db.vv {c1: [c1:1], c2: [c2:1]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d2.ActorID(), 2))
+		// d2.vv = [], minvv = [], db.vv {}
+		assertVectorEquality(t, d2.VersionVector())
 
 		err := d1.Update(func(root *json.Object, p *presence.Presence) error {
 			root.SetNewTree("t", json.TreeNode{
@@ -321,39 +321,39 @@ func TestGarbageCollection(t *testing.T) {
 			return nil
 		})
 		assert.NoError(t, err)
-		//d1.vv = [c1:2]
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 2))
+		//d1.vv = [c1:1]
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
 		assert.Equal(t, 0, d1.GarbageLen())
 		assert.Equal(t, 0, d2.GarbageLen())
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv = [c1:3], minvv = [c1:0, c2:0], db.vv {c1: [c1:2], c2: [c2:1]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 3))
+		// d1.vv = [c1:1], minvv = [c1:1], db.vv {c1: [c1:1]}
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv = [c1:2, c2:3], minvv = [c1:1, c2:0], db.vv {c1: [c1:2], c2: [c1:1, c2:2]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 3))
+		// d2.vv = [c1:1, c2:2], minvv = [c1:1], db.vv {c1: [c1:1]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 2))
 
 		err = d2.Update(func(root *json.Object, p *presence.Presence) error {
 			root.GetTree("t").EditByPath([]int{0, 0, 0}, []int{0, 0, 2}, &json.TreeNode{Type: "text", Value: "gh"}, 0)
 			return nil
 		})
-		// d2.vv = [c1:2, c2:4]
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 4))
+		// d2.vv = [c1:1, c2:3]
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 3))
 		assert.NoError(t, err)
 		assert.Equal(t, 0, d1.GarbageLen())
 		assert.Equal(t, 2, d2.GarbageLen())
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv = [c1:2, c2:4], minvv = [c1:2, c2:0], db.vv {c1: [c1:2], c2: [c1:2, c2:4]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 4))
+		// d2.vv = [c1:1, c2:3], minvv = [c1:1, c2:0], db.vv {c1: [c1:1], c2: [c1:1, c2:3]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 3))
 		assert.NoError(t, err)
 		assert.Equal(t, 0, d1.GarbageLen())
 		assert.Equal(t, 2, d2.GarbageLen())
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv = [c1:5, c2:4], minvv = [c1:2, c2:1], db.vv {c1: [c1:3, c2:1], c2: [c1:2, c2:4]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 5), versionOf(d2.ActorID(), 4))
+		// d1.vv = [c1:4, c2:3], minvv = [c1:1], db.vv {c1: [c1:1], c2: [c1:1, c2:3]}
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 3))
 		assert.NoError(t, err)
 		assert.Equal(t, 2, d1.GarbageLen())
 		assert.Equal(t, 2, d2.GarbageLen())
@@ -362,38 +362,37 @@ func TestGarbageCollection(t *testing.T) {
 			root.GetTree("t").EditByPath([]int{0, 0, 0}, []int{0, 0, 0}, &json.TreeNode{Type: "text", Value: "g"}, 0)
 			return nil
 		})
-		//d1.vv = [c1:6, c2:4]
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 6), versionOf(d2.ActorID(), 4))
+		//d1.vv = [c1:5, c2:3]
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 5), versionOf(d2.ActorID(), 3))
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv = [c1:6, c2:4], minvv = [c1:2, c2:4], db.vv {c1: [c1:6, c2:4], c2: [c1:2, c2:4]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 6), versionOf(d2.ActorID(), 4))
+		// d1.vv = [c1:5, c2:3], minvv = [c1:2, c2:3], db.vv {c1: [c1:6, c2:3], c2: [c1:2, c2:4]}
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 5), versionOf(d2.ActorID(), 3))
 		assert.NoError(t, err)
 		// node removedAt = 4@c2, minVV[c2] = 4 meet GC condition
 		assert.Equal(t, 0, d1.GarbageLen())
 		assert.Equal(t, 2, d2.GarbageLen())
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv = [c1:6, c2:7], minvv = [c1:2, c2:4], db.vv {c1: [c1:6, c2:4], c2: [c1:2, c2:4]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 6), versionOf(d2.ActorID(), 7))
+		// d2.vv = [c1:5, c2:6], minvv = [c1:2, c2:3], db.vv {c1: [c1:6, c2:3], c2: [c1:2, c2:4]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 5), versionOf(d2.ActorID(), 6))
 		assert.NoError(t, err)
 		assert.Equal(t, 0, d1.GarbageLen())
-		// node removedAt = 4@c2, minVV[c2] = 4 meet GC condition
+		// node removedAt = 3@c2, minVV[c2] = 3 meet GC condition
 		assert.Equal(t, 0, d2.GarbageLen())
 	})
 
 	t.Run("garbage collection with detached document test", func(t *testing.T) {
-
 		ctx := context.Background()
 		d1 := document.New(helper.TestDocKey(t))
 		assert.NoError(t, c1.Attach(ctx, d1))
-		// d1.vv = [c1:1], minvv = [c1:1], db.vv {c1: [c1:1]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
+		// d1.vv = [], minvv = [], db.vv {}
+		assertVectorEquality(t, d1.VersionVector())
 
 		d2 := document.New(helper.TestDocKey(t))
 		assert.NoError(t, c2.Attach(ctx, d2))
-		// d2.vv = [c2:2], minvv = [c1:0, c2:0], db.vv {c1: [c1:1], c2: [c2:1]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d2.ActorID(), 2))
+		// d2.vv = [], minvv = [], db.vv {}
+		assertVectorEquality(t, d2.VersionVector())
 
 		err := d1.Update(func(root *json.Object, p *presence.Presence) error {
 			root.SetInteger("1", 1)
@@ -403,19 +402,19 @@ func TestGarbageCollection(t *testing.T) {
 			root.SetNewText("5").Edit(0, 0, "Hi", nil)
 			return nil
 		}, "sets 1,2,3,4,5")
-		// d1.vv = [c1:2]
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 2))
+		// d1.vv = [c1:1]
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
 		assert.NoError(t, err)
 		assert.Equal(t, 0, d1.GarbageLen())
 		assert.Equal(t, 0, d2.GarbageLen())
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv = [c1:3], minvv = [c1:0, c2:0], db.vv {c1: [c1:2], c2: [c2:1]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 3))
+		// d1.vv = [c1:1], minvv = [], db.vv {c1: [c1:1]}
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv = [c1:2, c2:3], minvv = [c1:0, c2:0], db.vv {c1: [c1:2], c2: [c2:2]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 3))
+		// d2.vv = [c1:1, c2:2], minvv = [c1:0], db.vv {c1: [c1:1]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 2))
 
 		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
 			root.Delete("2")
@@ -423,28 +422,27 @@ func TestGarbageCollection(t *testing.T) {
 			root.GetText("5").Edit(0, 1, "h", map[string]string{"b": "1"})
 			return nil
 		}, "removes 2 and edit text type elements")
-		//d1.vv = [c1:4]
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 4))
+		//d1.vv = [c1:2]
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 2))
 		assert.NoError(t, err)
 		assert.Equal(t, 6, d1.GarbageLen())
 		assert.Equal(t, 0, d2.GarbageLen())
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv = [c1:4], minvv = [c1:0, c2:0], db.vv {c1: [c1:4], c2: [c2:2]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 4))
+		// d1.vv = [c1:2], minvv = [c1:0, c2:0], db.vv {c1: [c1:1], c2: [c2:2]}
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 2))
 		assert.Equal(t, 6, d1.GarbageLen())
 		assert.Equal(t, 0, d2.GarbageLen())
 
 		assert.NoError(t, c2.Detach(ctx, d2)) // vv = [c1:2, c2:4]
-		// d2.vv = [c1:4, c2:5], minvv = [c1:2, c2:0], db.vv {c1: [c1:4]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 5))
+		// d2.vv = [c1:2, c2:3], minvv = [c1:2, c2:0], db.vv {c1: [c1:1]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 3))
 
 		assert.NoError(t, c1.Sync(ctx))
 		// remove c2 lamport from d1.vv after GC
-		// d1.vv = [c1:5, c2:4], minvv = [c1:4], db.vv {c1: [c1:4]}
-		// TODO(JOOHOJANG): We have to consider removing detached client's lamport
-		// from version vector.
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 5))
+		// d1.vv = [c1:2, c2:1], minvv = [c1:2], db.vv {c1: [c1:2]}
+		// TODO(JOOHOJANG): We have to consider removing detached client's lamport from version vector.
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 2))
 		assert.Equal(t, 0, d1.GarbageLen())
 		assert.Equal(t, 6, d2.GarbageLen())
 	})
@@ -456,8 +454,8 @@ func TestGarbageCollection(t *testing.T) {
 		d2 := document.New(docKey)
 
 		assert.NoError(t, c1.Attach(ctx, d1))
-		// d1.vv = [c1:1], minvv = [c1:1], db.vv {c1: [c1:1]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
+		// d1.vv = [], minvv = [], db.vv {}
+		assertVectorEquality(t, d1.VersionVector())
 
 		err := d1.Update(func(root *json.Object, p *presence.Presence) error {
 			root.SetNewObject("point").
@@ -466,23 +464,23 @@ func TestGarbageCollection(t *testing.T) {
 			return nil
 		})
 		assert.NoError(t, err)
-		// d1.vv = [c1:2]
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 2))
+		// d1.vv = [c:1]
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv = [c1:2], minvv = [c1:2], db.vv {c1: [c1:2]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 2))
+		// d1.vv = [c1:1], minvv = [c1:1], db.vv {c1: [c1:1]}
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
 
 		assert.NoError(t, c2.Attach(ctx, d2))
-		// d1.vv = [c1:2, c2:3], minvv = [c1:0, c2:0],  db.vv {c1: [c1:2], [c2:1]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 3))
+		// d2.vv = [c1:1, c2:2], minvv = [c1:1],  db.vv {c1: [c1:1]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 2))
 
 		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
 			root.Delete("point")
 			return nil
 		})
-		// d1.vv = [c1:3]
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 3))
+		// d1.vv = [c1:2]
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 2))
 		assert.NoError(t, err)
 		assert.Equal(t, 3, d1.GarbageLen())
 
@@ -490,29 +488,29 @@ func TestGarbageCollection(t *testing.T) {
 			root.GetObject("point").Delete("point.x")
 			return nil
 		})
-		// d2.vv = [c1:2, c2:4]
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 4))
+		// d2.vv = [c1:1, c2:3]
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 3))
 		assert.NoError(t, err)
 		assert.Equal(t, 1, d2.GarbageLen())
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv = [c1:4], minvv = [c1:0, c2:0], db.vv {c1: [c1:3], c2: [c2:1]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 4))
+		// d1.vv = [c1:2], minvv = [c1:2], db.vv {c1: [c1:2]}
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 2))
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv = [c1:3, c2:5], minvv = [c1:2, c2:0], db.vv {c1: [c1:3], c2: [c1:2, c2:4]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 3), versionOf(d2.ActorID(), 5))
+		// d2.vv = [c1:2, c2:4], minvv = [c1:1, c2:0], db.vv {c1: [c1:3], c2: [c1:1, c2:3]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 4))
 
 		assert.Equal(t, 3, d1.GarbageLen())
 		assert.Equal(t, 3, d2.GarbageLen())
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv = [c1:5, c2:4], minvv = [c1:2, c2:1], db.vv {c1: [c1:4, c2:1], c2: [c1:2, c2:4]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 5), versionOf(d2.ActorID(), 4))
+		// d1.vv = [c1:4, c2:3], minvv = [c1:2, c2:0], db.vv {c1: [c1:2], c2: [c1:2, c2:4]}
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 3))
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv = [c1:3, c2:5], minvv = [c1:3, c2:0], db.vv {c1: [c1:3], c2: [c1:3, c2:5]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 3), versionOf(d2.ActorID(), 5))
-		// node removedAt = 3@c1, minVV[c1] = 3 meet GC condition
+		// d2.vv = [c1:2, c2:4], minvv = [c1:2, c2:0], db.vv {c1: [c1:3], c2: [c1:2, c2:3]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 4))
+		// node removedAt = 2@c1, minVV[c1] = 2 meet GC condition
 		assert.Equal(t, 3, d1.GarbageLen())
 		assert.Equal(t, 0, d2.GarbageLen())
 		assert.Equal(t, 3, d1.GarbageCollect(helper.MaxVersionVector(d1.ActorID(), d2.ActorID())))
@@ -524,14 +522,14 @@ func TestGarbageCollection(t *testing.T) {
 		d1 := document.New(helper.TestDocKey(t))
 
 		assert.NoError(t, c1.Attach(ctx, d1))
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
+		assertVectorEquality(t, d1.VersionVector())
 
 		err := d1.Update(func(root *json.Object, p *presence.Presence) error {
 			root.SetNewObject("obj", yson.ParseObject(`{"array":["a","b","c"]}`))
 			root.Delete("obj")
 			return nil
 		})
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 2))
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
 		assert.NoError(t, err)
 
 		assert.Equal(t, 5, d1.GarbageLen())
@@ -543,20 +541,20 @@ func TestGarbageCollection(t *testing.T) {
 		d1 := document.New(helper.TestDocKey(t))
 
 		assert.NoError(t, c1.Attach(ctx, d1))
-		// d1.vv = [c1:1], minvv = [c1:1], db.vv {c1: [c1:1]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
+		// d1.vv = [], minvv = [], db.vv {}
+		assertVectorEquality(t, d1.VersionVector())
 
 		d2 := document.New(helper.TestDocKey(t))
 		assert.NoError(t, c2.Attach(ctx, d2))
-		// d1.vv = [c2:2], minvv = [c1:0, c2:0], db.vv {c1: [c1:1], c2:[c2:1]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d2.ActorID(), 2))
+		// d1.vv = [], minvv = [], db.vv {}
+		assertVectorEquality(t, d2.VersionVector())
 
 		err := d1.Update(func(root *json.Object, p *presence.Presence) error {
 			root.SetNewText("text").Edit(0, 0, "z")
 			return nil
 		})
-		// d1.vv = [c1:2]
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 2))
+		// d1.vv = [c1:1]
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
 		assert.NoError(t, err)
 
 		// "z" revmoedAt 3@c1
@@ -564,34 +562,34 @@ func TestGarbageCollection(t *testing.T) {
 			root.GetText("text").Edit(0, 1, "a")
 			return nil
 		})
-		// d1.vv = [c1:3]
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 3))
+		// d1.vv = [c1:2]
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 2))
 		assert.NoError(t, err)
 
 		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
 			root.GetText("text").Edit(1, 1, "b")
 			return nil
 		})
-		// d1.vv = [c1:4]
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 4))
+		// d1.vv = [c1:3]
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 3))
 		assert.NoError(t, err)
 
 		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
 			root.GetText("text").Edit(2, 2, "d")
 			return nil
 		})
-		// d1.vv = [c1:5]
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 5))
+		// d1.vv = [c1:4]
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 4))
 		assert.NoError(t, err)
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv = [c1:6], minvv = [c1:0, c2:0], db.vv {c1: [c1:5], c2:[c2:1]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 6))
+		// d1.vv = [c1:4], minvv = [c1:4], db.vv {c1: [c1:4]}
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 4))
 
 		assert.NoError(t, c2.Sync(ctx))
 		err = c2.Sync(ctx)
-		// d2.vv = [c1:5, c2:6], minvv = [c1:1, c2:0], db.vv {c1: [c1:5], c2:[c1:1, c2:2]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 5), versionOf(d2.ActorID(), 6))
+		// d2.vv = [c1:4, c2:5], minvv = [c1:4], db.vv {c1: [c1:4]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 5))
 		assert.NoError(t, err)
 		assert.Equal(t, `{"text":[{"val":"a"},{"val":"b"},{"val":"d"}]}`, d1.Marshal())
 		assert.Equal(t, `{"text":[{"val":"a"},{"val":"b"},{"val":"d"}]}`, d2.Marshal())
@@ -601,17 +599,17 @@ func TestGarbageCollection(t *testing.T) {
 			root.GetText("text").Edit(2, 2, "c")
 			return nil
 		})
-		// d1.vv = [c1:7]
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 7))
+		// d1.vv = [c1:5]
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 5))
 		assert.NoError(t, err)
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv = [c1:7], minvv = [c1:1, c2:0], db.vv {c1: [c1:7], c2:[c1:1, c2:2]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 7))
+		// d1.vv = [c1:5], minvv = [c1:4], db.vv {c1: [c1:4]}
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 5))
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv = [c1:7, c2:8], minvv = [c1:6, c2:0], db.vv {c1: [c1:7], c2:[c1:6, c2:7]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 7), versionOf(d2.ActorID(), 8))
+		// d2.vv = [c1:5, c2:6], minvv = [c1:4], db.vv {c1: [c1:4]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 5), versionOf(d2.ActorID(), 6))
 		assert.Equal(t, `{"text":[{"val":"a"},{"val":"b"},{"val":"c"},{"val":"d"}]}`, d1.Marshal())
 		assert.Equal(t, `{"text":[{"val":"a"},{"val":"b"},{"val":"c"},{"val":"d"}]}`, d2.Marshal())
 
@@ -619,13 +617,13 @@ func TestGarbageCollection(t *testing.T) {
 			root.GetText("text").Edit(1, 3, "")
 			return nil
 		})
-		//d1.vv = [c1:8]
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 8))
+		//d1.vv = [c1:6]
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 6))
 		assert.NoError(t, err)
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv = [c1:8], minvv = [c1:6, c2:0], db.vv {c1: [c1:8], c2:[c1:6, c2:7]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 8))
+		// d1.vv = [c1:6], minvv = [c1:6], db.vv {c1: [c1:6]}
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 6))
 		// "z"'s removedAt = 6@c1, minvv[c1] =6 meet GC Condition
 		assert.Equal(t, `{"text":[{"val":"a"},{"val":"d"}]}`, d1.Marshal())
 		assert.Equal(t, 2, d1.GarbageLen()) // a,b,c
@@ -634,29 +632,29 @@ func TestGarbageCollection(t *testing.T) {
 			root.GetText("text").Edit(0, 0, "a")
 			return nil
 		})
-		// d2.vv = [c1:7, c2:9]
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 7), versionOf(d2.ActorID(), 9))
+		// d2.vv = [c1:5, c2:7]
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 5), versionOf(d2.ActorID(), 7))
 		assert.NoError(t, err)
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv = [c1:8, c2:10], minvv = [c1:7, c2:1], db.vv {c1: [c1:8, c2:1], c2:[c1:7, c2:9]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 8), versionOf(d2.ActorID(), 10))
+		// d2.vv = [c1:6, c2:8], minvv = [c1:7, c2:1], db.vv {c1: [c1:8, c2:1], c2:[c1:7, c2:9]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 6), versionOf(d2.ActorID(), 8))
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv = [c1:10, c2:9], minvv = [c1:7, c2:1], db.vv {c1: [c1:8, c2:1], c2:[c1:7, c2:9]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 10), versionOf(d2.ActorID(), 9))
+		// d1.vv = [c1:8, c2:7], minvv = [c1:7, c2:1], db.vv {c1: [c1:8, c2:1], c2:[c1:7, c2:9]}
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 8), versionOf(d2.ActorID(), 7))
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv = [c1:8, c2:10], minvv = [c1:7, c2:1], db.vv {c1: [c1:8, c2:1], c2:[c1:8, c2:10]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 8), versionOf(d2.ActorID(), 10))
+		// d2.vv = [c1:6, c2:8], minvv = [c1:7, c2:1], db.vv {c1: [c1:8, c2:1], c2:[c1:8, c2:10]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 6), versionOf(d2.ActorID(), 8))
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d2.vv = [c1:10, c2:9], minvv = [c1:8, c2:9], db.vv {c1: [c1:10, c2:9], c2:[c1:8, c2:10]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 10), versionOf(d2.ActorID(), 9))
+		// d2.vv = [c1:8, c2:7], minvv = [c1:8, c2:9], db.vv {c1: [c1:10, c2:9], c2:[c1:8, c2:10]}
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 8), versionOf(d2.ActorID(), 7))
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv = [c1:8, c2:10], minvv = [c1:8, c2:9], db.vv {c1: [c1:10, c2:9], c2:[c1:8, c2:10]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 8), versionOf(d2.ActorID(), 10))
+		// d2.vv = [c1:6, c2:8], minvv = [c1:8, c2:9], db.vv {c1: [c1:10, c2:9], c2:[c1:8, c2:10]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 6), versionOf(d2.ActorID(), 8))
 		assert.Equal(t, `{"text":[{"val":"a"},{"val":"a"},{"val":"d"}]}`, d1.Marshal())
 		assert.Equal(t, `{"text":[{"val":"a"},{"val":"a"},{"val":"d"}]}`, d2.Marshal())
 		assert.Equal(t, 0, d1.GarbageLen())
@@ -668,13 +666,13 @@ func TestGarbageCollection(t *testing.T) {
 		d1 := document.New(helper.TestDocKey(t))
 
 		assert.NoError(t, c1.Attach(ctx, d1))
-		// d1.vv = [c1:1], minvv = [c1:1], db.vv {c1: [c1:1]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
+		// d1.vv = [], minvv = [], db.vv {}
+		assertVectorEquality(t, d1.VersionVector())
 
 		d2 := document.New(helper.TestDocKey(t))
 		assert.NoError(t, c2.Attach(ctx, d2))
-		// d1.vv = [c2:2], minvv = [c1:0, c2:0], db.vv {c1: [c1:1], c2:[c2:1]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d2.ActorID(), 2))
+		// d1.vv = [], minvv = [], db.vv {}
+		assertVectorEquality(t, d2.VersionVector())
 
 		err := d1.Update(func(root *json.Object, p *presence.Presence) error {
 			root.SetNewTree("tree", json.TreeNode{
@@ -685,12 +683,20 @@ func TestGarbageCollection(t *testing.T) {
 			})
 			return nil
 		})
+		// d1.vv =[c1:1]
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
+		assert.NoError(t, err)
+
+		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetTree("tree").EditByPath([]int{0}, []int{1}, &json.TreeNode{Type: "text", Value: "a"}, 0)
+			return nil
+		})
 		// d1.vv =[c1:2]
 		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 2))
 		assert.NoError(t, err)
 
 		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
-			root.GetTree("tree").EditByPath([]int{0}, []int{1}, &json.TreeNode{Type: "text", Value: "a"}, 0)
+			root.GetTree("tree").EditByPath([]int{1}, []int{1}, &json.TreeNode{Type: "text", Value: "b"}, 0)
 			return nil
 		})
 		// d1.vv =[c1:3]
@@ -698,28 +704,20 @@ func TestGarbageCollection(t *testing.T) {
 		assert.NoError(t, err)
 
 		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
-			root.GetTree("tree").EditByPath([]int{1}, []int{1}, &json.TreeNode{Type: "text", Value: "b"}, 0)
+			root.GetTree("tree").EditByPath([]int{2}, []int{2}, &json.TreeNode{Type: "text", Value: "d"}, 0)
 			return nil
 		})
 		// d1.vv =[c1:4]
 		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 4))
 		assert.NoError(t, err)
 
-		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
-			root.GetTree("tree").EditByPath([]int{2}, []int{2}, &json.TreeNode{Type: "text", Value: "d"}, 0)
-			return nil
-		})
-		// d1.vv =[c1:5]
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 5))
-		assert.NoError(t, err)
-
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv = [c1:6], minvv = [c1:0, c2:0], db.vv {c1: [c1:5], c2: [c2:1]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 6))
+		// d1.vv = [c1:4], minvv = [c1:4], db.vv {c1: [c1:4]}
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 4))
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv = [c1:5, c2:6], minvv = [c1:1, c2:0], db.vv {c1: [c1:5], c2: [c1:1, c2:2]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 5), versionOf(d2.ActorID(), 6))
+		// d2.vv = [c1:4, c2:5], minvv = [c1:4], db.vv {c1: [c1:4]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 5))
 
 		assert.Equal(t, `<r>abd</r>`, d1.Root().GetTree("tree").ToXML())
 		assert.Equal(t, `<r>abd</r>`, d2.Root().GetTree("tree").ToXML())
@@ -729,23 +727,23 @@ func TestGarbageCollection(t *testing.T) {
 			root.GetTree("tree").EditByPath([]int{2}, []int{2}, &json.TreeNode{Type: "text", Value: "c"}, 0)
 			return nil
 		})
-		//d1.vv =[c1:7]
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 7))
+		//d1.vv =[c1:5]
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 5))
 		assert.NoError(t, err)
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv =[c1:7], minvv = [c1:1, c2:0], db.vv {c1: [c1:7], c2: [c1:1, c2:2]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 7))
+		// d1.vv =[c1:5], minvv = [c1:5], db.vv {c1: [c1:5]}
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 5))
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv =[c1:7, c2:8], minvv =[c1:5, c2:0], db.vv {c1: [c1:7], c2: [c1:5, c2:6]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 7), versionOf(d2.ActorID(), 8))
+		// d2.vv =[c1:5, c2:6], minvv =[c1:5], db.vv {c1: [c1:5]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 5), versionOf(d2.ActorID(), 6))
 		// "z" removedAt = 3@c1, minvv[c1] =5 meet GC condition
 		assert.Equal(t, 0, d2.GarbageLen())
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv =[c1:7, c2:8], minvv =[c1:7, c2:0], db.vv {c1: [c1:7], c2: [c1:7, c2:8]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 7), versionOf(d2.ActorID(), 8))
+		// d2.vv =[c1:5, c2:6], minvv =[c1:5, c2:0], db.vv {c1: [c1:5], c2: [c1:5, c2:6]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 5), versionOf(d2.ActorID(), 6))
 
 		assert.Equal(t, `<r>abcd</r>`, d1.Root().GetTree("tree").ToXML())
 		assert.Equal(t, `<r>abcd</r>`, d2.Root().GetTree("tree").ToXML())
@@ -754,39 +752,39 @@ func TestGarbageCollection(t *testing.T) {
 			root.GetTree("tree").EditByPath([]int{1}, []int{3}, nil, 0)
 			return nil
 		})
-		// d1.vv = [c1:8]
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 8))
+		// d1.vv = [c1:6]
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 6))
 		assert.NoError(t, err)
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv = [c1:8], minvv = [c1:7, c2:0], db.vv {c1: [c1:8], c2: [c1:7, c2:8]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 8))
+		// d1.vv = [c1:6], minvv = [c1:6, c2:0], db.vv {c1: [c1:6]}
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 6))
 		assert.Equal(t, `<r>ad</r>`, d1.Root().GetTree("tree").ToXML())
 		assert.Equal(t, 2, d1.GarbageLen()) // b,c
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv =[c1:8, c2:9], minvv =[c1:7, c2:0], db.vv {c1: [c1:8], c2: [c1:7, c2:8]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 8), versionOf(d2.ActorID(), 9))
+		// d2.vv =[c1:6, c2:7], minvv =[c1:6, c2:0], db.vv {c1: [c1:6]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 6), versionOf(d2.ActorID(), 7))
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv =[c1:8], minvv =[c1:7, c2:0], db.vv {c1: [c1:8], c2: [c1:7, c2:8]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 8))
+		// d1.vv =[c1:6], minvv =[c1:6, c2:0], db.vv {c1: [c1:6]}
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 6))
 		assert.Equal(t, `<r>ad</r>`, d2.Root().GetTree("tree").ToXML())
 		assert.Equal(t, 2, d1.GarbageLen())
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv =[c1:8, c2:9], minvv =[c1:8, c2:0], db.vv {c1: [c1:8], c2: [c1:8, c2:9]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 8), versionOf(d2.ActorID(), 9))
+		// d2.vv =[c1:6, c2:7], minvv =[c1:6, c2:0], db.vv {c1: [c1:6]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 6), versionOf(d2.ActorID(), 7))
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv =[c1:8], minvv =[c1:8, c2:0], db.vv {c1: [c1:8], c2: [c1:8, c2:9]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 8))
-		// "b", "c" removedAt = 8@c1, minvv[c1] = 8 meet GC condition
+		// d1.vv =[c1:6], minvv =[c1:6, c2:0], db.vv {c1: [c1:6]}
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 6))
+		// "b", "c" removedAt = 6@c1, minvv[c1] = 6 meet GC condition
 		assert.Equal(t, 0, d1.GarbageLen())
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv =[c1:8, c2:9], minvv =[c1:8, c2:0], db.vv {c1: [c1:8], c2: [c1:8, c2:9]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 8), versionOf(d2.ActorID(), 9))
+		// d2.vv =[c1:6, c2:7], minvv =[c1:6, c2:0], db.vv {c1: [c1:6]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 6), versionOf(d2.ActorID(), 7))
 		assert.NoError(t, err)
 		assert.Equal(t, 0, d1.GarbageLen())
 	})
@@ -824,13 +822,13 @@ func TestGarbageCollection(t *testing.T) {
 			root.SetNewText("text").Edit(0, 0, "-")
 			return nil
 		}))
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 2))
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
 		for i := 0; i < int(conf.Backend.SnapshotInterval); i++ {
 			assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
 				root.GetText("text").Edit(0, 1, strconv.Itoa(i))
 				return nil
 			}))
-			assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), int64(2+i+1)))
+			assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), int64(2+i)))
 		}
 		assert.Equal(t, int(conf.Backend.SnapshotInterval), d1.GarbageLen())
 		assert.NoError(t, c1.Sync(ctx))
@@ -856,55 +854,55 @@ func TestGarbageCollection(t *testing.T) {
 		ctx := context.Background()
 		d1 := document.New(helper.TestDocKey(t))
 		assert.NoError(t, c1.Attach(ctx, d1))
-		// d1.vv =[c1:1], minvv =[c1:1], db.vv {c1: [c1:1]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
+		// d1.vv =[], minvv =[], db.vv {}
+		assertVectorEquality(t, d1.VersionVector())
 
 		d2 := document.New(helper.TestDocKey(t))
 		assert.NoError(t, c2.Attach(ctx, d2))
-		// d2.vv =[c2:2], minvv =[c1:0, c2:0], db.vv {c1: [c1:1], c2: [c2:1]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d2.ActorID(), 2))
+		// d2.vv =[], minvv =[], db.vv {}
+		assertVectorEquality(t, d2.VersionVector())
 
 		err := d1.Update(func(root *json.Object, p *presence.Presence) error {
 			root.SetNewText("text").Edit(0, 0, "a").Edit(1, 1, "b").Edit(2, 2, "c")
 			return nil
 		}, "sets text")
-		//d1.vv = [c1:2]
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 2))
+		//d1.vv = [c1:1]
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
 		assert.NoError(t, err)
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv =[c1:3], minvv =[c1:0, c2:0], db.vv {c1: [c1:2], c2: [c2:1]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 3))
+		// d1.vv =[c1:1], minvv =[c1:1], db.vv {}
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv =[c1:2, c2:3], minvv =[c1:0, c2:0], db.vv {c1: [c1:2], c2: [c1:1, c2:2]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 3))
+		// d2.vv =[c1:1, c2:2], minvv =[c1:1], db.vv {c1: [c1:1]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 2))
 
 		err = d2.Update(func(root *json.Object, p *presence.Presence) error {
 			root.GetText("text").Edit(2, 2, "c")
 			return nil
 		}, "insert c")
-		//d2.vv =[c1:2, c2:4]
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 4))
+		//d2.vv =[c1:1, c2:3]
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 3))
 		assert.NoError(t, err)
 
 		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
 			root.GetText("text").Edit(1, 3, "")
 			return nil
 		}, "delete bd")
-		//d1.vv = [c1:4]
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 4))
+		//d1.vv = [c1:2]
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 2))
 		assert.NoError(t, err)
 		assert.Equal(t, 2, d1.GarbageLen())
 		assert.Equal(t, 0, d2.GarbageLen())
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv = [c1:5], minvv = [c1:1, c2:0], db.vv {c1: [c1:4], c2: [c1:1, c2:2]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 4))
+		// d1.vv = [c1:2], minvv = [c1:1], db.vv {c1: [c1:1]}
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 2))
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv =[c1:4, c2:5], minvv = [c1:2, c2:0], db.vv {c1: [c1:4], c2: [c1:2, c2:4]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 5))
+		// d2.vv =[c1:2, c2:4], minvv = [c1:1], db.vv {c1: [c1:1]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 4))
 		assert.Equal(t, 2, d1.GarbageLen())
 		assert.Equal(t, 2, d2.GarbageLen())
 
@@ -912,20 +910,20 @@ func TestGarbageCollection(t *testing.T) {
 			root.GetText("text").Edit(2, 2, "1")
 			return nil
 		}, "insert 1")
-		//d2.vv =[c1:4, c2:6]
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 6))
+		//d2.vv =[c1:2, c2:5]
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 5))
 		assert.NoError(t, err)
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv =[c1:4, c2:6], minvv = [c1:4, c2:0], db.vv {c1: [c1:4], c2: [c1:4, c2:6]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 6))
-		// "b", "c" removedAt = 4@c1, minvv[c1] = 4 meet GC condition
+		// d2.vv =[c1:2, c2:5], minvv = [c1:2], db.vv {c1: [c1:2], c2: [c1:2, c2:5]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 5))
+		// "b", "c" removedAt = 2@c1, minvv[c1] = 2 meet GC condition
 		assert.Equal(t, 2, d1.GarbageLen())
 		assert.Equal(t, 0, d2.GarbageLen())
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv = [c1:7, c2:6], minvv = [c1:4, c2:0], db.vv {c1: [c1:5], c2: [c1:4, c2:6]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 7), versionOf(d2.ActorID(), 6))
+		// d1.vv = [c1:6, c2:5], minvv = [c1:2, c2:0], db.vv {c1: [c1:2], c2: [c1:2, c2:5]}
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 6), versionOf(d2.ActorID(), 5))
 		// "b", "c" removedAt = 4@c1, minvv[c1] = 4 meet GC condition
 		assert.Equal(t, 0, d1.GarbageLen())
 		assert.Equal(t, 0, d2.GarbageLen())
@@ -936,87 +934,87 @@ func TestGarbageCollection(t *testing.T) {
 		d1 := document.New(helper.TestDocKey(t))
 
 		assert.NoError(t, c1.Attach(ctx, d1))
-		// d2.vv =[c1:1], minvv =[c1:1], db.vv {c1: [c1:1]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
+		// d2.vv =[], minvv =[], db.vv {}
+		assertVectorEquality(t, d1.VersionVector())
 
 		d2 := document.New(helper.TestDocKey(t))
 
 		assert.NoError(t, c2.Attach(ctx, d2))
-		// d2.vv =[c2:2], minvv =[c1:0, c2:0], db.vv {c1: [c1:1], c2: [c2:1]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d2.ActorID(), 2))
+		// d2.vv =[], minvv =[], db.vv {}
+		assertVectorEquality(t, d2.VersionVector())
 
 		err := d1.Update(func(root *json.Object, p *presence.Presence) error {
 			root.SetNewText("text").Edit(0, 0, "a").Edit(1, 1, "b")
 			return nil
 		}, "insert ab")
-		// d1/vv = [c1:2]
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 2))
+		// d1/vv = [c1:1]
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
 		assert.NoError(t, err)
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv = [c1:3], minvv = [c1:0, c2:0], db.vv {c1: [c1:2], c2: [c2:1]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 3))
+		// d1.vv = [c1:1], minvv = [c1:1], db.vv {c1: [c1:1]}
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv = [c1:2, c2:3], minvv = [c1:1, c2:0], db.vv {c1: [c1:2], c2: [c1:1, c2:2]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 3))
+		// d2.vv = [c1:1, c2:2], minvv = [c1:1], db.vv {c1: [c1:1]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 2))
 
 		err = d2.Update(func(root *json.Object, p *presence.Presence) error {
 			root.GetText("text").Edit(2, 2, "d")
 			return nil
 		}, "insert d")
-		//d2.vv = [c1:2, c2:4]
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 4))
+		//d2.vv = [c1:1, c2:3]
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 3))
 		assert.NoError(t, err)
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv = [c1:2, c2:4], minvv = [c1:2, c2:0], db.vv {c1: [c1:2], c2: [c1:2, c2:4]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 4))
+		// d2.vv = [c1:1, c2:3], minvv = [c1:1], db.vv {c1: [c1:1]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 3))
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv = [c1:5, c2:4], minvv = [c1:2, c2:1], db.vv {c1: [c1:3, c2:1], c2: [c1:2, c2:4]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 5), versionOf(d2.ActorID(), 4))
+		// d1.vv = [c1:4, c2:3], minvv = [c1:1], db.vv {c1: [c1:1}
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 3))
 
 		err = d2.Update(func(root *json.Object, p *presence.Presence) error {
 			root.GetText("text").Edit(2, 2, "c")
 			return nil
 		}, "insert c")
-		//d2.vv = [c1:2, c2:5]
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 5))
+		//d2.vv = [c1:1, c2:4]
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 4))
 		assert.NoError(t, err)
 
 		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
 			root.GetText("text").Edit(1, 3, "")
 			return nil
 		}, "remove ac")
-		//c1.vv = [c1:6, c2:4]
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 6), versionOf(d2.ActorID(), 4))
+		//c1.vv = [c1:5, c2:3]
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 5), versionOf(d2.ActorID(), 3))
 		assert.NoError(t, err)
 
 		// sync pushonly
 		assert.NoError(t, c2.Sync(ctx, client.WithDocKey(d2.Key()).WithPushOnly()))
-		// d2.vv = [c1:2, c2:5], minvv = [c1:2, c2:1], db.vv {c1: [c1:3, c2:1], c2: [c1:2, c2:5]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 5))
+		// d2.vv = [c1:1, c2:4], minvv = [c1:1], db.vv {}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 4))
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv = [c1:7, c2:5], minvv = [c1:2, c2:4], db.vv {c1: [c1:6, c2:4], c2: [c1:2, c2:5]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 7), versionOf(d2.ActorID(), 5))
+		// d1.vv = [c1:6, c2:4], minvv = [c1:1, c2:3], db.vv {c1: [c1:5, c2:3], c2: [c1:1, c2:4]}
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 6), versionOf(d2.ActorID(), 4))
 
 		err = d2.Update(func(root *json.Object, p *presence.Presence) error {
 			root.GetText("text").Edit(2, 2, "1")
 			return nil
 		}, "insert 1 (pushonly)")
-		//d2.vv = [c1:2, c2:6]
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 6))
+		//d2.vv = [c1:1, c2:5]
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 5))
 		assert.NoError(t, err)
 
 		assert.NoError(t, c2.Sync(ctx, client.WithDocKey(d2.Key()).WithPushOnly()))
-		// d2.vv = [c1:2, c2:6], minvv = [c1:2, c2:4], db.vv {c1: [c1:6, c2:4], c2: [c1:2, c2:6]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 6))
+		// d2.vv = [c1:1, c2:5], minvv = [c1:1, c2:4], db.vv {c1: [c1:6, c2:4], c2: [c1:1, c2:5]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 5))
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv = [c1:8, c2:6], minvv = [c1:2, c2:5], db.vv {c1: [c1:7, c2:5], c2: [c1:2, c2:6]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 8), versionOf(d2.ActorID(), 6))
+		// d1.vv = [c1:7, c2:5], minvv = [c1:1, c2:4], db.vv {c1: [c1:6, c2:4], c2: [c1:1, c2:5]}
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 7), versionOf(d2.ActorID(), 5))
 		assert.Equal(t, 2, d1.GarbageLen())
 		assert.Equal(t, 0, d2.GarbageLen())
 
@@ -1024,34 +1022,34 @@ func TestGarbageCollection(t *testing.T) {
 			root.GetText("text").Edit(2, 2, "2")
 			return nil
 		}, "insert 2 (pushonly)")
-		//c2.vv = [c1:2, c2:7]
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 7))
+		//c2.vv = [c1:1, c2:6]
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 6))
 		assert.NoError(t, err)
 
 		assert.NoError(t, c2.Sync(ctx, client.WithDocKey(d2.Key()).WithPushOnly()))
-		// d2.vv = [c1:2, c2:7], minvv = [c1:2, c2:5], db.vv {c1: [c1:7, c2:5], c2: [c1:2, c2:7]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 7))
+		// d2.vv = [c1:1, c2:6], minvv = [c1:1, c2:4], db.vv {c1: [c1:7, c2:5], c2: [c1:2, c2:7]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 6))
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv = [c1:6, c2:8], minvv = [c1:2, c2:5], db.vv {c1: [c1:7, c2:5], c2: [c1:2, c2:7]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 6), versionOf(d2.ActorID(), 8))
+		// d2.vv = [c1:5, c2:7], minvv = [c1:2, c2:5], db.vv {c1: [c1:7, c2:5], c2: [c1:2, c2:7]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 5), versionOf(d2.ActorID(), 7))
 
 		assert.NoError(t, c1.Sync(ctx))
 		// d1.vv = [c1:9, c2:7]], minvv = [c1:2, c2:6], db.vv {c1: [c1:8, c2:6], c2: [c1:2, c2:7]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 9), versionOf(d2.ActorID(), 7))
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 8), versionOf(d2.ActorID(), 6))
 		assert.Equal(t, d1.GarbageLen(), 2)
 		assert.Equal(t, d2.GarbageLen(), 2)
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv = [c1:6, c2:8], minvv = [c1:6, c2:6], db.vv {c1: [c1:8, c2:6], c2: [c1:6, c2:8]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 6), versionOf(d2.ActorID(), 8))
+		// d2.vv = [c1:5, c2:7], minvv = [c1:6, c2:6], db.vv {c1: [c1:8, c2:6], c2: [c1:6, c2:8]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 5), versionOf(d2.ActorID(), 7))
 		// removedAt = 6@c1, minvv[c1] = 6, meet GC condition
 		assert.Equal(t, 2, d1.GarbageLen())
 		assert.Equal(t, 0, d2.GarbageLen())
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d2.vv = [c1:9, c2:7], minvv = [c1:6, c2:7], db.vv {c1: [c1:9, c2:7], c2: [c1:6, c2:8]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 9), versionOf(d2.ActorID(), 7))
+		// d2.vv = [c1:8, c2:6], minvv = [c1:6, c2:7], db.vv {c1: [c1:9, c2:7], c2: [c1:6, c2:8]}
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 8), versionOf(d2.ActorID(), 6))
 		// removedAt = 6@c1, minvv[c1] = 6, meet GC condition
 		assert.Equal(t, 0, d1.GarbageLen())
 		assert.Equal(t, 0, d2.GarbageLen())
@@ -1137,44 +1135,44 @@ func TestGarbageCollection(t *testing.T) {
 		ctx := context.Background()
 		d1 := document.New(helper.TestDocKey(t))
 		assert.NoError(t, c1.Attach(ctx, d1))
-		// d2.vv =[c1:1], minvv =[c1:1], db.vv {c1: [c1:1]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
+		// d2.vv =[], minvv =[], db.vv {}
+		assertVectorEquality(t, d1.VersionVector())
 
 		d2 := document.New(helper.TestDocKey(t))
 		assert.NoError(t, c2.Attach(ctx, d2))
-		// d2.vv =[c2:2], minvv =[c1:0, c2:0], db.vv {c1: [c1:1], c2: [c2:1]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d2.ActorID(), 2))
+		// d2.vv =[], minvv =[], db.vv {}
+		assertVectorEquality(t, d2.VersionVector())
 
 		err := d1.Update(func(root *json.Object, p *presence.Presence) error {
 			root.SetNewText("text").Edit(0, 0, "a").Edit(1, 1, "b").Edit(2, 2, "c")
 			return nil
 		}, "sets text")
-		//d1.vv = [c1:2]
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 2))
+		//d1.vv = [c1:1]
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
 		assert.NoError(t, err)
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv =[c1:3], minvv =[c1:0, c2:0], db.vv {c1: [c1:2], c2: [c2:1]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 3))
+		// d1.vv =[c1:1], minvv =[c1:1]
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv =[c1:2, c2:3], minvv =[c1:0, c2:0], db.vv {c1: [c1:2], c2: [c1:1, c2:2]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 3))
+		// d2.vv =[c1:1, c2:2], minvv =[c1:1], db.vv {c1: [c1:1]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 2))
 
 		err = d2.Update(func(root *json.Object, p *presence.Presence) error {
 			root.GetText("text").Edit(2, 2, "c")
 			return nil
 		}, "insert c")
-		//d2.vv =[c1:2, c2:4]
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 4))
+		//d2.vv =[c1:1, c2:3]
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 3))
 		assert.NoError(t, err)
 
 		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
 			root.GetText("text").Edit(1, 3, "")
 			return nil
 		}, "delete bd")
-		//d1.vv = [c1:4]
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 4))
+		//d1.vv = [c1:2]
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 2))
 		assert.NoError(t, err)
 		assert.Equal(t, 2, d1.GarbageLen())
 		assert.Equal(t, 0, d2.GarbageLen())
@@ -1211,9 +1209,9 @@ func TestGarbageCollection(t *testing.T) {
 		assert.NoError(t, c1.Sync(ctx))
 		assert.NoError(t, c1.Sync(ctx))
 
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 3))
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d2.ActorID(), 3))
-		assertVectorEquality(t, d3.VersionVector(), versionOf(d3.ActorID(), 3))
+		assertVectorEquality(t, d1.VersionVector())
+		assertVectorEquality(t, d2.VersionVector())
+		assertVectorEquality(t, d3.VersionVector())
 
 		err := d1.Update(func(root *json.Object, p *presence.Presence) error {
 			root.SetNewText("text").Edit(0, 0, "a").Edit(1, 1, "b").Edit(2, 2, "c")
@@ -1227,9 +1225,9 @@ func TestGarbageCollection(t *testing.T) {
 		assert.NoError(t, c3.Sync(ctx))
 		assert.NoError(t, c3.Sync(ctx))
 
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 4))
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 5))
-		assertVectorEquality(t, d3.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d3.ActorID(), 5))
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 2))
+		assertVectorEquality(t, d3.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d3.ActorID(), 2))
 
 		err = d3.Update(func(root *json.Object, p *presence.Presence) error {
 			root.GetText("text").Edit(1, 3, "") // delete bc
@@ -1268,9 +1266,9 @@ func TestGarbageCollection(t *testing.T) {
 
 		assert.Equal(t, `{"text":[{"val":"3"},{"val":"2"},{"val":"1"},{"val":"a"},{"val":"b"},{"val":"c"},{"val":"x"},{"val":"y"}]}`, d1.Marshal())
 		assert.Equal(t, `{"text":[{"val":"3"},{"val":"2"},{"val":"1"},{"val":"a"},{"val":"b"},{"val":"c"},{"val":"x"},{"val":"y"}]}`, d2.Marshal())
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 9), versionOf(d2.ActorID(), 7))
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 7), versionOf(d2.ActorID(), 10))
-		assertVectorEquality(t, d3.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d3.ActorID(), 6))
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 6), versionOf(d2.ActorID(), 4))
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 7))
+		assertVectorEquality(t, d3.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d3.ActorID(), 3))
 
 		assert.NoError(t, c3.Detach(ctx, d3))
 		err = d2.Update(func(root *json.Object, p *presence.Presence) error {
@@ -1288,8 +1286,8 @@ func TestGarbageCollection(t *testing.T) {
 		assert.NoError(t, c1.Sync(ctx))
 		// TODO(JOOHOJANG): We have to consider removing detached client's lamport
 		// from version vector.
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 12), versionOf(d2.ActorID(), 11), versionOf(d3.ActorID(), 6))
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 7), versionOf(d2.ActorID(), 13), versionOf(d3.ActorID(), 6))
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 9), versionOf(d2.ActorID(), 8), versionOf(d3.ActorID(), 3))
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 9), versionOf(d3.ActorID(), 3))
 		assert.Equal(t, `{"text":[{"val":"3"},{"val":"2"},{"val":"1"},{"val":"a"},{"val":"z"},{"val":"x"},{"val":"y"}]}`, d1.Marshal())
 		assert.Equal(t, `{"text":[{"val":"3"},{"val":"2"},{"val":"1"},{"val":"a"},{"val":"z"},{"val":"x"},{"val":"y"}]}`, d2.Marshal())
 		assert.Equal(t, 2, d1.GarbageLen())
@@ -1308,53 +1306,53 @@ func TestGarbageCollection(t *testing.T) {
 		ctx := context.Background()
 		d1 := document.New(helper.TestDocKey(t))
 		assert.NoError(t, c1.Attach(ctx, d1))
-		// d2.vv =[c1:1], minvv =[c1:1], db.vv {c1: [c1:1]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
+		// d2.vv =[], minvv =[], db.vv {}
+		assertVectorEquality(t, d1.VersionVector())
 
 		d2 := document.New(helper.TestDocKey(t))
 		assert.NoError(t, c2.Attach(ctx, d2))
-		// d2.vv =[ c2:2], minvv =[c1:0, c2:0], db.vv {c1: [c1:1], c2: [c2:1]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d2.ActorID(), 2))
+		// d2.vv =[], minvv =[], db.vv {}
+		assertVectorEquality(t, d2.VersionVector())
 
 		err := d1.Update(func(root *json.Object, p *presence.Presence) error {
 			root.SetNewText("text").Edit(0, 0, "a").Edit(1, 1, "b").Edit(2, 2, "c")
 			return nil
 		}, "sets text")
-		// d1/vv = [c1:2]
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 2))
+		// d1/vv = [c1:1]
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
 		assert.NoError(t, err)
 
 		assert.NoError(t, c1.Sync(ctx))
-		// d1.vv = [c1:3], minvv = [c1:0, c2:0], db.vv {c1: [c1:2], c2: [c2:1]}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 3))
+		// d1.vv = [c1:1], minvv = [c1:1]
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
 
 		assert.NoError(t, c2.Sync(ctx))
-		// d2.vv = [c1:2, c2:3], minvv = [c1:1, c2:0], db.vv {c1: [c1:2], c2: [c1:1, c2:2]}
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 3))
+		// d2.vv = [c1:1, c2:2], minvv = [c1:1], db.vv {c1: [c1:1]}
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 2))
 
 		err = d2.Update(func(root *json.Object, p *presence.Presence) error {
 			root.GetText("text").Edit(2, 2, "c")
 			return nil
 		}, "insert c")
-		//d2.vv = [c1:2, c2:4]
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 4))
+		//d2.vv = [c1:1, c2:3]
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 3))
 		assert.NoError(t, err)
 
 		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
 			root.GetText("text").Edit(1, 3, "")
 			return nil
 		}, "delete bc")
-		//d1.vv = [c1:4]
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 4))
+		//d1.vv = [c1:2]
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 2))
 		assert.NoError(t, err)
 		assert.Equal(t, 2, d1.GarbageLen())
 		assert.Equal(t, 0, d2.GarbageLen())
 
 		assert.NoError(t, c1.Sync(ctx))
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 4))
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 2))
 
 		assert.NoError(t, c2.Sync(ctx))
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 5))
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 4))
 
 		assert.Equal(t, 2, d1.GarbageLen())
 		assert.Equal(t, 2, d2.GarbageLen())
@@ -1363,23 +1361,23 @@ func TestGarbageCollection(t *testing.T) {
 			root.GetText("text").Edit(2, 2, "1")
 			return nil
 		}, "insert c")
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 6))
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 5))
 		assert.NoError(t, err)
 
 		assert.NoError(t, c2.Sync(ctx))
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 6))
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 5))
 
 		assert.Equal(t, 2, d1.GarbageLen())
 		assert.Equal(t, 0, d2.GarbageLen())
 
 		assert.NoError(t, c1.Sync(ctx))
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 7), versionOf(d2.ActorID(), 6))
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 6), versionOf(d2.ActorID(), 5))
 
 		// TODO(JOOHOJANG): we have to consider removing detached client's lamport from version vector
 		assert.NoError(t, c1.Detach(ctx, d1))
 
 		assert.NoError(t, c2.Sync(ctx))
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 9))
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 5))
 		assert.Equal(t, `{"text":[{"val":"a"},{"val":"c"},{"val":"1"}]}`, d2.Marshal())
 
 		err = d2.Update(func(root *json.Object, p *presence.Presence) error {
@@ -1387,7 +1385,7 @@ func TestGarbageCollection(t *testing.T) {
 			return nil
 		}, "delete all")
 		assert.NoError(t, err)
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 10))
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 6))
 		assert.Equal(t, `{"text":[]}`, d2.Marshal())
 
 		assert.Equal(t, 3, d2.GarbageLen())
@@ -1478,9 +1476,9 @@ func TestGarbageCollection(t *testing.T) {
 		assert.Equal(t, `{"text":[{"val":"a"}]}`, d1.Marshal())
 		assert.Equal(t, `{"text":[{"val":"a"}]}`, d2.Marshal())
 		assert.Equal(t, `{"text":[{"val":"a"}]}`, d3.Marshal())
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 4))
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 4))
-		assertVectorEquality(t, d3.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d3.ActorID(), 4))
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 2))
+		assertVectorEquality(t, d3.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d3.ActorID(), 2))
 
 		// 01. Update changes over snapshot threshold.
 		for i := 0; i <= int(helper.SnapshotThreshold)/2; i++ {
@@ -1504,9 +1502,9 @@ func TestGarbageCollection(t *testing.T) {
 			err = c1.Sync(ctx)
 			assert.NoError(t, err)
 		}
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 28), versionOf(d2.ActorID(), 27))
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 25), versionOf(d2.ActorID(), 27))
-		assertVectorEquality(t, d3.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d3.ActorID(), 4))
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 25), versionOf(d2.ActorID(), 24))
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 22), versionOf(d2.ActorID(), 24))
+		assertVectorEquality(t, d3.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d3.ActorID(), 2))
 
 		// 02. Makes local changes then pull a snapshot from the server.
 		err = d3.Update(func(root *json.Object, p *presence.Presence) error {
@@ -1516,7 +1514,7 @@ func TestGarbageCollection(t *testing.T) {
 		assert.NoError(t, err)
 		err = c3.Sync(ctx)
 		assert.NoError(t, err)
-		assertVectorEquality(t, d3.VersionVector(), versionOf(d1.ActorID(), 25), versionOf(d2.ActorID(), 27), versionOf(d3.ActorID(), 30))
+		assertVectorEquality(t, d3.VersionVector(), versionOf(d1.ActorID(), 22), versionOf(d2.ActorID(), 24), versionOf(d3.ActorID(), 27))
 		assert.Equal(t, `{"text":[{"val":"5"},{"val":"5"},{"val":"4"},{"val":"4"},{"val":"3"},{"val":"3"},{"val":"2"},{"val":"2"},{"val":"1"},{"val":"1"},{"val":"0"},{"val":"c"},{"val":"0"},{"val":"a"}]}`, d3.Marshal())
 
 		// 03. Delete text after receiving the snapshot.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Update garbage collection related TCs

In https://github.com/yorkie-team/yorkie/pull/1257, after the logical clock was removed from presence change, the related test cases were left skipped. 

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated test assertions and comments to reflect that newly created documents now start with empty version vectors instead of initial lamport entries.
  - Adjusted expected version vector values to align with updated initialization and progression semantics.
  - No changes to test logic or flow; only expected values and explanatory comments have been revised.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->