### PR TITLE
Fix incorrect condition placement in deployment.yaml

### DIFF
--- a/build/charts/yorkie-cluster/templates/yorkie/deployment.yaml
+++ b/build/charts/yorkie-cluster/templates/yorkie/deployment.yaml
@@ -103,6 +103,7 @@ spec:
           {{- if .Values.yorkie.args.kafkaAddresses }}
           "--kafka-addresses",
           "{{ .Values.yorkie.args.kafkaAddresses }}",
+          {{- end }}
           {{- if .Values.yorkie.args.kafkaTopic }}
           "--kafka-topic",
           "{{ .Values.yorkie.args.kafkaTopic }}",
@@ -146,7 +147,6 @@ spec:
           {{- if .Values.yorkie.args.starrocksDSN }}
           "--starrocks-dsn",
           "{{ .Values.yorkie.args.starrocksDSN }}",
-          {{- end }}
           {{- end }}
         ]
         ports:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix the placement of the condition end handling for the `kafka-addresses` argument in the YAML file. The previous placement led to unexpected behavior and configuration errors.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration template syntax to ensure proper conditional block rendering. This maintenance improves deployment consistency and reliability across Kafka and StarRocks configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->