### PR TITLE
Update clients shard key and indexing

### DIFF
--- a/build/docker/sharding/scripts/init-mongos1.js
+++ b/build/docker/sharding/scripts/init-mongos1.js
@@ -4,9 +4,9 @@ sh.addShard("shard-rs-2/shard2-1:27017");
 function findAnotherShard(shard) {
   if (shard == "shard-rs-1") {
     return "shard-rs-2";
-  } else {
-    return "shard-rs-1";
   }
+
+  return "shard-rs-1";
 }
 
 function shardOfChunk(minKeyOfChunk) {
@@ -15,32 +15,32 @@ function shardOfChunk(minKeyOfChunk) {
     .chunks.findOne({ min: { project_id: minKeyOfChunk } }).shard;
 }
 
-// Shard the database for the mongo client test
-const mongoClientDB = "test-yorkie-meta-mongo-client";
-sh.enableSharding(mongoClientDB);
-sh.shardCollection(mongoClientDB + ".clients", { project_id: 1 });
-sh.shardCollection(mongoClientDB + ".documents", { project_id: 1 });
-sh.shardCollection(mongoClientDB + ".schemas", { project_id: 1 });
-sh.shardCollection(mongoClientDB + ".changes", { doc_id: "hashed" });
-sh.shardCollection(mongoClientDB + ".snapshots", { doc_id: "hashed" });
-sh.shardCollection(mongoClientDB + ".versionvectors", { doc_id: "hashed" });
+// Sharded DB for the client test
+const clientTestDB = "test-yorkie-meta-mongo-client";
+sh.enableSharding(clientTestDB);
+sh.shardCollection(clientTestDB + ".clients", { project_id: 1, _id: "hashed" });
+sh.shardCollection(clientTestDB + ".documents", { project_id: 1 });
+sh.shardCollection(clientTestDB + ".schemas", { project_id: 1 });
+sh.shardCollection(clientTestDB + ".changes", { doc_id: "hashed" });
+sh.shardCollection(clientTestDB + ".snapshots", { doc_id: "hashed" });
+sh.shardCollection(clientTestDB + ".versionvectors", { doc_id: "hashed" });
 
 // Split the inital range at `splitPoint` to allow doc_ids duplicate in different shards.
 const splitPoint = ObjectId("500000000000000000000000");
-sh.splitAt(mongoClientDB + ".documents", { project_id: splitPoint });
+sh.splitAt(clientTestDB + ".documents", { project_id: splitPoint });
 // Move the chunk to another shard.
 db.adminCommand({
-  moveChunk: mongoClientDB + ".documents",
+  moveChunk: clientTestDB + ".documents",
   find: { project_id: splitPoint },
   to: findAnotherShard(shardOfChunk(splitPoint)),
 });
 
-// Shard the database for the server test
-const serverDB = "test-yorkie-meta-server";
-sh.enableSharding(serverDB);
-sh.shardCollection(serverDB + ".clients", { project_id: 1 });
-sh.shardCollection(serverDB + ".documents", { project_id: 1 });
-sh.shardCollection(serverDB + ".schemas", { project_id: 1 });
-sh.shardCollection(serverDB + ".changes", { doc_id: "hashed" });
-sh.shardCollection(serverDB + ".snapshots", { doc_id: "hashed" });
-sh.shardCollection(serverDB + ".versionvectors", { doc_id: "hashed" });
+// Sharded DB for the server test
+const serverTestDB = "test-yorkie-meta-server";
+sh.enableSharding(serverTestDB);
+sh.shardCollection(serverTestDB + ".clients", { project_id: 1, _id: "hashed" });
+sh.shardCollection(serverTestDB + ".documents", { project_id: 1 });
+sh.shardCollection(serverTestDB + ".schemas", { project_id: 1 });
+sh.shardCollection(serverTestDB + ".changes", { doc_id: "hashed" });
+sh.shardCollection(serverTestDB + ".snapshots", { doc_id: "hashed" });
+sh.shardCollection(serverTestDB + ".versionvectors", { doc_id: "hashed" });

--- a/server/backend/database/memory/indexes.go
+++ b/server/backend/database/memory/indexes.go
@@ -109,16 +109,6 @@ var schema = &memdb.DBSchema{
 					Name:    "project_id",
 					Indexer: &memdb.StringFieldIndex{Field: "ProjectID"},
 				},
-				"project_id_key": {
-					Name:   "project_id_key",
-					Unique: true,
-					Indexer: &memdb.CompoundIndex{
-						Indexes: []memdb.Indexer{
-							&memdb.StringFieldIndex{Field: "ProjectID"},
-							&memdb.StringFieldIndex{Field: "Key"},
-						},
-					},
-				},
 				"project_id_status_updated_at": {
 					Name: "project_id_status_updated_at",
 					Indexer: &memdb.CompoundIndex{

--- a/server/backend/database/mongo/indexes.go
+++ b/server/backend/database/mongo/indexes.go
@@ -115,23 +115,17 @@ var collectionInfos = []collectionInfo{
 		name: ColClients,
 		indexes: []mongo.IndexModel{{
 			Keys: bson.D{
-				{Key: "project_id", Value: int32(1)}, // shard key
-				{Key: "key", Value: int32(1)},
-			},
-			Options: options.Index().SetUnique(true),
-		}, {
-			Keys: bson.D{
-				{Key: "project_id", Value: int32(1)}, // shard key
+				{Key: "project_id", Value: int32(1)}, // shard key: [project_id, _id]
 				{Key: "status", Value: int32(1)},
 				{Key: "updated_at", Value: int32(1)},
 			},
 		}, {
 			Keys: bson.D{
-				{Key: "project_id", Value: int32(1)}, // shard key
+				{Key: "project_id", Value: int32(1)}, // shard key: [project_id, _id]
 				{Key: "attached_docs", Value: int32(1)},
 			},
 		}, {
-			// NOTE(hackerwins): This index is for deactivating clients efficiently.
+			// TODO(hackerwins): This index is for deactivating clients efficiently.
 			// But it skips the shard key to cover all clients in all projects.
 			// We should monitor performance because this may cause scatter-gather.
 			Keys: bson.D{
@@ -144,7 +138,7 @@ var collectionInfos = []collectionInfo{
 		name: ColDocuments,
 		indexes: []mongo.IndexModel{{
 			Keys: bson.D{
-				{Key: "project_id", Value: int32(1)}, // shard key
+				{Key: "project_id", Value: int32(1)}, // shard key: [project_id]
 				{Key: "key", Value: int32(1)},
 				{Key: "removed_at", Value: int32(1)},
 			},
@@ -155,7 +149,7 @@ var collectionInfos = []collectionInfo{
 		name: ColSchemas,
 		indexes: []mongo.IndexModel{{
 			Keys: bson.D{
-				{Key: "project_id", Value: int32(1)}, // shard key
+				{Key: "project_id", Value: int32(1)}, // shard key: [project_id]
 				{Key: "name", Value: int32(1)},
 				{Key: "version", Value: int32(1)},
 			},
@@ -166,14 +160,14 @@ var collectionInfos = []collectionInfo{
 		name: ColChanges,
 		indexes: []mongo.IndexModel{{
 			Keys: bson.D{
-				{Key: "doc_id", Value: int32(1)}, // shard key
+				{Key: "doc_id", Value: int32(1)}, // shard key: [doc_id]
 				{Key: "project_id", Value: int32(1)},
 				{Key: "server_seq", Value: int32(1)},
 			},
 			Options: options.Index().SetUnique(true),
 		}, {
 			Keys: bson.D{
-				{Key: "doc_id", Value: int32(1)}, // shard key
+				{Key: "doc_id", Value: int32(1)}, // shard key: [doc_id]
 				{Key: "project_id", Value: int32(1)},
 				{Key: "actor_id", Value: int32(1)},
 				{Key: "server_seq", Value: int32(1)},
@@ -184,7 +178,7 @@ var collectionInfos = []collectionInfo{
 		name: ColSnapshots,
 		indexes: []mongo.IndexModel{{
 			Keys: bson.D{
-				{Key: "doc_id", Value: int32(1)}, // shard key
+				{Key: "doc_id", Value: int32(1)}, // shard key: [doc_id]
 				{Key: "project_id", Value: int32(1)},
 				{Key: "server_seq", Value: int32(1)},
 			},
@@ -194,7 +188,7 @@ var collectionInfos = []collectionInfo{
 		name: ColVersionVectors,
 		indexes: []mongo.IndexModel{{
 			Keys: bson.D{
-				{Key: "doc_id", Value: int32(1)}, // shard key
+				{Key: "doc_id", Value: int32(1)}, // shard key: [doc_id]
 				{Key: "project_id", Value: int32(1)},
 				{Key: "client_id", Value: int32(1)},
 			},

--- a/server/backend/database/testcases/testcases.go
+++ b/server/backend/database/testcases/testcases.go
@@ -842,25 +842,26 @@ func RunActivateClientDeactivateClientTest(t *testing.T, db database.Database, p
 		})
 		assert.ErrorIs(t, err, database.ErrClientNotFound)
 
-		clientInfo, err := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
+		info1, err := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
 		assert.NoError(t, err)
 
-		assert.Equal(t, t.Name(), clientInfo.Key)
-		assert.Equal(t, database.ClientActivated, clientInfo.Status)
+		assert.Equal(t, t.Name(), info1.Key)
+		assert.Equal(t, database.ClientActivated, info1.Status)
 
-		// try to activate the client twice.
-		clientInfo, err = db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
+		// activate another client with the same key (now creates a new client).
+		info2, err := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
 		assert.NoError(t, err)
-		assert.Equal(t, t.Name(), clientInfo.Key)
-		assert.Equal(t, database.ClientActivated, clientInfo.Status)
+		assert.Equal(t, t.Name(), info2.Key)
+		assert.Equal(t, database.ClientActivated, info2.Status)
+		assert.NotEqual(t, info1.ID, info2.ID) // Different client IDs
 
-		clientInfo, err = db.DeactivateClient(ctx, clientInfo.RefKey())
+		info1, err = db.DeactivateClient(ctx, info1.RefKey())
 		assert.NoError(t, err)
-		assert.Equal(t, t.Name(), clientInfo.Key)
-		assert.Equal(t, database.ClientDeactivated, clientInfo.Status)
+		assert.Equal(t, t.Name(), info1.Key)
+		assert.Equal(t, database.ClientDeactivated, info1.Status)
 
 		// already deactivated
-		_, err = db.DeactivateClient(ctx, clientInfo.RefKey())
+		_, err = db.DeactivateClient(ctx, info1.RefKey())
 		assert.ErrorIs(t, err, database.ErrClientNotFound)
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This commit switches to hashed/composite shard keys for better client
distribution across fewer projects. Client key is only used for API
server sharding and is not used as a unique value to distinguish
clients as before.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated sharding and index strategy to use hashed/composite shard keys for better distribution.
  * Client activation now always creates distinct client records; same client key can produce different client IDs.
  * Removed uniqueness constraint on client keys to allow multiple client records with the same key.

* **Documentation**
  * Revised sharding and data-model guidance, query patterns, and risk/mitigation notes to match the new shard-key design.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->