### PR TITLE
Optimize Client.Deactivate by removing N+1 query

### DIFF
--- a/server/backend/database/database.go
+++ b/server/backend/database/database.go
@@ -236,6 +236,13 @@ type Database interface {
 		docKeys []key.Key,
 	) ([]*DocInfo, error)
 
+	// FindDocInfosByIDs finds the documents of the given IDs.
+	FindDocInfosByIDs(
+		ctx context.Context,
+		projectID types.ID,
+		docIDs []types.ID,
+	) ([]*DocInfo, error)
+
 	// FindOrCreateDocInfo finds the document or creates it if it does not exist.
 	FindOrCreateDocInfo(
 		ctx context.Context,

--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -1166,6 +1166,27 @@ func (d *DB) findDocInfoByKey(txn *memdb.Txn, projectID types.ID, docKey key.Key
 	return docInfo, nil
 }
 
+// findDocInfoById finds the document of the given id.
+func (d *DB) findDocInfoById(txn *memdb.Txn, projectID types.ID, docId types.ID) (*database.DocInfo, error) {
+	iter, err := txn.Get(
+		tblDocuments,
+		"project_id_id",
+		projectID.String(),
+		docId.String(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("find document of %s: %w", docId, err)
+	}
+	var docInfo *database.DocInfo
+	for val := iter.Next(); val != nil; val = iter.Next() {
+		if info := val.(*database.DocInfo); info.RemovedAt.IsZero() {
+			docInfo = info
+		}
+	}
+
+	return docInfo, nil
+}
+
 // FindDocInfoByKey finds the document of the given key.
 func (d *DB) FindDocInfoByKey(
 	_ context.Context,
@@ -1200,6 +1221,31 @@ func (d *DB) FindDocInfosByKeys(
 		info, err := d.findDocInfoByKey(txn, projectID, k)
 		if err != nil {
 			return nil, fmt.Errorf("find documents of %v: %w", keys, err)
+		}
+		if info == nil {
+			continue
+		}
+
+		infos = append(infos, info.DeepCopy())
+	}
+
+	return infos, nil
+}
+
+// FindDocInfosByIDs finds the documents of the given ids.
+func (d *DB) FindDocInfosByIDs(
+	ctx context.Context,
+	projectID types.ID,
+	docIDs []types.ID,
+) ([]*database.DocInfo, error) {
+	txn := d.db.Txn(false)
+	defer txn.Abort()
+
+	var infos []*database.DocInfo
+	for _, id := range docIDs {
+		info, err := d.findDocInfoById(txn, projectID, id)
+		if err != nil {
+			return nil, fmt.Errorf("find documents of %v: %w", docIDs, err)
 		}
 		if info == nil {
 			continue

--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -1166,16 +1166,16 @@ func (d *DB) findDocInfoByKey(txn *memdb.Txn, projectID types.ID, docKey key.Key
 	return docInfo, nil
 }
 
-// findDocInfoById finds the document of the given id.
-func (d *DB) findDocInfoById(txn *memdb.Txn, projectID types.ID, docId types.ID) (*database.DocInfo, error) {
+// findDocInfoByID finds the document of the given id.
+func (d *DB) findDocInfoByID(txn *memdb.Txn, projectID types.ID, docID types.ID) (*database.DocInfo, error) {
 	iter, err := txn.Get(
 		tblDocuments,
 		"project_id_id",
 		projectID.String(),
-		docId.String(),
+		docID.String(),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("find document of %s: %w", docId, err)
+		return nil, fmt.Errorf("find document of %s: %w", docID, err)
 	}
 	var docInfo *database.DocInfo
 	for val := iter.Next(); val != nil; val = iter.Next() {
@@ -1243,7 +1243,7 @@ func (d *DB) FindDocInfosByIDs(
 
 	var infos []*database.DocInfo
 	for _, id := range docIDs {
-		info, err := d.findDocInfoById(txn, projectID, id)
+		info, err := d.findDocInfoByID(txn, projectID, id)
 		if err != nil {
 			return nil, fmt.Errorf("find documents of %v: %w", docIDs, err)
 		}

--- a/server/backend/database/memory/database_test.go
+++ b/server/backend/database/memory/database_test.go
@@ -52,8 +52,8 @@ func TestDB(t *testing.T) {
 		testcases.RunFindDocInfoTest(t, db, projectID)
 	})
 
-	t.Run("RunFindDocInfosByKeys test", func(t *testing.T) {
-		testcases.RunFindDocInfosByKeysTest(t, db, projectID)
+	t.Run("RunFindDocInfosByKeysAndIDs test", func(t *testing.T) {
+		testcases.RunFindDocInfosByKeysAndIDsTest(t, db, projectID)
 	})
 
 	t.Run("RunFindDocInfosByQuery test", func(t *testing.T) {

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -1217,6 +1217,35 @@ func (c *Client) FindDocInfosByKeys(
 	return docInfos, nil
 }
 
+// FindDocInfosByIDs finds the documents of the given ids.
+func (c *Client) FindDocInfosByIDs(
+	ctx context.Context,
+	projectID types.ID,
+	docIDs []types.ID,
+) ([]*database.DocInfo, error) {
+	if len(docIDs) == 0 {
+		return nil, nil
+	}
+	filter := bson.M{
+		"project_id": projectID,
+		"_id": bson.M{
+			"$in": docIDs,
+		},
+	}
+
+	cursor, err := c.collection(ColDocuments).Find(ctx, filter)
+	if err != nil {
+		return nil, fmt.Errorf("find documents of %v: %w", docIDs, err)
+	}
+
+	var docInfos []*database.DocInfo
+	if err := cursor.All(ctx, &docInfos); err != nil {
+		return nil, fmt.Errorf("find documents of %v: %w", docIDs, err)
+	}
+
+	return docInfos, nil
+}
+
 // FindDocInfoByRefKey finds a docInfo of the given refKey.
 func (c *Client) FindDocInfoByRefKey(
 	ctx context.Context,

--- a/server/backend/database/mongo/client_test.go
+++ b/server/backend/database/mongo/client_test.go
@@ -69,8 +69,8 @@ func TestClient(t *testing.T) {
 		testcases.RunFindDocInfoTest(t, cli, dummyProjectID)
 	})
 
-	t.Run("RunFindDocInfosByKeys test", func(t *testing.T) {
-		testcases.RunFindDocInfosByKeysTest(t, cli, dummyProjectID)
+	t.Run("RunFindDocInfosByKeysAndIDs test", func(t *testing.T) {
+		testcases.RunFindDocInfosByKeysAndIDsTest(t, cli, dummyProjectID)
 	})
 
 	t.Run("RunFindDocInfosByQuery test", func(t *testing.T) {

--- a/server/backend/database/testcases/testcases.go
+++ b/server/backend/database/testcases/testcases.go
@@ -257,8 +257,8 @@ func RunFindDocInfosByKeysAndIDsTest(
 		docIDs := make([]types.ID, 0)
 		for _, docKey := range docKeys {
 			docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
-			docIDs = append(docIDs, docInfo.ID)
 			assert.NoError(t, err)
+			docIDs = append(docIDs, docInfo.ID)
 		}
 
 		// 02. Find documents by keys
@@ -324,8 +324,8 @@ func RunFindDocInfosByKeysAndIDsTest(
 		docIDs := make([]types.ID, 0)
 		for _, docKey := range docKeys {
 			docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
-			docIDs = append(docIDs, docInfo.ID)
 			assert.NoError(t, err)
+			docIDs = append(docIDs, docInfo.ID)
 		}
 
 		// 02. append a key and id that does not exist

--- a/server/backend/database/testcases/testcases.go
+++ b/server/backend/database/testcases/testcases.go
@@ -233,18 +233,18 @@ func RunFindDocInfoTest(
 		assert.NoError(t, err)
 
 		// 03. Find the document
-		info, err = db.FindDocInfoByKey(ctx, projectID, docKey)
+		_, err = db.FindDocInfoByKey(ctx, projectID, docKey)
 		assert.ErrorIs(t, err, database.ErrDocumentNotFound)
 	})
 }
 
-// RunFindDocInfosByKeysTest runs the FindDocInfosByKeys test for the given db.
-func RunFindDocInfosByKeysTest(
+// RunFindDocInfosByKeysAndIDsTest runs the FindDocInfosByKeys and FindDocInfosByIDs test for the given db.
+func RunFindDocInfosByKeysAndIDsTest(
 	t *testing.T,
 	db database.Database,
 	projectID types.ID,
 ) {
-	t.Run("find docInfos by keys test", func(t *testing.T) {
+	t.Run("find docInfos by keys and ids test", func(t *testing.T) {
 		ctx := context.Background()
 		clientInfo, err := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
 		assert.NoError(t, err)
@@ -254,12 +254,14 @@ func RunFindDocInfosByKeysTest(
 			"test", "test$3", "test123", "test$0",
 			"search$test", "abcde", "test abc",
 		}
+		docIDs := make([]types.ID, 0)
 		for _, docKey := range docKeys {
-			_, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+			docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+			docIDs = append(docIDs, docInfo.ID)
 			assert.NoError(t, err)
 		}
 
-		// 02. Find documents
+		// 02. Find documents by keys
 		infos, err := db.FindDocInfosByKeys(ctx, projectID, docKeys)
 		assert.NoError(t, err)
 
@@ -270,9 +272,21 @@ func RunFindDocInfosByKeysTest(
 
 		assert.ElementsMatch(t, docKeys, actualKeys)
 		assert.Len(t, infos, len(docKeys))
+
+		// 03. Find documents by ids
+		infos, err = db.FindDocInfosByIDs(ctx, projectID, docIDs)
+		assert.NoError(t, err)
+
+		actualIDs := make([]types.ID, len(infos))
+		for i, info := range infos {
+			actualIDs[i] = info.ID
+		}
+
+		assert.ElementsMatch(t, docIDs, actualIDs)
+		assert.Len(t, infos, len(docIDs))
 	})
 
-	t.Run("find docInfos by empty key slice test", func(t *testing.T) {
+	t.Run("find docInfos by empty key and id slice test", func(t *testing.T) {
 		ctx := context.Background()
 		clientInfo, err := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
 		assert.NoError(t, err)
@@ -287,13 +301,18 @@ func RunFindDocInfosByKeysTest(
 			assert.NoError(t, err)
 		}
 
-		// 02. Find documents
+		// 02. Find documents by empty key
 		infos, err := db.FindDocInfosByKeys(ctx, projectID, nil)
+		assert.NoError(t, err)
+		assert.Len(t, infos, 0)
+
+		// 03. Find documents by empty ids
+		infos, err = db.FindDocInfosByIDs(ctx, projectID, nil)
 		assert.NoError(t, err)
 		assert.Len(t, infos, 0)
 	})
 
-	t.Run("find docInfos by keys where some keys are not found test", func(t *testing.T) {
+	t.Run("find docInfos by keys and ids where some are not found test", func(t *testing.T) {
 		ctx := context.Background()
 		clientInfo, err := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
 		assert.NoError(t, err)
@@ -302,15 +321,18 @@ func RunFindDocInfosByKeysTest(
 		docKeys := []key.Key{
 			"exist-key1", "exist-key2", "exist-key3",
 		}
+		docIDs := make([]types.ID, 0)
 		for _, docKey := range docKeys {
-			_, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+			docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+			docIDs = append(docIDs, docInfo.ID)
 			assert.NoError(t, err)
 		}
 
-		// 02. append a key that does not exist
+		// 02. append a key and id that does not exist
 		docKeysWithNonExistKey := append(docKeys, "non-exist-key")
+		docIDsWithNonExistID := append(docIDs, types.ID("000000000000000000000000"))
 
-		// 03. Find documents
+		// 03. Find documents by keys
 		infos, err := db.FindDocInfosByKeys(ctx, projectID, docKeysWithNonExistKey)
 		assert.NoError(t, err)
 
@@ -321,6 +343,18 @@ func RunFindDocInfosByKeysTest(
 
 		assert.ElementsMatch(t, docKeys, actualKeys)
 		assert.Len(t, infos, len(docKeys))
+
+		// 04. Find documents by ids
+		infos, err = db.FindDocInfosByIDs(ctx, projectID, docIDsWithNonExistID)
+		assert.NoError(t, err)
+
+		actualIDs := make([]types.ID, len(infos))
+		for i, info := range infos {
+			actualIDs[i] = info.ID
+		}
+
+		assert.ElementsMatch(t, docIDs, actualIDs)
+		assert.Len(t, infos, len(docIDs))
 	})
 }
 
@@ -1909,7 +1943,7 @@ func RunPurgeDocument(t *testing.T, db database.Database, projectID types.ID) {
 		// 02. Purge the document and check the document is purged.
 		counts, err := db.PurgeDocument(ctx, docRefKey)
 		assert.NoError(t, err)
-		docInfo, err = db.FindDocInfoByRefKey(ctx, docRefKey)
+		_, err = db.FindDocInfoByRefKey(ctx, docRefKey)
 		assert.ErrorIs(t, err, database.ErrDocumentNotFound)
 
 		// NOTE(raararaara): This test is only checking the document is purged.

--- a/server/backend/database/testcases/testcases.go
+++ b/server/backend/database/testcases/testcases.go
@@ -306,7 +306,7 @@ func RunFindDocInfosByKeysAndIDsTest(
 		assert.NoError(t, err)
 		assert.Len(t, infos, 0)
 
-		// 03. Find documents by empty ids
+		// 03. Find documents by empty id
 		infos, err = db.FindDocInfosByIDs(ctx, projectID, nil)
 		assert.NoError(t, err)
 		assert.Len(t, infos, 0)

--- a/server/clients/clients.go
+++ b/server/clients/clients.go
@@ -72,7 +72,7 @@ func Deactivate(
 			return nil, err
 		}
 		if len(docInfos) != len(docIDs) {
-			return nil, fmt.Errorf("failed to find all documents; expected: %d, actual: %d",
+			return nil, fmt.Errorf("find documents for detachment, expected: %d, actual: %d",
 				len(docIDs), len(docInfos))
 		}
 		actorID, err := info.ID.ToActorID()

--- a/test/bench/deactive_bench_test.go
+++ b/test/bench/deactive_bench_test.go
@@ -1,0 +1,84 @@
+//go:build bench
+
+/*
+ * Copyright 2025 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bench
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yorkie-team/yorkie/client"
+	"github.com/yorkie-team/yorkie/pkg/document"
+	"github.com/yorkie-team/yorkie/server"
+	"github.com/yorkie-team/yorkie/server/logging"
+	"github.com/yorkie-team/yorkie/test/helper"
+)
+
+func benchmarkDeactivate(
+	b *testing.B,
+	ctx context.Context,
+	svr *server.Yorkie,
+	totalDocCount int,
+	attachedDocCount int,
+) {
+	b.StopTimer()
+	c, err := client.Dial(svr.RPCAddr())
+	assert.NoError(b, err)
+	err = c.Activate(ctx)
+	assert.NoError(b, err)
+	for i := range totalDocCount {
+		d := document.New(helper.TestDocKey(b, i))
+		err := c.Attach(ctx, d)
+		assert.NoError(b, err)
+		if i >= attachedDocCount {
+			err := c.Detach(ctx, d)
+			assert.NoError(b, err)
+		}
+	}
+	b.StartTimer()
+	err = svr.DeactivateClient(ctx, c)
+	b.StopTimer()
+	assert.NoError(b, err)
+}
+
+func BenchmarkDeactivate(b *testing.B) {
+	assert.NoError(b, logging.SetLogLevel("error"))
+
+	svr := helper.TestServer()
+	assert.NoError(b, svr.Start())
+
+	b.Cleanup(func() {
+		if err := svr.Shutdown(true); err != nil {
+			b.Fatal(err)
+		}
+	})
+
+	ctx := context.Background()
+	b.Run("deactivate with 100 total 10 attached", func(b *testing.B) {
+		for range b.N {
+			benchmarkDeactivate(b, ctx, svr, 100, 10)
+		}
+	})
+
+	b.Run("deactivate with 100 total 100 attached", func(b *testing.B) {
+		for range b.N {
+			benchmarkDeactivate(b, ctx, svr, 100, 100)
+		}
+	})
+}

--- a/test/bench/deactive_bench_test.go
+++ b/test/bench/deactive_bench_test.go
@@ -40,19 +40,22 @@ func benchmarkDeactivate(
 	b.StopTimer()
 	c, err := client.Dial(svr.RPCAddr())
 	assert.NoError(b, err)
+	defer c.Close()
+
 	err = c.Activate(ctx)
 	assert.NoError(b, err)
 	for i := range totalDocCount {
 		d := document.New(helper.TestDocKey(b, i))
-		err := c.Attach(ctx, d)
+		err = c.Attach(ctx, d)
 		assert.NoError(b, err)
 		if i >= attachedDocCount {
-			err := c.Detach(ctx, d)
+			err = c.Detach(ctx, d)
 			assert.NoError(b, err)
 		}
 	}
+
 	b.StartTimer()
-	err = svr.DeactivateClient(ctx, c)
+	err = c.Deactivate(ctx)
 	b.StopTimer()
 	assert.NoError(b, err)
 }

--- a/test/bench/deactive_bench_test.go
+++ b/test/bench/deactive_bench_test.go
@@ -73,9 +73,9 @@ func BenchmarkDeactivate(b *testing.B) {
 	})
 
 	ctx := context.Background()
-	b.Run("deactivate with 100 total 10 attached", func(b *testing.B) {
+	b.Run("deactivate with 100 total 50 attached", func(b *testing.B) {
 		for range b.N {
-			benchmarkDeactivate(b, ctx, svr, 100, 10)
+			benchmarkDeactivate(b, ctx, svr, 100, 50)
 		}
 	})
 

--- a/test/complex/mongo_client_test.go
+++ b/test/complex/mongo_client_test.go
@@ -72,8 +72,8 @@ func TestClientWithShardedDB(t *testing.T) {
 		testcases.RunFindDocInfoTest(t, cli, dummyProjectID)
 	})
 
-	t.Run("RunFindDocInfosByKeys test", func(t *testing.T) {
-		testcases.RunFindDocInfosByKeysTest(t, cli, dummyProjectID)
+	t.Run("RunFindDocInfosByKeysAndIDs test", func(t *testing.T) {
+		testcases.RunFindDocInfosByKeysAndIDsTest(t, cli, dummyProjectID)
 	})
 
 	t.Run("RunFindDocInfosByQuery test", func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 In `Yorkie.DeactivateClient`, firstly it finds attached or attaching documents to detach via DB query.
Previously, the number of query is N+1 (1 for `FindClientInfo`, N for `FindDocInfoByRefKey`) to find it.
Execute `N * FindDocInfoByRefKey` can be changed to batch query `FindDocInfosByDocIDs` in both mongoDB and memDB to reduce execution time.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:
 Let me share benchmark result for mongoDB case. You can refer `deactivate_bench_test.go` for detailed scenario.
This change reduces about **10%** of `Client.Deactivate` execution time in all number of attached documents, while memory consumption and number of allocation is almost same.

- Small case (attached document is 1 to 20)

| Case                                | Before (ms) | After (ms) | % (after/before) |
|-------------------------------------|-------------|------------|------------------|
| deactivate_with_1_total_1_attached  | 2.86        | 2.58       | 90.11%           |
| deactivate_with_2_total_2_attached  | 4.65        | 4.55       | 97.93%           |
| deactivate_with_3_total_3_attached  | 6.14        | 5.90       | 96.11%           |
| deactivate_with_4_total_4_attached  | 8.73        | 7.90       | 90.50%           |
| deactivate_with_5_total_5_attached  | 11.53       | 9.14       | 79.27%           |
| deactivate_with_6_total_6_attached  | 12.27       | 13.72      | 111.80%          |
| deactivate_with_7_total_7_attached  | 12.84       | 12.39      | 96.45%           |
| deactivate_with_8_total_8_attached  | 17.66       | 13.89      | 78.64%           |
| deactivate_with_9_total_9_attached  | 17.27       | 14.34      | 83.02%           |
| deactivate_with_10_total_10_attached | 19.90      | 17.01      | 85.46%           |
| deactivate_with_11_total_11_attached | 19.34      | 20.38      | 105.41%          |
| deactivate_with_12_total_12_attached | 22.46      | 21.45      | 95.53%           |
| deactivate_with_13_total_13_attached | 22.46      | 23.53      | 104.76%          |
| deactivate_with_14_total_14_attached | 23.85      | 24.97      | 104.69%          |
| deactivate_with_15_total_15_attached | 29.06      | 29.00      | 99.82%           |
| deactivate_with_16_total_16_attached | 29.76      | 31.47      | 105.74%          |
| deactivate_with_17_total_17_attached | 31.52      | 28.24      | 89.59%           |
| deactivate_with_18_total_18_attached | 32.24      | 29.85      | 92.59%           |
| deactivate_with_19_total_19_attached | 36.86      | 30.76      | 83.44%           |
| deactivate_with_20_total_20_attached | 39.46      | 34.26      | 86.83%           |

- Large case (x-axis is attached documents in client, measured from 10 to 1000 in step of 10)

**Execution Time**
<img width="704" height="422" alt="image" src="https://github.com/user-attachments/assets/cbf86d26-14b4-4b9f-a965-be9bfc8696df" />

**Memory Usage**
<img width="704" height="422" alt="image" src="https://github.com/user-attachments/assets/abfcc697-1257-47c2-9bc2-e714eea2cd81" />

**Number of Allocation**
<img width="704" height="422" alt="image" src="https://github.com/user-attachments/assets/ad126c45-864b-42b3-8535-0c613d7e0897" />

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [X] Added relevant tests or not required
- [X] Addressed and resolved all CodeRabbit review comments
- [X] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch document retrieval by IDs for faster multi-document operations.
* **Refactor**
  * Client deactivation now uses batched lookups with validation of fetched results to improve performance and reliability.
* **Tests**
  * Expanded tests to cover retrieval by keys and IDs (including empty/not‑found cases) and updated test labels.
  * Added deactivation benchmarks to track performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->