### PR TITLE
Implement Fallback Logic for Project Secret Key to Use Default Project

### DIFF
--- a/server/projects/projects.go
+++ b/server/projects/projects.go
@@ -150,6 +150,15 @@ func GetProjectFromAPIKey(ctx context.Context, be *backend.Backend, apiKey strin
 
 // ProjectFromSecretKey returns a project from a secret key.
 func ProjectFromSecretKey(ctx context.Context, be *backend.Backend, secretKey string) (*types.Project, error) {
+	// NOTE(kokodak): If the secretKey is empty, fallback to the default project.
+	if secretKey == "" {
+		info, err := be.DB.FindProjectInfoByID(ctx, database.DefaultProjectID)
+		if err != nil {
+			return nil, err
+		}
+		return info.ToProject(), nil
+	}
+
 	info, err := be.DB.FindProjectInfoBySecretKey(ctx, secretKey)
 	if err != nil {
 		return nil, err

--- a/server/rpc/interceptors/admin.go
+++ b/server/rpc/interceptors/admin.go
@@ -222,7 +222,10 @@ func (i *AdminServiceInterceptor) authenticate(
 		}
 	case strings.EqualFold(scheme, types.AuthSchemeAPIKey):
 		// If the scheme is API-Key, verify the secret key and retrieve the project.
-		project, err := projects.ProjectFromSecretKey(ctx, i.backend, param)
+		if strings.TrimSpace(param) == "" && !i.backend.Config.UseDefaultProject {
+			return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("secret key is not provided"))
+		}
+		project, err := projects.ProjectFromSecretKey(ctx, i.backend, strings.TrimSpace(param))
 		if err == nil {
 			ctx = projects.With(ctx, project)
 			return ctx, nil


### PR DESCRIPTION
…t key is empty

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR implements fallback logic to use the default project when the project secret key provided via the API-Key Scheme is empty and the `UseDefaultProject` setting is enabled. This is necessary since the `projectName` option is no longer utilized, and access to the default project can now only be done through the secret key.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Related to #1471 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [ ] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [ ] Didn't break anything
