### PR TITLE
Fix queryCount to use sql.NullInt64

### DIFF
--- a/server/backend/warehouse/starrocks.go
+++ b/server/backend/warehouse/starrocks.go
@@ -369,7 +369,7 @@ func (r *StarRocks) queryCount(query string) (int, error) {
 		}
 	}()
 
-	var count int
+	var count sql.NullInt64
 	if rows.Next() {
 		if err := rows.Scan(&count); err != nil {
 			return 0, fmt.Errorf("scan row: %w", err)
@@ -378,5 +378,8 @@ func (r *StarRocks) queryCount(query string) (int, error) {
 	if err := rows.Err(); err != nil {
 		return 0, fmt.Errorf("iterate rows: %w", err)
 	}
-	return count, nil
+	if !count.Valid {
+		return 0, nil
+	}
+	return int(count.Int64), nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Related https://github.com/yorkie-team/yorkie/pull/1588

- Change starrocks queryCount to use `sql.NullInt64` for count handling
<img width="701" height="385" alt="image" src="https://github.com/user-attachments/assets/73356c50-cd63-4502-aea0-a9110cb8e4c3" />

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved robustness of count query operations to properly handle edge cases where database queries return NULL values, ensuring consistent and predictable results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->