### PR TITLE
Add MongoDB-based leader election mechanism

### DIFF
--- a/server/backend/database/database.go
+++ b/server/backend/database/database.go
@@ -20,6 +20,7 @@ package database
 import (
 	"context"
 	"errors"
+	gotime "time"
 
 	"github.com/yorkie-team/yorkie/api/types"
 	"github.com/yorkie-team/yorkie/pkg/document"
@@ -67,12 +68,31 @@ var (
 
 	// ErrSchemaAlreadyExists is returned when the schema already exists.
 	ErrSchemaAlreadyExists = errors.New("schema already exists")
+
+	// ErrInvalidLeaseToken is returned when the provided token is invalid.
+	ErrInvalidLeaseToken = errors.New("invalid lease token")
 )
 
 // Database represents database which reads or saves Yorkie data.
 type Database interface {
 	// Close all resources of this database.
 	Close() error
+
+	// TryLeadership attempts to acquire or renew leadership with the given lease duration.
+	// If leaseToken is empty, it attempts to acquire new leadership.
+	// If leaseToken is provided, it attempts to renew the existing lease.
+	TryLeadership(
+		ctx context.Context,
+		hostname string,
+		leaseToken string,
+		leaseDuration gotime.Duration,
+	) (*LeadershipInfo, error)
+
+	// FindLeadership returns the current leadership information.
+	FindLeadership(ctx context.Context) (*LeadershipInfo, error)
+
+	// ClearLeadership removes the current leadership information for testing purposes.
+	ClearLeadership(ctx context.Context) error
 
 	// FindProjectInfoByPublicKey returns a project by public key.
 	FindProjectInfoByPublicKey(

--- a/server/backend/database/leadership_info.go
+++ b/server/backend/database/leadership_info.go
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package database
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+// LeadershipInfo represents the leadership information of a node in the cluster.
+type LeadershipInfo struct {
+	Hostname   string    `bson:"hostname"`
+	LeaseToken string    `bson:"lease_token"`
+	ElectedAt  time.Time `bson:"elected_at"`
+	ExpiresAt  time.Time `bson:"expires_at"`
+	RenewedAt  time.Time `bson:"renewed_at"`
+	Term       int64     `bson:"term"`
+	Singleton  int       `bson:"singleton"`
+}
+
+// IsExpired returns true if the leadership lease has expired.
+func (li *LeadershipInfo) IsExpired() bool {
+	return time.Now().After(li.ExpiresAt)
+}
+
+// TimeUntilExpiry returns the duration until the lease expires.
+func (li *LeadershipInfo) TimeUntilExpiry() time.Duration {
+	return time.Until(li.ExpiresAt)
+}
+
+// GenerateLeaseToken generates a cryptographically secure random token
+func GenerateLeaseToken() (string, error) {
+	bytes := make([]byte, 16)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", fmt.Errorf("generate random bytes: %w", err)
+	}
+	return hex.EncodeToString(bytes), nil
+}

--- a/server/backend/database/leadership_info_test.go
+++ b/server/backend/database/leadership_info_test.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package database_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/server/backend/database"
+)
+
+func TestLeadershipInfo(t *testing.T) {
+	now := time.Now()
+
+	t.Run("IsExpired should return false for future expiry", func(t *testing.T) {
+		info := &database.LeadershipInfo{
+			ExpiresAt: now.Add(10 * time.Second),
+		}
+		assert.False(t, info.IsExpired())
+	})
+
+	t.Run("IsExpired should return true for past expiry", func(t *testing.T) {
+		info := &database.LeadershipInfo{
+			ExpiresAt: now.Add(-10 * time.Second),
+		}
+		assert.True(t, info.IsExpired())
+	})
+
+	t.Run("TimeUntilExpiry should return correct duration", func(t *testing.T) {
+		future := now.Add(30 * time.Second)
+		info := &database.LeadershipInfo{
+			ExpiresAt: future,
+		}
+
+		duration := info.TimeUntilExpiry()
+		assert.True(t, duration > 25*time.Second)
+		assert.True(t, duration <= 30*time.Second)
+	})
+}

--- a/server/backend/database/memory/database_test.go
+++ b/server/backend/database/memory/database_test.go
@@ -36,6 +36,10 @@ func TestDB(t *testing.T) {
 	db, err := memory.New()
 	assert.NoError(t, err)
 
+	t.Run("RunLeadership Test", func(t *testing.T) {
+		testcases.RunLeadershipTest(t, db)
+	})
+
 	t.Run("FindNextNCyclingProjectInfos test", func(t *testing.T) {
 		testcases.RunFindNextNCyclingProjectInfosTest(t, db)
 	})

--- a/server/backend/database/memory/indexes.go
+++ b/server/backend/database/memory/indexes.go
@@ -27,6 +27,7 @@ var (
 	tblSnapshots      = "snapshots"
 	tblVersionVectors = "versionvectors"
 	tblSchemas        = "schemas"
+	tblLeaderships    = "leaderships"
 )
 
 var schema = &memdb.DBSchema{
@@ -284,6 +285,16 @@ var schema = &memdb.DBSchema{
 							&memdb.IntFieldIndex{Field: "Version"},
 						},
 					},
+				},
+			},
+		},
+		tblLeaderships: {
+			Name: tblLeaderships,
+			Indexes: map[string]*memdb.IndexSchema{
+				"id": {
+					Name:    "id",
+					Unique:  true,
+					Indexer: &memdb.StringFieldIndex{Field: "ID"},
 				},
 			},
 		},

