### PR TITLE
Tree split butfix 1282

### DIFF
--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -367,14 +367,19 @@ func (n *TreeNode) SplitElement(
 
 	prvSize := n.DataSize()
 
+	// TODO(raararaara): We need to check if the attributes are copied correctly when splitting elements.
+	var attrs *RHT
+	if n.Attrs != nil {
+		attrs = n.Attrs.DeepCopy()
+	}
+
 	// TODO(hackerwins): Define IDString of split node for concurrent editing.
 	// Text has fixed content and its split nodes could have limited offset
 	// range. But element node could have arbitrary children and its split
 	// nodes could have arbitrary offset range. So, id could be duplicated
 	// and its order could be broken when concurrent editing happens.
 	// Currently, we use the similar IDString of split element with the split text.
-	// TODO(raararaara): We need to check if the attributes are copied correctly when splitting elements.
-	split := NewTreeNode(&TreeNodeID{CreatedAt: issueTimeTicket(), Offset: 0}, n.Type(), nil)
+	split := NewTreeNode(&TreeNodeID{CreatedAt: issueTimeTicket(), Offset: 0}, n.Type(), attrs)
 	split.removedAt = n.removedAt
 	if err := n.Index.Parent.InsertAfterInternal(split.Index, n.Index); err != nil {
 		return nil, diff, err

--- a/pkg/document/crdt/tree_test.go
+++ b/pkg/document/crdt/tree_test.go
@@ -684,31 +684,6 @@ func TestTreeSplit(t *testing.T) {
 		assert.Equal(t, "<r><p>abcd</p></r>", tree.ToXML())
 		assert.Equal(t, 6, tree.Root().Len())
 	})
-
-	t.Run("split element nodes with attributes", func(t *testing.T) {
-		attributes := crdt.NewRHT()
-		attributes.Set("bold", "true", time.InitialTicket)
-
-		root := crdt.NewTreeNode(dummyTreeNodeID, "r", nil)
-		para := crdt.NewTreeNode(dummyTreeNodeID, "p", attributes)
-		assert.NoError(t, root.Append(para))
-		assert.NoError(t, para.Append(crdt.NewTreeNode(dummyTreeNodeID, "text", nil, "helloworld")))
-		assert.Equal(t, `<r><p bold="true">helloworld</p></r>`, crdt.ToXML(root))
-
-		// split text node
-		left, err := para.Child(0)
-		assert.NoError(t, err)
-		_, _, err = left.SplitText(5, 0)
-		assert.NoError(t, err)
-
-		// split element node
-		right, _, err := para.SplitElement(1, func() *time.Ticket {
-			return time.InitialTicket
-		})
-		assert.NoError(t, err)
-		assert.Equal(t, `<p bold="true">hello</p>`, crdt.ToXML(para))
-		assert.Equal(t, `<p bold="true">world</p>`, crdt.ToXML(right))
-	})
 }
 
 func TestTreeMerge(t *testing.T) {

--- a/pkg/document/crdt/tree_test.go
+++ b/pkg/document/crdt/tree_test.go
@@ -684,6 +684,31 @@ func TestTreeSplit(t *testing.T) {
 		assert.Equal(t, "<r><p>abcd</p></r>", tree.ToXML())
 		assert.Equal(t, 6, tree.Root().Len())
 	})
+
+	t.Run("split element nodes with attributes", func(t *testing.T) {
+		attributes := crdt.NewRHT()
+		attributes.Set("bold", "true", time.InitialTicket)
+
+		root := crdt.NewTreeNode(dummyTreeNodeID, "r", nil)
+		para := crdt.NewTreeNode(dummyTreeNodeID, "p", attributes)
+		assert.NoError(t, root.Append(para))
+		assert.NoError(t, para.Append(crdt.NewTreeNode(dummyTreeNodeID, "text", nil, "helloworld")))
+		assert.Equal(t, `<r><p bold="true">helloworld</p></r>`, crdt.ToXML(root))
+
+		// split text node
+		left, err := para.Child(0)
+		assert.NoError(t, err)
+		_, _, err = left.SplitText(5, 0)
+		assert.NoError(t, err)
+
+		// split element node
+		right, _, err := para.SplitElement(1, func() *time.Ticket {
+			return time.InitialTicket
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, `<p bold="true">hello</p>`, crdt.ToXML(para))
+		assert.Equal(t, `<p bold="true">world</p>`, crdt.ToXML(right))
+	})
 }
 
 func TestTreeMerge(t *testing.T) {

--- a/pkg/document/size_test.go
+++ b/pkg/document/size_test.go
@@ -65,7 +65,6 @@ func TestTreeNodeSize(t *testing.T) {
 	})
 
 	t.Run("split tree node with attribute test", func(t *testing.T) {
-		t.Skip("TODO(raararaara): We need to check if the attributes are copied correctly when splitting elements.")
 		attributes := crdt.NewRHT()
 		attributes.Set("bold", "true", time.InitialTicket)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fixes a bug where the right-side node from `SplitElement`(`pkg/document/crdt/tree.go`) was missing its attributes due to the lack of copying `Attrs` field. Ensures structural consistency of the CRDT tree nodes during editing operations.

Also, a corresponding test case named `split tree node with attribute test` was added in `pkg/document/size_test.go`.

**Which issue(s) this PR fixes**:

Fixes #1282 

**Special notes for your reviewer**:

Special notes for your reviewer:

I gave some thought to the memory footprint — while the Copy operation does consume additional memory, I believe it should be acceptable since, at the end of the function, the code have:
```go
diff.Add(n.DataSize(), split.DataSize())
diff.Sub(prvSize)
```
which seems to account for the size difference.

I'm still in the process of understanding the overall logic. It appears that `TreeNode` plays the role of a tree structure and consists of an index along with left/right sibling references (`InsPrevID`, `InsNextID`), but I’m not entirely sure yet.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation**:

```docs

```

**Checklist**:

- [ ] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [ ] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of attributes when splitting tree nodes to ensure attributes are properly copied to new nodes.

* **Tests**
  * Enabled a previously skipped test to verify correct attribute preservation and data size when splitting tree nodes with attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->