### PR TITLE
Optimize `FindCompactionCandidatesPerProject` and `ListDocumentSummaries` via removing N+1 query

### DIFF
--- a/server/backend/database/database.go
+++ b/server/backend/database/database.go
@@ -197,8 +197,11 @@ type Database interface {
 	// after handling PushPull.
 	UpdateClientInfoAfterPushPull(ctx context.Context, clientInfo *ClientInfo, docInfo *DocInfo) error
 
-	// FindAttachedClientInfosByRefKey returns the client infos of the given document.
+	// FindAttachedClientInfosByRefKey returns the attached client infos of the given document.
 	FindAttachedClientInfosByRefKey(ctx context.Context, refKey types.DocRefKey) ([]*ClientInfo, error)
+
+	// FindAttachedClientCountsByDocIDs returns the number of attached clients of the given documents.
+	FindAttachedClientCountsByDocIDs(ctx context.Context, projectID types.ID, docIDs []types.ID) (map[types.ID]int, error)
 
 	// FindNextNCyclingProjectInfos finds the next N cycling projects from the given projectID.
 	FindNextNCyclingProjectInfos(

--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -1081,7 +1081,7 @@ func (d *DB) FindCompactionCandidatesPerProject(
 	return infos, nil
 }
 
-// FindAttachedClientInfosByRefKey finds the client infos of the given document.
+// FindAttachedClientInfosByRefKey returns the attached client infos of the given document.
 func (d *DB) FindAttachedClientInfosByRefKey(
 	_ context.Context,
 	docRefKey types.DocRefKey,
@@ -1103,6 +1103,35 @@ func (d *DB) FindAttachedClientInfosByRefKey(
 		}
 	}
 	return infos, nil
+}
+
+// FindAttachedClientCountsByDocIDs returns the number of attached clients of the given documents.
+func (d *DB) FindAttachedClientCountsByDocIDs(
+	ctx context.Context,
+	projectID types.ID,
+	docIDs []types.ID,
+) (map[types.ID]int, error) {
+	txn := d.db.Txn(false)
+	defer txn.Abort()
+
+	iter, err := txn.Get(tblClients, "project_id", projectID.String())
+	if err != nil {
+		return nil, fmt.Errorf("find attached client counts of %s: %w", docIDs, err)
+	}
+
+	var results = make(map[types.ID]int)
+	for _, docID := range docIDs {
+		results[docID] = 0
+	}
+	for raw := iter.Next(); raw != nil; raw = iter.Next() {
+		info := raw.(*database.ClientInfo)
+		for _, docID := range docIDs {
+			if info.Documents[docID] != nil && info.Documents[docID].Status == database.DocumentAttached {
+				results[docID]++
+			}
+		}
+	}
+	return results, nil
 }
 
 // FindOrCreateDocInfo finds the document or creates it if it does not exist.

--- a/server/backend/database/memory/database_test.go
+++ b/server/backend/database/memory/database_test.go
@@ -44,6 +44,10 @@ func TestDB(t *testing.T) {
 		testcases.RunFindNextNCyclingProjectInfosTest(t, db)
 	})
 
+	t.Run("FindCompactionCandidatesPerProject test", func(t *testing.T) {
+		testcases.RunFindCompactionCandidatesPerProjectTest(t, db)
+	})
+
 	t.Run("FindDeactivateCandidatesPerProject test", func(t *testing.T) {
 		testcases.RunFindDeactivateCandidatesPerProjectTest(t, db)
 	})

--- a/server/backend/database/memory/database_test.go
+++ b/server/backend/database/memory/database_test.go
@@ -132,6 +132,10 @@ func TestDB(t *testing.T) {
 		testcases.RunFindClientInfosByAttachedDocRefKeyTest(t, db, projectID)
 	})
 
+	t.Run("FindAttachedClientCountsByDocIDs test", func(t *testing.T) {
+		testcases.RunFindAttachedClientCountsByDocIDsTest(t, db, projectID)
+	})
+
 	t.Run("RunPurgeDocument test", func(t *testing.T) {
 		testcases.RunPurgeDocument(t, db, projectID)
 	})

