### PR TITLE
Add VSCode setting guide in CONTRIBUTING.md for test files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,17 @@ make lint
 > [!NOTE]  
 > If you have an old version of `golangci-lint` installed locally, running `make lint` may fail—especially if the linter doesn't support the newer version of Go. It's recommended to run `make tools` periodically to keep your tools up to date.
 
+### Setting for VSCode
+If you are using VSCode, add the following in your `.vscode/settings.json` so that proper language features work correctly in test files
+with build tag `integration`, `bench`, or `complex`.
+```json
+{
+  "gopls": {
+    "build.buildFlags": ["-tags=integration,bench,complex"]
+  }
+}
+```
+
 ## Design Documents
 
 For developers, [design documents](design/README.md) about core features are provided. You can refer to the docs for understanding the overall structure of Yorkie.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds a description for VSCode setting to properly support Go language feature in test files with build tag (integration, bench, complex). Without this setting, VSCode's language server (gopls) cannot correctly recognize packages in these test files, causing "No packages found for open file" error.

**Which issue(s) this PR fixes**: #1399 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added instructions for configuring VSCode settings to improve language support in test files with specific build tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->