### PR TITLE
Filter detached client from vv

### DIFF
--- a/admin/client.go
+++ b/admin/client.go
@@ -402,7 +402,7 @@ func (c *Client) ListChangeSummaries(
 	}
 	var summaries []*types.ChangeSummary
 	for _, c := range changes {
-		if _, err := newDoc.ApplyChanges(c); err != nil {
+		if _, err := newDoc.ApplyChanges(nil, c); err != nil {
 			return nil, err
 		}
 

--- a/pkg/document/change/change.go
+++ b/pkg/document/change/change.go
@@ -51,9 +51,9 @@ func New(id ID, message string, operations []operations.Operation, pc *innerpres
 }
 
 // Execute applies this change to the given JSON root.
-func (c *Change) Execute(root *crdt.Root, presences *innerpresence.Map) error {
+func (c *Change) Execute(root *crdt.Root, presences *innerpresence.Map, vector time.VersionVector) error {
 	for _, op := range c.operations {
-		if err := op.Execute(root, c.ID().versionVector); err != nil {
+		if err := op.Execute(root, c.ID().versionVector, vector); err != nil {
 			return err
 		}
 	}

--- a/pkg/document/crdt/rga_tree_split.go
+++ b/pkg/document/crdt/rga_tree_split.go
@@ -554,7 +554,7 @@ func (s *RGATreeSplit[V]) deleteNodes(
 			if ok {
 				clientLamportAtChange = lamport
 			} else {
-				clientLamportAtChange = 0
+				clientLamportAtChange = vector.MaxLamport()
 			}
 		}
 

--- a/pkg/document/crdt/rga_tree_split.go
+++ b/pkg/document/crdt/rga_tree_split.go
@@ -471,6 +471,7 @@ func (s *RGATreeSplit[V]) edit(
 	content V,
 	editedAt *time.Ticket,
 	versionVector time.VersionVector,
+	minVersionVector time.VersionVector,
 ) (*RGATreeSplitNodePos, []GCPair, error) {
 	// 01. Split nodes with from and to
 	toLeft, toRight, err := s.findNodeWithSplit(to, editedAt)
@@ -484,7 +485,7 @@ func (s *RGATreeSplit[V]) edit(
 
 	// 02. delete between from and to
 	nodesToDelete := s.findBetween(fromRight, toRight)
-	removedNodes := s.deleteNodes(nodesToDelete, editedAt, versionVector)
+	removedNodes := s.deleteNodes(nodesToDelete, editedAt, versionVector, minVersionVector)
 
 	var caretID *RGATreeSplitNodeID
 	if toRight == nil {
@@ -526,6 +527,7 @@ func (s *RGATreeSplit[V]) deleteNodes(
 	candidates []*RGATreeSplitNode[V],
 	editedAt *time.Ticket,
 	vector time.VersionVector,
+	minVector time.VersionVector,
 ) map[string]*RGATreeSplitNode[V] {
 	removedNodeMap := make(map[string]*RGATreeSplitNode[V])
 	isVersionVectorEmpty := len(vector) == 0
@@ -554,7 +556,7 @@ func (s *RGATreeSplit[V]) deleteNodes(
 			if ok {
 				clientLamportAtChange = lamport
 			} else {
-				clientLamportAtChange = vector.MaxLamport()
+				clientLamportAtChange = 0
 			}
 		}
 

--- a/pkg/document/crdt/text.go
+++ b/pkg/document/crdt/text.go
@@ -326,6 +326,7 @@ func (t *Text) Edit(
 	attributes map[string]string,
 	executedAt *time.Ticket,
 	versionVector time.VersionVector,
+	minVersionVector time.VersionVector,
 ) (*RGATreeSplitNodePos, []GCPair, error) {
 	val := NewTextValue(content, NewRHT())
 	for key, value := range attributes {
@@ -338,6 +339,7 @@ func (t *Text) Edit(
 		val,
 		executedAt,
 		versionVector,
+		minVersionVector,
 	)
 }
 
@@ -348,6 +350,7 @@ func (t *Text) Style(
 	attributes map[string]string,
 	executedAt *time.Ticket,
 	versionVector time.VersionVector,
+	minVersionVector time.VersionVector,
 ) ([]GCPair, error) {
 	// 01. Split nodes with from and to
 	_, toRight, err := t.rgaTreeSplit.findNodeWithSplit(to, executedAt)

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -753,7 +753,7 @@ func (t *Tree) EditT(
 		return err
 	}
 
-	_, err = t.Edit(fromPos, toPos, contents, splitLevel, editedAt, issueTimeTicket, nil)
+	_, err = t.Edit(fromPos, toPos, contents, splitLevel, editedAt, issueTimeTicket, nil, nil)
 	return err
 }
 
@@ -801,6 +801,7 @@ func (t *Tree) Edit(
 	editedAt *time.Ticket,
 	issueTimeTicket func() *time.Ticket,
 	versionVector time.VersionVector,
+	minVersionVector time.VersionVector,
 ) ([]GCPair, error) {
 	// 01. find nodes from the given range and split nodes.
 	fromParent, fromLeft, err := t.FindTreeNodesWithSplitText(from, editedAt)
@@ -814,7 +815,7 @@ func (t *Tree) Edit(
 
 	toBeRemoveds, toBeMovedToFromParents, err := t.collectBetween(
 		fromParent, fromLeft, toParent, toLeft,
-		editedAt, versionVector,
+		editedAt, versionVector, minVersionVector,
 	)
 	if err != nil {
 		return nil, err
@@ -891,6 +892,7 @@ func (t *Tree) collectBetween(
 	toParent *TreeNode, toLeft *TreeNode,
 	editedAt *time.Ticket,
 	versionVector time.VersionVector,
+	minVersionVector time.VersionVector,
 ) ([]*TreeNode, []*TreeNode, error) {
 	var toBeRemoveds []*TreeNode
 	var toBeMovedToFromParents []*TreeNode
@@ -1019,7 +1021,7 @@ func (t *Tree) StyleByIndex(
 		return nil, err
 	}
 
-	return t.Style(fromPos, toPos, attributes, editedAt, versionVector)
+	return t.Style(fromPos, toPos, attributes, editedAt, versionVector, nil)
 }
 
 // Style applies the given attributes of the given range.
@@ -1028,6 +1030,7 @@ func (t *Tree) Style(
 	attrs map[string]string,
 	editedAt *time.Ticket,
 	versionVector time.VersionVector,
+	minVersionVector time.VersionVector,
 ) ([]GCPair, error) {
 	fromParent, fromLeft, err := t.FindTreeNodesWithSplitText(from, editedAt)
 	if err != nil {
@@ -1083,6 +1086,7 @@ func (t *Tree) RemoveStyle(
 	attrs []string,
 	editedAt *time.Ticket,
 	versionVector time.VersionVector,
+	minVersionVector time.VersionVector,
 ) ([]GCPair, error) {
 	fromParent, fromLeft, err := t.FindTreeNodesWithSplitText(from, editedAt)
 	if err != nil {

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -222,7 +222,19 @@ func (d *Document) ApplyChangePack(pack *change.Pack) error {
 		d.GarbageCollect(pack.VersionVector)
 	}
 
-	// 05. Update the status.
+	// 05. Remove detached client's lamport from version vector if it exists
+	if pack.VersionVector != nil && !hasSnapshot {
+		actorIDs, err := pack.VersionVector.Keys()
+		if err != nil {
+			return err
+		}
+
+		if !d.doc.changeID.VersionVector().IsEmpty() {
+			d.doc.changeID = d.doc.changeID.SetVersionVector(d.doc.changeID.VersionVector().Filter(actorIDs))
+		}
+	}
+
+	// 06. Update the status.
 	if pack.IsRemoved {
 		d.SetStatus(StatusRemoved)
 	}

--- a/pkg/document/internal_document.go
+++ b/pkg/document/internal_document.go
@@ -192,6 +192,18 @@ func (d *InternalDocument) ApplyChangePack(pack *change.Pack, disableGC bool) er
 		}
 	}
 
+	// 04. Remove detached client's lamport from version vector if it exists
+	if pack.VersionVector != nil && !hasSnapshot {
+		actorIDs, err := pack.VersionVector.Keys()
+		if err != nil {
+			return err
+		}
+
+		if !d.changeID.VersionVector().IsEmpty() {
+			d.changeID = d.changeID.SetVersionVector(d.changeID.VersionVector().Filter(actorIDs))
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/document/internal_document.go
+++ b/pkg/document/internal_document.go
@@ -169,7 +169,7 @@ func (d *InternalDocument) ApplyChangePack(pack *change.Pack, disableGC bool) er
 			return err
 		}
 	} else {
-		if _, err := d.ApplyChanges(pack.Changes...); err != nil {
+		if _, err := d.ApplyChanges(pack.VersionVector, pack.Changes...); err != nil {
 			return err
 		}
 	}
@@ -303,7 +303,7 @@ func (d *InternalDocument) applySnapshot(snapshot []byte, vector time.VersionVec
 }
 
 // ApplyChanges applies remote changes to the document.
-func (d *InternalDocument) ApplyChanges(changes ...*change.Change) ([]DocEvent, error) {
+func (d *InternalDocument) ApplyChanges(vector time.VersionVector, changes ...*change.Change) ([]DocEvent, error) {
 	var events []DocEvent
 	for _, c := range changes {
 		if c.PresenceChange() != nil {
@@ -343,7 +343,7 @@ func (d *InternalDocument) ApplyChanges(changes ...*change.Change) ([]DocEvent, 
 			}
 		}
 
-		if err := c.Execute(d.root, d.presences); err != nil {
+		if err := c.Execute(d.root, d.presences, vector); err != nil {
 			return nil, err
 		}
 

--- a/pkg/document/json/text.go
+++ b/pkg/document/json/text.go
@@ -83,6 +83,7 @@ func (p *Text) Edit(
 		attrs,
 		ticket,
 		nil,
+		nil,
 	)
 	if err != nil {
 		panic(err)
@@ -134,6 +135,7 @@ func (p *Text) Style(from, to int, attributes map[string]string) *Text {
 		toPos,
 		attributes,
 		ticket,
+		nil,
 		nil,
 	)
 	if err != nil {

--- a/pkg/document/json/tree.go
+++ b/pkg/document/json/tree.go
@@ -202,7 +202,7 @@ func (t *Tree) Style(fromIdx, toIdx int, attributes map[string]string) bool {
 	}
 
 	ticket := t.context.IssueTimeTicket()
-	pairs, err := t.Tree.Style(fromPos, toPos, attributes, ticket, nil)
+	pairs, err := t.Tree.Style(fromPos, toPos, attributes, ticket, nil, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -242,7 +242,7 @@ func (t *Tree) RemoveStyle(fromIdx, toIdx int, attributesToRemove []string) bool
 	}
 
 	ticket := t.context.IssueTimeTicket()
-	pairs, err := t.Tree.RemoveStyle(fromPos, toPos, attributesToRemove, ticket, nil)
+	pairs, err := t.Tree.RemoveStyle(fromPos, toPos, attributesToRemove, ticket, nil, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -332,6 +332,7 @@ func (t *Tree) edit(fromPos, toPos *crdt.TreePos, contents []*TreeNode, splitLev
 		splitLevel,
 		ticket,
 		t.context.IssueTimeTicket,
+		nil,
 		nil,
 	)
 	if err != nil {

--- a/pkg/document/operations/add.go
+++ b/pkg/document/operations/add.go
@@ -52,7 +52,7 @@ func NewAdd(
 }
 
 // Execute executes this operation on the given document(`root`).
-func (o *Add) Execute(root *crdt.Root, _ time.VersionVector) error {
+func (o *Add) Execute(root *crdt.Root, _ time.VersionVector, _ time.VersionVector) error {
 	parent := root.FindByCreatedAt(o.parentCreatedAt)
 
 	obj, ok := parent.(*crdt.Array)

--- a/pkg/document/operations/array_set.go
+++ b/pkg/document/operations/array_set.go
@@ -52,7 +52,7 @@ func NewArraySet(
 }
 
 // Execute executes this operation on the given document(`root`).
-func (o *ArraySet) Execute(root *crdt.Root, _ time.VersionVector) error {
+func (o *ArraySet) Execute(root *crdt.Root, _ time.VersionVector, _ time.VersionVector) error {
 	parent := root.FindByCreatedAt(o.parentCreatedAt)
 	obj, ok := parent.(*crdt.Array)
 	if !ok {

--- a/pkg/document/operations/edit.go
+++ b/pkg/document/operations/edit.go
@@ -64,12 +64,12 @@ func NewEdit(
 }
 
 // Execute executes this operation on the given document(`root`).
-func (e *Edit) Execute(root *crdt.Root, versionVector time.VersionVector) error {
+func (e *Edit) Execute(root *crdt.Root, versionVector time.VersionVector, minVersionVector time.VersionVector) error {
 	parent := root.FindByCreatedAt(e.parentCreatedAt)
 
 	switch obj := parent.(type) {
 	case *crdt.Text:
-		_, pairs, err := obj.Edit(e.from, e.to, e.content, e.attributes, e.executedAt, versionVector)
+		_, pairs, err := obj.Edit(e.from, e.to, e.content, e.attributes, e.executedAt, versionVector, minVersionVector)
 		if err != nil {
 			return err
 		}

--- a/pkg/document/operations/increase.go
+++ b/pkg/document/operations/increase.go
@@ -43,7 +43,7 @@ func NewIncrease(
 }
 
 // Execute executes this operation on the given document(`root`).
-func (o *Increase) Execute(root *crdt.Root, _ time.VersionVector) error {
+func (o *Increase) Execute(root *crdt.Root, _ time.VersionVector, _ time.VersionVector) error {
 	parent := root.FindByCreatedAt(o.parentCreatedAt)
 	cnt, ok := parent.(*crdt.Counter)
 	if !ok {

--- a/pkg/document/operations/move.go
+++ b/pkg/document/operations/move.go
@@ -52,7 +52,7 @@ func NewMove(
 }
 
 // Execute executes this operation on the given document(`root`).
-func (o *Move) Execute(root *crdt.Root, _ time.VersionVector) error {
+func (o *Move) Execute(root *crdt.Root, _ time.VersionVector, _ time.VersionVector) error {
 	parent := root.FindByCreatedAt(o.parentCreatedAt)
 
 	obj, ok := parent.(*crdt.Array)

--- a/pkg/document/operations/operation.go
+++ b/pkg/document/operations/operation.go
@@ -34,7 +34,7 @@ var (
 // Operation represents an operation to be executed on a document.
 type Operation interface {
 	// Execute executes this operation on the given document(`root`).
-	Execute(root *crdt.Root, versionVector time.VersionVector) error
+	Execute(root *crdt.Root, versionVector time.VersionVector, minVersionVector time.VersionVector) error
 
 	// ExecutedAt returns execution time of this operation.
 	ExecutedAt() *time.Ticket

--- a/pkg/document/operations/remove.go
+++ b/pkg/document/operations/remove.go
@@ -48,7 +48,7 @@ func NewRemove(
 }
 
 // Execute executes this operation on the given document(`root`).
-func (o *Remove) Execute(root *crdt.Root, _ time.VersionVector) error {
+func (o *Remove) Execute(root *crdt.Root, _ time.VersionVector, _ time.VersionVector) error {
 	parentElem := root.FindByCreatedAt(o.parentCreatedAt)
 
 	switch parent := parentElem.(type) {

--- a/pkg/document/operations/set.go
+++ b/pkg/document/operations/set.go
@@ -53,7 +53,7 @@ func NewSet(
 }
 
 // Execute executes this operation on the given document(`root`).
-func (o *Set) Execute(root *crdt.Root, _ time.VersionVector) error {
+func (o *Set) Execute(root *crdt.Root, _ time.VersionVector, _ time.VersionVector) error {
 	parent := root.FindByCreatedAt(o.parentCreatedAt)
 
 	obj, ok := parent.(*crdt.Object)

--- a/pkg/document/operations/style.go
+++ b/pkg/document/operations/style.go
@@ -57,14 +57,14 @@ func NewStyle(
 }
 
 // Execute executes this operation on the given document(`root`).
-func (e *Style) Execute(root *crdt.Root, versionVector time.VersionVector) error {
+func (e *Style) Execute(root *crdt.Root, versionVector time.VersionVector, minVersionVector time.VersionVector) error {
 	parent := root.FindByCreatedAt(e.parentCreatedAt)
 	obj, ok := parent.(*crdt.Text)
 	if !ok {
 		return ErrNotApplicableDataType
 	}
 
-	pairs, err := obj.Style(e.from, e.to, e.attributes, e.executedAt, versionVector)
+	pairs, err := obj.Style(e.from, e.to, e.attributes, e.executedAt, versionVector, minVersionVector)
 	if err != nil {
 		return err
 	}

--- a/pkg/document/operations/tree_edit.go
+++ b/pkg/document/operations/tree_edit.go
@@ -63,7 +63,7 @@ func NewTreeEdit(
 }
 
 // Execute executes this operation on the given `CRDTRoot`.
-func (e *TreeEdit) Execute(root *crdt.Root, versionVector time.VersionVector) error {
+func (e *TreeEdit) Execute(root *crdt.Root, versionVector time.VersionVector, minVersionVector time.VersionVector) error {
 	parent := root.FindByCreatedAt(e.parentCreatedAt)
 
 	switch obj := parent.(type) {
@@ -111,6 +111,7 @@ func (e *TreeEdit) Execute(root *crdt.Root, versionVector time.VersionVector) er
 				}
 			}(),
 			versionVector,
+			minVersionVector,
 		)
 		if err != nil {
 			return err

--- a/pkg/document/operations/tree_style.go
+++ b/pkg/document/operations/tree_style.go
@@ -79,7 +79,7 @@ func NewTreeStyleRemove(
 }
 
 // Execute executes this operation on the given `CRDTRoot`.
-func (e *TreeStyle) Execute(root *crdt.Root, versionVector time.VersionVector) error {
+func (e *TreeStyle) Execute(root *crdt.Root, versionVector time.VersionVector, minVersionVector time.VersionVector) error {
 	parent := root.FindByCreatedAt(e.parentCreatedAt)
 	obj, ok := parent.(*crdt.Tree)
 	if !ok {
@@ -89,12 +89,12 @@ func (e *TreeStyle) Execute(root *crdt.Root, versionVector time.VersionVector) e
 	var pairs []crdt.GCPair
 	var err error
 	if len(e.attributes) > 0 {
-		pairs, err = obj.Style(e.from, e.to, e.attributes, e.executedAt, versionVector)
+		pairs, err = obj.Style(e.from, e.to, e.attributes, e.executedAt, versionVector, minVersionVector)
 		if err != nil {
 			return err
 		}
 	} else {
-		pairs, err = obj.RemoveStyle(e.from, e.to, e.attributesToRemove, e.executedAt, versionVector)
+		pairs, err = obj.RemoveStyle(e.from, e.to, e.attributesToRemove, e.executedAt, versionVector, minVersionVector)
 		if err != nil {
 			return err
 		}

--- a/server/backend/database/detached_clients.go
+++ b/server/backend/database/detached_clients.go
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package database
+
+import "github.com/yorkie-team/yorkie/api/types"
+
+// DetachedClients is a structure representing information about the detached client's lamport for each document and client.
+type DetachedClients struct {
+	ID        types.ID `bson:"_id"`
+	ProjectID types.ID `bson:"project_id"`
+	DocID     types.ID `bson:"doc_id"`
+	ClientID  types.ID `bson:"client_id"`
+	Lamport   int64    `bson:"lamport"`
+	ServerSeq int64    `bson:"server_seq"`
+}

--- a/server/backend/database/detached_clients.go
+++ b/server/backend/database/detached_clients.go
@@ -18,7 +18,8 @@ package database
 
 import "github.com/yorkie-team/yorkie/api/types"
 
-// DetachedClients is a structure representing information about the detached client's lamport for each document and client.
+// DetachedClients is a structure representing information about
+// the detached client's lamport for each document and client.
 type DetachedClients struct {
 	ID        types.ID `bson:"_id"`
 	ProjectID types.ID `bson:"project_id"`

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -88,6 +88,9 @@ func Dial(conf *Config) (*Client, error) {
 	}
 
 	clientsCache, err := lru.New[types.DocRefKey, *cmap.Map[types.ID, int64]](1000)
+	if err != nil {
+		return nil, fmt.Errorf("initialize clients cache: %w", err)
+	}
 
 	logging.DefaultLogger().Infof("MongoDB connected, URI: %s, DB: %s", conf.ConnectionURI, conf.YorkieDatabase)
 
@@ -1463,7 +1466,8 @@ func (c *Client) UpdateAndFindMinVersionVector(
 					minVersionVector.Unset(actorID)
 				}
 			} else {
-				// every client recognizes the actor has been detached, so now it's safe to remove actor's info from detachedClientsCache
+				// every client recognizes the actor has been detached, so now it's safe
+				// to remove actor's info from detachedClientsCache
 				detachedClientsMap.Delete(keys[i], func(value int64, exists bool) bool {
 					return true
 				})

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -1370,11 +1370,15 @@ func (c *Client) UpdateAndFindMinVersionVector(
 				return vector
 			})
 		} else {
-			// NOTE(hackerwins): Considering removing the detached client's lamport
-			// from the other clients' version vectors. For now, we just ignore it.
-			vvMap.Delete(clientInfo.ID, func(value time.VersionVector, exists bool) bool {
-				return exists
-			})
+			infoMap := cmap.New[types.ID, int64]()
+			actorID, err := clientInfo.ID.ToActorID()
+
+			if err != nil {
+				return nil, err
+			}
+
+			infoMap.Set(clientInfo.ID, vector[actorID])
+			c.detachedClientsCache.Add(docRefKey, infoMap)
 		}
 	}
 

--- a/server/backend/database/mongo/indexes.go
+++ b/server/backend/database/mongo/indexes.go
@@ -40,6 +40,8 @@ const (
 	ColSnapshots = "snapshots"
 	// ColVersionVectors represents the versionvector collection in the database.
 	ColVersionVectors = "versionvectors"
+	// ColDetachedClients represents the detachedclients collection in the database.
+	ColDetachedClients = "detachedclients"
 )
 
 // Collections represents the list of all collections in the database.
@@ -142,6 +144,16 @@ var collectionInfos = []collectionInfo{
 		}},
 	}, {
 		name: ColVersionVectors,
+		indexes: []mongo.IndexModel{{
+			Keys: bsonx.Doc{
+				{Key: "doc_id", Value: bsonx.Int32(1)}, // shard key
+				{Key: "project_id", Value: bsonx.Int32(1)},
+				{Key: "client_id", Value: bsonx.Int32(1)},
+			},
+			Options: options.Index().SetUnique(true),
+		}},
+	}, {
+		name: ColDetachedClients,
 		indexes: []mongo.IndexModel{{
 			Keys: bsonx.Doc{
 				{Key: "doc_id", Value: bsonx.Int32(1)}, // shard key

--- a/test/integration/gc_test.go
+++ b/test/integration/gc_test.go
@@ -1281,16 +1281,10 @@ func TestGarbageCollection(t *testing.T) {
 
 		assert.NoError(t, c2.Sync(ctx))
 		assert.NoError(t, c1.Sync(ctx))
-		// TODO(JOOHOJANG): We have to consider removing detached client's lamport
-		// from version vector.
-		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 9), versionOf(d2.ActorID(), 8), versionOf(d3.ActorID(), 3))
-		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 9), versionOf(d3.ActorID(), 3))
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 9), versionOf(d2.ActorID(), 8))
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 9))
 		assert.Equal(t, `{"text":[{"val":"3"},{"val":"2"},{"val":"1"},{"val":"a"},{"val":"z"},{"val":"x"},{"val":"y"}]}`, d1.Marshal())
 		assert.Equal(t, `{"text":[{"val":"3"},{"val":"2"},{"val":"1"},{"val":"a"},{"val":"z"},{"val":"x"},{"val":"y"}]}`, d2.Marshal())
-		assert.Equal(t, 2, d1.GarbageLen())
-		assert.Equal(t, 2, d2.GarbageLen())
-		assert.NoError(t, c2.Sync(ctx))
-		assert.NoError(t, c1.Sync(ctx))
 		assert.Equal(t, 0, d1.GarbageLen())
 		assert.Equal(t, 0, d2.GarbageLen())
 	})
@@ -1530,5 +1524,111 @@ func TestGarbageCollection(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, `{"text":[{"val":"5"},{"val":"4"},{"val":"3"},{"val":"3"},{"val":"2"},{"val":"2"},{"val":"1"},{"val":"1"},{"val":"0"},{"val":"c"},{"val":"0"},{"val":"a"}]}`, d2.Marshal())
 		assert.Equal(t, `{"text":[{"val":"5"},{"val":"4"},{"val":"3"},{"val":"3"},{"val":"2"},{"val":"2"},{"val":"1"},{"val":"1"},{"val":"0"},{"val":"c"},{"val":"0"},{"val":"a"}]}`, d1.Marshal())
+	})
+
+	t.Run("detach gc test", func(t *testing.T) {
+		clients := activeClients(t, 3)
+		c1, c2, c3 := clients[0], clients[1], clients[2]
+		defer deactivateAndCloseClients(t, clients)
+		ctx := context.Background()
+		d1 := document.New(helper.TestDocKey(t))
+		d2 := document.New(helper.TestDocKey(t))
+		d3 := document.New(helper.TestDocKey(t))
+
+		assert.NoError(t, c1.Attach(ctx, d1))
+		assert.NoError(t, c2.Attach(ctx, d2))
+		assert.NoError(t, c3.Attach(ctx, d3))
+		assert.NoError(t, c3.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c1.Sync(ctx))
+
+		assertVectorEquality(t, d1.VersionVector())
+		assertVectorEquality(t, d2.VersionVector())
+		assertVectorEquality(t, d3.VersionVector())
+
+		err := d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewText("text").Edit(0, 0, "a").Edit(1, 1, "b").Edit(2, 2, "c") // abc
+			return nil
+		}, "insert abc")
+		assert.NoError(t, err)
+
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c3.Sync(ctx))
+		assert.NoError(t, c3.Sync(ctx))
+		assert.NoError(t, c3.Sync(ctx))
+		assert.NoError(t, c3.Sync(ctx))
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c3.Sync(ctx))
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 1))
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d2.ActorID(), 2))
+		assertVectorEquality(t, d3.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d3.ActorID(), 2))
+
+		err = d3.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(1, 3, "") // delete bc
+			return nil
+		}, "delete bc")
+		assert.NoError(t, err)
+
+		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(0, 0, "1") // 1abc
+			return nil
+		}, "insert 1")
+		assert.NoError(t, err)
+		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(0, 0, "2") // 21abc
+			return nil
+		}, "insert 2")
+		assert.NoError(t, err)
+		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(0, 0, "3") // 321abc
+			return nil
+		}, "insert 3")
+		assert.NoError(t, err)
+		err = d2.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(3, 3, "x") // abcx
+			return nil
+		}, "insert x")
+		assert.NoError(t, err)
+		err = d2.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(4, 4, "y") // abcxy
+			return nil
+		}, "insert y")
+		assert.NoError(t, err)
+
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c1.Sync(ctx))
+
+		assert.Equal(t, "321abcxy", d1.Root().GetText("text").String())
+		assert.Equal(t, "321abcxy", d2.Root().GetText("text").String())
+		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 6), versionOf(d2.ActorID(), 4))
+		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 4), versionOf(d2.ActorID(), 7))
+		assertVectorEquality(t, d3.VersionVector(), versionOf(d1.ActorID(), 1), versionOf(d3.ActorID(), 3))
+
+		// c3 detach
+		assert.NoError(t, c3.Detach(ctx, d3))
+		err = d2.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(5, 5, "z") // 321abzcxy
+			return nil
+		}, "insert z")
+		assert.NoError(t, err)
+		assert.Equal(t, "321abzcxy", d2.Root().GetText("text").String())
+
+		assert.NoError(t, c1.Sync(ctx))
+		assert.Equal(t, "321axy", d1.Root().GetText("text").String())
+		assert.Equal(t, 2, d1.GarbageLen())
+
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c1.Sync(ctx))
+		assert.Equal(t, 0, d1.GarbageLen())
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
**What this PR does / why we need it**:
Since version vector's size grow infinitely, it causes performance and memory issues.

We used the min version vector to remove the Lamport of detached clients.

A separate database table was created to store detached clients. When a user detaches, their information is added to this table. Later, during a push-pull operation, we compare the computed min version vector with the list of detached clients. If `minVV[client] == detached client's Lamport`, we remove the corresponding key from the min version vector. This ensures that when a user receives a sync pack, their version vector is filtered accordingly.

Conceptually, removing a user's Lamport from the min version vector implies that all users have acknowledged the user's detachment. This condition can be confirmed when `minVV[detached client ID] == detached client’s Lamport`

Although introducing a separate table may raise concerns about potential performance overhead, the impact is expected to be minimal.

**Changed**

- [x] Add new database table (detached clients)
- [x] Filter min version vector using detached clients table(using cache to improve performance)
- [x] Filter every client's local version vector when receiving change pack
- [x] Add related TCs

<img width="574" alt="image" src="https://github.com/user-attachments/assets/1ee20e32-8a22-4d91-bf37-5497f0fd28eb" />


### Next tasks
- [ ] Update memory db in same ways
- [ ] Implement local version vector update logic into SDKs
- [ ] Testing in many ways 


**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://github.com/yorkie-team/yorkie/issues/1144

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced tracking and management of detached clients to improve document synchronization and garbage collection.
- **Bug Fixes**
  - Enhanced version vector handling to exclude detached clients, ensuring accurate document state and cleanup.
- **Tests**
  - Added integration tests to verify correct garbage collection behavior after client detachment.
- **Chores**
  - Updated database schema and indexing to support detached client tracking.
  - Extended document editing and styling operations with enhanced version vector parameters for improved consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->