### PR TITLE
Rollback lock-free implementation due to CPU overhead

### DIFF
--- a/design/fine-grained-document-locking.md
+++ b/design/fine-grained-document-locking.md
@@ -1,6 +1,6 @@
 ---
 title: fine-grained-document-locking
-target-version: 0.6.15
+target-version: 0.6.16
 ---
 
 <!-- Make sure to append document link in design README.md after creating the document. -->
@@ -30,7 +30,7 @@ This proposal introduces a fine-grained document locking mechanism to improve co
 | ---------------- | ----------------------------------------------------------------------------------- |
 | `doc`            | Coordinates consistency between PushPull-series requests(RLock) and compaction      |
 | `doc.attachment` | Ensures consistency during Attach/Detach operations                                 |
-| `doc.push`       | Ensures consistency while pushing changes to server (lock-free implementation)      |
+| `doc.push`       | Ensures consistency while pushing changes to server                                 |
 | `doc.pull`       | Ensures consistency when clients have already pushed changes or pull unseen changes |
 
 ### Lock Acquisition by API
@@ -77,9 +77,11 @@ This proposal introduces a fine-grained document locking mechanism to improve co
 
 **PushPull(Internal Function)**
 
-1. 🔒 Acquire `doc.push` (conceptually lock, but uses lock-free implementation for high concurrency)
-2. Push changes and assign `ServerSeq`
-3. 🔓 Release `doc.push`
+1. 🔒 Acquire `doc.push`
+2. `findDoc` to fetch `server_seq`
+3. Push `changes` and assign `server_seq`
+4. `updateDoc` with `server_seq`
+5. 🔓 Release `doc.push`
 
 ```ts
 // 01. Atomically Reserve ServerSeq

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -1055,59 +1055,17 @@ func (c *Client) CreateChangeInfos(
 	changes []*change.Change,
 	isRemoved bool,
 ) (*database.DocInfo, change.Checkpoint, error) {
-	// 01. If there are no changes, return the existing docInfo.
-	if !isRemoved && len(changes) == 0 {
-		docInfo, err := c.FindDocInfoByRefKey(ctx, refKey)
-		if err != nil {
-			return nil, change.InitialCheckpoint, err
-		}
+	// 01. Fetch the document info.
+	docInfo, err := c.FindDocInfoByRefKey(ctx, refKey)
+	if err != nil {
+		return nil, change.InitialCheckpoint, err
+	}
+	if len(changes) == 0 && !isRemoved {
 		return docInfo, checkpoint, nil
 	}
 
-	// 02. First, update the document info with the given changes.
-	// If the insertion changes is failed, document will spend server_seq
-	// without corresponding changes.
-	hasOperations := false
-	for _, cn := range changes {
-		if len(cn.Operations()) > 0 {
-			hasOperations = true
-			break
-		}
-	}
-
-	now := gotime.Now()
-	updateOps := bson.M{}
-	if len(changes) > 0 {
-		updateOps["$inc"] = bson.M{"server_seq": len(changes)}
-	}
-	setFields := bson.M{}
-	if hasOperations {
-		setFields["updated_at"] = now
-	}
-	if isRemoved {
-		setFields["removed_at"] = now
-	}
-	if len(setFields) > 0 {
-		updateOps["$set"] = setFields
-	}
-	result := c.collection(ColDocuments).FindOneAndUpdate(
-		ctx,
-		bson.M{
-			"project_id": refKey.ProjectID,
-			"_id":        refKey.DocID,
-		},
-		updateOps,
-		options.FindOneAndUpdate().SetReturnDocument(options.Before),
-	)
-	docInfo := &database.DocInfo{}
-	if err := result.Decode(docInfo); err != nil {
-		if err == mongo.ErrNoDocuments {
-			return nil, change.InitialCheckpoint, fmt.Errorf("%s: %w", refKey.DocID, database.ErrDocumentNotFound)
-		}
-		return nil, change.InitialCheckpoint, fmt.Errorf("decode document: %w", err)
-	}
-
-	// 03. Insert changes into the changes collection.
+	// 02. Insert changes into the changes collection.
+	initialServerSeq := docInfo.ServerSeq
 	var models []mongo.WriteModel
 	for _, cn := range changes {
 		serverSeq := docInfo.IncreaseServerSeq()
@@ -1134,12 +1092,6 @@ func (c *Client) CreateChangeInfos(
 			"presence_change": cn.PresenceChange(),
 		}}).SetUpsert(true))
 	}
-
-	// NOTE(hackerwins): If InsertMany operation fails, there will be a mismatch
-	// between the already incremented server_seq and the actual stored changes.
-	// This can lead to gaps in the sequence numbers, which can cause data
-	// consistency issues. We need to handle this case by either rolling back
-	// the increment or ensuring that the changes are always pushed successfully.
 	if len(changes) > 0 {
 		if _, err := c.collection(ColChanges).BulkWrite(
 			ctx,
@@ -1149,6 +1101,38 @@ func (c *Client) CreateChangeInfos(
 			return nil, change.InitialCheckpoint, fmt.Errorf("bulk write changes: %w", err)
 		}
 	}
+
+	// 03. Update the document info with the given changes.
+	now := gotime.Now()
+	updateFields := bson.M{
+		"server_seq": docInfo.ServerSeq,
+	}
+
+	for _, cn := range changes {
+		if len(cn.Operations()) > 0 {
+			updateFields["updated_at"] = now
+			break
+		}
+	}
+
+	if isRemoved {
+		updateFields["removed_at"] = now
+	}
+
+	res, err := c.collection(ColDocuments).UpdateOne(ctx, bson.M{
+		"project_id": refKey.ProjectID,
+		"_id":        refKey.DocID,
+		"server_seq": initialServerSeq,
+	}, bson.M{
+		"$set": updateFields,
+	})
+	if err != nil {
+		return nil, change.InitialCheckpoint, fmt.Errorf("update document: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		return nil, change.InitialCheckpoint, fmt.Errorf("%s: %w", refKey, database.ErrConflictOnUpdate)
+	}
+
 	if isRemoved {
 		docInfo.RemovedAt = now
 	}

--- a/server/backend/database/testcases/testcases.go
+++ b/server/backend/database/testcases/testcases.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	gosync "sync"
 	"testing"
 	gotime "time"
 
@@ -1197,52 +1196,6 @@ func RunCreateChangeInfosTest(t *testing.T, db database.Database, projectID type
 		assert.NoError(t, err)
 		docInfo3, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
 		assert.NotEqual(t, updatedAt, docInfo3.UpdatedAt)
-	})
-
-	t.Run("create change infos without conflict test", func(t *testing.T) {
-		ctx := context.Background()
-		docKey := helper.TestDocKey(t)
-		numOfClients := 100
-
-		owner, err := db.ActivateClient(ctx, projectID, fmt.Sprintf("%s", t.Name()), map[string]string{})
-		assert.NoError(t, err)
-		docInfo, err := db.FindOrCreateDocInfo(ctx, owner.RefKey(), docKey)
-		assert.NoError(t, err)
-
-		var clients []*database.ClientInfo
-		for i := range numOfClients {
-			c, err := db.ActivateClient(ctx, projectID, fmt.Sprintf("%s-%d", t.Name(), i), map[string]string{})
-			assert.NoError(t, err)
-			assert.NoError(t, c.AttachDocument(docInfo.ID, false))
-			assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c, docInfo))
-			clients = append(clients, c)
-		}
-
-		wg := gosync.WaitGroup{}
-		for i, c := range clients {
-			wg.Add(1)
-			go func(client *database.ClientInfo, idx int) {
-				defer wg.Done()
-				ctx := context.Background()
-				doc := document.New(docKey)
-				actorID, err := client.ID.ToActorID()
-				assert.NoError(t, err)
-				doc.SetActor(actorID)
-
-				assert.NoError(t, doc.Update(func(r *json.Object, p *presence.Presence) error {
-					p.Set("key", fmt.Sprintf("val-%d", idx))
-					return nil
-				}))
-				pack := doc.CreateChangePack()
-				_, _, err = db.CreateChangeInfos(ctx, docInfo.RefKey(), pack.Checkpoint, pack.Changes, false)
-				assert.NoError(t, err)
-			}(c, i)
-		}
-		wg.Wait()
-
-		changes, err := db.FindChangesBetweenServerSeqs(ctx, docInfo.RefKey(), 1, int64(numOfClients))
-		assert.NoError(t, err)
-		assert.Equal(t, numOfClients, len(changes))
 	})
 }
 

--- a/server/packs/pushpull.go
+++ b/server/packs/pushpull.go
@@ -177,8 +177,10 @@ func pushPack(
 	}
 
 	// 02. Push the changes to the database.
-	// NOTE(hackerwins): We replace the push lock with the lock-free implementation
-	// to increase the performance of the push operation.
+	if len(pushables) > 0 || reqPack.IsRemoved {
+		locker := be.Lockers.Locker(DocPushKey(docKey))
+		defer locker.Unlock()
+	}
 	docInfo, cpAfterPush, err := be.DB.CreateChangeInfos(
 		ctx,
 		docKey,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Lock-free approach eliminated write lock contention. However, waiting
shifted to MongoDB Driver level causing unexpected CPU overhead.

This commit restores push-lock for immediate performance recovery.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [ ] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [ ] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to clarify the locking process during document push operations and revised workflow descriptions for improved clarity.

- **Refactor**
  - Improved the process for pushing changes to the database by restructuring the sequence of operations for better concurrency control.
  - Enhanced locking behavior to ensure consistency when pushing document changes.

- **Tests**
  - Removed a test case related to concurrent creation of change information for documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->