### PR TITLE
Fix memDB iteration logic to match MongoDB behavior

### DIFF
--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -1564,7 +1564,13 @@ func (d *DB) FindDocInfosByPaging(
 	var docInfos []*database.DocInfo
 	for raw := iterator.Next(); raw != nil; raw = iterator.Next() {
 		info := raw.(*database.DocInfo)
-		if len(docInfos) >= paging.PageSize || info.ProjectID != projectID {
+		// NOTE(raararaara): Unlike MongoDB, which treats PageSize == 0 as "no limit",
+		// memDB requires explicit handling. If PageSize == 0, do not apply any limit.
+		if paging.PageSize > 0 && len(docInfos) >= paging.PageSize {
+			break
+		}
+
+		if info.ProjectID != projectID {
 			break
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR addresses the test failure in the document tests when using memDB.
The failure occurs because memDB implements a different iteration logic compared to MongoDB when the pageSize param is set to 0.

In MongoDB, setting pageSize to 0 retrieves all documents, as stated in the [official documentation](https://www.mongodb.com/docs/drivers/go/v1.11/fundamentals/crud/read-operations/limit/#limit). However, memDB currently limits the iteration to stop when the length of docInfo is greater than or equal to pageSize. This inconsistency is leading to failures in the tests.



**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #1018 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [ ] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved paging behavior so that setting the page size to zero now returns all results without limitation, matching expected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->