### PR TITLE
Fix removedAt timestamp handling in tree deletions

### DIFF
--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -420,6 +420,8 @@ func (n *TreeNode) remove(removedAt *time.Ticket, creationKnown, tombstoneKnown 
 	}
 
 	if n.removedAt == nil {
+		n.removedAt = removedAt
+		n.Index.UpdateAncestorsSize()
 		return true
 	}
 
@@ -427,7 +429,6 @@ func (n *TreeNode) remove(removedAt *time.Ticket, creationKnown, tombstoneKnown 
 	// (concurrent or unseen) and newer.
 	if !tombstoneKnown && removedAt.After(n.removedAt) {
 		n.removedAt = removedAt
-		n.Index.UpdateAncestorsSize()
 		return true
 	}
 	return false

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -874,7 +874,6 @@ func (t *Tree) Edit(
 		return nil, resource.DataSize{}, err
 	}
 
-
 	// 02. Delete: delete the nodes that are marked as removed.
 	var pairs []GCPair
 	for _, node := range toBeRemoveds {
@@ -1039,12 +1038,12 @@ func (t *Tree) collectBetween(
 		if slices.Contains(toBeRemoveds, node) {
 			continue
 		}
-		
+
 		// Skip if not deleted
 		if node.removedAt == nil {
 			continue
 		}
-		
+
 		// Check if we know about the creation
 		creationKnown := false
 		if isLocal {
@@ -1052,11 +1051,11 @@ func (t *Tree) collectBetween(
 		} else if l, ok := versionVector.Get(node.id.CreatedAt.ActorID()); ok && l >= node.id.CreatedAt.Lamport() {
 			creationKnown = true
 		}
-		
+
 		if !creationKnown {
 			continue
 		}
-		
+
 		// Check if the tombstone is known
 		tombstoneKnown := false
 		if isLocal {
@@ -1064,7 +1063,7 @@ func (t *Tree) collectBetween(
 		} else if l, ok := versionVector.Get(node.removedAt.ActorID()); ok && l >= node.removedAt.Lamport() {
 			tombstoneKnown = true
 		}
-		
+
 		// If this node needs LWW processing, add it to toBeRemoveds
 		if node.canDelete(editedAt, creationKnown, tombstoneKnown) {
 			toBeRemoveds = append(toBeRemoveds, node)

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -429,7 +429,6 @@ func (n *TreeNode) remove(removedAt *time.Ticket, creationKnown, tombstoneKnown 
 	// (concurrent or unseen) and newer.
 	if !tombstoneKnown && removedAt.After(n.removedAt) {
 		n.removedAt = removedAt
-		return true
 	}
 	return false
 }
@@ -446,9 +445,9 @@ func (n *TreeNode) canDelete(removedAt *time.Ticket, creationKnown, tombstoneKno
 
 	// NOTE(sigmaith): Overwrite only if prior tombstone was not known
 	// (concurrent or unseen) and newer.
-	if !tombstoneKnown && removedAt.After(n.removedAt) {
-		return true
-	}
+	// if !tombstoneKnown && removedAt.After(n.removedAt) {
+	// return true
+	// }
 	return false
 }
 
@@ -876,8 +875,54 @@ func (t *Tree) Edit(
 	}
 
 	// 02. Delete: delete the nodes that are marked as removed.
+	// Also process nodes that are already deleted but need LWW updates.
 	var pairs []GCPair
-	for _, node := range toBeRemoveds {
+
+	// IMPORTANT: Check ALL nodes in the tree for potential LWW updates
+	// This is necessary because deleted nodes might be outside the current range
+	var additionalNodes []*TreeNode
+	for _, node := range t.Nodes() {
+		// Skip if already in toBeRemoveds
+		if slices.Contains(toBeRemoveds, node) {
+			continue
+		}
+
+		// Check if this is a deleted node that needs LWW processing
+		if node.removedAt != nil {
+			isLocal := len(versionVector) == 0
+
+			// Check if we know about the creation
+			creationKnown := false
+			if isLocal {
+				creationKnown = true
+			} else if l, ok := versionVector.Get(node.id.CreatedAt.ActorID()); ok && l >= node.id.CreatedAt.Lamport() {
+				creationKnown = true
+			}
+
+			// Only process if creation was known (otherwise we can't delete it)
+			if !creationKnown {
+				continue
+			}
+
+			// Check if the tombstone is known
+			tombstoneKnown := false
+			if isLocal {
+				tombstoneKnown = true
+			} else if l, ok := versionVector.Get(node.removedAt.ActorID()); ok && l >= node.removedAt.Lamport() {
+				tombstoneKnown = true
+			}
+
+			// If tombstone is not known and new deletion is later, include it for LWW
+			if !tombstoneKnown && editedAt.After(node.removedAt) {
+				additionalNodes = append(additionalNodes, node)
+			}
+		}
+	}
+
+	// Combine toBeRemoveds with additionalNodes
+	allNodesToProcess := append(toBeRemoveds, additionalNodes...)
+
+	for _, node := range allNodesToProcess {
 
 		isLocal := len(versionVector) == 0
 
@@ -899,7 +944,9 @@ func (t *Tree) Edit(
 			}
 		}
 
-		if node.remove(editedAt, creationKnown, tombstoneKnown) {
+		removed := node.remove(editedAt, creationKnown, tombstoneKnown)
+
+		if removed {
 			pairs = append(pairs, GCPair{
 				Parent: t,
 				Child:  node,

--- a/test/integration/tree_test.go
+++ b/test/integration/tree_test.go
@@ -3918,7 +3918,7 @@ func TestTree(t *testing.T) {
 		syncClientsThenAssertEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
 
 		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
-			root.GetTree("t").Edit(4, 7, nil, 0) // <i>cd</i> 삭제
+			root.GetTree("t").Edit(4, 7, nil, 0)
 			return nil
 		}, "delete <i>cd</i>")
 		assert.NoError(t, err)
@@ -3926,7 +3926,7 @@ func TestTree(t *testing.T) {
 		syncClientsThenAssertEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
 
 		err = d2.Update(func(root *json.Object, p *presence.Presence) error {
-			root.GetTree("t").Edit(1, 7, nil, 0) // <b>ab</b><i>cd</i> 전체 삭제
+			root.GetTree("t").Edit(1, 7, nil, 0)
 			return nil
 		}, "delete <b>ab</b><i>cd</i>")
 		assert.NoError(t, err)
@@ -4053,7 +4053,6 @@ func TestTree(t *testing.T) {
 			t.Logf("  timestamp: %s", ts)
 		}
 
-		// Todo(sigmaith): make pass
 		assert.Equal(t, 1, len(timestampSet), "Should have 1 timestamp in concurrent deletion")
 
 		assert.Equal(t, "<root><p></p></root>", d1.Root().GetTree("t").ToXML())

--- a/test/integration/tree_test.go
+++ b/test/integration/tree_test.go
@@ -3918,7 +3918,7 @@ func TestTree(t *testing.T) {
 		syncClientsThenAssertEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
 
 		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
-			root.GetTree("t").Edit(4, 7, nil, 0)
+			root.GetTree("t").Edit(5, 9, nil, 0)
 			return nil
 		}, "delete <i>cd</i>")
 		assert.NoError(t, err)
@@ -3926,7 +3926,7 @@ func TestTree(t *testing.T) {
 		syncClientsThenAssertEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
 
 		err = d2.Update(func(root *json.Object, p *presence.Presence) error {
-			root.GetTree("t").Edit(1, 7, nil, 0)
+			root.GetTree("t").Edit(1, 5, nil, 0)
 			return nil
 		}, "delete <b>ab</b><i>cd</i>")
 		assert.NoError(t, err)
@@ -3989,13 +3989,13 @@ func TestTree(t *testing.T) {
 		syncClientsThenAssertEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
 
 		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
-			root.GetTree("t").Edit(4, 8, nil, 0)
+			root.GetTree("t").Edit(5, 9, nil, 0)
 			return nil
 		}, "delete <i>cd</i> by c1")
 		assert.NoError(t, err)
 
 		err = d2.Update(func(root *json.Object, p *presence.Presence) error {
-			root.GetTree("t").Edit(1, 8, nil, 0)
+			root.GetTree("t").Edit(1, 9, nil, 0)
 			return nil
 		}, "delete <b>ab</b><i>cd</i> by c2")
 		assert.NoError(t, err)

--- a/test/integration/tree_test.go
+++ b/test/integration/tree_test.go
@@ -3989,13 +3989,13 @@ func TestTree(t *testing.T) {
 		syncClientsThenAssertEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
 
 		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
-			root.GetTree("t").Edit(4, 7, nil, 0)
+			root.GetTree("t").Edit(4, 8, nil, 0)
 			return nil
 		}, "delete <i>cd</i> by c1")
 		assert.NoError(t, err)
 
 		err = d2.Update(func(root *json.Object, p *presence.Presence) error {
-			root.GetTree("t").Edit(1, 7, nil, 0)
+			root.GetTree("t").Edit(1, 8, nil, 0)
 			return nil
 		}, "delete <b>ab</b><i>cd</i> by c2")
 		assert.NoError(t, err)


### PR DESCRIPTION
# **What this PR does / why we need it**:

Fixes an issue where `removedAt` timestamps were not properly updated for already-deleted nodes during range deletion operations in text/tree CRDTs.    

## Problem

During range deletion operations, nodes already marked as deleted (tombstones) within the range should have their `removedAt` timestamps updated for proper CRDT semantics:                                                                                                                                   

- **Causal deletions**: Preserve original timestamps to maintain causality                                                                                                                                                                                                                                   
- **Concurrent deletions**: Apply Last Write Wins (LWW) for conflict resolution                                                                                                                                                                                                                          
- **Future undo/redo**: Critical for proper timestamp management    

In the main branch, LWW logic is not supported in concurrent overlapped deletion.
<img width="708" height="199" alt="image" src="https://github.com/user-attachments/assets/5f4e6366-c84d-482b-b893-0e0a6dbc14fe" />




## Solution

### Core Changes
 - Fixed removedAt timestamp update logic for already-deleted nodes during range deletion operations
- Implemented proper Last Write Wins (LWW) conflict resolution for concurrent overlapped deletions
- Added support for collecting out-of-range deleted nodes to ensure correct CRDT semantics
- Updated tree deletion mechanism to properly handle causal and concurrent deletion scenarios

# **Which issue(s) this PR fixes**:

Address yorkie-team/yorkie-js-sdk#821       

**Special notes for your reviewer**:

For example:
  - Client A deletes range (4,8)
  - Client B deletes range (1,8) concurrently
  - When Client B's operation is applied after Client A's, the nodes at (4,8) are already deleted and their indices have shifted
  - `traverseInPosRange` uses index-based traversal, so it only sees nodes in the current index range (1,8), missing the already-deleted nodes that were originally at (4,8)
  - Without checking these deleted nodes, LWW (Last Write Wins) cannot work properly for concurrent deletions

  Therefore, in `collectBetween`, I had to add additional logic to check all deleted nodes outside the current range to ensure LWW works correctly. This is necessary because `traverseInPosRange` performs
   index-based operations where ranges are adjusted after deletions.

  If there are alternative approaches to handle this more efficiently, please feel free to suggest them.

Note) call `Children(true)` resulted in a different test failure.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More robust deletion and conflict-resolution in collaborative document trees (LWW-style tombstone handling and cross-client consistency).
* **Tests**
  * Added integration tests for causal and concurrent deletions to verify removal ordering and cross-client convergence.
* **Notes**
  * No user interface changes; behavior affects synchronization and deletion correctness behind the scenes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->