### PR TITLE
Add MoveFront/MoveLast and port array tests from JS SDK

### DIFF
--- a/pkg/document/crdt/array_test.go
+++ b/pkg/document/crdt/array_test.go
@@ -21,7 +21,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/yorkie-team/yorkie/pkg/document"
 	"github.com/yorkie-team/yorkie/pkg/document/crdt"
+	"github.com/yorkie-team/yorkie/pkg/document/json"
+	"github.com/yorkie-team/yorkie/pkg/document/presence"
+	"github.com/yorkie-team/yorkie/pkg/document/time"
 	"github.com/yorkie-team/yorkie/test/helper"
 )
 
@@ -57,4 +61,326 @@ func TestArray(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, `["1","2","3"]`, a.Marshal())
 	})
+
+	t.Run("should handle delete operations using document", func(t *testing.T) {
+		doc := document.New(helper.TestDocKey(t))
+
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			arr := root.SetNewArray("k1")
+			arr.AddString("1", "2", "3")
+			assert.Equal(t, `{"k1":["1","2","3"]}`, root.Marshal())
+			return nil
+		}, "initialize array"))
+
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			arr := root.GetArray("k1")
+			_ = arr.Delete(1)
+			arr.AddString("4")
+			assert.Equal(t, `{"k1":["1","3","4"]}`, root.Marshal())
+			return nil
+		}, "delete '2' and add '4'"))
+	})
+
+	t.Run("can push array element after delete operation (document-based)", func(t *testing.T) {
+		doc := document.New(helper.TestDocKey(t))
+
+		// Step 1: ["1", "2", "3"]
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			arr := root.SetNewArray("k1")
+			arr.AddString("1", "2", "3")
+			assert.Equal(t, `{"k1":["1","2","3"]}`, root.Marshal())
+			return nil
+		}))
+
+		// Step 2: delete "2", then push "4"
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			arr := root.GetArray("k1")
+			_ = arr.Delete(1)
+			arr.AddString("4")
+			return nil
+		}))
+
+		// Step 3: push nested array [4,5,6]
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			subArr := root.GetArray("k1").AddNewArray()
+			subArr.AddInteger(4, 5, 6)
+			assert.Equal(t, `{"k1":["1","3","4",[4,5,6]]}`, root.Marshal())
+			return nil
+		}))
+
+		// Final check
+		assert.Equal(t, `{"k1":["1","3","4",[4,5,6]]}`, doc.Marshal())
+	})
+
+	t.Run("can push object element after delete operation", func(t *testing.T) {
+		doc := document.New(helper.TestDocKey(t))
+
+		// Step 1: 초기 배열 ["1", "2", "3"]
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			arr := root.SetNewArray("k1")
+			arr.AddString("1", "2", "3")
+			assert.Equal(t, `{"k1":["1","2","3"]}`, root.Marshal())
+			return nil
+		}, "set [1,2,3]"))
+
+		// Step 2: "2" 삭제, "4" 추가
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			arr := root.GetArray("k1")
+			_ = arr.Delete(1)
+			arr.AddString("4")
+			return nil
+		}, "delete '2' and push '4'"))
+
+		// Step 3: 객체 {"a":"a", "b":"b"} 추가
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			obj := root.GetArray("k1").AddNewObject()
+			obj.SetString("a", "a")
+			obj.SetString("b", "b")
+			assert.Equal(t, `{"k1":["1","3","4",{"a":"a","b":"b"}]}`, root.Marshal())
+			return nil
+		}, "push object"))
+
+		// 최종 확인
+		assert.Equal(t, `{"k1":["1","3","4",{"a":"a","b":"b"}]}`, doc.Marshal())
+	})
+
+	t.Run("can push array (document-based)", func(t *testing.T) {
+		doc := document.New(helper.TestDocKey(t))
+
+		// 초기 상태: [1,2,3]
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			arr := root.SetNewArray("arr")
+			arr.AddInteger(1, 2, 3)
+			return nil
+		}))
+
+		// 중첩 배열 [4,5,6] 추가
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			sub := root.GetArray("arr").AddNewArray()
+			sub.AddInteger(4, 5, 6)
+			assert.Equal(t, `{"arr":[1,2,3,[4,5,6]]}`, root.Marshal())
+			return nil
+		}))
+
+		assert.Equal(t, `{"arr":[1,2,3,[4,5,6]]}`, doc.Marshal())
+	})
+
+	t.Run("can push element then delete it by ID in array (document-based)", func(t *testing.T) {
+		doc := document.New(helper.TestDocKey(t))
+
+		// 초기 상태: [4,3,2,1]
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			arr := root.SetNewArray("list")
+			arr.AddInteger(4, 3, 2, 1)
+			assert.Equal(t, `{"list":[4,3,2,1]}`, root.Marshal())
+			return nil
+		}))
+
+		// 삭제: 2
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			arr := root.GetArray("list")
+			_ = arr.Delete(2)
+			assert.Equal(t, `{"list":[4,3,1]}`, root.Marshal())
+			return nil
+		}))
+
+		// 다시 push 2
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			arr := root.GetArray("list")
+			arr.AddInteger(2)
+			assert.Equal(t, `{"list":[4,3,1,2]}`, root.Marshal())
+			return nil
+		}))
+
+		assert.Equal(t, `{"list":[4,3,1,2]}`, doc.Marshal())
+	})
+
+	t.Run("can insert an element after the given element in array (document-based)", func(t *testing.T) {
+		doc := document.New(helper.TestDocKey(t))
+
+		// Step 1: 초기 배열 [1,2,4], prev = 2의 ID
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			arr := root.SetNewArray("list")
+			arr.AddInteger(1, 2, 4)
+			assert.Equal(t, `{"list":[1,2,4]}`, root.Marshal())
+			return nil
+		}))
+
+		// Step 2: prev(2) 뒤에 3 삽입 => [1,2,3,4]
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			arr := root.GetArray("list")
+			arr.InsertIntegerAfter(1, 3)
+			assert.Equal(t, `{"list":[1,2,3,4]}`, root.Marshal())
+			return nil
+		}))
+
+		// Step 3: index 1 (2) 삭제 => [1,3,4]
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			arr := root.GetArray("list")
+			arr.Delete(1)
+			assert.Equal(t, `{"list":[1,3,4]}`, root.Marshal())
+			return nil
+		}))
+
+		// Step 4: index 0 (1)의 뒤에 2 삽입 => [1,2,3,4]
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			arr := root.GetArray("list")
+			arr.InsertIntegerAfter(0, 2)
+			assert.Equal(t, `{"list":[1,2,3,4]}`, root.Marshal())
+
+			// 마지막 검증: 값 검증
+			for i := 0; i < arr.Len(); i++ {
+				elem := arr.Get(i)
+				prim := elem.(*crdt.Primitive).Value()
+				assert.Equal(t, int32(i+1), prim)
+			}
+			return nil
+		}))
+	})
+
+	t.Run("can move an element before the given element in array (document-based)", func(t *testing.T) {
+		doc := document.New(helper.TestDocKey(t))
+		var prevID, targetID *time.Ticket
+
+		// Step 1: 초기 배열 [0,1,2]
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			arr := root.SetNewArray("list")
+			arr.AddInteger(0, 1, 2)
+			assert.Equal(t, `{"list":[0,1,2]}`, root.Marshal())
+			return nil
+		}, "initialize"))
+
+		// Step 2: Move 2 before 0 => [2,0,1]
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			arr := root.GetArray("list")
+			prev := arr.Get(0)
+			target := arr.Get(2)
+			prevID = prev.CreatedAt()
+			targetID = target.CreatedAt()
+			arr.MoveBefore(prevID, targetID)
+			assert.Equal(t, `{"list":[2,0,1]}`, root.Marshal())
+			return nil
+		}, "move 2 before 0"))
+
+		// Step 3: Move 1 before 2 => [1,2,0]
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			arr := root.GetArray("list")
+			prev := arr.Get(0)   // 2
+			target := arr.Get(2) // 1
+			prevID = prev.CreatedAt()
+			targetID = target.CreatedAt()
+			arr.MoveBefore(prevID, targetID)
+			assert.Equal(t, `{"list":[1,2,0]}`, root.Marshal())
+			return nil
+		}, "move 1 before 2"))
+	})
+
+	t.Run("can move an element after the given element in array (document-based)", func(t *testing.T) {
+		doc := document.New(helper.TestDocKey(t))
+
+		// Step 1: 초기 배열 [0,1,2]
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			arr := root.SetNewArray("list")
+			arr.AddInteger(0, 1, 2)
+			assert.Equal(t, `{"list":[0,1,2]}`, root.Marshal())
+			return nil
+		}, "initialize"))
+
+		// Step 2: Move 2 after 0 => [0,2,1]
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			arr := root.GetArray("list")
+			arr.MoveAfterByIndex(0, 2)
+			assert.Equal(t, `{"list":[0,2,1]}`, root.Marshal())
+			return nil
+		}, "move 2 after 0"))
+
+		// Step 3: Move 1 after 0 => [0,1,2]
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			arr := root.GetArray("list")
+			arr.MoveAfterByIndex(0, 2)
+			assert.Equal(t, `{"list":[0,1,2]}`, root.Marshal())
+			return nil
+		}, "move 1 after 0"))
+	})
+
+	t.Run("can insert an element at the first of array (document-based)", func(t *testing.T) {
+		doc := document.New(helper.TestDocKey(t))
+		var targetID *time.Ticket
+
+		// Step 1: 초기 배열 [0,1,2]
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			arr := root.SetNewArray("list")
+			arr.AddInteger(0, 1, 2)
+			assert.Equal(t, `{"list":[0,1,2]}`, root.Marshal())
+			return nil
+		}, "initialize"))
+
+		// Step 2: Move 2 to front => [2,0,1]
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			arr := root.GetArray("list")
+			targetID = arr.Get(2).CreatedAt()
+			arr.MoveFront(targetID)
+			assert.Equal(t, `{"list":[2,0,1]}`, root.Marshal())
+			return nil
+		}, "move 2 to front"))
+
+		// Step 3: Move 0 to front => [0,2,1]
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			arr := root.GetArray("list")
+			targetID = arr.Get(1).CreatedAt() // 0 now at index 1
+			arr.MoveFront(targetID)
+			assert.Equal(t, `{"list":[0,2,1]}`, root.Marshal())
+			return nil
+		}, "move 0 to front"))
+
+		// Step 4: Move 0 to front again (noop) => [0,2,1]
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			arr := root.GetArray("list")
+			targetID = arr.Get(0).CreatedAt() // 0 already at front
+			arr.MoveFront(targetID)
+			assert.Equal(t, `{"list":[0,2,1]}`, root.Marshal())
+			return nil
+		}, "noop move 0 again"))
+	})
+
+	t.Run("can move an element at the last of array (document-based)", func(t *testing.T) {
+		doc := document.New(helper.TestDocKey(t))
+		var targetID *time.Ticket
+
+		// Step 1: 초기 배열 [0,1,2]
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			arr := root.SetNewArray("list")
+			arr.AddInteger(0, 1, 2)
+			assert.Equal(t, `{"list":[0,1,2]}`, root.Marshal())
+			return nil
+		}, "initialize list"))
+
+		// Step 2: Move 2 to last (noop) => [0,1,2]
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			arr := root.GetArray("list")
+			targetID = arr.Get(2).CreatedAt()
+			arr.MoveLast(targetID)
+			assert.Equal(t, `{"list":[0,1,2]}`, root.Marshal())
+			return nil
+		}, "move 2 to last"))
+
+		// Step 3: Move 1 to last => [0,2,1]
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			arr := root.GetArray("list")
+			targetID = arr.Get(1).CreatedAt() // 1
+			arr.MoveLast(targetID)
+			assert.Equal(t, `{"list":[0,2,1]}`, root.Marshal())
+			return nil
+		}, "move 1 to last"))
+
+		// Step 4: Move 0 to last => [2,1,0]
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			arr := root.GetArray("list")
+			targetID = arr.Get(0).CreatedAt() // 0
+			arr.MoveLast(targetID)
+			assert.Equal(t, `{"list":[2,1,0]}`, root.Marshal())
+			return nil
+		}, "move 0 to last"))
+	})
+
 }

