### PR TITLE
Update shardKeys for document-wide collections to hashed

### DIFF
--- a/build/charts/yorkie-cluster/charts/yorkie-mongodb/values.yaml
+++ b/build/charts/yorkie-cluster/charts/yorkie-mongodb/values.yaml
@@ -45,17 +45,17 @@ sharded:
       - collectionName: changes
         shardKeys:
           - name: doc_id
-            method: "1"
+            method: "\"hashed\""
         unique: false
       - collectionName: snapshots
         shardKeys:
           - name: doc_id
-            method: "1"
+            method: "\"hashed\""
         unique: false
       - collectionName: versionvectors
         shardKeys:
           - name: doc_id
-            method: "1"
+            method: "\"hashed\""
         unique: false
 
 # Configuration for manual dmongodb sharded stack

--- a/build/docker/sharding/scripts/init-mongos1.js
+++ b/build/docker/sharding/scripts/init-mongos1.js
@@ -20,9 +20,9 @@ const mongoClientDB = "test-yorkie-meta-mongo-client";
 sh.enableSharding(mongoClientDB);
 sh.shardCollection(mongoClientDB + ".clients", { project_id: 1 });
 sh.shardCollection(mongoClientDB + ".documents", { project_id: 1 });
-sh.shardCollection(mongoClientDB + ".changes", { doc_id: 1 });
-sh.shardCollection(mongoClientDB + ".snapshots", { doc_id: 1 });
-sh.shardCollection(mongoClientDB + ".versionvectors", { doc_id: 1 });
+sh.shardCollection(mongoClientDB + ".changes", { doc_id: "hashed" });
+sh.shardCollection(mongoClientDB + ".snapshots", { doc_id: "hashed" });
+sh.shardCollection(mongoClientDB + ".versionvectors", { doc_id: "hashed" });
 
 // Split the inital range at `splitPoint` to allow doc_ids duplicate in different shards.
 const splitPoint = ObjectId("500000000000000000000000");
@@ -39,6 +39,6 @@ const serverDB = "test-yorkie-meta-server";
 sh.enableSharding(serverDB);
 sh.shardCollection(serverDB + ".clients", { project_id: 1 });
 sh.shardCollection(serverDB + ".documents", { project_id: 1 });
-sh.shardCollection(serverDB + ".changes", { doc_id: 1 });
-sh.shardCollection(serverDB + ".snapshots", { doc_id: 1 });
-sh.shardCollection(serverDB + ".versionvectors", { doc_id: 1 });
+sh.shardCollection(serverDB + ".changes", { doc_id: "hashed" });
+sh.shardCollection(serverDB + ".snapshots", { doc_id: "hashed" });
+sh.shardCollection(serverDB + ".versionvectors", { doc_id: "hashed" });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Previously, doc_id fields(based on time-ordered ObjectIds) caused uneven shard distribution due to the ranged shard key, concentrating load on a single shard.

<img width="1417" alt="image" src="https://github.com/user-attachments/assets/68431179-9a20-451b-9acc-a32e1cd03b91" />

This commit updates shard key strategy to `hashed` for `changes`, `snapshots`, and `versionvectors` collections.

<img width="1421" alt="image" src="https://github.com/user-attachments/assets/4fea01e2-5d11-4fd0-9aa7-7767110b936a" />

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the sharding strategy for specific collections to use hashed shard keys instead of ranged shard keys. This change may improve data distribution and performance for affected collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->