### PR TITLE
Improve DB error messages with contextual information

### DIFF
--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -175,7 +175,7 @@ func (d *DB) TryLeadership(
 	}
 
 	if err := txn.Insert(tblLeaderships, record); err != nil {
-		return nil, fmt.Errorf("update leadership: %w", err)
+		return nil, fmt.Errorf("renew leadership: %w", err)
 	}
 
 	txn.Commit()
@@ -539,6 +539,45 @@ func (d *DB) UpdateProjectInfo(
 	return info, nil
 }
 
+// RotateProjectKeys rotates the API keys of the project.
+func (d *DB) RotateProjectKeys(
+	_ context.Context,
+	owner types.ID,
+	id types.ID,
+	publicKey string,
+	secretKey string,
+) (*database.ProjectInfo, error) {
+	txn := d.db.Txn(true)
+	defer txn.Abort()
+
+	// Find project by ID and owner
+	raw, err := txn.First(tblProjects, "id", id.String())
+	if err != nil {
+		return nil, fmt.Errorf("rotate project keys of %s: %w", id, err)
+	}
+	if raw == nil {
+		return nil, fmt.Errorf("%s: %w", id, database.ErrProjectNotFound)
+	}
+
+	project := raw.(*database.ProjectInfo).DeepCopy()
+	if project.Owner != owner {
+		return nil, database.ErrProjectNotFound
+	}
+
+	// Update project keys
+	project.PublicKey = publicKey
+	project.SecretKey = secretKey
+	project.UpdatedAt = gotime.Now()
+
+	// Save updated project
+	if err := txn.Insert(tblProjects, project); err != nil {
+		return nil, fmt.Errorf("rotate project keys of %s: %w", id, err)
+	}
+
+	txn.Commit()
+	return project, nil
+}
+
 // CreateUserInfo creates a new user.
 func (d *DB) CreateUserInfo(
 	_ context.Context,
@@ -550,16 +589,16 @@ func (d *DB) CreateUserInfo(
 
 	existing, err := txn.First(tblUsers, "username", username)
 	if err != nil {
-		return nil, fmt.Errorf("find user by username: %w", err)
+		return nil, fmt.Errorf("create user %s: %w", username, err)
 	}
 	if existing != nil {
-		return nil, fmt.Errorf("%s: %w", username, database.ErrUserAlreadyExists)
+		return nil, fmt.Errorf("create user %s: %w", username, database.ErrUserAlreadyExists)
 	}
 
 	info := database.NewUserInfo(username, hashedPassword)
 	info.ID = newID()
 	if err := txn.Insert(tblUsers, info); err != nil {
-		return nil, fmt.Errorf("insert user: %w", err)
+		return nil, fmt.Errorf("create user %s: %w", username, err)
 	}
 	txn.Commit()
 
@@ -576,7 +615,7 @@ func (d *DB) GetOrCreateUserInfoByGitHubID(
 
 	raw, err := txn.First(tblUsers, "username", githubID)
 	if err != nil {
-		return nil, fmt.Errorf("find user by github id: %w", err)
+		return nil, fmt.Errorf("find user %s: %w", githubID, err)
 	}
 
 	now := gotime.Now()
@@ -591,13 +630,13 @@ func (d *DB) GetOrCreateUserInfoByGitHubID(
 			AccessedAt:   now,
 		}
 		if err := txn.Insert(tblUsers, info); err != nil {
-			return nil, fmt.Errorf("create user: %w", err)
+			return nil, fmt.Errorf("create user %s: %w", githubID, err)
 		}
 	} else {
 		info = raw.(*database.UserInfo).DeepCopy()
 		info.AccessedAt = now
 		if err := txn.Insert(tblUsers, info); err != nil {
-			return nil, fmt.Errorf("update user: %w", err)
+			return nil, fmt.Errorf("update user %s: %w", githubID, err)
 		}
 	}
 
@@ -620,7 +659,7 @@ func (d *DB) DeleteUserInfoByName(_ context.Context, username string) error {
 
 	info := raw.(*database.UserInfo).DeepCopy()
 	if err = txn.Delete(tblUsers, info); err != nil {
-		return fmt.Errorf("delete account %s: %w", info.ID, err)
+		return fmt.Errorf("delete user %s: %w", username, err)
 	}
 
 	txn.Commit()
@@ -634,7 +673,7 @@ func (d *DB) ChangeUserPassword(_ context.Context, username, hashedNewPassword s
 
 	raw, err := txn.First(tblUsers, "username", username)
 	if err != nil {
-		return fmt.Errorf("find user by username: %w", err)
+		return fmt.Errorf("change password of %s: %w", username, err)
 	}
 	if raw == nil {
 		return fmt.Errorf("%s: %w", username, database.ErrUserNotFound)
@@ -643,7 +682,7 @@ func (d *DB) ChangeUserPassword(_ context.Context, username, hashedNewPassword s
 	info := raw.(*database.UserInfo).DeepCopy()
 	info.HashedPassword = hashedNewPassword
 	if err := txn.Insert(tblUsers, info); err != nil {
-		return fmt.Errorf("change password user: %w", err)
+		return fmt.Errorf("change password %s: %w", username, err)
 	}
 
 	txn.Commit()
@@ -652,16 +691,16 @@ func (d *DB) ChangeUserPassword(_ context.Context, username, hashedNewPassword s
 }
 
 // FindUserInfoByID finds a user by the given ID.
-func (d *DB) FindUserInfoByID(_ context.Context, clientID types.ID) (*database.UserInfo, error) {
+func (d *DB) FindUserInfoByID(_ context.Context, userID types.ID) (*database.UserInfo, error) {
 	txn := d.db.Txn(false)
 	defer txn.Abort()
 
-	raw, err := txn.First(tblUsers, "id", clientID.String())
+	raw, err := txn.First(tblUsers, "id", userID.String())
 	if err != nil {
-		return nil, fmt.Errorf("find user by id: %w", err)
+		return nil, fmt.Errorf("find user %s: %w", userID, err)
 	}
 	if raw == nil {
-		return nil, fmt.Errorf("%s: %w", clientID, database.ErrUserNotFound)
+		return nil, fmt.Errorf("find user %s: %w", userID, database.ErrUserNotFound)
 	}
 
 	return raw.(*database.UserInfo).DeepCopy(), nil
@@ -674,10 +713,10 @@ func (d *DB) FindUserInfoByName(_ context.Context, username string) (*database.U
 
 	raw, err := txn.First(tblUsers, "username", username)
 	if err != nil {
-		return nil, fmt.Errorf("find user by username: %w", err)
+		return nil, fmt.Errorf("find user %s: %w", username, err)
 	}
 	if raw == nil {
-		return nil, fmt.Errorf("%s: %w", username, database.ErrUserNotFound)
+		return nil, fmt.Errorf("find user %s: %w", username, database.ErrUserNotFound)
 	}
 
 	return raw.(*database.UserInfo).DeepCopy(), nil
@@ -690,7 +729,7 @@ func (d *DB) ListUserInfos(_ context.Context) ([]*database.UserInfo, error) {
 
 	iter, err := txn.Get(tblUsers, "id")
 	if err != nil {
-		return nil, fmt.Errorf("fetch users: %w", err)
+		return nil, fmt.Errorf("list all users: %w", err)
 	}
 
 	var infos []*database.UserInfo
@@ -717,7 +756,7 @@ func (d *DB) ActivateClient(
 
 	raw, err := txn.First(tblClients, "project_id_key", projectID.String(), key)
 	if err != nil {
-		return nil, fmt.Errorf("find client by project id and key: %w", err)
+		return nil, fmt.Errorf("activate client of %s: %w", key, err)
 	}
 
 	now := gotime.Now()
@@ -740,7 +779,7 @@ func (d *DB) ActivateClient(
 	}
 
 	if err := txn.Insert(tblClients, clientInfo); err != nil {
-		return nil, fmt.Errorf("insert client: %w", err)
+		return nil, fmt.Errorf("activate client of %s: %w", key, err)
 	}
 
 	txn.Commit()
@@ -762,7 +801,7 @@ func (d *DB) TryAttaching(_ context.Context, refKey types.ClientRefKey, docID ty
 
 	raw, err := txn.First(tblClients, "id", refKey.ClientID.String())
 	if err != nil {
-		return nil, fmt.Errorf("find client by id: %w", err)
+		return nil, fmt.Errorf("try attaching %s to %s: %w", docID, refKey.ClientID, err)
 	}
 
 	if raw == nil {
@@ -777,8 +816,8 @@ func (d *DB) TryAttaching(_ context.Context, refKey types.ClientRefKey, docID ty
 	// Check if client is activated
 	if clientInfo.Status != database.ClientActivated {
 		return nil, fmt.Errorf(
-			"conditions not satisfied to attach document: %w",
-			database.ErrClientNotFound,
+			"try attaching %s to %s: %w",
+			docID, refKey.ClientID, database.ErrClientNotFound,
 		)
 	}
 
@@ -787,8 +826,8 @@ func (d *DB) TryAttaching(_ context.Context, refKey types.ClientRefKey, docID ty
 		clientInfo.Documents[docID] != nil &&
 		clientInfo.Documents[docID].Status == database.DocumentAttached {
 		return nil, fmt.Errorf(
-			"conditions not satisfied to attach document: %w",
-			database.ErrClientNotFound,
+			"try attaching %s to %s: %w",
+			docID, refKey.ClientID, database.ErrClientNotFound,
 		)
 	}
 
@@ -808,7 +847,7 @@ func (d *DB) TryAttaching(_ context.Context, refKey types.ClientRefKey, docID ty
 	clientInfo.UpdatedAt = gotime.Now()
 
 	if err := txn.Insert(tblClients, clientInfo); err != nil {
-		return nil, fmt.Errorf("update client: %w", err)
+		return nil, fmt.Errorf("try attaching %s to %s: %w", docID, refKey.ClientID, err)
 	}
 
 	txn.Commit()
@@ -826,7 +865,7 @@ func (d *DB) DeactivateClient(_ context.Context, refKey types.ClientRefKey) (*da
 
 	raw, err := txn.First(tblClients, "id", refKey.ClientID.String())
 	if err != nil {
-		return nil, fmt.Errorf("find client by id: %w", err)
+		return nil, fmt.Errorf("deactivate client of %s: %w", refKey.ClientID, err)
 	}
 
 	if raw == nil {
@@ -841,7 +880,8 @@ func (d *DB) DeactivateClient(_ context.Context, refKey types.ClientRefKey) (*da
 	// Check if client is not already deactivated
 	if clientInfo.Status == database.ClientDeactivated {
 		return nil, fmt.Errorf(
-			"conditions not satisfied to deactivate client: %w",
+			"deactivate client of %s: already deactivated: %w",
+			refKey.ClientID,
 			database.ErrClientNotFound,
 		)
 	}
@@ -851,7 +891,8 @@ func (d *DB) DeactivateClient(_ context.Context, refKey types.ClientRefKey) (*da
 		if docInfo.Status == database.DocumentAttaching ||
 			docInfo.Status == database.DocumentAttached {
 			return nil, fmt.Errorf(
-				"conditions not satisfied to deactivate client: %w",
+				"deactivate client of %s: has attached documents: %w",
+				refKey.ClientID,
 				database.ErrClientNotFound,
 			)
 		}
@@ -864,7 +905,7 @@ func (d *DB) DeactivateClient(_ context.Context, refKey types.ClientRefKey) (*da
 	clientInfo.Deactivate()
 
 	if err := txn.Insert(tblClients, clientInfo); err != nil {
-		return nil, fmt.Errorf("update client: %w", err)
+		return nil, fmt.Errorf("deactivate client of %s: %w", refKey.ClientID, err)
 	}
 
 	txn.Commit()
@@ -882,7 +923,7 @@ func (d *DB) FindClientInfoByRefKey(_ context.Context, refKey types.ClientRefKey
 
 	raw, err := txn.First(tblClients, "id", refKey.ClientID.String())
 	if err != nil {
-		return nil, fmt.Errorf("find client by id: %w", err)
+		return nil, fmt.Errorf("find client of %s: %w", refKey, err)
 	}
 	if raw == nil {
 		return nil, fmt.Errorf("%s: %w", refKey.ClientID, database.ErrClientNotFound)
@@ -915,10 +956,10 @@ func (d *DB) UpdateClientInfoAfterPushPull(
 
 	raw, err := txn.First(tblClients, "id", clientInfo.ID.String())
 	if err != nil {
-		return fmt.Errorf("find client by id: %w", err)
+		return fmt.Errorf("update client of %s after PushPull %s: %w", clientInfo.ID, docInfo.ID, err)
 	}
 	if raw == nil {
-		return fmt.Errorf("%s: %w", clientInfo.ID, database.ErrClientNotFound)
+		return fmt.Errorf("update client of %s after PushPull %s: %w", clientInfo.ID, docInfo.ID, database.ErrClientNotFound)
 	}
 
 	loaded := raw.(*database.ClientInfo).DeepCopy()
@@ -945,7 +986,7 @@ func (d *DB) UpdateClientInfoAfterPushPull(
 	}
 
 	if err := txn.Insert(tblClients, loaded); err != nil {
-		return fmt.Errorf("update client: %w", err)
+		return fmt.Errorf("update client of %s after PushPull %s: %w", clientInfo.ID, docInfo.ID, err)
 	}
 	txn.Commit()
 
@@ -977,7 +1018,7 @@ func (d *DB) FindDeactivateCandidatesPerProject(
 		offset,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("fetch deactivated clients: %w", err)
+		return nil, fmt.Errorf("find deactivated candidates of %s: %w", project.ID, err)
 	}
 
 	for raw := iterator.Next(); raw != nil; raw = iterator.Next() {
@@ -1009,7 +1050,7 @@ func (d *DB) FindCompactionCandidatesPerProject(
 	var infos []*database.DocInfo
 	iterator, err := txn.Get(tblDocuments, "project_id", project.ID.String())
 	if err != nil {
-		return nil, fmt.Errorf("fetch documents: %w", err)
+		return nil, fmt.Errorf("find compaction candidates of %s: %w", project.ID, err)
 	}
 
 	for raw := iterator.Next(); raw != nil; raw = iterator.Next() {
@@ -1050,7 +1091,7 @@ func (d *DB) FindAttachedClientInfosByRefKey(
 
 	iter, err := txn.Get(tblClients, "project_id", docRefKey.ProjectID.String())
 	if err != nil {
-		return nil, fmt.Errorf("find client infos by attached doc ref key: %w", err)
+		return nil, fmt.Errorf("find attached clients of %s: %w", docRefKey, err)
 	}
 
 	var infos []*database.ClientInfo
@@ -1068,12 +1109,12 @@ func (d *DB) FindAttachedClientInfosByRefKey(
 func (d *DB) FindOrCreateDocInfo(
 	_ context.Context,
 	clientRefKey types.ClientRefKey,
-	key key.Key,
+	docKey key.Key,
 ) (*database.DocInfo, error) {
 	txn := d.db.Txn(true)
 	defer txn.Abort()
 
-	info, err := d.findDocInfoByKey(txn, clientRefKey.ProjectID, key)
+	info, err := d.findDocInfoByKey(txn, clientRefKey.ProjectID, docKey)
 	if err != nil {
 		return info, err
 	}
@@ -1083,7 +1124,7 @@ func (d *DB) FindOrCreateDocInfo(
 		info = &database.DocInfo{
 			ID:         newID(),
 			ProjectID:  clientRefKey.ProjectID,
-			Key:        key,
+			Key:        docKey,
 			Owner:      clientRefKey.ClientID,
 			ServerSeq:  0,
 			Schema:     "",
@@ -1092,7 +1133,7 @@ func (d *DB) FindOrCreateDocInfo(
 			AccessedAt: now,
 		}
 		if err := txn.Insert(tblDocuments, info); err != nil {
-			return nil, fmt.Errorf("create document: %w", err)
+			return nil, fmt.Errorf("find or create document of %s: %w", docKey, err)
 		}
 		txn.Commit()
 	}
@@ -1101,7 +1142,7 @@ func (d *DB) FindOrCreateDocInfo(
 }
 
 // findDocInfoByKey finds the document of the given key.
-func (d *DB) findDocInfoByKey(txn *memdb.Txn, projectID types.ID, key key.Key) (*database.DocInfo, error) {
+func (d *DB) findDocInfoByKey(txn *memdb.Txn, projectID types.ID, docKey key.Key) (*database.DocInfo, error) {
 	// TODO(hackerwins): Removed documents should be filtered out by the query, but
 	// somehow it does not work. This is a workaround.
 	// val, err := txn.First(tblDocuments, "project_id_key_removed_at", projectID.String(), key.String(), gotime.Time{})
@@ -1109,11 +1150,11 @@ func (d *DB) findDocInfoByKey(txn *memdb.Txn, projectID types.ID, key key.Key) (
 		tblDocuments,
 		"project_id_key_removed_at",
 		projectID.String(),
-		key.String(),
+		docKey.String(),
 		gotime.Time{},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("find doc info by key: %w", err)
+		return nil, fmt.Errorf("find document of %s: %w", docKey, err)
 	}
 	var docInfo *database.DocInfo
 	for val := iter.Next(); val != nil; val = iter.Next() {
@@ -1136,7 +1177,7 @@ func (d *DB) FindDocInfoByKey(
 
 	info, err := d.findDocInfoByKey(txn, projectID, key)
 	if err != nil {
-		return nil, fmt.Errorf("find doc info by key: %w", err)
+		return nil, fmt.Errorf("find document of %s: %w", key, err)
 	}
 	if info == nil {
 		return nil, fmt.Errorf("%s: %w", key, database.ErrDocumentNotFound)
@@ -1158,7 +1199,7 @@ func (d *DB) FindDocInfosByKeys(
 	for _, k := range keys {
 		info, err := d.findDocInfoByKey(txn, projectID, k)
 		if err != nil {
-			return nil, fmt.Errorf("find doc info by key: %w", err)
+			return nil, fmt.Errorf("find documents of %v: %w", keys, err)
 		}
 		if info == nil {
 			continue
@@ -1180,16 +1221,16 @@ func (d *DB) FindDocInfoByRefKey(
 
 	raw, err := txn.First(tblDocuments, "id", refKey.DocID.String())
 	if err != nil {
-		return nil, fmt.Errorf("find document by id: %w", err)
+		return nil, fmt.Errorf("find document of %s: %w", refKey, err)
 	}
 
 	if raw == nil {
-		return nil, fmt.Errorf("finding doc info by ID(%s): %w", refKey.DocID, database.ErrDocumentNotFound)
+		return nil, fmt.Errorf("find document of %s: %w", refKey, database.ErrDocumentNotFound)
 	}
 
 	docInfo := raw.(*database.DocInfo)
 	if docInfo.ProjectID != refKey.ProjectID {
-		return nil, fmt.Errorf("finding doc info by ID(%s): %w", refKey.DocID, database.ErrDocumentNotFound)
+		return nil, fmt.Errorf("find document of %s: %w", refKey.DocID, database.ErrDocumentNotFound)
 	}
 
 	return docInfo.DeepCopy(), nil
@@ -1205,25 +1246,25 @@ func (d *DB) UpdateDocInfoStatusToRemoved(
 
 	raw, err := txn.First(tblDocuments, "id", refKey.DocID.String())
 	if err != nil {
-		return fmt.Errorf("find document by id: %w", err)
+		return fmt.Errorf("update %s to removed: %w", refKey, err)
 	}
 
 	if raw == nil {
-		return fmt.Errorf("finding doc info by ID(%s): %w", refKey.DocID, database.ErrDocumentNotFound)
+		return fmt.Errorf("update %s to removed: %w", refKey.DocID, database.ErrDocumentNotFound)
 	}
 
 	docInfo := raw.(*database.DocInfo)
 	if docInfo.ProjectID != refKey.ProjectID {
-		return fmt.Errorf("finding doc info by ID(%s): %w", refKey.DocID, database.ErrDocumentNotFound)
+		return fmt.Errorf("update %s to removed: %w", refKey.DocID, database.ErrDocumentNotFound)
 	}
 
 	docInfo.RemovedAt = gotime.Now()
 
 	if err := txn.Delete(tblDocuments, docInfo); err != nil {
-		return fmt.Errorf("delete document: %w", err)
+		return fmt.Errorf("update %s to removed: %w", refKey, err)
 	}
 	if err := txn.Insert(tblDocuments, docInfo); err != nil {
-		return fmt.Errorf("insert document: %w", err)
+		return fmt.Errorf("update %s to removed: %w", refKey, err)
 	}
 
 	txn.Commit()
@@ -1242,22 +1283,22 @@ func (d *DB) UpdateDocInfoSchema(
 
 	raw, err := txn.First(tblDocuments, "id", refKey.DocID.String())
 	if err != nil {
-		return fmt.Errorf("find document by id: %w", err)
+		return fmt.Errorf("update schema %s of %s: %w", schemaKey, refKey, err)
 	}
 
 	if raw == nil {
-		return fmt.Errorf("finding doc info by ID(%s): %w", refKey.DocID, database.ErrDocumentNotFound)
+		return fmt.Errorf("update schema %s of %s: %w", schemaKey, refKey, database.ErrDocumentNotFound)
 	}
 
 	docInfo := raw.(*database.DocInfo).DeepCopy()
 	if docInfo.ProjectID != refKey.ProjectID {
-		return fmt.Errorf("finding doc info by ID(%s): %w", refKey.DocID, database.ErrDocumentNotFound)
+		return fmt.Errorf("update schema %s of %s: %w", schemaKey, refKey, database.ErrDocumentNotFound)
 	}
 
 	docInfo.Schema = schemaKey
 
 	if err := txn.Insert(tblDocuments, docInfo); err != nil {
-		return fmt.Errorf("update document schema: %w", err)
+		return fmt.Errorf("update schema %s of %s: %w", schemaKey, refKey, database.ErrDocumentNotFound)
 	}
 
 	txn.Commit()
@@ -1274,7 +1315,7 @@ func (d *DB) GetDocumentsCount(
 
 	iter, err := txn.Get(tblDocuments, "project_id", projectID.String())
 	if err != nil {
-		return 0, fmt.Errorf("fetch documents: %w", err)
+		return 0, fmt.Errorf("count documents of %s: %w", projectID, err)
 	}
 
 	count := int64(0)
@@ -1296,7 +1337,7 @@ func (d *DB) GetClientsCount(ctx context.Context, projectID types.ID) (int64, er
 
 	iter, err := txn.Get(tblClients, "project_id", projectID.String())
 	if err != nil {
-		return 0, fmt.Errorf("fetch clients: %w", err)
+		return 0, fmt.Errorf("count clients of %s: %w", projectID, err)
 	}
 
 	count := int64(0)
@@ -1325,15 +1366,15 @@ func (d *DB) CreateChangeInfos(
 
 	raw, err := txn.First(tblDocuments, "id", refKey.DocID.String())
 	if err != nil {
-		return nil, change.InitialCheckpoint, fmt.Errorf("find document by id: %w", err)
+		return nil, change.InitialCheckpoint, fmt.Errorf("create changes of %s: %w", refKey, err)
 	}
 	if raw == nil {
-		return nil, change.InitialCheckpoint, fmt.Errorf("find document by id: %w", database.ErrDocumentNotFound)
+		return nil, change.InitialCheckpoint, fmt.Errorf("create changes of %s: %w", refKey, database.ErrDocumentNotFound)
 	}
 
 	docInfo := raw.(*database.DocInfo).DeepCopy()
 	if docInfo.ProjectID != refKey.ProjectID {
-		return nil, change.InitialCheckpoint, fmt.Errorf("find document by id: %w", database.ErrDocumentNotFound)
+		return nil, change.InitialCheckpoint, fmt.Errorf("create changes of %s: %w", refKey, database.ErrDocumentNotFound)
 	}
 	initialServerSeq := docInfo.ServerSeq
 
@@ -1356,7 +1397,7 @@ func (d *DB) CreateChangeInfos(
 			Operations:     cn.Operations,
 			PresenceChange: cn.PresenceChange,
 		}); err != nil {
-			return nil, change.InitialCheckpoint, fmt.Errorf("create change: %w", err)
+			return nil, change.InitialCheckpoint, fmt.Errorf("create changes of %s: %w", refKey, err)
 		}
 	}
 
@@ -1367,14 +1408,14 @@ func (d *DB) CreateChangeInfos(
 		docInfo.ID.String(),
 	)
 	if err != nil {
-		return nil, change.InitialCheckpoint, fmt.Errorf("find document: %w", err)
+		return nil, change.InitialCheckpoint, fmt.Errorf("create changes of %s: %w", refKey, err)
 	}
 	if raw == nil {
-		return nil, change.InitialCheckpoint, fmt.Errorf("%s: %w", docInfo.ID, database.ErrDocumentNotFound)
+		return nil, change.InitialCheckpoint, fmt.Errorf("create changes of %s: %w", refKey, database.ErrDocumentNotFound)
 	}
 	loadedDocInfo := raw.(*database.DocInfo).DeepCopy()
 	if loadedDocInfo.ServerSeq != initialServerSeq {
-		return nil, change.InitialCheckpoint, fmt.Errorf("%s: %w", docInfo.ID, database.ErrConflictOnUpdate)
+		return nil, change.InitialCheckpoint, fmt.Errorf("create changes of %s: %w", refKey, database.ErrConflictOnUpdate)
 	}
 
 	now := gotime.Now()
@@ -1391,7 +1432,7 @@ func (d *DB) CreateChangeInfos(
 		loadedDocInfo.RemovedAt = now
 	}
 	if err := txn.Insert(tblDocuments, loadedDocInfo); err != nil {
-		return nil, change.InitialCheckpoint, fmt.Errorf("update document: %w", err)
+		return nil, change.InitialCheckpoint, fmt.Errorf("create changes of %s: %w", refKey, err)
 	}
 	txn.Commit()
 
@@ -1425,14 +1466,14 @@ func (d *DB) CompactChangeInfos(
 		docInfo.ID.String(),
 	)
 	if err != nil {
-		return fmt.Errorf("find document: %w", err)
+		return fmt.Errorf("compact document of %s: %w", docInfo.RefKey(), err)
 	}
 	if raw == nil {
-		return fmt.Errorf("%s: %w", docInfo.ID, database.ErrDocumentNotFound)
+		return fmt.Errorf("compact document of %s: %w", docInfo.RefKey(), database.ErrDocumentNotFound)
 	}
 	loadedDocInfo := raw.(*database.DocInfo).DeepCopy()
 	if loadedDocInfo.ServerSeq != lastServerSeq {
-		return fmt.Errorf("%s: %w", docInfo.ID, database.ErrConflictOnUpdate)
+		return fmt.Errorf("compact document of %s: %w", docInfo.RefKey(), database.ErrConflictOnUpdate)
 	}
 
 	if len(changes) == 0 {
@@ -1440,7 +1481,7 @@ func (d *DB) CompactChangeInfos(
 	} else if len(changes) == 1 {
 		loadedDocInfo.ServerSeq = 1
 	} else {
-		return fmt.Errorf("invalid number of changes: %d", len(changes))
+		return fmt.Errorf("compact document of %s: invalid changes size %d", docInfo.RefKey(), len(changes))
 	}
 
 	for _, cn := range changes {
@@ -1462,7 +1503,7 @@ func (d *DB) CompactChangeInfos(
 			Operations:     encodedOperations,
 			PresenceChange: cn.PresenceChange(),
 		}); err != nil {
-			return fmt.Errorf("store change: %w", err)
+			return fmt.Errorf("compact document of %s: %w", docInfo.RefKey(), err)
 		}
 	}
 
@@ -1470,7 +1511,7 @@ func (d *DB) CompactChangeInfos(
 	now := gotime.Now()
 	loadedDocInfo.CompactedAt = now
 	if err := txn.Insert(tblDocuments, loadedDocInfo); err != nil {
-		return fmt.Errorf("update document: %w", err)
+		return fmt.Errorf("compact document of %s: %w", docInfo.RefKey(), err)
 	}
 
 	txn.Commit()
@@ -1495,7 +1536,7 @@ func (d *DB) FindLatestChangeInfoByActor(
 		serverSeq,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("fetch changes of %s: %w", actorID, err)
+		return nil, fmt.Errorf("find the last change of %s: %w", actorID, err)
 	}
 
 	for raw := iterator.Next(); raw != nil; raw = iterator.Next() {
@@ -1555,7 +1596,7 @@ func (d *DB) FindChangeInfosBetweenServerSeqs(
 		from,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("fetch changes from %d: %w", from, err)
+		return nil, fmt.Errorf("find changes of %s: %w", docRefKey, err)
 	}
 
 	for raw := iterator.Next(); raw != nil; raw = iterator.Next() {
@@ -1592,7 +1633,7 @@ func (d *DB) CreateSnapshotInfo(
 		Snapshot:      snapshot,
 		CreatedAt:     gotime.Now(),
 	}); err != nil {
-		return fmt.Errorf("create snapshot: %w", err)
+		return fmt.Errorf("create snapshot of %s: %w", docRefKey, err)
 	}
 	txn.Commit()
 	return nil
@@ -1637,7 +1678,7 @@ func (d *DB) FindClosestSnapshotInfo(
 		serverSeq,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("fetch snapshots before %d: %w", serverSeq, err)
+		return nil, fmt.Errorf("find snapshot before %d of %s: %w", serverSeq, docRefKey, err)
 	}
 
 	var snapshotInfo *database.SnapshotInfo
@@ -1691,7 +1732,7 @@ func (d *DB) updateVersionVector(
 			docRefKey.DocID.String(),
 			clientInfo.ID.String(),
 		); err != nil {
-			return fmt.Errorf("delete version vector of %s: %w", docRefKey.DocID, err)
+			return fmt.Errorf("update version vector of %s: %w", docRefKey, err)
 		}
 
 		txn.Commit()
@@ -1705,7 +1746,7 @@ func (d *DB) updateVersionVector(
 		clientInfo.ID.String(),
 	)
 	if err != nil {
-		return fmt.Errorf("fetch version vector of %s: %w", docRefKey.DocID, err)
+		return fmt.Errorf("update version vector of %s: %w", docRefKey, err)
 	}
 
 	versionVectorInfo := &database.VersionVectorInfo{
@@ -1720,7 +1761,7 @@ func (d *DB) updateVersionVector(
 	}
 
 	if err := txn.Insert(tblVersionVectors, versionVectorInfo); err != nil {
-		return fmt.Errorf("insert version vector of %s: %w", docRefKey.DocID, err)
+		return fmt.Errorf("update version vector of %s: %w", docRefKey, err)
 	}
 
 	txn.Commit()
@@ -1757,7 +1798,7 @@ func (d *DB) GetMinVersionVector(
 	defer txn.Abort()
 	iterator, err := txn.Get(tblVersionVectors, "doc_id", docRefKey.DocID.String())
 	if err != nil {
-		return nil, fmt.Errorf("find all version vectors: %w", err)
+		return nil, fmt.Errorf("find min version vector: %w", err)
 	}
 
 	var infos []database.VersionVectorInfo
@@ -1807,7 +1848,7 @@ func (d *DB) FindDocInfosByPaging(
 		)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("fetch documents of %s: %w", projectID, err)
+		return nil, fmt.Errorf("find documents of %s: %w", projectID, err)
 	}
 
 	var docInfos []*database.DocInfo
@@ -1843,7 +1884,7 @@ func (d *DB) FindDocInfosByQuery(
 
 	iterator, err := txn.Get(tblDocuments, "project_id_key_prefix", projectID.String(), query)
 	if err != nil {
-		return nil, fmt.Errorf("find docInfos by query: %w", err)
+		return nil, fmt.Errorf("find documents by query %s: %w", query, err)
 	}
 
 	var docInfos []*database.DocInfo
@@ -1920,10 +1961,10 @@ func (d *DB) CreateSchemaInfo(
 		version,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("find schema: %w", err)
+		return nil, fmt.Errorf("create schema of %s: %w", name, err)
 	}
 	if existing != nil {
-		return nil, fmt.Errorf("%s: %w", name, database.ErrSchemaAlreadyExists)
+		return nil, fmt.Errorf("create schema of %s: %w", name, database.ErrSchemaAlreadyExists)
 	}
 
 	info := &database.SchemaInfo{
@@ -1960,10 +2001,10 @@ func (d *DB) GetSchemaInfo(
 		version,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("find schema: %w", err)
+		return nil, fmt.Errorf("find schema of %s@%d: %w", name, version, err)
 	}
 	if raw == nil {
-		return nil, fmt.Errorf("%s: %w", name, database.ErrSchemaNotFound)
+		return nil, fmt.Errorf("find schema of %s@%d: %w", name, version, database.ErrSchemaNotFound)
 	}
 
 	return raw.(*database.SchemaInfo).DeepCopy(), nil
@@ -1995,7 +2036,7 @@ func (d *DB) GetSchemaInfos(
 	})
 
 	if len(infos) == 0 {
-		return nil, fmt.Errorf("%s: %w", name, database.ErrSchemaNotFound)
+		return nil, fmt.Errorf("find schemas of %s: %w", name, database.ErrSchemaNotFound)
 	}
 	return infos, nil
 }
@@ -2009,7 +2050,7 @@ func (d *DB) ListSchemaInfos(
 
 	iter, err := txn.Get(tblSchemas, "project_id", projectID.String())
 	if err != nil {
-		return nil, fmt.Errorf("find schema: %w", err)
+		return nil, fmt.Errorf("list schemas of %s: %w", projectID, err)
 	}
 
 	schemaMap := make(map[string]*database.SchemaInfo)
@@ -2045,15 +2086,15 @@ func (d *DB) RemoveSchemaInfo(
 		version,
 	)
 	if err != nil {
-		return fmt.Errorf("find schema: %w", err)
+		return fmt.Errorf("remove schema %s@%d: %w", name, version, err)
 	}
 	if raw == nil {
-		return fmt.Errorf("%s: %w", name, database.ErrSchemaNotFound)
+		return fmt.Errorf("remove schema %s@%d: %w", name, version, database.ErrSchemaNotFound)
 	}
 
 	schemaInfo := raw.(*database.SchemaInfo)
 	if err := txn.Delete(tblSchemas, schemaInfo); err != nil {
-		return fmt.Errorf("delete schema: %w", err)
+		return fmt.Errorf("remove schema %s@%d: %w", name, version, err)
 	}
 
 	txn.Commit()
@@ -2070,12 +2111,12 @@ func (d *DB) PurgeDocument(
 
 	raw, err := txn.First(tblDocuments, "id", docRefKey.DocID.String())
 	if err != nil {
-		return nil, fmt.Errorf("find document by id: %w", err)
+		return nil, fmt.Errorf("purge document of %s: %w", docRefKey, err)
 	}
 
 	docInfo := raw.(*database.DocInfo)
 	if docInfo.ProjectID != docRefKey.ProjectID {
-		return nil, fmt.Errorf("finding doc info by ID(%s): %w", docRefKey.DocID, database.ErrDocumentNotFound)
+		return nil, fmt.Errorf("purge document of %s: %w", docRefKey, database.ErrDocumentNotFound)
 	}
 
 	res, err := d.purgeDocumentInternals(ctx, docRefKey.ProjectID, docRefKey.DocID, txn)
@@ -2084,7 +2125,7 @@ func (d *DB) PurgeDocument(
 	}
 
 	if err := txn.Delete(tblDocuments, docInfo); err != nil {
-		return nil, fmt.Errorf("delete document: %w", err)
+		return nil, fmt.Errorf("purge document of %s: %w", docRefKey, err)
 	}
 
 	txn.Commit()
@@ -2101,19 +2142,19 @@ func (d *DB) purgeDocumentInternals(
 
 	count, err := txn.DeleteAll(tblChanges, "doc_id", docID.String())
 	if err != nil {
-		return nil, fmt.Errorf("purge changes: %w", err)
+		return nil, fmt.Errorf("purge changes of %s: %w", docID, err)
 	}
 	counts[tblChanges] = int64(count)
 
 	count, err = txn.DeleteAll(tblSnapshots, "doc_id", docID.String())
 	if err != nil {
-		return nil, fmt.Errorf("purge snapshots: %w", err)
+		return nil, fmt.Errorf("purge snapshots of %s: %w", docID, err)
 	}
 	counts[tblSnapshots] = int64(count)
 
 	count, err = txn.DeleteAll(tblVersionVectors, "doc_id", docID.String())
 	if err != nil {
-		return nil, fmt.Errorf("purge version vectors: %w", err)
+		return nil, fmt.Errorf("purge version vectors of %s: %w", docID, err)
 	}
 	counts[tblVersionVectors] = int64(count)
 
@@ -2122,45 +2163,6 @@ func (d *DB) purgeDocumentInternals(
 
 func newID() types.ID {
 	return types.ID(bson.NewObjectID().Hex())
-}
-
-// RotateProjectKeys rotates the API keys of the project.
-func (d *DB) RotateProjectKeys(
-	_ context.Context,
-	owner types.ID,
-	id types.ID,
-	publicKey string,
-	secretKey string,
-) (*database.ProjectInfo, error) {
-	txn := d.db.Txn(true)
-	defer txn.Abort()
-
-	// Find project by ID and owner
-	raw, err := txn.First(tblProjects, "id", id.String())
-	if err != nil {
-		return nil, fmt.Errorf("find project by id: %w", err)
-	}
-	if raw == nil {
-		return nil, fmt.Errorf("%s: %w", id, database.ErrProjectNotFound)
-	}
-
-	project := raw.(*database.ProjectInfo).DeepCopy()
-	if project.Owner != owner {
-		return nil, database.ErrProjectNotFound
-	}
-
-	// Update project keys
-	project.PublicKey = publicKey
-	project.SecretKey = secretKey
-	project.UpdatedAt = gotime.Now()
-
-	// Save updated project
-	if err := txn.Insert(tblProjects, project); err != nil {
-		return nil, fmt.Errorf("update project: %w", err)
-	}
-
-	txn.Commit()
-	return project, nil
 }
 
 // IsSchemaAttached returns true if the schema is being used by any documents.
@@ -2178,7 +2180,7 @@ func (d *DB) IsSchemaAttached(
 		projectID.String(),
 	)
 	if err != nil {
-		return false, fmt.Errorf("find documents by project id: %w", err)
+		return false, fmt.Errorf("check if schema %s is attached: %w", schema, err)
 	}
 
 	for raw := iter.Next(); raw != nil; raw = iter.Next() {

--- a/server/backend/database/mongo/indexes.go
+++ b/server/backend/database/mongo/indexes.go
@@ -184,7 +184,7 @@ func ensureIndexes(ctx context.Context, db *mongo.Database) error {
 	for _, info := range collectionInfos {
 		_, err := db.Collection(info.name).Indexes().CreateMany(ctx, info.indexes)
 		if err != nil {
-			return fmt.Errorf("create indexes: %w", err)
+			return fmt.Errorf("create indexes for %s: %w", info.name, err)
 		}
 	}
 	return nil

--- a/server/packs/compaction.go
+++ b/server/packs/compaction.go
@@ -57,7 +57,7 @@ func Compact(
 	if isAttached {
 		// TODO(hackerwins): ErrDocumentNotAttached exists in documents package,
 		// but it can not be here because of the circular dependency.
-		return fmt.Errorf("document is attached")
+		return fmt.Errorf("compact document %s: document is attached", docInfo.ID)
 	}
 
 	// 2. Build compacted changes and check if the content is the same.
@@ -130,7 +130,7 @@ func Purge(
 
 	// 1. Check if the document is removed.
 	if !docInfo.IsRemoved() {
-		return fmt.Errorf("document %s is not removed: %w", docInfo.ID, ErrDocumentNotRemoved)
+		return fmt.Errorf("purge document %s: %w", docInfo.ID, ErrDocumentNotRemoved)
 	}
 
 	// 2. Purge the document from the database.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Previously, errors were returned with minimal context.
e.g.: `return fmt.Errorf("store change: %w", err)`

This made it difficult to identify which resource caused the issue
during debugging.

Now, errors include specific context such as the document key.
e.g.: `fmt.Errorf("compact document of %s: %w", docInfo.RefKey(), err)`

Following Go conventions, errors are wrapped using `fmt.Errorf` with `%w`
so that sentinel errors can still be detected using `errors.Is` / `errors.As`.
This improves debuggability without breaking existing error handling.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified and clarified error/log messages across database and compaction/purge flows; messages now include relevant IDs, keys, ref keys, usernames and collection names. Aligned terminology for documents/projects/schemas and improved cache/init logs.
* **Chores**
  * Renamed a user-lookup parameter in a public API — update any integrations if needed.
* **No functional changes**
  * Behavior and control flow unchanged; changes are message/log text only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->