### PR TITLE
Add feature to filter out stale presences

### DIFF
--- a/server/rpc/cluster_server.go
+++ b/server/rpc/cluster_server.go
@@ -211,7 +211,18 @@ func (s *clusterServer) GetDocument(
 
 		// Set presences if requested
 		if req.Msg.IncludePresences {
-			summary.Presences = doc.AllPresences()
+			docRefKey := types.DocRefKey{ProjectID: project.ID, DocID: docInfo.ID}
+			clientIDs := s.backend.PubSub.ClientIDs(docRefKey)
+			if len(clientIDs) > 0 {
+				summary.Presences = make(map[string]innerpresence.Presence)
+				presences := doc.AllPresences()
+				for _, clientID := range clientIDs {
+					presence, ok := presences[clientID.String()]
+					if ok {
+						summary.Presences[clientID.String()] = presence
+					}
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR filters stale presences so that only presences of online clients with established physical streams are displayed. Currently, stale presences remain visible even when the document is detached, and the presence clearing mechanism isn't functioning as intended. While this PR improves the situation by ensuring only relevant presences are shown, **it does not address the root cause of the lingering stale presences issue.**

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Related to #1256 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [ ] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [ ] Didn't break anything
