### PR TITLE
Introduce Lock-Free Mechanism with Gap Detection

### DIFF
--- a/server/backend/database/memory/database_test.go
+++ b/server/backend/database/memory/database_test.go
@@ -104,8 +104,12 @@ func TestDB(t *testing.T) {
 		testcases.RunFindDocInfosByPagingTest(t, db, projectTwoID)
 	})
 
-	t.Run("CreateClientInfo test", func(t *testing.T) {
+	t.Run("CreateChangeInfos test", func(t *testing.T) {
 		testcases.RunCreateChangeInfosTest(t, db, projectID)
+	})
+
+	t.Run("RunConcurrentChangeInfos test", func(t *testing.T) {
+		testcases.RunConcurrentChangeInfosTest(t, db, projectID)
 	})
 
 	t.Run("UpdateClientInfoAfterPushPull test", func(t *testing.T) {

--- a/server/backend/database/mongo/client_test.go
+++ b/server/backend/database/mongo/client_test.go
@@ -127,6 +127,10 @@ func TestClient(t *testing.T) {
 		testcases.RunCreateChangeInfosTest(t, cli, dummyProjectID)
 	})
 
+	t.Run("RunConcurrentChangeInfos test", func(t *testing.T) {
+		testcases.RunConcurrentChangeInfosTest(t, cli, dummyProjectID)
+	})
+
 	t.Run("UpdateClientInfoAfterPushPull test", func(t *testing.T) {
 		testcases.RunUpdateClientInfoAfterPushPullTest(t, cli, dummyProjectID)
 	})

--- a/server/packs/pushpull.go
+++ b/server/packs/pushpull.go
@@ -182,10 +182,6 @@ func pushPack(
 	}
 
 	// 02. Push the changes to the database.
-	if len(pushables) > 0 || reqPack.IsRemoved {
-		locker := be.Lockers.Locker(DocPushKey(docKey))
-		defer locker.Unlock()
-	}
 	docInfo, cpAfterPush, err := be.DB.CreateChangeInfos(
 		ctx,
 		docKey,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Introduce Lock-Free Mechanism with Gap Detection

Previously, PushLock was used to coordinate concurrent access, but it introduced performance bottlenecks under high load. To improve concurrency, this commit introduces a lock-free approach.

However, this introduced a race condition between `CreateChangeInfos` and `FindChangeInfosBetweenServerSeqs`, where a reader could observe a partial sequence of changes due to write timing gaps.

To address this, we added gap detection in PullPack. If a gap in `server_seq` is detected, the operation is retried until the full expected sequence is available.

We also explored using MongoDB transactions to mitigate the race condition, but this approach resulted in lower concurrency levels than the previous PushLock solution. In particular, under load (e.g., 500+ virtual users), a significant number of slow queries were observed.

🧪 Gap Reproduction Scenario:

- Client A calls `CreateChangeInfos` and writes `change_1` and `change_2` with `server_seq` = 1, 2 using a BulkWrite with `SetOrdered(true)`.
- Client B concurrently writes `change_3` and `change_4` with `server_seq` = 3, 4 using a separate BulkWrite.
- Client C reads changes between `server_seq` 1 and 4 using `FindChangeInfosBetweenServerSeqs`, but only sees `change_3` and `change_4` due to timing issues.

⚠️ MongoDB Limitations:
- No guaranteed write order across concurrent operations, even with `SetOrdered(true)`.
- Read operations can observe partial data if writes are not yet visible (e.g., with default `readConcern: local`).
- Without explicit sorting, document read order is non-deterministic.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #1285

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability when handling document changes by adding retry logic and gap detection for change retrieval.
	- Enhanced error handling for client activation to ensure accurate client information retrieval in case of conflicts.

- **Tests**
	- Introduced new tests to verify concurrent document change operations and detect potential race conditions.
	- Expanded test coverage for creating and retrieving document changes under concurrent scenarios.

- **Refactor**
	- Streamlined internal logic for managing document changes and client activation.
	- Removed synchronization locks around document push operations to simplify processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->