### PR TITLE
Replace SnapshotRefKey with DocRefKey and ServerSeq

### DIFF
--- a/api/types/resource_ref_key.go
+++ b/api/types/resource_ref_key.go
@@ -42,17 +42,6 @@ func (r ClientRefKey) String() string {
 	return fmt.Sprintf("Client (%s.%s)", r.ProjectID, r.ClientID)
 }
 
-// SnapshotRefKey represents an identifier used to reference a snapshot.
-type SnapshotRefKey struct {
-	DocRefKey
-	ServerSeq int64
-}
-
-// String returns the string representation of the given SnapshotRefKey.
-func (r SnapshotRefKey) String() string {
-	return fmt.Sprintf("Snapshot (%s.%s.%d)", r.ProjectID, r.DocID, r.ServerSeq)
-}
-
 // EventRefKey represents an identifier used to reference an event.
 type EventRefKey struct {
 	DocRefKey

--- a/server/backend/database/database.go
+++ b/server/backend/database/database.go
@@ -279,10 +279,11 @@ type Database interface {
 		doc *document.InternalDocument,
 	) error
 
-	// FindSnapshotInfoByRefKey returns the snapshot by the given refKey.
-	FindSnapshotInfoByRefKey(
+	// FindSnapshotInfo return the snapshot by the given DocRefKey and serverSeq.
+	FindSnapshotInfo(
 		ctx context.Context,
-		refKey types.SnapshotRefKey,
+		refKey types.DocRefKey,
+		serverSeq int64,
 	) (*SnapshotInfo, error)
 
 	// FindClosestSnapshotInfo finds the closest snapshot info in a given serverSeq.

--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -1314,22 +1314,23 @@ func (d *DB) CreateSnapshotInfo(
 	return nil
 }
 
-// FindSnapshotInfoByRefKey returns the snapshot by the given refKey.
-func (d *DB) FindSnapshotInfoByRefKey(
+// FindSnapshotInfo returns the snapshot info of the given DocRefKey and serverSeq.
+func (d *DB) FindSnapshotInfo(
 	_ context.Context,
-	refKey types.SnapshotRefKey,
+	docKey types.DocRefKey,
+	serverSeq int64,
 ) (*database.SnapshotInfo, error) {
 	txn := d.db.Txn(false)
 	defer txn.Abort()
 	raw, err := txn.First(tblSnapshots, "doc_id_server_seq",
-		refKey.DocID.String(),
-		refKey.ServerSeq,
+		docKey.DocID.String(),
+		serverSeq,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("find snapshot by id: %w", err)
 	}
 	if raw == nil {
-		return nil, fmt.Errorf("%s: %w", refKey, database.ErrSnapshotNotFound)
+		return nil, fmt.Errorf("%s: %w", docKey, database.ErrSnapshotNotFound)
 	}
 
 	return raw.(*database.SnapshotInfo).DeepCopy(), nil

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -1373,15 +1373,16 @@ func (c *Client) CreateSnapshotInfo(
 	return nil
 }
 
-// FindSnapshotInfoByRefKey returns the snapshot by the given refKey.
-func (c *Client) FindSnapshotInfoByRefKey(
+// FindSnapshotInfo returns the snapshot info of the given DocRefKey and serverSeq.
+func (c *Client) FindSnapshotInfo(
 	ctx context.Context,
-	refKey types.SnapshotRefKey,
+	docKey types.DocRefKey,
+	serverSeq int64,
 ) (*database.SnapshotInfo, error) {
 	result := c.collection(ColSnapshots).FindOne(ctx, bson.M{
-		"project_id": refKey.ProjectID,
-		"doc_id":     refKey.DocID,
-		"server_seq": refKey.ServerSeq,
+		"project_id": docKey.ProjectID,
+		"doc_id":     docKey.DocID,
+		"server_seq": serverSeq,
 	})
 
 	snapshotInfo := &database.SnapshotInfo{}

--- a/server/backend/database/snapshot_info.go
+++ b/server/backend/database/snapshot_info.go
@@ -69,12 +69,9 @@ func (i *SnapshotInfo) DeepCopy() *SnapshotInfo {
 }
 
 // RefKey returns the refKey of the snapshot.
-func (i *SnapshotInfo) RefKey() types.SnapshotRefKey {
-	return types.SnapshotRefKey{
-		DocRefKey: types.DocRefKey{
-			ProjectID: i.ProjectID,
-			DocID:     i.DocID,
-		},
-		ServerSeq: i.ServerSeq,
+func (i *SnapshotInfo) DocRefKey() types.DocRefKey {
+	return types.DocRefKey{
+		ProjectID: i.ProjectID,
+		DocID:     i.DocID,
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

After introducing MongoDB sharding, we added ClientRefKey, DocRefKey to ensure
targeted queries to include shard key. However, only the `snapshots` collection
had its own SnapshotRefKey, while `changes` and `versionvectors` used DocRefKey.
This inconsistency added complexity and imbalance to the design.

This commit removes SnapshotRefKey and modifies queries to use the same
combination of DocRefKey and ServerSeq across collections.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the way snapshot information is referenced and retrieved, simplifying key structures and method signatures for snapshot lookups.
  * Renamed methods and parameters related to snapshot retrieval for improved clarity.
  * Removed unused structures and methods related to snapshot reference keys.

* **Style**
  * Improved variable naming for better code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->