### PR TITLE
Fix nil pointer dereference in LLRB Floor function

### DIFF
--- a/pkg/llrb/llrb.go
+++ b/pkg/llrb/llrb.go
@@ -37,12 +37,11 @@ type Value interface {
 
 // Node is a node of Tree.
 type Node[K Key, V Value] struct {
-	key    K
-	value  V
-	parent *Node[K, V]
-	left   *Node[K, V]
-	right  *Node[K, V]
-	isRed  bool
+	key   K
+	value V
+	left  *Node[K, V]
+	right *Node[K, V]
+	isRed bool
 }
 
 // NewNode creates a new instance of Node.
@@ -101,39 +100,22 @@ func (t *Tree[K, V]) Remove(key K) {
 // Floor returns the greatest key less than or equal to the given key.
 func (t *Tree[K, V]) Floor(key K) (K, V) {
 	node := t.root
+	var resultK K
+	var resultV V
 
 	for node != nil {
-		compare := key.Compare(node.key)
-		if compare > 0 {
-			if node.right != nil {
-				node.right.parent = node
-				node = node.right
-			} else {
-				return node.key, node.value
-			}
-		} else if compare < 0 {
-			if node.left != nil {
-				node.left.parent = node
-				node = node.left
-			} else {
-				parent := node.parent
-				child := node
-				for parent != nil && child == parent.left {
-					child = parent
-					parent = parent.parent
-				}
-
-				// TODO(hackerwins): check below warning
-				return parent.key, parent.value
-			}
-		} else {
+		switch key.Compare(node.key) {
+		case 0:
 			return node.key, node.value
+		case -1:
+			node = node.left
+		case 1:
+			resultK, resultV = node.key, node.value
+			node = node.right
 		}
 	}
 
-	var zeroK K
-	var zeroV V
-	return zeroK, zeroV
+	return resultK, resultV
 }
 
 // Len returns the length of the tree.

--- a/pkg/llrb/llrb_test.go
+++ b/pkg/llrb/llrb_test.go
@@ -58,18 +58,38 @@ func (v *intValue) String() string {
 	return fmt.Sprintf("%d", v.value)
 }
 
-func TestTree(t *testing.T) {
-	t.Run("keeping order test", func(t *testing.T) {
-		arrays := [][]int{
-			{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
-			{8, 5, 7, 9, 1, 3, 6, 0, 4, 2},
-			{7, 2, 0, 3, 1, 9, 8, 4, 6, 5},
-			{2, 0, 3, 5, 8, 6, 4, 1, 9, 7},
-			{8, 4, 7, 9, 2, 6, 0, 3, 1, 5},
-			{7, 1, 5, 2, 8, 6, 3, 4, 0, 9},
-			{9, 8, 7, 6, 5, 4, 3, 2, 1, 0},
+func checkFloor(t *testing.T, tree *llrb.Tree[*intKey, *intValue], arr []*intKey, loop int) {
+	for floorKey := range loop {
+		Key := newIntKey(floorKey)
+		var expectedKey *intKey
+		for _, v := range arr {
+			if v.key <= Key.key {
+				if expectedKey == nil || expectedKey.key <= v.key {
+					expectedKey = v
+				}
+			}
 		}
+		resultKey, _ := tree.Floor(Key)
 
+		if expectedKey == nil {
+			assert.Nil(t, resultKey)
+		} else {
+			assert.Equal(t, expectedKey.key, resultKey.key)
+		}
+	}
+}
+
+func TestTree(t *testing.T) {
+	arrays := [][]int{
+		{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+		{8, 5, 7, 9, 1, 3, 6, 0, 4, 2},
+		{7, 2, 0, 3, 1, 9, 8, 4, 6, 5},
+		{2, 0, 3, 5, 8, 6, 4, 1, 9, 7},
+		{8, 4, 7, 9, 2, 6, 0, 3, 1, 5},
+		{7, 1, 5, 2, 8, 6, 3, 4, 0, 9},
+		{9, 8, 7, 6, 5, 4, 3, 2, 1, 0},
+	}
+	t.Run("keeping order test", func(t *testing.T) {
 		for _, array := range arrays {
 			tree := llrb.NewTree[*intKey, *intValue]()
 			for _, value := range array {
@@ -85,6 +105,19 @@ func TestTree(t *testing.T) {
 
 			tree.Remove(newIntKey(5))
 			assert.Equal(t, "0,1,3,4,6,7,9", tree.String())
+		}
+	})
+
+	t.Run("floor test", func(t *testing.T) {
+		for _, array := range arrays {
+			testArr := []*intKey{}
+			tree := llrb.NewTree[*intKey, *intValue]()
+			for _, value := range array {
+				checkFloor(t, tree, testArr, 10)
+				tree.Put(newIntKey(value), newIntValue(value))
+				testArr = append(testArr, newIntKey(value))
+				checkFloor(t, tree, testArr, 10)
+			}
 		}
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
LLRB Floor function can make `nil pointer dereference error` that key of Floor(key) is less than all tree element keys (= root->left is nil and no parent node) Also parent pointer is not needed in Floor().
Red-Black Tree follows all BST rules, so simple O(h) iteration from root to leaf with keeping candidate elements is enough.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #1560 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [X] Added relevant tests or not required
- [X] Addressed and resolved all CodeRabbit review comments
- [X] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized tree data structure implementation with streamlined floor operation logic for more efficient key lookups and improved handling of edge cases.

* **Tests**
  * Enhanced floor operation test coverage with improved organization and dedicated verification helper functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->