### PR TITLE
Rename ancestor size updates to length

### DIFF
--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -380,8 +380,8 @@ func (n *TreeNode) SplitElement(
 	if err := n.Index.Parent.InsertAfterInternal(split.Index, n.Index); err != nil {
 		return nil, diff, err
 	}
-	split.Index.UpdateAncestorsSize(split.Index.PaddedLength())
-	split.Index.UpdateAncestorsSize(split.Index.PaddedLength(true), true)
+	split.Index.UpdateAncestorsLength(split.Index.PaddedLength())
+	split.Index.UpdateAncestorsLength(split.Index.PaddedLength(true), true)
 
 	leftChildren := n.Index.Children(true)[0:offset]
 	rightChildren := n.Index.Children(true)[offset:]
@@ -433,7 +433,7 @@ func (n *TreeNode) remove(removedAt *time.Ticket) bool {
 
 		// NOTE(hackerwins): Decrease only VisibleLength because
 		// this node marked as tombstone, not purged.
-		n.Index.UpdateAncestorsSize(-(n.Index.PaddedLength()))
+		n.Index.UpdateAncestorsLength(-(n.Index.PaddedLength()))
 		return true
 	}
 
@@ -1313,15 +1313,7 @@ func (t *Tree) toTreePos(parentNode, leftNode *TreeNode, includeRemoved ...bool)
 		return nil, err
 	}
 
-	if !include && !leftNode.IsRemoved() {
-		if leftNode.IsText() {
-			return &index.TreePos[*TreeNode]{
-				Node:   leftNode.Index,
-				Offset: leftNode.Index.PaddedLength(include),
-			}, nil
-		}
-		offset++
-	} else if include {
+	if include || !leftNode.IsRemoved() {
 		if leftNode.IsText() {
 			return &index.TreePos[*TreeNode]{
 				Node:   leftNode.Index,

--- a/pkg/index/tree.go
+++ b/pkg/index/tree.go
@@ -314,8 +314,8 @@ func (n *Node[V]) Append(newNodes ...*Node[V]) error {
 	n.children = append(n.children, newNodes...)
 	for _, newNode := range newNodes {
 		newNode.Parent = n
-		newNode.UpdateAncestorsSize(newNode.PaddedLength())
-		newNode.UpdateAncestorsSize(newNode.PaddedLength(true), true)
+		newNode.UpdateAncestorsLength(newNode.PaddedLength())
+		newNode.UpdateAncestorsLength(newNode.PaddedLength(true), true)
 	}
 
 	return nil
@@ -352,10 +352,10 @@ func (n *Node[V]) SetChildren(children []*Node[V]) error {
 	return nil
 }
 
-// UpdateAncestorsSize updates the size of ancestors. It is used when
-// the size of the node is changed. If includeRemoved is true, it
+// UpdateAncestorsLength updates the length of ancestors. It is used when
+// the length of the node is changed. If includeRemoved is true, it
 // updates ancestors TotalLength including removed nodes.
-func (n *Node[V]) UpdateAncestorsSize(delta int, includeRemoved ...bool) {
+func (n *Node[V]) UpdateAncestorsLength(delta int, includeRemoved ...bool) {
 	include := len(includeRemoved) > 0 && includeRemoved[0]
 
 	parent := n.Parent
@@ -553,8 +553,8 @@ func (n *Node[V]) InsertAt(newNode *Node[V], offset int) error {
 		return err
 	}
 
-	newNode.UpdateAncestorsSize(newNode.PaddedLength())
-	newNode.UpdateAncestorsSize(newNode.PaddedLength(true), true)
+	newNode.UpdateAncestorsLength(newNode.PaddedLength())
+	newNode.UpdateAncestorsLength(newNode.PaddedLength(true), true)
 
 	return nil
 }
@@ -615,7 +615,7 @@ func (n *Node[V]) RemoveChild(child *Node[V]) error {
 	n.children = append(n.children[:offset], n.children[offset+1:]...)
 	// NOTE(hackerwins): Decrease TotalLength including removed nodes
 	// since this node is being purged (physically removed from tree).
-	child.UpdateAncestorsSize(-(child.PaddedLength(true)), true)
+	child.UpdateAncestorsLength(-(child.PaddedLength(true)), true)
 	child.Parent = nil
 
 	return nil
@@ -636,8 +636,8 @@ func (n *Node[V]) InsertBefore(newNode, referenceNode *Node[V]) error {
 		return err
 	}
 
-	newNode.UpdateAncestorsSize(newNode.PaddedLength())
-	newNode.UpdateAncestorsSize(newNode.PaddedLength(true), true)
+	newNode.UpdateAncestorsLength(newNode.PaddedLength())
+	newNode.UpdateAncestorsLength(newNode.PaddedLength(true), true)
 
 	return nil
 }
@@ -657,8 +657,8 @@ func (n *Node[V]) InsertAfter(newNode, referenceNode *Node[V]) error {
 		return err
 	}
 
-	newNode.UpdateAncestorsSize(newNode.PaddedLength())
-	newNode.UpdateAncestorsSize(newNode.PaddedLength(true), true)
+	newNode.UpdateAncestorsLength(newNode.PaddedLength())
+	newNode.UpdateAncestorsLength(newNode.PaddedLength(true), true)
 
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

related to https://github.com/yorkie-team/yorkie/pull/1538

- rename `UpdateAncestorsSize` to `UpdateAncestorsLength`
- refactor `toTreePos` logic simplify.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code restructuring and optimization updates to improve maintainability and code semantics. No user-facing changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->