### PR TITLE
documents are detached when client is deactivated"

### DIFF
--- a/server/backend/database/mongo/client_test.go
+++ b/server/backend/database/mongo/client_test.go
@@ -136,4 +136,8 @@ func TestClient(t *testing.T) {
 	t.Run("FindClientInfosByAttachedDocRefKey test", func(t *testing.T) {
 		testcases.RunFindClientInfosByAttachedDocRefKeyTest(t, cli, dummyProjectID)
 	})
+
+	t.Run("DeactivateClient test", func(t *testing.T) {
+		testcases.RunDeactivateClientTest(t, cli)
+	})
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
What this PR does / why we need it:

This PR ensures that when a client is deactivated, all documents attached to that client are automatically detached. This resolves the inconsistency where some documents remained in the attached state despite the client being deactivated, potentially causing data integrity issues.

Which issue(s) this PR fixes:

Fixes #1256 

<!-- Replace with the actual issue number if tracked -->
Special notes for your reviewer:

Please verify that the detachment logic covers all edge cases where a client might be deactivated mid-operation.

Feedback on the test coverage for the detachment mechanism is appreciated.

Does this PR introduce a user-facing change?:

Clients that are deactivated will now correctly cause all attached documents to transition to the detached state, preventing unintended access and improving consistency in document lifecycle management.
Additional documentation:

Checklist:

 - [x] Added relevant tests or not required

 - [x] Addressed and resolved all CodeRabbit review comments

 - [x] Didn't break anything