### PR TITLE
Separate correction logic in RegisterGCPair for editing and build

### DIFF
--- a/pkg/document/change/context.go
+++ b/pkg/document/change/context.go
@@ -115,6 +115,11 @@ func (c *Context) Acc(diff resource.DataSize) {
 	c.root.Acc(diff)
 }
 
+// AdjustDiffForGCPair adjusts the given diff for the given GCPair to the root.
+func (c *Context) AdjustDiffForGCPair(diff *resource.DataSize, pair crdt.GCPair) {
+	c.root.AdjustDiffForGCPair(diff, pair)
+}
+
 // LastTimeTicket returns the last time ticket issued by this context.
 func (c *Context) LastTimeTicket() *time.Ticket {
 	return c.nextID.NewTimeTicket(c.delimiter)

--- a/pkg/document/crdt/root.go
+++ b/pkg/document/crdt/root.go
@@ -241,3 +241,17 @@ func (r *Root) RegisterGCPair(pair GCPair) {
 func (r *Root) Acc(diff resource.DataSize) {
 	r.docSize.Live.Add(diff)
 }
+
+// AdjustDiffForGCPair adjusts the given diff for the given GCPair.
+func (r *Root) AdjustDiffForGCPair(diff *resource.DataSize, pair GCPair) {
+	size := pair.Child.DataSize()
+	diff.Sub(size)
+
+	// NOTE(hackerwins): In general cases, when removing a node, its size
+	// includes removedAt, so when subtracting the node size from docSize.Live,
+	// we need to subtract the removedAt size. However, RHTNode doesn't have
+	// removedAt, so we don't need to subtract it from the Live size.
+	if _, isRHTNode := pair.Child.(*RHTNode); !isRHTNode {
+		diff.Meta += time.TicketSize
+	}
+}

--- a/pkg/document/crdt/root.go
+++ b/pkg/document/crdt/root.go
@@ -235,15 +235,6 @@ func (r *Root) RegisterGCPair(pair GCPair) {
 
 	size := pair.Child.DataSize()
 	r.docSize.GC.Add(size)
-	//r.docSize.Live.Sub(size)
-
-	// NOTE(hackerwins): In general cases, when removing a node, its size
-	// includes removedAt, so when subtracting the node size from docSize.Live,
-	// we need to subtract the removedAt size. However, RHTNode doesn't have
-	// removedAt, so we don't need to subtract it from the Live size.
-	//if _, isRHTNode := pair.Child.(*RHTNode); !isRHTNode {
-	//	r.docSize.Live.Meta += time.TicketSize
-	//}
 }
 
 // Acc accumulates the given DataSize to Live.

--- a/pkg/document/crdt/root.go
+++ b/pkg/document/crdt/root.go
@@ -235,15 +235,15 @@ func (r *Root) RegisterGCPair(pair GCPair) {
 
 	size := pair.Child.DataSize()
 	r.docSize.GC.Add(size)
-	r.docSize.Live.Sub(size)
+	//r.docSize.Live.Sub(size)
 
 	// NOTE(hackerwins): In general cases, when removing a node, its size
 	// includes removedAt, so when subtracting the node size from docSize.Live,
 	// we need to subtract the removedAt size. However, RHTNode doesn't have
 	// removedAt, so we don't need to subtract it from the Live size.
-	if _, isRHTNode := pair.Child.(*RHTNode); !isRHTNode {
-		r.docSize.Live.Meta += time.TicketSize
-	}
+	//if _, isRHTNode := pair.Child.(*RHTNode); !isRHTNode {
+	//	r.docSize.Live.Meta += time.TicketSize
+	//}
 }
 
 // Acc accumulates the given DataSize to Live.

--- a/pkg/document/json/text.go
+++ b/pkg/document/json/text.go
@@ -22,7 +22,6 @@ import (
 	"github.com/yorkie-team/yorkie/pkg/document/change"
 	"github.com/yorkie-team/yorkie/pkg/document/crdt"
 	"github.com/yorkie-team/yorkie/pkg/document/operations"
-	"github.com/yorkie-team/yorkie/pkg/document/time"
 	"github.com/yorkie-team/yorkie/pkg/document/yson"
 )
 
@@ -91,15 +90,7 @@ func (p *Text) Edit(
 
 	for _, pair := range pairs {
 		p.context.RegisterGCPair(pair)
-
-		size := pair.Child.DataSize()
-		diff.Sub(size)
-
-		// NOTE(hackerwins): In general cases, when removing a node, its size
-		// includes removedAt, so when subtracting the node size from docSize.Live,
-		// we need to subtract the removedAt size. However, RHTNode doesn't have
-		// removedAt, so we don't need to subtract it from the Live size.
-		diff.Meta += time.TicketSize
+		p.context.AdjustDiffForGCPair(&diff, pair)
 	}
 
 	p.context.Acc(diff)
@@ -154,9 +145,7 @@ func (p *Text) Style(from, to int, attributes map[string]string) *Text {
 
 	for _, pair := range pairs {
 		p.context.RegisterGCPair(pair)
-
-		size := pair.Child.DataSize()
-		diff.Sub(size)
+		p.context.AdjustDiffForGCPair(&diff, pair)
 	}
 
 	p.context.Acc(diff)

--- a/pkg/document/json/text.go
+++ b/pkg/document/json/text.go
@@ -17,12 +17,12 @@
 package json
 
 import (
-	"github.com/yorkie-team/yorkie/pkg/document/time"
 	"unicode/utf16"
 
 	"github.com/yorkie-team/yorkie/pkg/document/change"
 	"github.com/yorkie-team/yorkie/pkg/document/crdt"
 	"github.com/yorkie-team/yorkie/pkg/document/operations"
+	"github.com/yorkie-team/yorkie/pkg/document/time"
 	"github.com/yorkie-team/yorkie/pkg/document/yson"
 )
 

--- a/pkg/document/json/tree.go
+++ b/pkg/document/json/tree.go
@@ -209,9 +209,7 @@ func (t *Tree) Style(fromIdx, toIdx int, attributes map[string]string) bool {
 
 	for _, pair := range pairs {
 		t.context.RegisterGCPair(pair)
-
-		size := pair.Child.DataSize()
-		diff.Sub(size)
+		t.context.AdjustDiffForGCPair(&diff, pair)
 	}
 
 	t.context.Acc(diff)
@@ -347,15 +345,7 @@ func (t *Tree) edit(fromPos, toPos *crdt.TreePos, contents []*TreeNode, splitLev
 
 	for _, pair := range pairs {
 		t.context.RegisterGCPair(pair)
-
-		size := pair.Child.DataSize()
-		diff.Sub(size)
-
-		// NOTE(hackerwins): In general cases, when removing a node, its size
-		// includes removedAt, so when subtracting the node size from docSize.Live,
-		// we need to subtract the removedAt size. However, RHTNode doesn't have
-		// removedAt, so we don't need to subtract it from the Live size.
-		diff.Meta += time.TicketSize
+		t.context.AdjustDiffForGCPair(&diff, pair)
 	}
 
 	t.context.Acc(diff)

--- a/pkg/document/operations/edit.go
+++ b/pkg/document/operations/edit.go
@@ -74,11 +74,21 @@ func (e *Edit) Execute(root *crdt.Root, versionVector time.VersionVector) error 
 			return err
 		}
 
-		root.Acc(diff)
-
 		for _, pair := range pairs {
 			root.RegisterGCPair(pair)
+
+			size := pair.Child.DataSize()
+			diff.Sub(size)
+
+			// NOTE(hackerwins): In general cases, when removing a node, its size
+			// includes removedAt, so when subtracting the node size from docSize.Live,
+			// we need to subtract the removedAt size. However, RHTNode doesn't have
+			// removedAt, so we don't need to subtract it from the Live size.
+			diff.Meta += time.TicketSize
 		}
+
+		root.Acc(diff)
+
 	default:
 		return ErrNotApplicableDataType
 	}

--- a/pkg/document/operations/edit.go
+++ b/pkg/document/operations/edit.go
@@ -76,15 +76,7 @@ func (e *Edit) Execute(root *crdt.Root, versionVector time.VersionVector) error 
 
 		for _, pair := range pairs {
 			root.RegisterGCPair(pair)
-
-			size := pair.Child.DataSize()
-			diff.Sub(size)
-
-			// NOTE(hackerwins): In general cases, when removing a node, its size
-			// includes removedAt, so when subtracting the node size from docSize.Live,
-			// we need to subtract the removedAt size. However, RHTNode doesn't have
-			// removedAt, so we don't need to subtract it from the Live size.
-			diff.Meta += time.TicketSize
+			root.AdjustDiffForGCPair(&diff, pair)
 		}
 
 		root.Acc(diff)

--- a/pkg/document/operations/style.go
+++ b/pkg/document/operations/style.go
@@ -71,9 +71,7 @@ func (e *Style) Execute(root *crdt.Root, versionVector time.VersionVector) error
 
 	for _, pair := range pairs {
 		root.RegisterGCPair(pair)
-
-		size := pair.Child.DataSize()
-		diff.Sub(size)
+		root.AdjustDiffForGCPair(&diff, pair)
 	}
 
 	root.Acc(diff)

--- a/pkg/document/operations/style.go
+++ b/pkg/document/operations/style.go
@@ -69,11 +69,14 @@ func (e *Style) Execute(root *crdt.Root, versionVector time.VersionVector) error
 		return err
 	}
 
-	root.Acc(diff)
-
 	for _, pair := range pairs {
 		root.RegisterGCPair(pair)
+
+		size := pair.Child.DataSize()
+		diff.Sub(size)
 	}
+
+	root.Acc(diff)
 
 	return nil
 }

--- a/pkg/document/operations/tree_edit.go
+++ b/pkg/document/operations/tree_edit.go
@@ -116,12 +116,20 @@ func (e *TreeEdit) Execute(root *crdt.Root, versionVector time.VersionVector) er
 			return err
 		}
 
-		root.Acc(diff)
-
 		for _, pair := range pairs {
 			root.RegisterGCPair(pair)
 
+			size := pair.Child.DataSize()
+			diff.Sub(size)
+
+			// NOTE(hackerwins): In general cases, when removing a node, its size
+			// includes removedAt, so when subtracting the node size from docSize.Live,
+			// we need to subtract the removedAt size. However, RHTNode doesn't have
+			// removedAt, so we don't need to subtract it from the Live size.
+			diff.Meta += time.TicketSize
 		}
+
+		root.Acc(diff)
 
 	default:
 		return ErrNotApplicableDataType

--- a/pkg/document/operations/tree_edit.go
+++ b/pkg/document/operations/tree_edit.go
@@ -118,15 +118,7 @@ func (e *TreeEdit) Execute(root *crdt.Root, versionVector time.VersionVector) er
 
 		for _, pair := range pairs {
 			root.RegisterGCPair(pair)
-
-			size := pair.Child.DataSize()
-			diff.Sub(size)
-
-			// NOTE(hackerwins): In general cases, when removing a node, its size
-			// includes removedAt, so when subtracting the node size from docSize.Live,
-			// we need to subtract the removedAt size. However, RHTNode doesn't have
-			// removedAt, so we don't need to subtract it from the Live size.
-			diff.Meta += time.TicketSize
+			root.AdjustDiffForGCPair(&diff, pair)
 		}
 
 		root.Acc(diff)

--- a/pkg/document/operations/tree_style.go
+++ b/pkg/document/operations/tree_style.go
@@ -104,9 +104,7 @@ func (e *TreeStyle) Execute(root *crdt.Root, versionVector time.VersionVector) e
 
 	for _, pair := range pairs {
 		root.RegisterGCPair(pair)
-
-		size := pair.Child.DataSize()
-		diff.Sub(size)
+		root.AdjustDiffForGCPair(&diff, pair)
 	}
 
 	root.Acc(diff)

--- a/pkg/document/operations/tree_style.go
+++ b/pkg/document/operations/tree_style.go
@@ -102,11 +102,14 @@ func (e *TreeStyle) Execute(root *crdt.Root, versionVector time.VersionVector) e
 		}
 	}
 