--- a/server/backend/database/mongo/client_test.go
+++ b/server/backend/database/mongo/client_test.go
@@ -53,6 +53,10 @@ func setupTestWithDummyData(t *testing.T) *mongo.Client {
 func TestClient(t *testing.T) {
 	cli := setupTestWithDummyData(t)
 
+	t.Run("RunLeadership Test", func(t *testing.T) {
+		testcases.RunLeadershipTest(t, cli)
+	})
+
 	t.Run("FindNextNCyclingProjectInfos test", func(t *testing.T) {
 		testcases.RunFindNextNCyclingProjectInfosTest(t, cli)
 	})

--- a/server/backend/database/mongo/indexes.go
+++ b/server/backend/database/mongo/indexes.go
@@ -26,6 +26,8 @@ import (
 )
 
 const (
+	// ColLeaderships represents the leadership collection in the database.
+	ColLeaderships = "leaderships"
 	// ColProjects represents the projects collection in the database.
 	ColProjects = "projects"
 	// ColUsers represents the users collection in the database.
@@ -34,25 +36,27 @@ const (
 	ColClients = "clients"
 	// ColDocuments represents the documents collection in the database.
 	ColDocuments = "documents"
+	// ColSchemas represents the schemas collection in the database.
+	ColSchemas = "schemas"
 	// ColChanges represents the changes collection in the database.
 	ColChanges = "changes"
 	// ColSnapshots represents the snapshots collection in the database.
 	ColSnapshots = "snapshots"
 	// ColVersionVectors represents the versionvector collection in the database.
 	ColVersionVectors = "versionvectors"
-	// ColSchemas represents the schemas collection in the database.
-	ColSchemas = "schemas"
 )
 
 // Collections represents the list of all collections in the database.
 var Collections = []string{
+	ColLeaderships,
 	ColProjects,
 	ColUsers,
 	ColClients,
 	ColDocuments,
+	ColSchemas,
 	ColChanges,
 	ColSnapshots,
-	ColSchemas,
+	ColVersionVectors,
 }
 
 type collectionInfo struct {
@@ -62,6 +66,20 @@ type collectionInfo struct {
 
 // Below are names and indexes information of Collections that stores Yorkie data.
 var collectionInfos = []collectionInfo{
+	{
+		name: ColLeaderships,
+		indexes: []mongo.IndexModel{{
+			Keys:    bson.D{{Key: "singleton", Value: int32(1)}},
+			Options: options.Index().SetUnique(true),
+		}},
+	},
+	{
+		name: ColUsers,
+		indexes: []mongo.IndexModel{{
+			Keys:    bson.D{{Key: "username", Value: int32(1)}},
+			Options: options.Index().SetUnique(true),
+		}},
+	},
 	{
 		name: ColProjects,
 		indexes: []mongo.IndexModel{{
@@ -75,13 +93,6 @@ var collectionInfos = []collectionInfo{
 			Options: options.Index().SetUnique(true),
 		}, {
 			Keys:    bson.D{{Key: "secret_key", Value: int32(1)}},
-			Options: options.Index().SetUnique(true),
-		}},
-	},
-	{
-		name: ColUsers,
-		indexes: []mongo.IndexModel{{
-			Keys:    bson.D{{Key: "username", Value: int32(1)}},
 			Options: options.Index().SetUnique(true),
 		}},
 	},
@@ -116,7 +127,19 @@ var collectionInfos = []collectionInfo{
 			},
 			Options: options.Index().SetUnique(true),
 		}},
-	}, {
+	},
+	{
+		name: ColSchemas,
+		indexes: []mongo.IndexModel{{
+			Keys: bson.D{
+				{Key: "project_id", Value: int32(1)}, // shard key
+				{Key: "name", Value: int32(1)},
+				{Key: "version", Value: int32(1)},
+			},
+			Options: options.Index().SetUnique(true),
+		}},
+	},
+	{
 		name: ColChanges,
 		indexes: []mongo.IndexModel{{
 			Keys: bson.D{
@@ -151,17 +174,6 @@ var collectionInfos = []collectionInfo{
 				{Key: "doc_id", Value: int32(1)}, // shard key
 				{Key: "project_id", Value: int32(1)},
 				{Key: "client_id", Value: int32(1)},
-			},
-			Options: options.Index().SetUnique(true),
-		}},
-	},
-	{
-		name: ColSchemas,
-		indexes: []mongo.IndexModel{{
-			Keys: bson.D{
-				{Key: "project_id", Value: int32(1)}, // shard key
-				{Key: "name", Value: int32(1)},
-				{Key: "version", Value: int32(1)},
 			},
 			Options: options.Index().SetUnique(true),
 		}},

--- a/server/backend/database/testcases/testcases.go
+++ b/server/backend/database/testcases/testcases.go
@@ -26,6 +26,7 @@ import (
 	gotime "time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	mongodb "go.mongodb.org/mongo-driver/v2/mongo"
 
 	"github.com/yorkie-team/yorkie/api/types"
@@ -44,7 +45,146 @@ const (
 	otherOwnerID              = types.ID("000000000000000000000001")
 	dummyClientID             = types.ID("000000000000000000000000")
 	clientDeactivateThreshold = "1h"
+
+	nodeIDOne = "node-1"
+	nodeIDTwo = "node-2"
 )
+
+func RunLeadershipTest(
+	t *testing.T,
+	db database.Database,
+) {
+	t.Run("TryLeadership should work for new leadership", func(t *testing.T) {
+		ctx := context.Background()
+		require.NoError(t, db.ClearLeadership(ctx))
+
+		leaseDuration := 30 * gotime.Second
+
+		info, err := db.TryLeadership(ctx, nodeIDOne, "", leaseDuration)
+		require.NoError(t, err)
+		assert.Equal(t, nodeIDOne, info.Hostname)
+		assert.NotEmpty(t, info.LeaseToken)
+		assert.Equal(t, int64(1), info.Term)
+		assert.False(t, info.IsExpired())
+	})
+
+	t.Run("TryLeadership should return existing leader when valid", func(t *testing.T) {
+		ctx := context.Background()
+		require.NoError(t, db.ClearLeadership(ctx))
+
+		// First node acquires leadership
+		leaseDuration := 30 * gotime.Second
+
+		info1, err := db.TryLeadership(ctx, nodeIDOne, "", leaseDuration)
+		require.NoError(t, err)
+
+		// Second node tries to acquire leadership
+		info2, err := db.TryLeadership(ctx, nodeIDTwo, "", leaseDuration)
+		require.NoError(t, err)
+
+		// Should return the first node's leadership
+		assert.Equal(t, nodeIDOne, info2.Hostname)
+		assert.Equal(t, info1.LeaseToken, info2.LeaseToken)
+	})
+
+	t.Run("TryLeadership should allow takeover after expiry", func(t *testing.T) {
+		ctx := context.Background()
+		require.NoError(t, db.ClearLeadership(ctx))
+
+		// First node acquires leadership with short lease
+		shortLease := 100 * gotime.Millisecond
+
+		_, err := db.TryLeadership(ctx, nodeIDOne, "", shortLease)
+		require.NoError(t, err)
+
+		// Wait for lease to expire
+		gotime.Sleep(150 * gotime.Millisecond)
+
+		// Second node acquires leadership
+		leaseDuration := 30 * gotime.Second
+
+		info, err := db.TryLeadership(ctx, nodeIDTwo, "", leaseDuration)
+		require.NoError(t, err)
+
+		assert.Equal(t, nodeIDTwo, info.Hostname)
+		assert.Equal(t, int64(2), info.Term) // Term should increment
+	})
+
+	t.Run("TryLeadership should work for renewal with valid token", func(t *testing.T) {
+		ctx := context.Background()
+		require.NoError(t, db.ClearLeadership(ctx))
+
+		leaseDuration := 30 * gotime.Second
+
+		// Acquire leadership
+		info, err := db.TryLeadership(ctx, nodeIDOne, "", leaseDuration)
+		require.NoError(t, err)
+
+		// Renew leadership
+		renewedInfo, err := db.TryLeadership(ctx, nodeIDOne, info.LeaseToken, leaseDuration)
+		require.NoError(t, err)
+
+		assert.Equal(t, nodeIDOne, renewedInfo.Hostname)
+		assert.NotEqual(t, info.LeaseToken, renewedInfo.LeaseToken) // Token should change
+		assert.True(t, renewedInfo.ExpiresAt.After(info.ExpiresAt)) // Expiry should extend
+		assert.Equal(t, info.Term, renewedInfo.Term)                // Term should stay same
+	})
+
+	t.Run("TryLeadership should fail with invalid token", func(t *testing.T) {
+		ctx := context.Background()
+		require.NoError(t, db.ClearLeadership(ctx))
+
+		leaseDuration := 30 * gotime.Second
+
+		// Acquire leadership
+		_, err := db.TryLeadership(ctx, nodeIDOne, "", leaseDuration)
+		require.NoError(t, err)
+
+		// Try to renew with invalid token
+		_, err = db.TryLeadership(ctx, nodeIDOne, "invalid-token", leaseDuration)
+		assert.ErrorIs(t, err, database.ErrInvalidLeaseToken)
+	})
+
+	t.Run("TryLeadership should fail for wrong node with token", func(t *testing.T) {
+		ctx := context.Background()
+		require.NoError(t, db.ClearLeadership(ctx))
+
+		leaseDuration := 30 * gotime.Second
+
+		// Acquire leadership
+		info, err := db.TryLeadership(ctx, nodeIDOne, "", leaseDuration)
+		require.NoError(t, err)
+
+		// Try to renew from different node
+		_, err = db.TryLeadership(ctx, nodeIDTwo, info.LeaseToken, leaseDuration)
+		assert.ErrorIs(t, err, database.ErrInvalidLeaseToken)
+	})
+
+	t.Run("FindLeadership should return current leader", func(t *testing.T) {
+		ctx := context.Background()
+		require.NoError(t, db.ClearLeadership(ctx))
+
+		// No leadership initially
+		info, err := db.FindLeadership(ctx)
+		require.NoError(t, err)
+		assert.Nil(t, info)
+
+		// Acquire leadership
+		leaseDuration := 30 * gotime.Second
+
+		acquired, err := db.TryLeadership(ctx, nodeIDOne, "", leaseDuration)
+		require.NoError(t, err)
+
+		// Get leadership should return the same info
+		info, err = db.FindLeadership(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+
+		assert.Equal(t, acquired.Hostname, info.Hostname)
+		assert.Equal(t, acquired.LeaseToken, info.LeaseToken)
+		assert.Equal(t, acquired.Term, info.Term)
+	})
+}
 
 // RunFindDocInfoTest runs the FindDocInfo test for the given db.
 func RunFindDocInfoTest(

--- a/server/backend/housekeeping/config.go
+++ b/server/backend/housekeeping/config.go
@@ -36,6 +36,12 @@ type Config struct {
 
 	// CompactionMinChanges is the minimum number of changes to compact a document.
 	CompactionMinChanges int `yaml:"CompactionMinChanges"`
+
+	// LeadershipLeaseDuration is the duration of leadership lease.
+	LeadershipLeaseDuration string `yaml:"LeadershipLeaseDuration"`
+
+	// LeadershipRenewalInterval is the interval for leadership renewal.
+	LeadershipRenewalInterval string `yaml:"LeadershipRenewalInterval"`
 }
 
 // Validate validates the configuration.
@@ -68,6 +74,27 @@ func (c *Config) Validate() error {
 			c.CompactionMinChanges,
 		)
 	}
+
+	if c.LeadershipLeaseDuration != "" {
+		if _, err := time.ParseDuration(c.LeadershipLeaseDuration); err != nil {
+			return fmt.Errorf(
+				`invalid argument %s for "--housekeeping-leadership-lease-duration" flag: %w`,
+				c.LeadershipLeaseDuration,
+				err,
+			)
+		}
+	}
+
+	if c.LeadershipRenewalInterval != "" {
+		if _, err := time.ParseDuration(c.LeadershipRenewalInterval); err != nil {
+			return fmt.Errorf(
+				`invalid argument %s for "--housekeeping-leadership-renewal-interval" flag: %w`,
+				c.LeadershipRenewalInterval,
+				err,
+			)
+		}
+	}
+
 	return nil
 }
 
@@ -76,6 +103,34 @@ func (c *Config) ParseInterval() (time.Duration, error) {
 	interval, err := time.ParseDuration(c.Interval)
 	if err != nil {
 		return 0, fmt.Errorf("parse interval %s: %w", c.Interval, err)
+	}
+
+	return interval, nil
+}
+
+// ParseLeadershipLeaseDuration parses the leadership lease duration.
+func (c *Config) ParseLeadershipLeaseDuration() (time.Duration, error) {
+	if c.LeadershipLeaseDuration == "" {
+		return 15 * time.Second, nil // default value
+	}
+
+	duration, err := time.ParseDuration(c.LeadershipLeaseDuration)
+	if err != nil {
+		return 0, fmt.Errorf("parse leadership lease duration %s: %w", c.LeadershipLeaseDuration, err)
+	}
+
+	return duration, nil
+}
+
+// ParseLeadershipRenewalInterval parses the leadership renewal interval.
+func (c *Config) ParseLeadershipRenewalInterval() (time.Duration, error) {
+	if c.LeadershipRenewalInterval == "" {
+		return 5 * time.Second, nil // default value
+	}
+
+	interval, err := time.ParseDuration(c.LeadershipRenewalInterval)
+	if err != nil {
+		return 0, fmt.Errorf("parse leadership renewal interval %s: %w", c.LeadershipRenewalInterval, err)
 	}
 
 	return interval, nil

--- a/server/backend/housekeeping/housekeeping.go
+++ b/server/backend/housekeeping/housekeeping.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/go-co-op/gocron/v2"
 
+	"github.com/yorkie-team/yorkie/server/backend/database"
 	"github.com/yorkie-team/yorkie/server/logging"
 )
 
@@ -31,19 +32,39 @@ import (
 type Housekeeping struct {
 	Config *Config
 
-	scheduler gocron.Scheduler
+	scheduler  gocron.Scheduler
+	leadership *LeadershipManager
 }
 
 // New creates a new housekeeping instance.
-func New(conf *Config) (*Housekeeping, error) {
+func New(conf *Config, db database.Database, nodeID string) (*Housekeeping, error) {
 	scheduler, err := gocron.NewScheduler()
 	if err != nil {
 		return nil, fmt.Errorf("new scheduler: %w", err)
 	}
 
+	// Create leadership config from housekeeping config
+	leaseDuration, err := conf.ParseLeadershipLeaseDuration()
+	if err != nil {
+		return nil, fmt.Errorf("parse leadership lease duration: %w", err)
+	}
+
+	renewalInterval, err := conf.ParseLeadershipRenewalInterval()
+	if err != nil {
+		return nil, fmt.Errorf("parse leadership renewal interval: %w", err)
+	}
+
+	leadershipConf := &LeadershipConfig{
+		LeaseDuration:   leaseDuration,
+		RenewalInterval: renewalInterval,
+	}
+
+	leadershipManager := NewLeadershipManager(db, nodeID, leadershipConf)
+
 	return &Housekeeping{
-		Config:    conf,
-		scheduler: scheduler,
+		Config:     conf,
+		scheduler:  scheduler,
+		leadership: leadershipManager,
 	}, nil
 }
 
@@ -56,6 +77,13 @@ func (h *Housekeeping) RegisterTask(
 		gocron.DurationJob(interval),
 		gocron.NewTask(func() {
 			ctx := context.Background()
+
+			if !h.leadership.IsLeader() {
+				logging.From(ctx).Debug("skipping task - not leader")
+				return
+			}
+
+			logging.From(ctx).Debugf("running housekeeping task with interval %s", interval)
 			if err := task(ctx); err != nil {
 				logging.From(ctx).Error(err)
 			}
@@ -68,13 +96,25 @@ func (h *Housekeeping) RegisterTask(
 }
 
 // Start starts the housekeeping service.
-func (h *Housekeeping) Start() error {
+func (h *Housekeeping) Start(ctx context.Context) error {
+	// Start the leadership manager
+	if h.leadership != nil {
+		if err := h.leadership.Start(ctx); err != nil {
+			return fmt.Errorf("start leadership manager: %w", err)
+		}
+	}
+
 	h.scheduler.Start()
 	return nil
 }
 
 // Stop stops the housekeeping service.
 func (h *Housekeeping) Stop() error {
+	// Stop the leadership manager first
+	if h.leadership != nil {
+		h.leadership.Stop()
+	}
+
 	if err := h.scheduler.StopJobs(); err != nil {
 		return fmt.Errorf("scheduler stop jobs: %w", err)
 	}

--- a/server/backend/housekeeping/leadership.go
+++ b/server/backend/housekeeping/leadership.go
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2025 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package housekeeping
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/yorkie-team/yorkie/server/backend/database"
+	"github.com/yorkie-team/yorkie/server/logging"
+)
+
+// LeadershipManager manages leader election and lease renewal.
+type LeadershipManager struct {
+	database        database.Database
+	hostname        string
+	leaseDuration   time.Duration
+	renewalInterval time.Duration
+
+	// State management
+	isLeader     atomic.Bool
+	currentLease atomic.Pointer[database.LeadershipInfo]
+	stopCh       chan struct{}
+	wg           sync.WaitGroup
+	mutex        sync.RWMutex
+}
+
+// LeadershipConfig contains configuration for leadership management.
+type LeadershipConfig struct {
+	LeaseDuration   time.Duration
+	RenewalInterval time.Duration
+}
+
+// DefaultLeadershipConfig returns the default leadership configuration.
+func DefaultLeadershipConfig() *LeadershipConfig {
+	return &LeadershipConfig{
+		LeaseDuration:   15 * time.Second,
+		RenewalInterval: 5 * time.Second,
+	}
+}
+
+// NewLeadershipManager creates a new leadership manager.
+func NewLeadershipManager(db database.Database, hostname string, conf *LeadershipConfig) *LeadershipManager {
+	if hostname == "" {
+		panic("hostname must not be empty")
+	}
+
+	if conf == nil {
+		conf = DefaultLeadershipConfig()
+	}
+
+	return &LeadershipManager{
+		database:        db,
+		hostname:        hostname,
+		leaseDuration:   conf.LeaseDuration,
+		renewalInterval: conf.RenewalInterval,
+		stopCh:          make(chan struct{}),
+	}
+}
+
+// Start starts the leadership manager.
+func (lm *LeadershipManager) Start(ctx context.Context) error {
+	lm.mutex.Lock()
+	defer lm.mutex.Unlock()
+
+	// Start leadership acquisition loop
+	lm.wg.Add(1)
+	go lm.leadershipLoop(ctx)
+
+	if logger := logging.From(ctx); logger != nil {
+		logger.Infof("leadership manager started: %s", lm.hostname)
+	}
+	return nil
+}
+
+// Stop stops the leadership manager.
+func (lm *LeadershipManager) Stop() {
+	lm.mutex.Lock()
+	defer lm.mutex.Unlock()
+
+	close(lm.stopCh)
+	lm.wg.Wait()
+}
+
+// IsLeader returns true if the current node is the leader.
+func (lm *LeadershipManager) IsLeader() bool {
+	return lm.isLeader.Load()
+}
+
+// Leader returns the current leader information.
+func (lm *LeadershipManager) Leader(ctx context.Context) (*database.LeadershipInfo, error) {
+	return lm.database.FindLeadership(ctx)
+}
+
+// CurrentLease returns the current lease information if this node is the leader.
+func (lm *LeadershipManager) CurrentLease() *database.LeadershipInfo {
+	return lm.currentLease.Load()
+}
+
+// leadershipLoop manages the leadership acquisition and renewal process.
+func (lm *LeadershipManager) leadershipLoop(ctx context.Context) {
+	defer lm.wg.Done()
+
+	ticker := time.NewTicker(lm.renewalInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			lm.handleLeadershipCycle(ctx)
+
+		case <-lm.stopCh:
+			return
+
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// handleLeadershipCycle handles one cycle of leadership management.
+func (lm *LeadershipManager) handleLeadershipCycle(ctx context.Context) {
+	if lm.isLeader.Load() {
+		// We are the leader, try to renew the lease
+		if err := lm.renewLease(ctx); err != nil {
+			if logger := logging.From(ctx); logger != nil {
+				logger.Warn("failed to renew leadership lease", "error", err)
+			}
+			lm.becomeFollower()
+		}
+	} else {
+		// We are not the leader, try to acquire leadership
+		if err := lm.tryAcquireLeadership(ctx); err != nil {
+			if logger := logging.From(ctx); logger != nil {
+				logger.Debug("failed to acquire leadership", "error", err)
+			}
+		}
+	}
+}
+
+// tryAcquireLeadership attempts to acquire leadership.
+func (lm *LeadershipManager) tryAcquireLeadership(ctx context.Context) error {
+	lease, err := lm.database.TryLeadership(ctx, lm.hostname, "", lm.leaseDuration)
+	if err != nil {
+		return fmt.Errorf("acquire leadership: %w", err)
+	}
+
+	if lease.Hostname == lm.hostname {
+		lm.becomeLeader(lease)
+		if logger := logging.From(ctx); logger != nil {
+			logger.Infof("leadership acquired term: %d, expires_at: %s", lease.Term, lease.ExpiresAt)
+		}
+	}
+
+	return nil
+}
+
+// renewLease renews the current leadership lease.
+func (lm *LeadershipManager) renewLease(ctx context.Context) error {
+	currentLease := lm.currentLease.Load()
+	if currentLease == nil {
+		return fmt.Errorf("no current lease to renew")
+	}
+
+	lease, err := lm.database.TryLeadership(ctx, lm.hostname, currentLease.LeaseToken, lm.leaseDuration)
+	if err != nil {
+		return fmt.Errorf("renew leadership: %w", err)
+	}
+
+	lm.currentLease.Store(lease)
+	if logger := logging.From(ctx); logger != nil {
+		logger.Debug("renewed leadership lease", "expires_at", lease.ExpiresAt)
+	}
+
+	return nil
+}
+
+// becomeLeader transitions to leader state.
+func (lm *LeadershipManager) becomeLeader(lease *database.LeadershipInfo) {
+	lm.isLeader.Store(true)
+	lm.currentLease.Store(lease)
+}
+
+// becomeFollower transitions to follower state.
+func (lm *LeadershipManager) becomeFollower() {
+	lm.isLeader.Store(false)
+	lm.currentLease.Store(nil)
+}

--- a/server/backend/housekeeping/leadership_test.go
+++ b/server/backend/housekeeping/leadership_test.go
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2025 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package housekeeping
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yorkie-team/yorkie/server/backend/database"
+	"github.com/yorkie-team/yorkie/server/backend/database/memory"
+)
+
+func newDatabase() database.Database {
+	// Create a new in-memory database for testing
+	db, err := memory.New()
+	if err != nil {
+		panic(fmt.Sprintf("failed to create in-memory database: %v", err))
+	}
+
+	return db
+}
+
+func TestLeadershipManager(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("LeadershipManager should acquire leadership", func(t *testing.T) {
+		db := newDatabase()
+		conf := DefaultLeadershipConfig()
+		conf.RenewalInterval = 100 * time.Millisecond
+
+		manager := NewLeadershipManager(db, "node-1", conf)
+
+		err := manager.Start(ctx)
+		require.NoError(t, err)
+		defer manager.Stop()
+
+		// Wait for leadership acquisition
+		assert.Eventually(t, func() bool {
+			return manager.IsLeader()
+		}, 1*time.Second, 50*time.Millisecond)
+
+		// Verify leadership info
+		lease := manager.CurrentLease()
+		require.NotNil(t, lease)
+		assert.Equal(t, "node-1", lease.Hostname)
+	})
+
+	t.Run("Multiple managers should compete for leadership", func(t *testing.T) {
+		db := newDatabase()
+		conf := DefaultLeadershipConfig()
+		conf.RenewalInterval = 50 * time.Millisecond
+
+		manager1 := NewLeadershipManager(db, "node-1", conf)
+		manager2 := NewLeadershipManager(db, "node-2", conf)
+
+		err := manager1.Start(ctx)
+		require.NoError(t, err)
+		defer manager1.Stop()
+
+		err = manager2.Start(ctx)
+		require.NoError(t, err)
+		defer manager2.Stop()
+
+		// Wait for one to become leader
+		assert.Eventually(t, func() bool {
+			return manager1.IsLeader() || manager2.IsLeader()
+		}, 1*time.Second, 50*time.Millisecond)
+
+		// Only one should be leader
+		leaders := 0
+		if manager1.IsLeader() {
+			leaders++
+		}
+		if manager2.IsLeader() {
+			leaders++
+		}
+		assert.Equal(t, 1, leaders)
+	})
+
+	t.Run("Leadership should transfer after lease expires", func(t *testing.T) {
+		db := newDatabase()
+		conf := DefaultLeadershipConfig()
+		conf.LeaseDuration = 200 * time.Millisecond
+		conf.RenewalInterval = 50 * time.Millisecond
+
+		manager1 := NewLeadershipManager(db, "node-1", conf)
+
+		err := manager1.Start(ctx)
+		require.NoError(t, err)
+
+		// Wait for leadership acquisition
+		assert.Eventually(t, func() bool {
+			return manager1.IsLeader()
+		}, 1*time.Second, 50*time.Millisecond)
+
+		// Stop manager1 (simulating node failure)
+		manager1.Stop()
+
+		// Start manager2
+		manager2 := NewLeadershipManager(db, "node-2", conf)
+		err = manager2.Start(ctx)
+		require.NoError(t, err)
+		defer manager2.Stop()
+
+		// Manager2 should eventually become leader
+		assert.Eventually(t, func() bool {
+			return manager2.IsLeader()
+		}, 1*time.Second, 50*time.Millisecond)
+	})
+}
+
+func TestLeadershipConcurrency(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase()
+
+	const numGoroutines = 10
+	const leaseDuration = 100 * time.Millisecond
+
+	var wg sync.WaitGroup
+	acquiredCount := make([]int, numGoroutines)
+
+	// Start multiple goroutines trying to acquire leadership
+	for i := range numGoroutines {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+
+			nodeID := fmt.Sprintf("node-%d", id)
+
+			for range 50 {
+				info, err := db.TryLeadership(ctx, nodeID, "", leaseDuration)
+				if err == nil && info.Hostname == nodeID {
+					acquiredCount[id]++
+
+					// Hold leadership briefly then let it expire
+					time.Sleep(10 * time.Millisecond)
+				}
+				time.Sleep(5 * time.Millisecond)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify that leadership was acquired by various nodes
+	totalAcquisitions := 0
+	for i, count := range acquiredCount {
+		t.Logf("Node %d acquired leadership %d times", i, count)
+		totalAcquisitions += count
+	}
+
+	assert.Greater(t, totalAcquisitions, 0, "At least some leadership acquisitions should have occurred")
+}

--- a/server/server.go
+++ b/server/server.go
@@ -103,7 +103,7 @@ func (r *Yorkie) Start() error {
 		return err
 	}
 
-	if err := r.backend.Start(); err != nil {
+	if err := r.backend.Start(context.Background()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR introduces a lightweight leader election mechanism using MongoDB for the housekeeping process in Yorkie. The goal is to ensure that only one node in the cluster performs housekeeping tasks at a time, without introducing external coordination systems.

Yorkie runs in multi-node environments where housekeeping tasks(e.g., client cleanup, document compaction) should only be executed by a single node to avoid conflicts or redundant work.

Instead of introducing an external system such as etcd, we designed a MongoDB-based lease lock system for leader election, leveraging our existing infrastructure.

### How it Works

Key Components

- LeadershipManager: Handles leader election, lease renewal, and state transitions (leader <-> follower).
- LeadershipInfo
Stores the current lease metadata in MongoDB, including:
  - singleton (constant value to enforce single document)
  - term (incremental round counter)
  - expires_at (lease expiration time)
  - leader_id and encrypted token

Core Mechanism

- Leader Election (tryAcquireLeadership)
  - Uses atomic FindOneAndUpdate with conditional upsert.
  - Only acquires leadership if the current lease is expired.
- Lease Renewal (tryRenewLeadership)
  - On successful renewal, a new encrypted token is issued.
  - If renewal fails (e.g., token mismatch or expired lease), the node becomes a follower.

- Execution Control (leadershipLoop)
  - Only the current leader runs housekeeping tasks on a periodic loop.
  - Follower nodes stay idle and monitor the lease.

### Why MongoDB-based leader election:

- We already rely on MongoDB.
- Housekeeping is not user-facing or latency-sensitive.
- Occasional duplicate executions are tolerable.
- Simplicity and operational overhead are prioritized over strong consistency guarantees.

### Limitations

Issue | Description | Planned Fix
-- | -- | --
Clock Skew | Nodes use local system time (time.Now()), which may differ and cause lease misinterpretation | Use `$$NOW` or server-side time in MongoDB queries
Immediate Follower Transition | On renewal failure, node immediately gives up leadership | Add retry logic and grace period before stepping down

### Future Work

- [ ] Evaluate using MongoDB `$currentDate` or `$$NOW` to mitigate clock skew.
- [ ] Introduce optional retry mechanism for lease renewal.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Introduced distributed leadership election and lease renewal capabilities, allowing nodes to acquire, renew, and track leadership status.
  * Added a leadership manager to automate leadership acquisition and renewal with configurable timing.
  * Leadership information, including node ID and lease details, is now accessible for monitoring cluster leadership status.
  * Housekeeping tasks now run exclusively on the leader node, ensuring coordinated task execution in distributed setups.

* **Bug Fixes**
  * None.

* **Tests**
  * Added comprehensive tests covering leadership acquisition, renewal, expiration, and concurrent leadership scenarios for both in-memory and MongoDB backends.
  * Included leadership management tests validating single and multiple node leadership behavior and concurrency stress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->