--- a/server/backend/database/mongo/client_test.go
+++ b/server/backend/database/mongo/client_test.go
@@ -61,6 +61,10 @@ func TestClient(t *testing.T) {
 		testcases.RunFindNextNCyclingProjectInfosTest(t, cli)
 	})
 
+	t.Run("FindCompactionCandidatesPerProject test", func(t *testing.T) {
+		testcases.RunFindCompactionCandidatesPerProjectTest(t, cli)
+	})
+
 	t.Run("FindDeactivateCandidatesPerProject test", func(t *testing.T) {
 		testcases.RunFindDeactivateCandidatesPerProjectTest(t, cli)
 	})

--- a/server/backend/database/mongo/client_test.go
+++ b/server/backend/database/mongo/client_test.go
@@ -150,6 +150,10 @@ func TestClient(t *testing.T) {
 	t.Run("FindClientInfosByAttachedDocRefKey test", func(t *testing.T) {
 		testcases.RunFindClientInfosByAttachedDocRefKeyTest(t, cli, dummyProjectID)
 	})
+
+	t.Run("FindAttachedClientCountsByDocIDs test", func(t *testing.T) {
+		testcases.RunFindAttachedClientCountsByDocIDsTest(t, cli, dummyProjectID)
+	})
 }
 
 func TestClient_RotateProjectKeys(t *testing.T) {

--- a/server/backend/housekeeping/config.go
+++ b/server/backend/housekeeping/config.go
@@ -57,7 +57,7 @@ func (c *Config) Validate() error {
 	if c.CandidatesLimitPerProject <= 0 {
 		return fmt.Errorf(
 			`invalid argument %d for "--housekeeping-candidates-limit-per-project" flag`,
-			c.ProjectFetchSize,
+			c.CandidatesLimitPerProject,
 		)
 	}
 

--- a/server/documents/documents.go
+++ b/server/documents/documents.go
@@ -153,17 +153,21 @@ func ListDocumentSummaries(
 	}
 
 	var summaries []*types.DocumentSummary
+	docIDs := make([]types.ID, 0, len(infos))
 	for _, info := range infos {
-		// TODO(hackerwins): Resolve the N+1 problem.
-		clientInfos, err := be.DB.FindAttachedClientInfosByRefKey(ctx, info.RefKey())
-		if err != nil {
-			return nil, err
-		}
+		docIDs = append(docIDs, info.ID)
+	}
 
+	attachedClientCounts, err := be.DB.FindAttachedClientCountsByDocIDs(ctx, project.ID, docIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, info := range infos {
 		summary := &types.DocumentSummary{
 			ID:              info.ID,
 			Key:             info.Key,
-			AttachedClients: len(clientInfos),
+			AttachedClients: attachedClientCounts[info.ID],
 			CreatedAt:       info.CreatedAt,
 			AccessedAt:      info.AccessedAt,
 			UpdatedAt:       info.UpdatedAt,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
### 1. Optimize `FindCompactionCandidatesPerProject`

Condition of returning `DocInfo` in `FindCompactionCandidatesPerProject` is below.
- server_seq ≥ compactionMinChanges
- Document must not be attached to any client
- maximum # of documents is candidatesLimit

 Previously, `FindCompactionCandidatesPerProject` in mongoDB finds `ColDouments` and iterates it with checking remained conditions via `ColClients`. It queries N+1 (`1 * FetchDocInfos + N * IsDocumentAttached`) times and fetch unnecessary `DocInfo`. So, I fixed with aggregate pipeline and lookup join with `ColClients`.

### 2. Optimize `ListDocumentSummaries`


**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:
### 1. Benchmark result of `FindCompactionCandidatesPerProject`
<img width="800" height="1200" alt="image" src="https://github.com/user-attachments/assets/88f4f09d-51b3-4ba2-be9e-870b58063134" />

### 2. Benchmark result of `ListDocumentSummaries`
<img width="800" height="1200" alt="image" src="https://github.com/user-attachments/assets/cfc81589-03c7-43bd-ae2f-c57689e30e48" />


**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [X] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [X] Didn't break anything
