### PR TITLE
Refine shard key routing logic in Envoy Lua filter

### DIFF
--- a/build/charts/yorkie-cluster/templates/istio/ingress-envoy-filter.yaml
+++ b/build/charts/yorkie-cluster/templates/istio/ingress-envoy-filter.yaml
@@ -48,7 +48,7 @@ spec:
           typed_config:
             "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
             default_source_code:
-              inline_string:
+              inline_string: |
                 function envoy_on_request(request_handle)
                   local x_shard_key_header = request_handle:headers():get("x-shard-key")
                   


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR enhances the Lua filter in the Envoy configuration to handle shard key routing more precisely based on request types.

**Key changes:**

1. **Skip if `x-shard-key` is already set**: Preserves existing shard key for requests that already include it (e.g., YorkieService document operations).

2. **Fixed shard key for `/auth` paths**: Requests to `/auth` paths (GitHub OAuth login/callback) are assigned a fixed `"auth-session"` shard key to ensure session consistency. This is required because `stateStore` shares state locally, and OAuth login and callback requests must hit the same pod in cluster mode.

3. **No shard key for AdminService**: AdminService requests (project-scoped APIs) don't set a shard key, allowing round-robin load balancing since they don't require document-level affinity.

4. **YorkieService uses `x-api-key`**: Document operations continue to use `x-api-key` for consistent routing, ensuring the same document operations hit the same pod for proper locking.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

This PR builds upon the changes from:

- #1586: Removed the problematic `"default"` fallback logic in the Lua filter that caused incorrect routing in cluster mode
- #1620: Restored the EnvoyFilter to address session consistency issues with `stateStore` during GitHub Login/callback processes

The key insight is that different request types require different routing strategies:
| Request Type | Shard Key Strategy | Reason |
|--------------|-------------------|--------|
| `/auth` paths | Fixed `"auth-session"` | `stateStore` session consistency required |
| AdminService | None (round-robin) | Project-scoped APIs don't need document affinity |
| YorkieService | `x-api-key` | Document-level sharding for proper locking |
| Pre-existing `x-shard-key` | Preserved | Maintain existing routing decisions |

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved request routing to avoid unnecessary modifications when a shard key is already present.
  * Added explicit handling for authentication paths so auth requests use a dedicated shard key.
  * Removed automatic generation of shard keys in most cases, simplifying and clarifying shard-key assignment behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->