### PR TITLE
Prevent project secret key from granting full user access

### DIFF
--- a/api/types/user.go
+++ b/api/types/user.go
@@ -19,6 +19,17 @@ package types
 
 import "time"
 
+// AccessScope is the scope of access for a user.
+type AccessScope string
+
+const (
+	// AccessScopeAdmin is the full administrative access scope for a user.
+	AccessScopeAdmin AccessScope = "admin"
+
+	// AccessScopeProject is the project-specific access scope for a user.
+	AccessScopeProject AccessScope = "project"
+)
+
 // User is a user that can access the project.
 type User struct {
 	// ID is the unique ID of the user.
@@ -33,4 +44,7 @@ type User struct {
 
 	// CreatedAt is the time when the user was created.
 	CreatedAt time.Time `json:"created_at"`
+
+	// AccessScope is the scope of access for the user.
+	AccessScope AccessScope `json:"access_scope"`
 }

--- a/server/rpc/admin_server.go
+++ b/server/rpc/admin_server.go
@@ -836,7 +836,12 @@ func (s *adminServer) GetProjectWithAuth(
 		// Verify project from context for project scope
 		ctxProject := projects.From(ctx)
 		if ctxProject.Name != projectName {
-			return nil, fmt.Errorf("project mismatch: key is for %s, got %s: %w", ctxProject.Name, projectName, auth.ErrUnauthenticated)
+			return nil, fmt.Errorf(
+				"project mismatch: key is for %s, got %s: %w",
+				ctxProject.Name,
+				projectName,
+				auth.ErrUnauthenticated,
+			)
 		}
 		return ctxProject, nil
 	case types.AccessScopeAdmin:

--- a/server/rpc/admin_server.go
+++ b/server/rpc/admin_server.go
@@ -836,7 +836,7 @@ func (s *adminServer) GetProjectWithAuth(
 		// Verify project from context for project scope
 		ctxProject := projects.From(ctx)
 		if ctxProject.Name != projectName {
-			return nil, fmt.Errorf("project mismatch: key is for %s, got %s", ctxProject.Name, projectName)
+			return nil, fmt.Errorf("project mismatch: key is for %s, got %s: %w", ctxProject.Name, projectName, interceptors.ErrUnauthenticated)
 		}
 		return ctxProject, nil
 	case types.AccessScopeAdmin:

--- a/server/rpc/admin_server.go
+++ b/server/rpc/admin_server.go
@@ -836,7 +836,7 @@ func (s *adminServer) GetProjectWithAuth(
 		// Verify project from context for project scope
 		ctxProject := projects.From(ctx)
 		if ctxProject.Name != projectName {
-			return nil, fmt.Errorf("project mismatch: key is for %s, got %s: %w", ctxProject.Name, projectName, interceptors.ErrUnauthenticated)
+			return nil, fmt.Errorf("project mismatch: key is for %s, got %s: %w", ctxProject.Name, projectName, auth.ErrUnauthenticated)
 		}
 		return ctxProject, nil
 	case types.AccessScopeAdmin:

--- a/server/rpc/admin_server.go
+++ b/server/rpc/admin_server.go
@@ -199,8 +199,7 @@ func (s *adminServer) GetProject(
 	ctx context.Context,
 	req *connect.Request[api.GetProjectRequest],
 ) (*connect.Response[api.GetProjectResponse], error) {
-	user := users.From(ctx)
-	project, err := projects.GetProject(ctx, s.backend, user.ID, req.Msg.Name)
+	project, err := s.GetProjectWithAuth(ctx, req.Msg.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -250,8 +249,7 @@ func (s *adminServer) GetProjectStats(
 		return nil, err
 	}
 
-	user := users.From(ctx)
-	project, err := projects.GetProject(ctx, s.backend, user.ID, req.Msg.ProjectName)
+	project, err := s.GetProjectWithAuth(ctx, req.Msg.ProjectName)
 	if err != nil {
 		return nil, err
 	}
@@ -274,8 +272,7 @@ func (s *adminServer) CreateDocument(
 	ctx context.Context,
 	req *connect.Request[api.CreateDocumentRequest],
 ) (*connect.Response[api.CreateDocumentResponse], error) {
-	user := users.From(ctx)
-	project, err := projects.GetProject(ctx, s.backend, user.ID, req.Msg.ProjectName)
+	project, err := s.GetProjectWithAuth(ctx, req.Msg.ProjectName)
 	if err != nil {
 		return nil, err
 	}
@@ -294,7 +291,7 @@ func (s *adminServer) CreateDocument(
 		ctx,
 		s.backend,
 		project,
-		user.ID,
+		project.Owner,
 		key.Key(req.Msg.DocumentKey),
 		initialRoot,
 	)
@@ -312,8 +309,7 @@ func (s *adminServer) GetDocument(
 	ctx context.Context,
 	req *connect.Request[api.GetDocumentRequest],
 ) (*connect.Response[api.GetDocumentResponse], error) {
-	user := users.From(ctx)
-	project, err := projects.GetProject(ctx, s.backend, user.ID, req.Msg.ProjectName)
+	project, err := s.GetProjectWithAuth(ctx, req.Msg.ProjectName)
 	if err != nil {
 		return nil, err
 	}
@@ -338,8 +334,7 @@ func (s *adminServer) GetDocuments(
 	ctx context.Context,
 	req *connect.Request[api.GetDocumentsRequest],
 ) (*connect.Response[api.GetDocumentsResponse], error) {
-	user := users.From(ctx)
-	project, err := projects.GetProject(ctx, s.backend, user.ID, req.Msg.ProjectName)
+	project, err := s.GetProjectWithAuth(ctx, req.Msg.ProjectName)
 	if err != nil {
 		return nil, err
 	}
@@ -371,8 +366,7 @@ func (s *adminServer) GetSnapshotMeta(
 	ctx context.Context,
 	req *connect.Request[api.GetSnapshotMetaRequest],
 ) (*connect.Response[api.GetSnapshotMetaResponse], error) {
-	user := users.From(ctx)
-	project, err := projects.GetProject(ctx, s.backend, user.ID, req.Msg.ProjectName)
+	project, err := s.GetProjectWithAuth(ctx, req.Msg.ProjectName)
 	if err != nil {
 		return nil, err
 	}
@@ -410,8 +404,7 @@ func (s *adminServer) ListDocuments(
 	ctx context.Context,
 	req *connect.Request[api.ListDocumentsRequest],
 ) (*connect.Response[api.ListDocumentsResponse], error) {
-	user := users.From(ctx)
-	project, err := projects.GetProject(ctx, s.backend, user.ID, req.Msg.ProjectName)
+	project, err := s.GetProjectWithAuth(ctx, req.Msg.ProjectName)
 	if err != nil {
 		return nil, err
 	}
@@ -441,8 +434,7 @@ func (s *adminServer) SearchDocuments(
 	ctx context.Context,
 	req *connect.Request[api.SearchDocumentsRequest],
 ) (*connect.Response[api.SearchDocumentsResponse], error) {
-	user := users.From(ctx)
-	project, err := projects.GetProject(ctx, s.backend, user.ID, req.Msg.ProjectName)
+	project, err := s.GetProjectWithAuth(ctx, req.Msg.ProjectName)
 	if err != nil {
 		return nil, err
 	}
@@ -469,8 +461,7 @@ func (s *adminServer) UpdateDocument(
 	ctx context.Context,
 	req *connect.Request[api.UpdateDocumentRequest],
 ) (*connect.Response[api.UpdateDocumentResponse], error) {
-	user := users.From(ctx)
-	project, err := projects.GetProject(ctx, s.backend, user.ID, req.Msg.ProjectName)
+	project, err := s.GetProjectWithAuth(ctx, req.Msg.ProjectName)
 	if err != nil {
 		return nil, err
 	}
@@ -562,8 +553,7 @@ func (s *adminServer) RemoveDocumentByAdmin(
 	ctx context.Context,
 	req *connect.Request[api.RemoveDocumentByAdminRequest],
 ) (*connect.Response[api.RemoveDocumentByAdminResponse], error) {
-	user := users.From(ctx)
-	project, err := projects.GetProject(ctx, s.backend, user.ID, req.Msg.ProjectName)
+	project, err := s.GetProjectWithAuth(ctx, req.Msg.ProjectName)
 	if err != nil {
 		return nil, err
 	}
@@ -608,8 +598,7 @@ func (s *adminServer) ListChanges(
 	ctx context.Context,
 	req *connect.Request[api.ListChangesRequest],
 ) (*connect.Response[api.ListChangesResponse], error) {
-	user := users.From(ctx)
-	project, err := projects.GetProject(ctx, s.backend, user.ID, req.Msg.ProjectName)
+	project, err := s.GetProjectWithAuth(ctx, req.Msg.ProjectName)
 	if err != nil {
 		return nil, err
 	}
@@ -662,8 +651,7 @@ func (s *adminServer) CreateSchema(
 		return nil, err
 	}
 
-	user := users.From(ctx)
-	project, err := projects.GetProject(ctx, s.backend, user.ID, req.Msg.ProjectName)
+	project, err := s.GetProjectWithAuth(ctx, req.Msg.ProjectName)
 	if err != nil {
 		return nil, err
 	}
@@ -691,8 +679,7 @@ func (s *adminServer) GetSchema(
 	ctx context.Context,
 	req *connect.Request[api.GetSchemaRequest],
 ) (*connect.Response[api.GetSchemaResponse], error) {
-	user := users.From(ctx)
-	project, err := projects.GetProject(ctx, s.backend, user.ID, req.Msg.ProjectName)
+	project, err := s.GetProjectWithAuth(ctx, req.Msg.ProjectName)
 	if err != nil {
 		return nil, err
 	}
@@ -718,8 +705,7 @@ func (s *adminServer) GetSchemas(
 	ctx context.Context,
 	req *connect.Request[api.GetSchemasRequest],
 ) (*connect.Response[api.GetSchemasResponse], error) {
-	user := users.From(ctx)
-	project, err := projects.GetProject(ctx, s.backend, user.ID, req.Msg.ProjectName)
+	project, err := s.GetProjectWithAuth(ctx, req.Msg.ProjectName)
 	if err != nil {
 		return nil, err
 	}
@@ -744,8 +730,7 @@ func (s *adminServer) ListSchemas(
 	ctx context.Context,
 	req *connect.Request[api.ListSchemasRequest],
 ) (*connect.Response[api.ListSchemasResponse], error) {
-	user := users.From(ctx)
-	project, err := projects.GetProject(ctx, s.backend, user.ID, req.Msg.ProjectName)
+	project, err := s.GetProjectWithAuth(ctx, req.Msg.ProjectName)
 	if err != nil {
 		return nil, err
 	}
@@ -769,8 +754,7 @@ func (s *adminServer) RemoveSchema(
 	ctx context.Context,
 	req *connect.Request[api.RemoveSchemaRequest],
 ) (*connect.Response[api.RemoveSchemaResponse], error) {
-	user := users.From(ctx)
-	project, err := projects.GetProject(ctx, s.backend, user.ID, req.Msg.ProjectName)
+	project, err := s.GetProjectWithAuth(ctx, req.Msg.ProjectName)
 	if err != nil {
 		return nil, err
 	}
@@ -838,4 +822,30 @@ func (s *adminServer) RotateProjectKeys(
 	return connect.NewResponse(&api.RotateProjectKeysResponse{
 		Project: converter.ToProject(newProject),
 	}), nil
+}
+
+// GetProjectWithAuth fetches the project based on the user's access scope.
+func (s *adminServer) GetProjectWithAuth(
+	ctx context.Context,
+	projectName string,
+) (*types.Project, error) {
+	user := users.From(ctx)
+
+	// If access scope is project, verify the project from context
+	if user.AccessScope == types.AccessScopeProject {
+		ctxProject := projects.From(ctx)
+		if ctxProject.Name != projectName {
+			return nil, fmt.Errorf("project mismatch: key is for %s, got %s", ctxProject.Name, projectName)
+		}
+
+		return ctxProject, nil
+	}
+
+	// For admin scope, fetch the project
+	project, err := projects.GetProject(ctx, s.backend, user.ID, projectName)
+	if err != nil {
+		return nil, err
+	}
+
+	return project, nil
 }

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -579,6 +579,15 @@ func WaitForServerToStart(addr string) error {
 	return fmt.Errorf("timeout for server to start: %s", addr)
 }
 
+// CreateProject creates a new project with given name.
+func CreateProject(t *testing.T, server *server.Yorkie, name string) *types.Project {
+	ctx := context.Background()
+	project, err := server.CreateProject(ctx, name)
+	assert.NoError(t, err)
+
+	return project
+}
+
 // CreateProjectAndDocuments creates a new project and documents for the given count.
 func CreateProjectAndDocuments(t *testing.T, server *server.Yorkie, count int) (*types.Project, []*document.Document) {
 	ctx := context.Background()


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

<h3>Issue</h3>
<ul>
<li><strong>Problem</strong>: When Admin A (owner of Project B) uses the secret key of Project B, they are unintentionally granted access to other projects they own.</li>
<li><strong>Cause</strong>: The current logic returns the project owner as a user, which implicitly grants full access across all projects owned by that user.</li>
</ul>
<pre><code class="language-go">project, err := projects.GetProjectFromSecretKey(ctx, i.backend, authorization)
if err == nil {
    user, err := users.GetUserByID(ctx, i.backend, project.Owner)
    if err == nil {
        return user, nil // This returns full user-level access instead of project-scoped access
    }
}

</code></pre>

<br>

<h3>Ideal Behavior</h3>

Item | Current (As-Is) | Desired (To-Be)
-- | -- | --
Project X's secret key | Grants access to all of Developer A’s projects | Grants access to Project X only
Developer A’s user token | Grants access to all of their own projects | Unchanged — full access to all own projects
---
**Which issue(s) this PR fixes**:
Fixes #813 

---

### Summary of Changes

To resolve this, I introduce the concept of access scope in the `User` model.

- **User Token** → Returns `User` with `AccessScopeAdmin`
- **Project Key** → Returns `User` with `AccessScopeProject` and sets the `Project` in context

This allows downstream handlers to determine the access level and use it appropriately.
```go
// If access scope is project, verify the project from context
if user.AccessScope == types.AccessScopeProject {
	ctxProject := projects.From(ctx)
	if ctxProject.Name != projectName {
		return nil, fmt.Errorf("project mismatch: key is for %s, got %s", ctxProject.Name, projectName)
	}
	return ctxProject, nil
}

// For admin scope, fetch the project
project, err := projects.GetProject(ctx, s.backend, user.ID, projectName)
if err != nil {
	return nil, err
}
```
---
<br>


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [ ] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [ ] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User accounts now include an access scope, distinguishing between full administrative access and project-specific access.

* **Refactor**
  * Improved authorization logic for project access, ensuring consistent enforcement of user access scopes.
  * Authentication process now enriches request context with user and project information for streamlined access control.

* **Tests**
  * Added integration test to verify that document access is restricted across different projects.
  * Introduced helper functions to simplify project creation and unauthorized access testing in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->