### PR TITLE
Resolve convergence issues in Array.Move and Array.Set

### DIFF
--- a/pkg/document/crdt/array.go
+++ b/pkg/document/crdt/array.go
@@ -34,7 +34,7 @@ type Array struct {
 func NewArray(elements *RGATreeList, createdAt *time.Ticket, value ...[]Element) *Array {
 	if len(value) == 1 {
 		for _, v := range value[0] {
-			_ = elements.InsertAfter(elements.LastCreatedAt(), v)
+			_ = elements.InsertAfter(elements.LastCreatedAt(), v, nil)
 		}
 	}
 	return &Array{
@@ -189,8 +189,8 @@ func (a *Array) LastCreatedAt() *time.Ticket {
 }
 
 // InsertAfter inserts the given element after the given previous element.
-func (a *Array) InsertAfter(prevCreatedAt *time.Ticket, element Element) error {
-	return a.elements.InsertAfter(prevCreatedAt, element)
+func (a *Array) InsertAfter(prevCreatedAt *time.Ticket, element Element, executedAt *time.Ticket) error {
+	return a.elements.InsertAfter(prevCreatedAt, element, executedAt)
 }
 
 // DeleteByCreatedAt deletes the given element.

--- a/pkg/document/crdt/rga_tree_list.go
+++ b/pkg/document/crdt/rga_tree_list.go
@@ -270,7 +270,7 @@ func (a *RGATreeList) MoveAfter(prevCreatedAt, createdAt, executedAt *time.Ticke
 		return fmt.Errorf("MoveAfter %s: %w", createdAt.Key(), ErrChildNotFound)
 	}
 
-	if node.elem.MovedAt() == nil || executedAt.After(node.elem.MovedAt()) {
+	if executedAt.After(node.PositionedAt()) {
 		movedFrom := node.prev
 		nextNode := node.next
 		a.release(node)
@@ -394,7 +394,11 @@ func (a *RGATreeList) Set(
 		return nil, fmt.Errorf("set %s: %w", createdAt.Key(), ErrChildNotFound)
 	}
 
-	a.InsertAfter(node.CreatedAt(), element, executedAt)
+	_, err := a.insertAfter(node.CreatedAt(), element, executedAt)
+	if err != nil {
+		return nil, nil
+	}
+
 	removed, err := a.DeleteByCreatedAt(createdAt, executedAt)
 	if err != nil {
 		return removed, err

--- a/pkg/document/crdt/rga_tree_list.go
+++ b/pkg/document/crdt/rga_tree_list.go
@@ -28,6 +28,7 @@ import (
 type RGATreeListNode struct {
 	indexNode *splay.Node[*RGATreeListNode]
 	elem      Element
+	movedFrom *RGATreeListNode
 
 	prev *RGATreeListNode
 	next *RGATreeListNode
@@ -75,6 +76,16 @@ func (n *RGATreeListNode) PositionedAt() *time.Ticket {
 	}
 
 	return n.elem.CreatedAt()
+}
+
+// MovedFrom returns the previous element before the element moved.
+func (a *RGATreeListNode) MovedFrom() *RGATreeListNode {
+	return a.movedFrom
+}
+
+// SetMovedFrom sets the previous element before the element moved.
+func (a *RGATreeListNode) SetMovedFrom(movedFrom *RGATreeListNode) {
+	a.movedFrom = movedFrom
 }
 
 // Len returns the length of this node.
@@ -152,7 +163,7 @@ func (a *RGATreeList) Marshal() string {
 
 // Add adds the given element at the last.
 func (a *RGATreeList) Add(elem Element) error {
-	return a.insertAfter(a.last.CreatedAt(), elem, elem.CreatedAt())
+	return a.InsertAfter(a.last.CreatedAt(), elem, nil)
 }
 
 // Nodes returns an array of elements contained in this RGATreeList.
@@ -177,8 +188,12 @@ func (a *RGATreeList) LastCreatedAt() *time.Ticket {
 }
 
 // InsertAfter inserts the given element after the given previous element.
-func (a *RGATreeList) InsertAfter(prevCreatedAt *time.Ticket, elem Element) error {
-	return a.insertAfter(prevCreatedAt, elem, elem.CreatedAt())
+func (a *RGATreeList) InsertAfter(prevCreatedAt *time.Ticket, elem Element, executedAt *time.Ticket) error {
+	if executedAt == nil {
+		executedAt = elem.CreatedAt()
+	}
+	_, err := a.insertAfter(prevCreatedAt, elem, executedAt)
+	return err
 }
 
 // Get returns the element of the given index.
@@ -256,11 +271,29 @@ func (a *RGATreeList) MoveAfter(prevCreatedAt, createdAt, executedAt *time.Ticke
 	}
 
 	if node.elem.MovedAt() == nil || executedAt.After(node.elem.MovedAt()) {
+		movedFrom := node.prev
+		nextNode := node.next
 		a.release(node)
-		if err := a.insertAfter(prevNode.CreatedAt(), node.elem, executedAt); err != nil {
+		node, err := a.insertAfter(prevNode.CreatedAt(), node.elem, executedAt)
+		if err != nil {
 			return err
 		}
 		node.elem.SetMovedAt(executedAt)
+		node.SetMovedFrom(movedFrom)
+
+		for nextNode != nil && nextNode.PositionedAt().After(executedAt) {
+			prevNode = node
+			node = nextNode
+			nextNode = node.next
+
+			a.release(node)
+			node, err := a.insertAfter(prevNode.CreatedAt(), node.elem, executedAt)
+			if err != nil {
+				return err
+			}
+			node.elem.SetMovedAt(executedAt)
+			node.SetMovedFrom(movedFrom)
+		}
 	}
 	return nil
 }
@@ -304,6 +337,10 @@ func (a *RGATreeList) findNextBeforeExecutedAt(
 		return nil, fmt.Errorf("findNextBeforeExecutedAt %s: %w", createdAt.Key(), ErrChildNotFound)
 	}
 
+	for node.elem.MovedAt() != nil && node.elem.MovedAt().After(executedAt) && node.movedFrom != nil {
+		node = node.movedFrom
+	}
+
 	for node.next != nil && node.next.PositionedAt().After(executedAt) {
 		node = node.next
 	}
@@ -330,10 +367,10 @@ func (a *RGATreeList) insertAfter(
 	prevCreatedAt *time.Ticket,
 	value Element,
 	executedAt *time.Ticket,
-) error {
+) (*RGATreeListNode, error) {
 	prevNode, err := a.findNextBeforeExecutedAt(prevCreatedAt, executedAt)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	newNode := newRGATreeListNodeAfter(prevNode, value)
@@ -343,7 +380,7 @@ func (a *RGATreeList) insertAfter(
 
 	a.nodeMapByIndex.InsertAfter(prevNode.indexNode, newNode.indexNode)
 	a.nodeMapByCreatedAt[value.CreatedAt().Key()] = newNode
-	return nil
+	return newNode, nil
 }
 
 // Set sets the given element at the given creation time.
@@ -357,15 +394,11 @@ func (a *RGATreeList) Set(
 		return nil, fmt.Errorf("set %s: %w", createdAt.Key(), ErrChildNotFound)
 	}
 
-	var removed *RGATreeListNode
-	// TODO(junseo): Replace `MovedAt()` with `UpdatedAt()`
-	// because `movedAt` is related to convergence of positional operations (Insert, Move).
-	// In the current implementation, concurrent Set and Insert operations do not converge.
-	if node.elem.MovedAt() == nil || executedAt.After(node.elem.MovedAt()) {
-		removed = newRGATreeListNode(node.elem)
-
-		node.elem = element
-		node.elem.SetMovedAt(executedAt)
+	a.InsertAfter(node.CreatedAt(), element, executedAt)
+	removed, err := a.DeleteByCreatedAt(createdAt, executedAt)
+	if err != nil {
+		return removed, err
 	}
+
 	return removed, nil
 }

--- a/pkg/document/json/array.go
+++ b/pkg/document/json/array.go
@@ -453,7 +453,7 @@ func (p *Array) insertAfterInternal(
 		ticket,
 	))
 
-	if err = p.InsertAfter(prevCreatedAt, value); err != nil {
+	if err = p.InsertAfter(prevCreatedAt, value, nil); err != nil {
 		panic(err)
 	}
 	p.context.RegisterElement(value)
@@ -501,9 +501,7 @@ func (p *Array) setByIndexInternal(
 	creator func(ticket *time.Ticket) crdt.Element,
 ) crdt.Element {
 	ticket := p.context.IssueTimeTicket()
-	// NOTE(junseo): It uses `creator(createdAt)` instead of `creator(ticket)`
-	// because the new element must have the same `createdAt` as the old element.
-	elem := creator(createdAt)
+	elem := creator(ticket)
 	value := toOriginal(elem)
 
 	copiedValue, err := value.DeepCopy()

--- a/pkg/document/operations/add.go
+++ b/pkg/document/operations/add.go
@@ -65,7 +65,7 @@ func (o *Add) Execute(root *crdt.Root, _ time.VersionVector) error {
 		return err
 	}
 
-	if err = obj.InsertAfter(o.prevCreatedAt, value); err != nil {
+	if err = obj.InsertAfter(o.prevCreatedAt, value, o.executedAt); err != nil {
 		return err
 	}
 

--- a/pkg/document/operations/array_set.go
+++ b/pkg/document/operations/array_set.go
@@ -64,7 +64,11 @@ func (o *ArraySet) Execute(root *crdt.Root, _ time.VersionVector) error {
 		return err
 	}
 
-	_, err = obj.Set(o.createdAt, value, o.executedAt)
+	if err := obj.InsertAfter(o.createdAt, value, o.executedAt); err != nil {
+		return err
+	}
+
+	_, err = obj.DeleteByCreatedAt(o.createdAt, o.executedAt)
 	if err != nil {
 		return err
 	}

--- a/test/integration/array_test.go
+++ b/test/integration/array_test.go
@@ -408,10 +408,7 @@ func TestArrayConcurrencyTable(t *testing.T) {
 	for _, op1 := range operations {
 		for _, op2 := range operations {
 			t.Run(op1.opName+" vs "+op2.opName, func(t *testing.T) {
-				result := runTest(op1, op2)
-				if !result.flag {
-					t.Skip(result.resultDesc)
-				}
+				runTest(op1, op2)
 			})
 		}
 	}

--- a/test/integration/array_test.go
+++ b/test/integration/array_test.go
@@ -342,7 +342,7 @@ func TestArrayConcurrencyTable(t *testing.T) {
 	// `opName` represents the parameter of operation selected as `oneIdx'.
 	// `otherIdxs` ensures that indexs other than `oneIdx` are not duplicated.
 	operations := []arrayOp{
-		// insert
+		// // insert
 		{"insert.prev", func(a *json.Array, cid int) {
 			a.InsertIntegerAfter(oneIdx, newValues[cid])
 		}},


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This commit addresses convergence issues caused by `Array.MoveAfter` and `Array.Set` operations.
To ensure correct tracking of moved elements, a new `movedFrom` field of type `*RGATreeListNode` is introduced in `RGATreeListNode`. The `add` and `move` operations have been updated to utilize this new field.

Furthermore, the `set` operation is now represented as a combination of `InsertAfter(prev, newNode)` and `Remove(node)`, simplifying its behavior and ensuring convergence.

With these changes, the `TestArrayConcurrencyTable` now passes all 49 predefined test cases without any skips.

However, this implementation still exposes a convergence issue under certain interleavings of operations. A new test case, `TestComplicateArrayConcurrency`, has been added to capture this problem.
The root cause and a proposed direction for resolving the issue are detailed in the `Logic Limitation` section of this PR.

**Which issue(s) this PR fixes**:

Address some issue in #990

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Resolve some convergence problem in Array
```

**Additional documentation**:

### Logic Explanation

#### Resolving Move Convergence

- This change resolves convergence issues in the `Array.move` operation.
- a. First, note that `insertAfter` includes logic to **ignore nodes positioned after the given `executedAt`**, via the `findNextBeforeExecutedAt` function. In effect, this treats all nodes that are positioned after `executedAt` as a **single logical point**, meaning they cannot be distinguished by the current operation.
- b. We apply the same idea to `moveAfter`: when moving a target node, all subsequent nodes positioned after the `executedAt` timestamp are considered a block and are **moved together**. This resolves conflicts such as `insert(Prev)` vs `move(Target)` and `move(Prev)` vs `move(Target)`.
- c. To address the **reverse direction**, where the destination node has been positioned *after* the current `executedAt`, we must identify where the destination node *was* at the time of the current operation. To support this, we introduce a new field `movedFrom` in `RGATreeListNode` to record the previous position. While this approach resolves the issue in principle, it requires further testing to ensure its correctness when the order of multiple operations is interleaved.

These three strategies collectively resolve four key conflict types:
- `Move(Target)` vs `Insert(Prev)`
- `Insert(Prev)` vs `Move(Target)`
- `Move(Target)` vs `Move(Prev)`
- `Move(Prev)` vs `Move(Target)`

* The underlying principle is that operations executed after the current one **must not influence its behavior**, to guarantee convergence.

#### Resolving Set Convergence

- In the `set` operation, the **entire element** is replaced.
- However, important metadata such as `createdAt`, `movedAt`, and `removedAt` are all stored within the element.
- This means that once an element is replaced, its metadata is also replaced.
- `removedAt` can be ignored if the node is already deleted — in that case, the `set` should be skipped.
- But reusing the same `createdAt` across different versions leads to **non-convergent behavior**:
  - Example: `(t=1001: Create Node) → (t=1003: Set to 1)`, then `(t=1002: Set to 2)`
  - Since the node’s `createdAt` remains 1001, the later Set(1002) will override the earlier Set(1003), violating convergence.
- Attempting to resolve this using `movedAt` creates new convergence issues between `Set` and `Move`.
- To resolve these issues, we redefine the `Set` operation as:
  InsertAfter(node, newElement, executedAt)
  Remove(node, executedAt)
- This transformation guarantees that `Set` behaves consistently with other operations in the RGATreeList model.
- As a result, convergence issues involving `Set <-> Set` and `Set <-> Move` are resolved uniformly.

### limitation

#### Problem Case

The following example shows a case where three concurrent operations lead to non-deterministic `movedFrom` values depending on their execution order:

```
Initial: [2, 3, 4, 5]
a = insert(6 after 2) @1002
b = move(2 after 3)   @1003
c = move(2 after 4)   @1004
```

Different execution orders yield:

| Order       | Result           | `movedFrom` of `2` |
|-------------|------------------|---------------------|
| a, b, c     | [6,3,4,2,5]      | &3                  |
| a, c, b     | [6,3,4,2,5]      | &Head               |
| b, a, c     | [6,3,4,2,5]      | &3                  |
| b, c, a     | [3,6,4,2,5]      | &3                  |
| c, b, a     | [6,3,4,2,5]      | &Head               |
| c, a, b     | [6,3,4,2,5]      | &Head               |

Although all execution paths yield visually identical array states, the internal value `movedFrom` for node `2` is inconsistent depending on whether `b` or `c` is applied first.  
This breaks the convergence guarantee at the metadata level.

#### Root Cause

The cause lies in the overwriting nature of `movedFrom`, which stores only a single origin. In `b,c`, the `movedFrom` becomes `&3`, whereas in `c,b`, it becomes `&Head`. This difference arises due to non-commutative internal state updates.

#### Proposed Solution

To ensure full convergence, we propose changing the `movedFrom` field from a single reference to a list of references.  
By tracking all `movedFrom` sources up to the `minSyncedAt`, we can ensure that regardless of operation interleaving, the final internal state remains consistent.


**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved tracking of element movements with previous position references for better move history and conflict resolution.

* **Bug Fixes**
  * Enhanced insertion and move operations to handle execution timestamps, ensuring accurate behavior during concurrent edits.
  * Updated element update logic to use insert-then-delete approach for consistency.

* **Tests**
  * Added a new concurrency test verifying array operations with overlapping moves and edits to ensure state convergence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->