### PR TITLE
Fix channel session configuration flags

### DIFF
--- a/cmd/yorkie/server.go
+++ b/cmd/yorkie/server.go
@@ -50,6 +50,11 @@ var (
 	authGitHubTokenURL            string
 	authGitHubDeviceAuthURL       string
 
+	channelSessionTTL             time.Duration
+	channelSessionCleanupInterval time.Duration
+	channelSessionCountCacheTTL   time.Duration
+	channelSessionCountCacheSize  int
+
 	housekeepingInterval time.Duration
 
 	mongoConnectionURI                string
@@ -104,6 +109,10 @@ func newServerCmd() *cobra.Command {
 			conf.Housekeeping.Interval = housekeepingInterval.String()
 
 			conf.Backend.AuthWebhookCacheTTL = authWebhookCacheTTL.String()
+			conf.Backend.ChannelSessionTTL = channelSessionTTL.String()
+			conf.Backend.ChannelSessionCleanupInterval = channelSessionCleanupInterval.String()
+			conf.Backend.ChannelSessionCountCacheTTL = channelSessionCountCacheTTL.String()
+			conf.Backend.ChannelSessionCountCacheSize = channelSessionCountCacheSize
 
 			if mongoConnectionURI != "" {
 				conf.Mongo = &mongo.Config{
@@ -535,6 +544,29 @@ func init() {
 		"",
 		"StarRocks DSN for the analytics",
 	)
-
+	cmd.Flags().DurationVar(
+		&channelSessionTTL,
+		"channel-session-ttl",
+		server.DefaultChannelSessionTTL,
+		"The TTL value for channel sessions.",
+	)
+	cmd.Flags().DurationVar(
+		&channelSessionCleanupInterval,
+		"channel-session-cleanup-interval",
+		server.DefaultChannelSessionCleanupInterval,
+		"The interval for running cleanup of expired channel sessions.",
+	)
+	cmd.Flags().DurationVar(
+		&channelSessionCountCacheTTL,
+		"channel-session-count-cache-ttl",
+		server.DefaultChannelSessionCountCacheTTL,
+		"The TTL value for channel session count cache.",
+	)
+	cmd.Flags().IntVar(
+		&channelSessionCountCacheSize,
+		"channel-session-count-cache-size",
+		server.DefaultChannelSessionCountCacheSize,
+		"The cache size of the channel session count.",
+	)
 	rootCmd.AddCommand(cmd)
 }

--- a/server/backend/config.go
+++ b/server/backend/config.go
@@ -54,12 +54,6 @@ type Config struct {
 	// SnapshotCacheSize is the cache size of the snapshot.
 	SnapshotCacheSize int `yaml:"SnapshotCacheSize"`
 
-	// ChannelSessionCountCacheSize is the cache size of the session count.
-	ChannelSessionCountCacheSize int `yaml:"ChannelSessionCountCacheSize"`
-
-	// ChannelSessionCountCacheTTL is the TTL value for session count cache.
-	ChannelSessionCountCacheTTL string `yaml:"ChannelSessionCountCacheTTL"`
-
 	// ChannelSessionTTL is the time-to-live duration for channel sessions.
 	// If a channel session is not refreshed within this duration, it will be removed.
 	// Default is "60s".
@@ -68,6 +62,12 @@ type Config struct {
 	// ChannelSessionCleanupInterval is the interval for running cleanup of expired channel sessions.
 	// Default is "10s".
 	ChannelSessionCleanupInterval string `yaml:"ChannelSessionCleanupInterval"`
+
+	// ChannelSessionCountCacheSize is the cache size of the session count.
+	ChannelSessionCountCacheSize int `yaml:"ChannelSessionCountCacheSize"`
+
+	// ChannelSessionCountCacheTTL is the TTL value for session count cache.
+	ChannelSessionCountCacheTTL string `yaml:"ChannelSessionCountCacheTTL"`
 
 	// Hostname is yorkie server hostname. hostname is used by metrics.
 	Hostname string `yaml:"Hostname"`
@@ -146,21 +146,6 @@ func (c *Config) ParseAuthWebhookCacheTTL() time.Duration {
 	return result
 }
 
-// ParseChannelSessionCountCacheTTL returns TTL for session count cache.
-func (c *Config) ParseChannelSessionCountCacheTTL() time.Duration {
-	if c.ChannelSessionCountCacheTTL == "" {
-		return 30 * time.Second // Default: 30 seconds
-	}
-
-	result, err := time.ParseDuration(c.ChannelSessionCountCacheTTL)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "parse session count cache ttl: %v\n", err)
-		os.Exit(1)
-	}
-
-	return result
-}
-
 // ParseChannelSessionTTL returns TTL for channel session.
 func (c *Config) ParseChannelSessionTTL() time.Duration {
 	if c.ChannelSessionTTL == "" {
@@ -185,6 +170,21 @@ func (c *Config) ParseChannelSessionCleanupInterval() time.Duration {
 	result, err := time.ParseDuration(c.ChannelSessionCleanupInterval)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "parse channel session cleanup interval: %v\n", err)
+		os.Exit(1)
+	}
+
+	return result
+}
+
+// ParseChannelSessionCountCacheTTL returns TTL for session count cache.
+func (c *Config) ParseChannelSessionCountCacheTTL() time.Duration {
+	if c.ChannelSessionCountCacheTTL == "" {
+		return 30 * time.Second // Default: 30 seconds
+	}
+
+	result, err := time.ParseDuration(c.ChannelSessionCountCacheTTL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "parse channel session count cache ttl: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/server/config.go
+++ b/server/config.go
@@ -64,6 +64,11 @@ const (
 	DefaultKafkaSessionEventsTopic  = "session-events"
 	DefaultKafkaWriteTimeout        = 5 * time.Second
 
+	DefaultChannelSessionTTL             = 60 * time.Second
+	DefaultChannelSessionCleanupInterval = 10 * time.Second
+	DefaultChannelSessionCountCacheTTL   = 30 * time.Second
+	DefaultChannelSessionCountCacheSize  = 10000
+
 	DefaultAdminUser     = "admin"
 	DefaultAdminPassword = "admin"
 	DefaultSecretKey     = "yorkie-secret"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Fix not working channel session configuration flags.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [ ] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [ ] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable CLI flags for channel session management, including session time-to-live duration, cleanup intervals, and session count cache size and TTL settings.
  * Introduced default values for all new channel session configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->