### PR TITLE
Fix leadership renewal failure in MemDB

### DIFF
--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -165,6 +165,7 @@ func (d *DB) TryLeadership(
 		LeaseToken: newToken,
 		ExpiresAt:  expiresAt,
 		UpdatedAt:  now,
+		IsLeader:   true,
 	}
 
 	record := &clusterNodeRecord{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Set IsLeader field when renewing leadership in memory database.
Without this, the field defaults to false, causing subsequent renewal
attempts to fail with "invalid lease token" error as the leader query
cannot find any node with IsLeader=true.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Related to #1502

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures the node is correctly marked as leader immediately after leadership renewal, improving accuracy of status reporting.
  * Reduces transient inconsistencies in leader-dependent behavior, leading to more reliable cluster health checks, admin/status endpoints, and monitoring dashboards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->