### PR TITLE
Fix stale channel metrics reset

### DIFF
--- a/server/backend/channel/manager.go
+++ b/server/backend/channel/manager.go
@@ -472,6 +472,8 @@ func pushTopSessions(topChannelSessions *heap.Heap[ChannelSessionCount], key typ
 
 // metricsChannelTotal updates metrics for the channel total.
 func metricsChannelTotal(metrics *Metrics, channelsCountByProjectID map[types.ID]int) {
+	metrics.Metrics.ResetChannelTotal()
+
 	for projectID, channelCount := range channelsCountByProjectID {
 		metrics.Metrics.SetChannelTotal(
 			metrics.Hostname,
@@ -483,6 +485,8 @@ func metricsChannelTotal(metrics *Metrics, channelsCountByProjectID map[types.ID
 
 // metricsChannelSessionsTotal updates metrics for the channel sessions by project ID.
 func metricsChannelSessionsTotal(metrics *Metrics, channelSessionsCountByProjectID map[types.ID]int) {
+	metrics.Metrics.ResetChannelSessionsTotal()
+
 	for projectID, sessionCount := range channelSessionsCountByProjectID {
 		metrics.Metrics.SetChannelSessionsTotal(
 			metrics.Hostname,

--- a/server/profiling/prometheus/metrics.go
+++ b/server/profiling/prometheus/metrics.go
@@ -456,12 +456,22 @@ func (m *Metrics) SetChannelTotal(hostname string, projectID types.ID, count int
 	}).Set(float64(count))
 }
 
+// ResetChannelTotal resets the number of channels.
+func (m *Metrics) ResetChannelTotal() {
+	m.channelTotal.Reset()
+}
+
 // SetChannelSessionsTotal adds the number of sessions in channel.
 func (m *Metrics) SetChannelSessionsTotal(hostname string, projectID types.ID, count int) {
 	m.channelSessionsTotal.With(prometheus.Labels{
 		projectIDLabel: projectID.String(),
 		hostnameLabel:  hostname,
 	}).Set(float64(count))
+}
+
+// ResetChannelSessionsTotal resets the number of sessions in channel.
+func (m *Metrics) ResetChannelSessionsTotal() {
+	m.channelSessionsTotal.Reset()
 }
 
 // SetChannelSessionsTopN adds the top N channels by session count.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Channel metrics (`yorkie_channel_total`, `yorkie_channel_sessions_total`) were not removed when channels were deleted, causing stale data to persist.
- Reset metrics on each cleanup cycle before collecting metrics.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Related https://github.com/yorkie-team/yorkie/pull/1569

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [ ] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [ ] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced metrics reset capabilities for improved monitoring of channel and session data tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->