--- a/pkg/document/crdt/rga_tree_list.go
+++ b/pkg/document/crdt/rga_tree_list.go
@@ -223,6 +223,15 @@ func (a *RGATreeList) Get(idx int) (*RGATreeListNode, error) {
 	return node, nil
 }
 
+// GetByCreatedAt returns the element of the given createdAt
+func (a *RGATreeList) GetByCreatedAt(createdAt *time.Ticket) (*RGATreeListNode, error) {
+	node, ok := a.nodeMapByCreatedAt[createdAt.Key()]
+	if !ok {
+		return nil, fmt.Errorf("DeleteByCreatedAt %s: %w", createdAt.Key(), ErrChildNotFound)
+	}
+	return node, nil
+}
+
 // DeleteByCreatedAt deletes the given element.
 func (a *RGATreeList) DeleteByCreatedAt(createdAt *time.Ticket, deletedAt *time.Ticket) (*RGATreeListNode, error) {
 	node, ok := a.nodeMapByCreatedAt[createdAt.Key()]
@@ -268,6 +277,10 @@ func (a *RGATreeList) MoveAfter(prevCreatedAt, createdAt, executedAt *time.Ticke
 	node, ok := a.nodeMapByCreatedAt[createdAt.Key()]
 	if !ok {
 		return fmt.Errorf("MoveAfter %s: %w", createdAt.Key(), ErrChildNotFound)
+	}
+
+	if prevCreatedAt == createdAt {
+		return nil
 	}
 
 	if executedAt.After(node.PositionedAt()) {

--- a/pkg/document/crdt/rga_tree_list.go
+++ b/pkg/document/crdt/rga_tree_list.go
@@ -223,15 +223,6 @@ func (a *RGATreeList) Get(idx int) (*RGATreeListNode, error) {
 	return node, nil
 }
 
-// GetByCreatedAt returns the element of the given createdAt
-func (a *RGATreeList) GetByCreatedAt(createdAt *time.Ticket) (*RGATreeListNode, error) {
-	node, ok := a.nodeMapByCreatedAt[createdAt.Key()]
-	if !ok {
-		return nil, fmt.Errorf("DeleteByCreatedAt %s: %w", createdAt.Key(), ErrChildNotFound)
-	}
-	return node, nil
-}
-
 // DeleteByCreatedAt deletes the given element.
 func (a *RGATreeList) DeleteByCreatedAt(createdAt *time.Ticket, deletedAt *time.Ticket) (*RGATreeListNode, error) {
 	node, ok := a.nodeMapByCreatedAt[createdAt.Key()]

--- a/pkg/document/json/array.go
+++ b/pkg/document/json/array.go
@@ -496,6 +496,14 @@ func (p *Array) moveAfterInternal(prevCreatedAt, createdAt *time.Ticket) {
 	}
 }
 
+func (p *Array) MoveFront(createdAt *time.Ticket) {
+	p.moveBeforeInternal(p.Get(0).CreatedAt(), createdAt)
+}
+
+func (p *Array) MoveLast(createdAt *time.Ticket) {
+	p.moveAfterInternal(p.LastCreatedAt(), createdAt)
+}
+
 func (p *Array) setByIndexInternal(
 	createdAt *time.Ticket,
 	creator func(ticket *time.Ticket) crdt.Element,


### PR DESCRIPTION


<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR ports array-related tests from
`yorkie-js-sdk/packages/sdk/test/integration/array_test.ts` to the Go SDK. It includes various insert/delete/move operations using Document-based approach.

The following changes are made:
- Implemented `MoveFront` and `MoveLast` in `json/array.go`, modeled after JS SDK's `moveBeforeInternal` and `moveAfterInternal`. These internally use `MoveBeforeInternal` and `MoveAfterInternal` respectively.
- Skipped tests under JS SDK's `Can handle concurrent ...` block since they overlap with `TestArrayConcurrencyTable` in `integration/array_test.go`.

Additionally, defensive logic was added to `rga_tree_list.go` at L282-L284 to prevent invalid access.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added methods to move array elements to the front or end of the array.

* **Bug Fixes**
  * Prevented moving an array element after itself to avoid unnecessary operations.

* **Tests**
  * Expanded test coverage for array operations, including complex moves and insertions.
  * Refactored and renamed concurrency test functions for improved clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->