### PR TITLE
Add functionality and benchmark test for GetDocuments API

### DIFF
--- a/server/rpc/server_test.go
+++ b/server/rpc/server_test.go
@@ -85,6 +85,7 @@ func TestMain(m *testing.M) {
 		ProjectCacheSize:            helper.ProjectCacheSize,
 		ProjectCacheTTL:             helper.ProjectCacheTTL.String(),
 		AdminTokenDuration:          helper.AdminTokenDuration,
+		GatewayAddr:                 helper.GatewayAddr,
 	}, &mongo.Config{
 		ConnectionURI:     helper.MongoConnectionURI,
 		YorkieDatabase:    helper.TestDBName(),
@@ -229,6 +230,10 @@ func TestAdminRPCServerBackend(t *testing.T) {
 
 	t.Run("admin get document test", func(t *testing.T) {
 		testcases.RunAdminGetDocumentTest(t, testClient, testAdminClient, testAdminAuthInterceptor)
+	})
+
+	t.Run("admin get documents test", func(t *testing.T) {
+		testcases.RunAdminGetDocumentsTest(t, testClient, testAdminClient, testAdminAuthInterceptor)
 	})
 
 	t.Run("admin list changes test", func(t *testing.T) {

--- a/server/rpc/testcases/testcases.go
+++ b/server/rpc/testcases/testcases.go
@@ -1322,18 +1322,18 @@ func RunAdminGetDocumentsTest(
 	assert.NoError(t, err)
 	assert.Len(t, resp1.Msg.Documents, 1)
 
-	// try to get documents including non-existing document name
+	// try to get document with non-existing document name
 	resp2, err := testAdminClient.GetDocuments(
 		context.Background(),
 		connect.NewRequest(&api.GetDocumentsRequest{
 			ProjectName:      defaultProjectName,
-			DocumentKeys:     []string{testDocumentKey, invalidChangePack.DocumentKey},
+			DocumentKeys:     []string{invalidChangePack.DocumentKey},
 			IncludeRoot:      true,
 			IncludePresences: true,
 		},
 		))
 	assert.NoError(t, err)
-	assert.Len(t, resp2.Msg.Documents, 1)
+	assert.Len(t, resp2.Msg.Documents, 0)
 }
 
 // RunAdminListChangesTest runs the ListChanges test in admin.

--- a/test/bench/get_documents_bench_test.go
+++ b/test/bench/get_documents_bench_test.go
@@ -1,0 +1,138 @@
+//go:build bench
+
+/*
+ * Copyright 2022 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bench
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/yorkie-team/yorkie/admin"
+	api "github.com/yorkie-team/yorkie/api/yorkie/v1"
+	"github.com/yorkie-team/yorkie/api/yorkie/v1/v1connect"
+	"github.com/yorkie-team/yorkie/server/logging"
+	"github.com/yorkie-team/yorkie/test/helper"
+)
+
+func benchmarkGetDocuments(
+	b *testing.B,
+	ctx context.Context,
+	cnt int,
+	docKeys []string,
+	adminClient v1connect.AdminServiceClient,
+	includeRoot bool,
+	includePresences bool,
+) {
+	b.StopTimer()
+	docKeys = docKeys[:cnt]
+	docRequest := &api.GetDocumentsRequest{
+		ProjectName:      "default",
+		DocumentKeys:     docKeys,
+		IncludeRoot:      includeRoot,
+		IncludePresences: includePresences,
+	}
+	b.StartTimer()
+	resp, err := adminClient.GetDocuments(
+		ctx,
+		connect.NewRequest(docRequest),
+	)
+	b.StopTimer()
+
+	assert.NoError(b, err)
+	assert.NotNil(b, resp.Msg)
+	assert.Len(b, resp.Msg.Documents, cnt)
+}
+
+func BenchmarkGetDocuments(b *testing.B) {
+	assert.NoError(b, logging.SetLogLevel("error"))
+
+	svr := helper.TestServer()
+	assert.NoError(b, svr.Start())
+
+	b.Cleanup(func() {
+		if err := svr.Shutdown(true); err != nil {
+			b.Fatal(err)
+		}
+	})
+
+	adminConn := http.DefaultClient
+	testAdminAuthInterceptor := admin.NewAuthInterceptor("")
+	testAdminClient := v1connect.NewAdminServiceClient(
+		adminConn,
+		"http://"+svr.RPCAddr(),
+		connect.WithInterceptors(testAdminAuthInterceptor),
+	)
+
+	ctx := context.Background()
+
+	resp, err := testAdminClient.LogIn(
+		ctx,
+		connect.NewRequest(&api.LogInRequest{
+			Username: helper.AdminUser,
+			Password: helper.AdminPassword,
+		},
+		))
+	assert.NoError(b, err)
+	testAdminAuthInterceptor.SetToken(resp.Msg.Token)
+
+	var docKeys []string
+	for i := range 1000 {
+		_, doc, err := helper.ClientAndAttachedDoc(ctx, svr.RPCAddr(), helper.TestDocKey(b, i))
+		assert.NoError(b, err)
+		docKeys = append(docKeys, doc.Key().String())
+	}
+
+	b.Run("without root presence 10", func(b *testing.B) {
+		for range b.N {
+			benchmarkGetDocuments(b, ctx, 10, docKeys, testAdminClient, false, false)
+		}
+	})
+
+	b.Run("with root presence 10", func(b *testing.B) {
+		for range b.N {
+			benchmarkGetDocuments(b, ctx, 10, docKeys, testAdminClient, true, true)
+		}
+	})
+
+	b.Run("without root presence 100", func(b *testing.B) {
+		for range b.N {
+			benchmarkGetDocuments(b, ctx, 100, docKeys, testAdminClient, false, false)
+		}
+	})
+
+	b.Run("with root presence 100", func(b *testing.B) {
+		for range b.N {
+			benchmarkGetDocuments(b, ctx, 100, docKeys, testAdminClient, true, true)
+		}
+	})
+
+	b.Run("without root presence 1000", func(b *testing.B) {
+		for range b.N {
+			benchmarkGetDocuments(b, ctx, 1000, docKeys, testAdminClient, false, false)
+		}
+	})
+
+	b.Run("with root presence 1000", func(b *testing.B) {
+		for range b.N {
+			benchmarkGetDocuments(b, ctx, 1000, docKeys, testAdminClient, true, true)
+		}
+	})
+}

--- a/test/bench/get_documents_bench_test.go
+++ b/test/bench/get_documents_bench_test.go
@@ -1,7 +1,7 @@
 //go:build bench
 
 /*
- * Copyright 2022 The Yorkie Authors. All rights reserved.
+ * Copyright 2025 The Yorkie Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/bench/splay_tree_bench_test.go
+++ b/test/bench/splay_tree_bench_test.go
@@ -1,3 +1,5 @@
+//go:build bench
+
 /*
 * Copyright 2024 The Yorkie Authors. All rights reserved.
 *

--- a/test/complex/server_test.go
+++ b/test/complex/server_test.go
@@ -99,6 +99,10 @@ func TestAdminRPCServerBackendWithShardedDB(t *testing.T) {
 		testcases.RunAdminGetDocumentTest(t, testClient, testAdminClient, testAdminAuthInterceptor)
 	})
 
+	t.Run("admin get documents test", func(t *testing.T) {
+		testcases.RunAdminGetDocumentsTest(t, testClient, testAdminClient, testAdminAuthInterceptor)
+	})
+
 	t.Run("admin list changes test", func(t *testing.T) {
 		testcases.RunAdminListChangesTest(t, testClient, testAdminClient, testAdminAuthInterceptor)
 	})

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -93,6 +93,7 @@ var (
 	EventWebhookCacheTTL        = 10 * gotime.Second
 	ProjectCacheSize            = 256
 	ProjectCacheTTL             = 5 * gotime.Second
+	GatewayAddr                 = fmt.Sprintf("localhost:%d", RPCPort)
 
 	MongoConnectionURI     = "mongodb://localhost:27017"
 	MongoConnectionTimeout = "5s"

--- a/test/integration/restapi_test.go
+++ b/test/integration/restapi_test.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	gotime "time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -123,7 +122,6 @@ func TestRESTAPI(t *testing.T) {
 					assert.NoError(t, cli.Close())
 				}()
 
-				gotime.Sleep(100 * gotime.Millisecond)
 				assert.NoError(t, cli.Sync(ctx))
 				res := post(
 					t,

--- a/test/integration/restapi_test.go
+++ b/test/integration/restapi_test.go
@@ -81,7 +81,7 @@ func TestRESTAPI(t *testing.T) {
 		assert.Len(t, summaries.Documents, 2)
 	})
 
-	t.Run("bulk document retrieval test", func(t *testing.T) {
+	t.Run("bulk document retrieval with options test", func(t *testing.T) {
 		numDocs, clientsPerDoc := 3, 1
 
 		testCases := []struct {

--- a/test/integration/restapi_test.go
+++ b/test/integration/restapi_test.go
@@ -27,12 +27,14 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	gotime "time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/yorkie-team/yorkie/api/types"
 	"github.com/yorkie-team/yorkie/client"
 	"github.com/yorkie-team/yorkie/pkg/document"
+	"github.com/yorkie-team/yorkie/pkg/document/innerpresence"
 	"github.com/yorkie-team/yorkie/pkg/document/json"
 	"github.com/yorkie-team/yorkie/pkg/document/presence"
 	"github.com/yorkie-team/yorkie/pkg/document/yson"
@@ -62,6 +64,7 @@ func TestRESTAPI(t *testing.T) {
 		summary := &documentSummary{}
 		assert.NoError(t, gojson.Unmarshal(res, summary))
 		assert.Equal(t, docs[0].Key(), summary.Document.Key)
+		assert.Nil(t, summary.Document.Presences)
 	})
 
 	t.Run("bulk document retrieval test", func(t *testing.T) {
@@ -76,6 +79,80 @@ func TestRESTAPI(t *testing.T) {
 		summaries := &documentSummaries{}
 		assert.NoError(t, gojson.Unmarshal(res, summaries))
 		assert.Len(t, summaries.Documents, 2)
+	})
+
+	t.Run("bulk document retrieval test", func(t *testing.T) {
+		numDocs, clientsPerDoc := 3, 1
+
+		testCases := []struct {
+			name             string
+			includeRoot      bool
+			includePresences bool
+		}{
+			{"include_root=0,include_presences=0", false, false},
+			{"include_root=1,include_presences=0", true, false},
+			{"include_root=0,include_presences=1", false, true},
+			{"include_root=1,include_presences=1", true, true},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				ctx := context.Background()
+				project, err := defaultServer.CreateProject(ctx, t.Name())
+				assert.NoError(t, err)
+
+				cli, err := client.Dial(defaultServer.RPCAddr(), client.WithAPIKey(project.PublicKey))
+				assert.NoError(t, err)
+				assert.NoError(t, cli.Activate(ctx))
+
+				var docs []*document.Document
+				for i := range numDocs {
+					doc := document.New(helper.TestDocKey(t, i))
+					assert.NoError(t, cli.Attach(ctx, doc,
+						client.WithInitialRoot(yson.ParseObject(`{"counter": Counter(Long(0))}`)),
+						client.WithPresence(innerpresence.Presence{"key": cli.Key()}),
+						client.WithRealtimeSync()))
+
+					docs = append(docs, doc)
+				}
+
+				defer func() {
+					for _, doc := range docs {
+						assert.NoError(t, cli.Detach(ctx, doc))
+					}
+					assert.NoError(t, cli.Close())
+				}()
+
+				gotime.Sleep(100 * gotime.Millisecond)
+				assert.NoError(t, cli.Sync(ctx))
+				res := post(
+					t,
+					project,
+					fmt.Sprintf("http://%s/yorkie.v1.AdminService/GetDocuments", defaultServer.RPCAddr()),
+					fmt.Sprintf(`{"project_name": "%s", "document_keys": ["%s", "%s", "%s"], "include_root": %t, "include_presences": %t}`,
+						project.Name, docs[0].Key(), docs[1].Key(), docs[2].Key(), tc.includeRoot, tc.includePresences),
+				)
+
+				summaries := &documentSummaries{}
+				gojson.Unmarshal(res, summaries)
+				assert.Len(t, summaries.Documents, numDocs)
+
+				for _, docSummary := range summaries.Documents {
+					if tc.includeRoot {
+						assert.Equal(t, `{"counter":0}`, docSummary.Root)
+					} else {
+						assert.Empty(t, docSummary.Root)
+					}
+
+					if tc.includePresences {
+						assert.Len(t, docSummary.Presences, clientsPerDoc)
+						assert.Contains(t, docSummary.Presences, cli.ID().String())
+					} else {
+						assert.Nil(t, docSummary.Presences)
+					}
+				}
+			})
+		}
 	})
 
 	t.Run("list documents test", func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
In GetDocuments Admin API, it adds include_presences option which calls cluster API internally. So, there should be REST API and RPC functionality and benchmark test with various option.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #1392 

**Special notes for your reviewer**:
Below is benchmark test result, it seems that `GetDocuments` with root and presence consumes more CPU and allocation because of internal cluster API call with goroutine.
```
cpu: Apple M4 Pro
BenchmarkGetDocuments/without_root_presence_10-12                                   1588            746549 ns/op          143709 B/op       1176 allocs/op
BenchmarkGetDocuments/with_root_presence_10-12                                       486           2590742 ns/op          797891 B/op       5653 allocs/op
BenchmarkGetDocuments/without_root_presence_100-12                                   844           5123490 ns/op          866236 B/op       6105 allocs/op
BenchmarkGetDocuments/with_root_presence_100-12                                       39          31919884 ns/op         8180760 B/op      64418 allocs/op
BenchmarkGetDocuments/without_root_presence_1000-12                                  100          13303705 ns/op         7962881 B/op      54831 allocs/op
BenchmarkGetDocuments/with_root_presence_1000-12                                       3         396407264 ns/op        78448936 B/op     659316 allocs/op
```

```
cpu: AMD EPYC 7763 64-Core Processor
BenchmarkGetDocuments/without_root_presence_10-4                        	     780	   1510243 ns/op	  130839 B/op	    1174 allocs/op
BenchmarkGetDocuments/with_root_presence_10-4                           	     271	   4279099 ns/op	  611723 B/op	    5775 allocs/op
BenchmarkGetDocuments/without_root_presence_100-4                       	     435	   2769122 ns/op	  834919 B/op	    6114 allocs/op
BenchmarkGetDocuments/with_root_presence_100-4                          	      26	  42290307 ns/op	 8012206 B/op	   66693 allocs/op
BenchmarkGetDocuments/without_root_presence_1000-4                      	      82	  15250600 ns/op	 7969632 B/op	   54836 allocs/op
BenchmarkGetDocuments/with_root_presence_1000-4                         	       3	 398232906 ns/op	72271584 B/op	  665564 allocs/op
```

**Does this PR introduce a user-facing change?**:
No, only test added

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [X] Added relevant tests or not required
- [X] Addressed and resolved all CodeRabbit review comments
- [X] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Added new tests for admin document retrieval, including handling of valid and invalid document keys.
  * Enhanced REST API bulk document retrieval tests to cover scenarios with and without root content and presence data.
  * Added validation for absence of presence data in single document retrieval tests.
  * Introduced benchmark tests measuring performance of document retrieval with various options.
  * Added new subtest for admin document retrieval in backend tests.

* **Chores**
  * Introduced a new test configuration variable for gateway address.
  * Added build constraint for benchmark test files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->