### PR TITLE
Fix garbage size accounting for Text nodes

### DIFF
--- a/pkg/document/crdt/root.go
+++ b/pkg/document/crdt/root.go
@@ -183,6 +183,7 @@ func (r *Root) GarbageCollect(vector time.VersionVector) (int, error) {
 				return 0, err
 			}
 
+			r.docSize.GC.Sub(pair.Child.DataSize())
 			delete(r.gcNodePairMap, pair.Child.IDString())
 			count++
 		}

--- a/pkg/document/gc_test.go
+++ b/pkg/document/gc_test.go
@@ -220,3 +220,94 @@ func TestTextGC(t *testing.T) {
 		})
 	}
 }
+
+func TestTextGCSize(t *testing.T) {
+	t.Run("should update gc size correctly after text garbage collection", func(t *testing.T) {
+		doc := document.New("test-doc")
+
+		// Initial state
+		err := doc.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewText("text")
+			return nil
+		})
+		assert.NoError(t, err)
+
+		initialSize := doc.DocSize()
+		assert.Equal(t, 0, initialSize.GC.Data)
+		assert.Equal(t, 0, initialSize.GC.Meta)
+
+		// Add and then remove text to create garbage
+		err = doc.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(0, 0, "Hello world")
+			return nil
+		})
+		assert.NoError(t, err)
+
+		err = doc.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(6, 11, "")
+			return nil
+		})
+		assert.NoError(t, err)
+
+		sizeBeforeGC := doc.DocSize()
+		assert.Equal(t, 10, sizeBeforeGC.GC.Data)
+		assert.Equal(t, 48, sizeBeforeGC.GC.Meta)
+		assert.Equal(t, 1, doc.GarbageLen())
+
+		// Perform garbage collection
+		collected := doc.GarbageCollect(helper.MaxVersionVector(doc.ActorID()))
+		assert.Equal(t, 1, collected)
+
+		// Verify gc size is properly reset after collection
+		sizeAfterGC := doc.DocSize()
+		assert.Equal(t, 0, sizeAfterGC.GC.Data)
+		assert.Equal(t, 0, sizeAfterGC.GC.Meta)
+		assert.Equal(t, 0, doc.GarbageLen())
+	})
+
+	t.Run("should update gc size correctly after multiple text operations and gc", func(t *testing.T) {
+		doc := document.New("test-doc")
+
+		err := doc.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewText("text")
+			return nil
+		})
+		assert.NoError(t, err)
+
+		// Create multiple text segments and then remove some
+		err = doc.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(0, 0, "ABC")
+			return nil
+		})
+		assert.NoError(t, err)
+
+		err = doc.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(1, 2, "X")
+			return nil
+		})
+		assert.NoError(t, err)
+
+		err = doc.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(2, 3, "")
+			return nil
+		})
+		assert.NoError(t, err)
+
+		sizeBeforeGC := doc.DocSize()
+		garbageLen := doc.GarbageLen()
+
+		assert.Equal(t, 4, sizeBeforeGC.GC.Data)
+		assert.Equal(t, 96, sizeBeforeGC.GC.Meta)
+		assert.Equal(t, 2, garbageLen) // B and C should be garbage
+
+		// Perform garbage collection
+		collected := doc.GarbageCollect(helper.MaxVersionVector(doc.ActorID()))
+		assert.Equal(t, garbageLen, collected)
+
+		// Verify all gc size is cleared
+		sizeAfterGC := doc.DocSize()
+		assert.Equal(t, 0, sizeAfterGC.GC.Data)
+		assert.Equal(t, 0, sizeAfterGC.GC.Meta)
+		assert.Equal(t, 0, doc.GarbageLen())
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix garbage size accounting for Text nodes

This commit fixes an issue where garbage size updates were missing for
Text nodes, since the accounting logic was previously applied only at
the Element level.

To address this, GC size accounting is now properly updated for Text
nodes as well, ensuring that the displayed totals are reliable.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Related to https://github.com/yorkie-team/yorkie-js-sdk/pull/1086

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected garbage collection size accounting so memory usage reflects removed text after cleanup.
  - Ensures GC metrics reset accurately after collection, improving stats reliability.

- Tests
  - Added tests validating GC size tracking across text edits and multiple garbage segments.
  - Verified metrics return to zero and garbage entries are cleared post-collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->