### PR TITLE
Add project cache invalidation on UpdateProject

### DIFF
--- a/server/rpc/admin_server.go
+++ b/server/rpc/admin_server.go
@@ -234,6 +234,9 @@ func (s *adminServer) UpdateProject(
 		return nil, err
 	}
 
+	// Invalidate project cache after successful update
+	s.yorkieInterceptor.InvalidateProjectCache(project.PublicKey)
+
 	return connect.NewResponse(&api.UpdateProjectResponse{
 		Project: converter.ToProject(project),
 	}), nil

--- a/server/rpc/interceptors/yorkie.go
+++ b/server/rpc/interceptors/yorkie.go
@@ -224,3 +224,8 @@ func (i *YorkieServiceInterceptor) checkCORS(ctx context.Context, header http.He
 		fmt.Errorf("origin %q not allowed", origin),
 	)
 }
+
+// InvalidateProjectCache invalidates the project cache for the given API key.
+func (i *YorkieServiceInterceptor) InvalidateProjectCache(apiKey string) {
+	i.backend.Cache.Project.Remove(apiKey)
+}

--- a/server/rpc/server_test.go
+++ b/server/rpc/server_test.go
@@ -223,6 +223,10 @@ func TestAdminRPCServerBackend(t *testing.T) {
 		testcases.RunAdminUpdateProjectTest(t, testAdminClient, testAdminAuthInterceptor)
 	})
 
+	t.Run("admin update project cache invalidation test", func(t *testing.T) {
+		testcases.RunAdminUpdateProjectCacheInvalidationTest(t, testClient, testAdminClient, testAdminAuthInterceptor)
+	})
+
 	t.Run("admin list documents test", func(t *testing.T) {
 		testcases.RunAdminListDocumentsTest(t, testAdminClient, testAdminAuthInterceptor)
 	})

--- a/test/complex/server_test.go
+++ b/test/complex/server_test.go
@@ -91,6 +91,10 @@ func TestAdminRPCServerBackendWithShardedDB(t *testing.T) {
 		testcases.RunAdminUpdateProjectTest(t, testAdminClient, testAdminAuthInterceptor)
 	})
 
+	t.Run("admin update project cache invalidation test", func(t *testing.T) {
+		testcases.RunAdminUpdateProjectCacheInvalidationTest(t, testClient, testAdminClient, testAdminAuthInterceptor)
+	})
+
 	t.Run("admin list documents test", func(t *testing.T) {
 		testcases.RunAdminListDocumentsTest(t, testAdminClient, testAdminAuthInterceptor)
 	})


### PR DESCRIPTION

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR addresses an issue where the project cache is not automatically invalidated when updateProject is called. Without proper cache invalidation, updated project metadata may not be reflected across the system, especially in a clustered environment where multiple instances are running concurrently. This can lead to data inconsistencies and unexpected behavior.
By introducing explicit cache invalidation, we ensure that project updates are propagated correctly and consistently throughout the system.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #1281 

**Special notes for your reviewer**:

Please review the added cache invalidation logic to ensure it aligns with existing caching mechanisms and doesn't introduce unintended side effects. Feedback is welcome!

**Does this PR introduce a user-facing change?**:

Project cache is now properly invalidated upon updates, ensuring consistent metadata across nodes.

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured that project cache is properly refreshed after project updates, so users always see the latest project information.

- **Tests**
  - Added new tests to verify that project cache invalidation works correctly after updates, improving reliability and consistency of project data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->