### PR TITLE
Allow bitnami legacy images explicitly in yorkie-analytics

### DIFF
--- a/build/charts/yorkie-analytics/values.yaml
+++ b/build/charts/yorkie-analytics/values.yaml
@@ -21,7 +21,7 @@ yorkie-analytics:
   kafka:
     enabled: true
     image:
-      # Using bitnamilegacy as temporary workaround (no updates, migration needed)
+      # TODO(hackerwins): Using bitnamilegacy as temporary workaround (no updates, migration needed)
       repository: bitnamilegacy/kafka
       tag: latest
     topic:
@@ -73,7 +73,7 @@ kube-starrocks:
       service:
         type: LoadBalancer
 
-# Using bitnamilegacy as temporary workaround (no updates, migration needed)
+# TODO(hackerwins): Using bitnamilegacy as temporary workaround (no updates, migration needed)
 kafka:
   image:
     repository: bitnamilegacy/kafka
@@ -91,6 +91,6 @@ kafka:
     create: true
   rbac:
     create: true
-  global: # TODO: Remove with bitnamilegacy/kafka image and helm chart
+  global:
     security:
       allowInsecureImages: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- `starrocks-fe` and `starrocks-be`'s default resource requests are `cpu:2 / memory:4G`. If the limits are set to `cpu:1 / memory:2G`, an `requests resources cannot exceed the limits` error occurs, causing the Hellchart installation to fail.
- Update resource `requests` and `limits` in Yorkie analytics chart
- Add `allowInsecureImages` options in kafka values

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted resource allocations for database service components (updated CPU/memory requests and limits).
  * Added a temporary setting to allow insecure container images in deployment configs.

* **Documentation**
  * Added a top-level TODO comment noting a temporary workaround.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->