### PR TITLE
Restore ingress-shard-key-header-filter EnvoyFilter

### DIFF
--- a/build/charts/yorkie-cluster/templates/istio/ingress-envoy-filter.yaml
+++ b/build/charts/yorkie-cluster/templates/istio/ingress-envoy-filter.yaml
@@ -21,3 +21,43 @@ spec:
           typed_config:
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
             stream_idle_timeout: {{ .Values.ingressGateway.httpConnection.streamIdleTimeout }}
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: ingress-shard-key-header-filter
+  namespace: {{ .Values.yorkie.namespace }}
+spec:
+  workloadSelector:
+    labels:
+      istio: yorkie-gateway
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.filters.network.http_connection_manager"
+              subFilter:
+                name: "envoy.filters.http.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.lua
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+            default_source_code:
+              inline_string:
+                function envoy_on_request(request_handle)
+                  local x_shard_key_header = request_handle:headers():get("x-shard-key")
+                  local x_api_key_header = request_handle:headers():get("x-api-key")
+                  
+                  if x_shard_key_header == nil then
+                    if x_api_key_header == nil then
+                      request_handle:headers():add("x-shard-key", "default")
+                    else
+                      request_handle:headers():add("x-shard-key", x_api_key_header)
+                    end
+                  end
+                end


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR restores the `envoyFilter` that was removed in #1586.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

The reason for this restoration is to address an issue with the local sharing of the state in `stateStore` during GitHub Login and callback processes. In cluster mode, these two requests may be processed by different servers, leading to potential inconsistencies and errors.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ingress gateway configuration to add intelligent header management capabilities. The system now automatically sets default request headers based on existing request data when certain headers are missing, ensuring consistent routing behavior and improving the overall request handling pipeline. This enhances system reliability and ensures proper request processing across the gateway infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->