### PR TITLE
Introduce presence memory cache

### DIFF
--- a/pkg/document/innerpresence/change.go
+++ b/pkg/document/innerpresence/change.go
@@ -46,3 +46,8 @@ func (c *Change) Execute(actorID time.ActorID, presences *Map) {
 		presences.Store(actorID.String(), c.Presence)
 	}
 }
+
+// IsClear returns true if the change is of type Clear.
+func (c *Change) IsClear() bool {
+	return c.ChangeType == Clear
+}

--- a/server/backend/database/change_info.go
+++ b/server/backend/database/change_info.go
@@ -139,6 +139,11 @@ func (i *ChangeInfo) DeepCopy() *ChangeInfo {
 	return clone
 }
 
+// PresenceOnly returns true if this change is a presence-only change.
+func (i *ChangeInfo) PresenceOnly() bool {
+	return len(i.Operations) == 0 && i.PresenceChange != nil
+}
+
 // EncodePresenceChange encodes the given PresenceChange into bytes array.
 func EncodePresenceChange(p *innerpresence.Change) ([]byte, error) {
 	if p == nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Presence is now stored in-memory(volatile) and removed when the client
is detached. This design avoids modifying ServerSeq while still enabling
efficient presence handling.

Changes:
- Add per-document presence cache alongside operation cache
- Store presences in presenceCache, operations in operationCache + DB
- Merge presences and operations when serving queries
- Clear presences when client detaches during checkpoint update

`k6 run -e -e TEST_MODE=even -e CONCURRENCY=10000 test/k6/presence.ts`


| Version | Threshold | Frame Graph |
|---------|---------|---------|
| Before | <img width="282" height="403" src="https://github.com/user-attachments/assets/6e4cb774-9ce5-4c95-980d-f28d48543e3e" />  | <img width="1281" height="562" src="https://github.com/user-attachments/assets/59f3f3e1-91f2-4fef-83ce-2b2d858dae4d" /> |
| After | <img width="292" height="404" src="https://github.com/user-attachments/assets/1e60fd7c-5ee8-4252-99b6-a61b4d0d16bb" /> | <img width="1278" height="542" src="https://github.com/user-attachments/assets/73c23012-6563-48a8-9c6d-5f3e0e129a9a" /> |

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Per-document presence cache for faster, lower-load presence updates.
  - Bulk replace/insert of change batches for faster sync.
  - Remove-all-changes-by-actor support for account/device cleanup.
  - Explicit detection of presence-only and presence-clear events to separate presence vs. operation data.

- Bug Fixes
  - Merged results deduplicate presence and operation changes.
  - Presence cleared when documents are purged or clients detach to avoid stale indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->