### PR TITLE
Add missing document locks to RestoreRevision APIs

### DIFF
--- a/design/fine-grained-document-locking.md
+++ b/design/fine-grained-document-locking.md
@@ -114,6 +114,13 @@ The following sections detail lock acquisition patterns for different types of o
 2. PushPull
 3. 🔓 Release `doc`
 
+**RestoreRevision(by SDK and Admin)**
+
+1. 🔒 Acquire `doc` RLock
+2. `findRevision` / `findDoc`
+3. PushPull (using SystemClient, no client checkpoint update)
+4. 🔓 Release `doc`
+
 #### System Operations
 
 **PurgeDocument/CompactDocument(by System)**

--- a/server/rpc/admin_server.go
+++ b/server/rpc/admin_server.go
@@ -921,6 +921,9 @@ func (s *adminServer) RestoreRevisionByAdmin(
 		return nil, err
 	}
 
+	locker := s.backend.Lockers.LockerWithRLock(packs.DocKey(project.ID, key.Key(req.Msg.DocumentKey)))
+	defer locker.RUnlock()
+
 	revision, err := s.backend.DB.FindRevisionInfoByID(ctx, types.ID(req.Msg.RevisionId))
 	if err != nil {
 		return nil, err

--- a/server/rpc/yorkie_server.go
+++ b/server/rpc/yorkie_server.go
@@ -1044,6 +1044,9 @@ func (s *yorkieServer) RestoreRevision(
 		return nil, err
 	}
 
+	locker := s.backend.Lockers.LockerWithRLock(packs.DocKey(project.ID, docInfo.Key))
+	defer locker.RUnlock()
+
 	if err := auth.VerifyAccess(ctx, s.backend, &types.AccessInfo{
 		Method:     types.RestoreRevision,
 		Attributes: types.NewAccessAttributes([]key.Key{docInfo.Key}, types.ReadWrite),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add missing document locks to RestoreRevision APIs

Both RestoreRevision and RestoreRevisionByAdmin were missing required document read locks, causing potential race conditions with compaction, purge operations, and concurrent restore requests.

This commit adds the appropriate RLocks to both APIs following the existing PushPull lock pattern, and updates the fine-grained locking documentation accordingly to ensure consistency.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [ ] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [ ] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added RestoreRevision administrative operation enabling document revision recovery and restoration for system administrators.

* **Improvements**
  * Enhanced document-level concurrency control and locking mechanisms during revision restoration to ensure consistent and reliable data access, improving system stability when restoring previous document versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->