### PR TITLE
Invalidate snapshot cache on compaction and purging

### DIFF
--- a/server/documents/documents.go
+++ b/server/documents/documents.go
@@ -60,9 +60,6 @@ var (
 
 	// ErrDocumentAlreadyExists is returned when the document already exists.
 	ErrDocumentAlreadyExists = errors.New("document already exists")
-
-	// ErrDocumentNotRemoved is returned when the document is not removed yet.
-	ErrDocumentNotRemoved = errors.New("document is not removed yet")
 )
 
 // CreateDocument creates a new document with the given key and server sequence.

--- a/server/packs/compaction.go
+++ b/server/packs/compaction.go
@@ -20,6 +20,7 @@ package packs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/yorkie-team/yorkie/api/types"
@@ -32,6 +33,11 @@ import (
 	"github.com/yorkie-team/yorkie/server/logging"
 )
 
+var (
+	// ErrDocumentNotRemoved is returned when the document is not removed yet.
+	ErrDocumentNotRemoved = errors.New("document is not removed yet")
+)
+
 // Compact compacts the given document and its metadata and stores them in the
 // database.
 func Compact(
@@ -40,6 +46,9 @@ func Compact(
 	projectID types.ID,
 	docInfo *database.DocInfo,
 ) error {
+	// 0. Invalidate snapshot cache.
+	be.SnapshotCache.Remove(docInfo.RefKey())
+
 	// 1. Check if the document is attached.
 	isAttached, err := be.DB.IsDocumentAttached(ctx, types.DocRefKey{
 		ProjectID: projectID,
@@ -105,6 +114,35 @@ func Compact(
 		)
 		return err
 	}
+
+	return nil
+}
+
+func Purge(
+	ctx context.Context,
+	be *backend.Backend,
+	projectID types.ID,
+	docInfo *database.DocInfo,
+) error {
+	// 0. Invalidate snapshot cache.
+	be.SnapshotCache.Remove(docInfo.RefKey())
+
+	// 1. Check if the document is removed.
+	if !docInfo.IsRemoved() {
+		return fmt.Errorf("document %s is not removed", docInfo.ID)
+	}
+
+	// 2. Purge the document from the database.
+	counts, err := be.DB.PurgeDocument(ctx, docInfo.RefKey())
+	if err != nil {
+		logging.From(ctx).Error("failed to purge document", "error", err)
+		return err
+	}
+
+	logging.From(ctx).Infow(fmt.Sprintf(
+		"purged document internals [project_id=%s doc_id=%s]",
+		projectID, docInfo.ID,
+	), "changes", counts["changes"], "snapshots", counts["snapshots"], "versionvectors", counts["versionvectors"])
 
 	return nil
 }

--- a/server/packs/compaction.go
+++ b/server/packs/compaction.go
@@ -58,7 +58,7 @@ func Compact(
 		return err
 	}
 	if isAttached {
-		// TODO(hackerwins): ErrDocumentNotRemoved exists in documents package,
+		// TODO(hackerwins): ErrDocumentNotAttached exists in documents package,
 		// but it can not be here because of the circular dependency.
 		return fmt.Errorf("document is attached")
 	}
@@ -118,6 +118,7 @@ func Compact(
 	return nil
 }
 
+// Purge removes the document from the database permanently.
 func Purge(
 	ctx context.Context,
 	be *backend.Backend,
@@ -129,13 +130,12 @@ func Purge(
 
 	// 1. Check if the document is removed.
 	if !docInfo.IsRemoved() {
-		return fmt.Errorf("document %s is not removed", docInfo.ID)
+		return fmt.Errorf("document %s is not removed: %w", docInfo.ID, ErrDocumentNotRemoved)
 	}
 
 	// 2. Purge the document from the database.
 	counts, err := be.DB.PurgeDocument(ctx, docInfo.RefKey())
 	if err != nil {
-		logging.From(ctx).Error("failed to purge document", "error", err)
 		return err
 	}
 

--- a/server/rpc/connecthelper/status.go
+++ b/server/rpc/connecthelper/status.go
@@ -77,7 +77,7 @@ var errorToConnectCode = map[error]connect.Code{
 	documents.ErrDocumentAttached:       connect.CodeFailedPrecondition,
 	packs.ErrInvalidServerSeq:           connect.CodeFailedPrecondition,
 	database.ErrConflictOnUpdate:        connect.CodeFailedPrecondition,
-	documents.ErrDocumentNotRemoved:     connect.CodeFailedPrecondition,
+	packs.ErrDocumentNotRemoved:         connect.CodeFailedPrecondition,
 
 	// Unimplemented means the server does not implement the functionality.
 	converter.ErrUnsupportedOperation:   connect.CodeUnimplemented,

--- a/server/server.go
+++ b/server/server.go
@@ -25,10 +25,12 @@ import (
 
 	"github.com/yorkie-team/yorkie/api/types"
 	"github.com/yorkie-team/yorkie/client"
+	"github.com/yorkie-team/yorkie/pkg/document/key"
 	"github.com/yorkie-team/yorkie/server/backend"
 	"github.com/yorkie-team/yorkie/server/backend/database"
 	"github.com/yorkie-team/yorkie/server/clients"
 	"github.com/yorkie-team/yorkie/server/documents"
+	"github.com/yorkie-team/yorkie/server/packs"
 	"github.com/yorkie-team/yorkie/server/profiling"
 	"github.com/yorkie-team/yorkie/server/profiling/prometheus"
 	"github.com/yorkie-team/yorkie/server/projects"
@@ -158,6 +160,21 @@ func (r *Yorkie) DeactivateClient(ctx context.Context, c1 *client.Client) error 
 		ClientID:  types.IDFromActorID(c1.ID()),
 	})
 	return err
+}
+
+// CompactDocument compacts the given document. It is used for testing.
+func (r *Yorkie) CompactDocument(ctx context.Context, docKey key.Key) error {
+	project, err := r.DefaultProject(ctx)
+	if err != nil {
+		return err
+	}
+
+	docInfo, err := documents.FindDocInfoByKey(ctx, r.backend, project, docKey)
+	if err != nil {
+		return err
+	}
+
+	return packs.Compact(ctx, r.backend, project.ID, docInfo)
 }
 
 // RegisterHousekeepingTasks registers housekeeping tasks.

--- a/test/integration/document_test.go
+++ b/test/integration/document_test.go
@@ -976,4 +976,35 @@ func TestDocumentWithInitialRoot(t *testing.T) {
 		// 03. client2 try to update counter
 		assert.Panics(t, func() { doc2.Root().GetText("k").Edit(0, 1, "a") })
 	})
+
+	t.Run("compaction test", func(t *testing.T) {
+		ctx := context.Background()
+		d1 := document.New(helper.TestDocKey(t))
+
+		// 01. create a document and update it 1000 times.
+		assert.NoError(t, c1.Attach(ctx, d1, client.WithInitialRoot(
+			yson.ParseObject(`{"c":Counter(Long(0))}`),
+		)))
+		assert.True(t, d1.IsAttached())
+		assert.NoError(t, c1.Sync(ctx))
+
+		for i := 0; i < 1000; i++ {
+			assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+				root.GetCounter("c").Increase(1)
+				return nil
+			}))
+		}
+		assert.Equal(t, `{"c":1000}`, d1.Marshal())
+		assert.NoError(t, c1.Detach(ctx, d1))
+		assert.Equal(t, int64(1003), d1.Checkpoint().ServerSeq)
+
+		// 02. compact the document.
+		assert.NoError(t, defaultServer.CompactDocument(ctx, d1.Key()))
+
+		// 03. attach again and check if the counter is compacted.
+		d2 := document.New(helper.TestDocKey(t))
+		assert.NoError(t, c2.Attach(ctx, d2))
+		assert.Equal(t, `{"c":1000}`, d2.Marshal())
+		assert.Equal(t, int64(2), d2.Checkpoint().ServerSeq)
+	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Invalidate snapshot cache on compaction and purging

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added the ability to compact documents on the server, reducing storage usage after many updates.
	- Introduced a new document purge function to permanently remove documents from the database.
- **Bug Fixes**
	- Corrected error mapping to ensure accurate status codes are returned for document removal errors.
- **Tests**
	- Introduced a new integration test to verify document compaction preserves state and optimizes server sequence numbers.
- **Refactor**
	- Streamlined document purge logic for improved maintainability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->