### PR TITLE
Handle invite error for owner accepting invites

### DIFF
--- a/server/authz/authorization_test.go
+++ b/server/authz/authorization_test.go
@@ -87,10 +87,10 @@ func TestAuthorization(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Setup: Add members with different roles
-	_, err = be.DB.CreateMemberInfo(ctx, project.ID, admin.ID, owner.ID, database.Admin)
+	_, err = be.DB.UpsertMemberInfo(ctx, project.ID, admin.ID, owner.ID, database.Admin)
 	assert.NoError(t, err)
 
-	_, err = be.DB.CreateMemberInfo(ctx, project.ID, member.ID, owner.ID, database.Member)
+	_, err = be.DB.UpsertMemberInfo(ctx, project.ID, member.ID, owner.ID, database.Member)
 	assert.NoError(t, err)
 
 	t.Run("GetUserRole test", func(t *testing.T) {

--- a/server/backend/database/database.go
+++ b/server/backend/database/database.go
@@ -90,12 +90,6 @@ var (
 	// ErrInviteAlreadyExists is returned when an invite with the same token already exists.
 	ErrInviteAlreadyExists = errors.AlreadyExists("invite already exists").WithCode("ErrInviteAlreadyExists")
 
-	// ErrInviteExpired is returned when the invite is expired.
-	ErrInviteExpired = errors.InvalidArgument("invite expired").WithCode("ErrInviteExpired")
-
-	// ErrInvalidInviteExpireOpt is returned when the invite expire option is invalid.
-	ErrInvalidInviteExpireOpt = errors.InvalidArgument("invalid invite expire opt").WithCode("ErrInvalidInviteExpireOpt")
-
 	// ErrInvalidInviteToken is returned when the invite token is invalid.
 	ErrInvalidInviteToken = errors.InvalidArgument("invalid invite token").WithCode("ErrInvalidInviteToken")
 )
@@ -184,8 +178,8 @@ type Database interface {
 	// ListUserInfos returns all users.
 	ListUserInfos(ctx context.Context) ([]*UserInfo, error)
 
-	// CreateMemberInfo creates a new project member.
-	CreateMemberInfo(
+	// UpsertMemberInfo creates a new member or returns the existing member if already exists.
+	UpsertMemberInfo(
 		ctx context.Context,
 		projectID types.ID,
 		userID types.ID,

--- a/server/backend/database/memory/database_test.go
+++ b/server/backend/database/memory/database_test.go
@@ -88,10 +88,6 @@ func TestDB(t *testing.T) {
 		testcases.RunFindProjectInfoByNameTest(t, db)
 	})
 
-	t.Run("CreateMemberInfo test", func(t *testing.T) {
-		testcases.RunCreateMemberInfoTest(t, db)
-	})
-
 	t.Run("ListMemberInfos test", func(t *testing.T) {
 		testcases.RunListMemberInfosTest(t, db)
 	})

--- a/server/backend/database/mongo/client_test.go
+++ b/server/backend/database/mongo/client_test.go
@@ -114,10 +114,6 @@ func TestClient(t *testing.T) {
 		testcases.RunFindProjectInfoByNameTest(t, cli)
 	})
 
-	t.Run("CreateMemberInfo test", func(t *testing.T) {
-		testcases.RunCreateMemberInfoTest(t, cli)
-	})
-
 	t.Run("ListMemberInfos test", func(t *testing.T) {
 		testcases.RunListMemberInfosTest(t, cli)
 	})

--- a/server/members/members_test.go
+++ b/server/members/members_test.go
@@ -57,9 +57,9 @@ func TestMembers(t *testing.T) {
 		assert.NoError(t, err)
 
 		// 02. Create members directly
-		_, err = db.CreateMemberInfo(ctx, projectID, u1.ID, invitedBy, database.Member)
+		_, err = db.UpsertMemberInfo(ctx, projectID, u1.ID, invitedBy, database.Member)
 		assert.NoError(t, err)
-		_, err = db.CreateMemberInfo(ctx, projectID, u2.ID, invitedBy, database.Admin)
+		_, err = db.UpsertMemberInfo(ctx, projectID, u2.ID, invitedBy, database.Admin)
 		assert.NoError(t, err)
 
 		// 03. List.
@@ -79,7 +79,7 @@ func TestMembers(t *testing.T) {
 		// 01. Create user and member.
 		u1, err := db.CreateUserInfo(ctx, username, "pw")
 		assert.NoError(t, err)
-		_, err = db.CreateMemberInfo(ctx, projectID, u1.ID, invitedBy, database.Member)
+		_, err = db.UpsertMemberInfo(ctx, projectID, u1.ID, invitedBy, database.Member)
 		assert.NoError(t, err)
 
 		// 02. Update role.
@@ -99,7 +99,7 @@ func TestMembers(t *testing.T) {
 		// 01. Create user and member.
 		u1, err := db.CreateUserInfo(ctx, username, "pw")
 		assert.NoError(t, err)
-		_, err = db.CreateMemberInfo(ctx, projectID, u1.ID, invitedBy, database.Member)
+		_, err = db.UpsertMemberInfo(ctx, projectID, u1.ID, invitedBy, database.Member)
 		assert.NoError(t, err)
 
 		// 02. Remove.

--- a/server/rpc/admin_server.go
+++ b/server/rpc/admin_server.go
@@ -420,7 +420,7 @@ func (s *adminServer) CreateInvite(
 	case api.InviteExpireOption_INVITE_EXPIRE_OPTION_SEVEN_DAYS:
 		opt = invites.ExpireSevenDays
 	default:
-		return nil, database.ErrInvalidInviteExpireOpt
+		return nil, invites.ErrInvalidInviteExpireOpt
 	}
 
 	token, _, err := invites.Create(ctx, s.backend, project.ID, role, user.ID, opt)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Handle invite error for owner accepting invites

It also updates membership creation logic to use upsert semantics,
ensuring duplicate member records are not created even in edge cases.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://github.com/yorkie-team/dashboard/issues/270

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Project owners can no longer accept invite links to their own projects.
  * Invite error responses standardized and clarified during creation and acceptance.
  * Membership creation now upserts to avoid duplicate member entries.

* **Tests**
  * Added integration test to verify owners cannot accept their own invites and updated tests for upsert behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->