-	root.Acc(diff)
-
 	for _, pair := range pairs {
 		root.RegisterGCPair(pair)
+
+		size := pair.Child.DataSize()
+		diff.Sub(size)
 	}
+
+	root.Acc(diff)
 
 	return nil
 }

--- a/pkg/document/size_test.go
+++ b/pkg/document/size_test.go
@@ -212,6 +212,10 @@ func TestDocumentSize(t *testing.T) {
 		assert.Equal(t, resource.DataSize{Data: 12, Meta: 120}, doc.DocSize().Live)
 		assert.Equal(t, resource.DataSize{Data: 10, Meta: 48}, doc.DocSize().GC)
 
+		clone, err := doc.InternalDocument().DeepCopy()
+		assert.NoError(t, err)
+		assert.Equal(t, doc.DocSize(), clone.DocSize())
+
 		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
 			root.GetText("text").Style(0, 5, map[string]string{"bold": "true"})
 			return nil
@@ -280,6 +284,10 @@ func TestDocumentSize(t *testing.T) {
 		assert.Equal(t, `<doc><p>world</p></doc>`, doc.Root().GetTree("tree").ToXML())
 		assert.Equal(t, resource.DataSize{Data: 10, Meta: 168}, doc.DocSize().Live)
 		assert.Equal(t, resource.DataSize{Data: 20, Meta: 144}, doc.DocSize().GC)
+
+		clone, err := doc.InternalDocument().DeepCopy()
+		assert.NoError(t, err)
+		assert.Equal(t, doc.DocSize(), clone.DocSize())
 
 		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
 			root.GetTree("tree").Style(0, 7, map[string]string{"bold": "true"})


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
This PR introduces a separation of the correction logic in the `RegisterGCPair` function based on the operational mode: editing and build mode. The size correction logic should only apply when a node is deleted during document editing and is being registered in the `GCPair`. 

When rebuilding the document from the Root, this correction logic should not be applied. By clearly defining two modes of operation, we ensure the correction logic is contextually appropriate.

#### Any background context you want to provide?
The current implementation applies the size correction logic universally within the `RegisterGCPair` function, which leads to incorrect behavior when the document is being rebuilt. Separating the functionality into specific modes allows for more precise and expected handling of size corrections during document edits versus rebuilding.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [ ] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of document size tracking during editing and styling operations, ensuring correct size adjustments related to garbage collection pairs.
- **Tests**
  - Enhanced tests to verify document size consistency after deep copying document states.
  - Added integration test validating document size correctness and synchronization behavior around snapshot thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->