### PR TITLE
Add connection pool size configuration for cluster client

### DIFF
--- a/cluster/client_test.go
+++ b/cluster/client_test.go
@@ -46,18 +46,15 @@ func TestOptions(t *testing.T) {
 		WithSecure(true)(&opts)
 		assert.True(t, opts.IsSecure)
 	})
+
+	t.Run("WithPoolSize sets pool size", func(t *testing.T) {
+		var opts Options
+		WithPoolSize(10)(&opts)
+		assert.Equal(t, 10, opts.PoolSize)
+	})
 }
 
 func TestNew(t *testing.T) {
-	t.Run("default timeouts when no options provided", func(t *testing.T) {
-		client, err := New()
-		require.NoError(t, err)
-		defer client.Close()
-
-		assert.Equal(t, defaultRPCTimeout, client.rpcTimeout)
-		assert.Equal(t, defaultClientTimeout, client.conn.Timeout)
-	})
-
 	t.Run("custom timeouts override defaults", func(t *testing.T) {
 		client, err := New(
 			WithRPCTimeout(5*time.Second),
@@ -68,18 +65,6 @@ func TestNew(t *testing.T) {
 
 		assert.Equal(t, 5*time.Second, client.rpcTimeout)
 		assert.Equal(t, 15*time.Second, client.conn.Timeout)
-	})
-
-	t.Run("zero timeout uses defaults", func(t *testing.T) {
-		client, err := New(
-			WithRPCTimeout(0),
-			WithClientTimeout(0),
-		)
-		require.NoError(t, err)
-		defer client.Close()
-
-		assert.Equal(t, defaultRPCTimeout, client.rpcTimeout)
-		assert.Equal(t, defaultClientTimeout, client.conn.Timeout)
 	})
 }
 

--- a/cluster/pool.go
+++ b/cluster/pool.go
@@ -19,60 +19,88 @@ package cluster
 
 import (
 	"sync"
+	"sync/atomic"
 )
 
 // ClientPool manages a pool of cluster clients for reuse.
+// It maintains multiple connections per host to reduce HTTP/2 mutex contention.
 type ClientPool struct {
-	clients map[string]*Client
-	opts    []Option
-	mu      sync.RWMutex
+	clients  map[string][]*Client
+	counters map[string]*uint64
+	opts     []Option
+	poolSize int
+	mu       sync.RWMutex
 }
 
 // NewClientPool creates a new client pool.
 func NewClientPool(opts ...Option) *ClientPool {
+	var options Options
+	for _, opt := range opts {
+		opt(&options)
+	}
+
 	return &ClientPool{
-		clients: make(map[string]*Client),
-		opts:    opts,
+		clients:  make(map[string][]*Client),
+		counters: make(map[string]*uint64),
+		opts:     opts,
+		poolSize: options.PoolSize,
 	}
 }
 
-// Get returns a client for the given address, creating one if it doesn't exist.
+// Get returns a client for the given address, creating clients if they don't exist.
+// It uses round-robin selection to distribute load across multiple connections.
 func (p *ClientPool) Get(rpcAddr string) (*Client, error) {
 	// Try to get existing client with read lock
 	p.mu.RLock()
-	if client, ok := p.clients[rpcAddr]; ok {
+	if clients, ok := p.clients[rpcAddr]; ok {
+		counter := atomic.AddUint64(p.counters[rpcAddr], 1)
+		client := clients[counter%uint64(len(clients))]
 		p.mu.RUnlock()
 		return client, nil
 	}
 	p.mu.RUnlock()
 
-	// Create new client with write lock
+	// Create new clients with write lock
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
 	// Double-check after acquiring write lock
-	if client, ok := p.clients[rpcAddr]; ok {
-		return client, nil
+	if clients, ok := p.clients[rpcAddr]; ok {
+		counter := atomic.AddUint64(p.counters[rpcAddr], 1)
+		return clients[counter%uint64(len(clients))], nil
 	}
 
-	// Create new client
-	client, err := Dial(rpcAddr, p.opts...)
-	if err != nil {
-		return nil, err
+	// Create pool of clients
+	clients := make([]*Client, p.poolSize)
+	for i := range clients {
+		cli, err := Dial(rpcAddr, p.opts...)
+		if err != nil {
+			// Cleanup already created clients
+			for j := 0; j < i; j++ {
+				clients[j].Close()
+			}
+			return nil, err
+		}
+		clients[i] = cli
 	}
 
-	p.clients[rpcAddr] = client
-	return client, nil
+	var counter uint64
+	p.clients[rpcAddr] = clients
+	p.counters[rpcAddr] = &counter
+	return clients[0], nil
 }
 
-// Remove removes a client from the pool and closes it.
+// Remove removes clients for the given address from the pool and closes them.
 func (p *ClientPool) Remove(rpcAddr string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	if client, ok := p.clients[rpcAddr]; ok {
-		client.Close()
+	if clients, ok := p.clients[rpcAddr]; ok {
+		for _, client := range clients {
+			client.Close()
+		}
 		delete(p.clients, rpcAddr)
+		delete(p.counters, rpcAddr)
 	}
 }
 
@@ -81,10 +109,13 @@ func (p *ClientPool) Close() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	for _, client := range p.clients {
-		client.Close()
+	for _, clients := range p.clients {
+		for _, client := range clients {
+			client.Close()
+		}
 	}
-	p.clients = make(map[string]*Client)
+	p.clients = make(map[string][]*Client)
+	p.counters = make(map[string]*uint64)
 }
 
 // Prune removes clients that are no longer in the active nodes list.
@@ -97,10 +128,13 @@ func (p *ClientPool) Prune(addrs []string) {
 		activeSet[addr] = true
 	}
 
-	for addr, client := range p.clients {
+	for addr, clients := range p.clients {
 		if !activeSet[addr] {
-			client.Close()
+			for _, client := range clients {
+				client.Close()
+			}
 			delete(p.clients, addr)
+			delete(p.counters, addr)
 		}
 	}
 }

--- a/cluster/pool_test.go
+++ b/cluster/pool_test.go
@@ -17,6 +17,7 @@
 package cluster
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -29,6 +30,7 @@ func TestClientPool(t *testing.T) {
 		pool := NewClientPool(
 			WithRPCTimeout(3*time.Second),
 			WithClientTimeout(7*time.Second),
+			WithPoolSize(1),
 		)
 		defer pool.Close()
 
@@ -43,6 +45,7 @@ func TestClientPool(t *testing.T) {
 		pool := NewClientPool(
 			WithRPCTimeout(3*time.Second),
 			WithClientTimeout(7*time.Second),
+			WithPoolSize(1),
 		)
 		defer pool.Close()
 
@@ -56,7 +59,7 @@ func TestClientPool(t *testing.T) {
 	})
 
 	t.Run("pool creates separate clients for different addresses", func(t *testing.T) {
-		pool := NewClientPool()
+		pool := NewClientPool(WithPoolSize(1))
 		defer pool.Close()
 
 		client1, err := pool.Get("http://127.0.0.1:1001")
@@ -67,15 +70,241 @@ func TestClientPool(t *testing.T) {
 
 		assert.NotSame(t, client1, client2)
 	})
+}
 
-	t.Run("pool uses default timeouts when no options provided", func(t *testing.T) {
-		pool := NewClientPool()
+func TestClientPoolSize(t *testing.T) {
+	t.Run("default pool size is 1", func(t *testing.T) {
+		pool := NewClientPool(WithPoolSize(1))
 		defer pool.Close()
 
-		client, err := pool.Get("http://127.0.0.1:0")
+		assert.Equal(t, 1, pool.poolSize)
+	})
+
+	t.Run("pool creates N clients per host", func(t *testing.T) {
+		poolSize := 3
+		pool := NewClientPool(WithPoolSize(poolSize))
+		defer pool.Close()
+
+		_, err := pool.Get("http://127.0.0.1:0")
 		require.NoError(t, err)
 
-		assert.Equal(t, defaultRPCTimeout, client.rpcTimeout)
-		assert.Equal(t, defaultClientTimeout, client.conn.Timeout)
+		pool.mu.RLock()
+		clients := pool.clients["http://127.0.0.1:0"]
+		pool.mu.RUnlock()
+
+		assert.Len(t, clients, poolSize)
+
+		// All clients should be distinct instances.
+		for i := range len(clients) {
+			for j := i + 1; j < len(clients); j++ {
+				assert.NotSame(t, clients[i], clients[j])
+			}
+		}
+	})
+
+	t.Run("round-robin distributes across pool clients", func(t *testing.T) {
+		poolSize := 3
+		pool := NewClientPool(WithPoolSize(poolSize))
+		defer pool.Close()
+
+		// Collect clients returned by Get over multiple calls.
+		seen := make(map[*Client]bool)
+		for i := 0; i < poolSize*2; i++ {
+			client, err := pool.Get("http://127.0.0.1:0")
+			require.NoError(t, err)
+			seen[client] = true
+		}
+
+		// All N clients in the pool should have been returned at least once.
+		assert.Equal(t, poolSize, len(seen))
+	})
+
+	t.Run("pool size 1 always returns same client", func(t *testing.T) {
+		pool := NewClientPool(WithPoolSize(1))
+		defer pool.Close()
+
+		client1, err := pool.Get("http://127.0.0.1:0")
+		require.NoError(t, err)
+
+		client2, err := pool.Get("http://127.0.0.1:0")
+		require.NoError(t, err)
+
+		assert.Same(t, client1, client2)
+	})
+
+	t.Run("each address has independent pool", func(t *testing.T) {
+		poolSize := 2
+		pool := NewClientPool(WithPoolSize(poolSize))
+		defer pool.Close()
+
+		_, err := pool.Get("http://127.0.0.1:1001")
+		require.NoError(t, err)
+		_, err = pool.Get("http://127.0.0.1:1002")
+		require.NoError(t, err)
+
+		pool.mu.RLock()
+		clients1 := pool.clients["http://127.0.0.1:1001"]
+		clients2 := pool.clients["http://127.0.0.1:1002"]
+		pool.mu.RUnlock()
+
+		assert.Len(t, clients1, poolSize)
+		assert.Len(t, clients2, poolSize)
+
+		// Clients from different addresses must not overlap.
+		for _, c1 := range clients1 {
+			for _, c2 := range clients2 {
+				assert.NotSame(t, c1, c2)
+			}
+		}
+	})
+}
+
+func TestClientPoolRemove(t *testing.T) {
+	t.Run("remove closes all clients for address", func(t *testing.T) {
+		pool := NewClientPool(WithPoolSize(3))
+
+		_, err := pool.Get("http://127.0.0.1:0")
+		require.NoError(t, err)
+
+		pool.Remove("http://127.0.0.1:0")
+
+		pool.mu.RLock()
+		_, exists := pool.clients["http://127.0.0.1:0"]
+		_, counterExists := pool.counters["http://127.0.0.1:0"]
+		pool.mu.RUnlock()
+
+		assert.False(t, exists)
+		assert.False(t, counterExists)
+	})
+
+	t.Run("remove non-existent address is no-op", func(t *testing.T) {
+		pool := NewClientPool(WithPoolSize(2))
+		defer pool.Close()
+
+		// Should not panic.
+		pool.Remove("http://127.0.0.1:9999")
+	})
+}
+
+func TestClientPoolClose(t *testing.T) {
+	t.Run("close clears all addresses", func(t *testing.T) {
+		pool := NewClientPool(WithPoolSize(2))
+
+		_, err := pool.Get("http://127.0.0.1:1001")
+		require.NoError(t, err)
+		_, err = pool.Get("http://127.0.0.1:1002")
+		require.NoError(t, err)
+
+		pool.Close()
+
+		pool.mu.RLock()
+		numClients := len(pool.clients)
+		numCounters := len(pool.counters)
+		pool.mu.RUnlock()
+
+		assert.Equal(t, 0, numClients)
+		assert.Equal(t, 0, numCounters)
+	})
+}
+
+func TestClientPoolPrune(t *testing.T) {
+	t.Run("prune removes inactive addresses", func(t *testing.T) {
+		pool := NewClientPool(WithPoolSize(2))
+		defer pool.Close()
+
+		_, err := pool.Get("http://127.0.0.1:1001")
+		require.NoError(t, err)
+		_, err = pool.Get("http://127.0.0.1:1002")
+		require.NoError(t, err)
+		_, err = pool.Get("http://127.0.0.1:1003")
+		require.NoError(t, err)
+
+		// Keep only 1001 and 1003 active.
+		pool.Prune([]string{"http://127.0.0.1:1001", "http://127.0.0.1:1003"})
+
+		pool.mu.RLock()
+		_, has1001 := pool.clients["http://127.0.0.1:1001"]
+		_, has1002 := pool.clients["http://127.0.0.1:1002"]
+		_, has1003 := pool.clients["http://127.0.0.1:1003"]
+		pool.mu.RUnlock()
+
+		assert.True(t, has1001)
+		assert.False(t, has1002)
+		assert.True(t, has1003)
+	})
+
+	t.Run("prune with empty list removes all", func(t *testing.T) {
+		pool := NewClientPool(WithPoolSize(2))
+
+		_, err := pool.Get("http://127.0.0.1:1001")
+		require.NoError(t, err)
+
+		pool.Prune(nil)
+
+		pool.mu.RLock()
+		numClients := len(pool.clients)
+		pool.mu.RUnlock()
+
+		assert.Equal(t, 0, numClients)
+	})
+}
+
+func TestClientPoolConcurrency(t *testing.T) {
+	t.Run("concurrent Get is safe", func(t *testing.T) {
+		pool := NewClientPool(WithPoolSize(3))
+		defer pool.Close()
+
+		var wg sync.WaitGroup
+		const goroutines = 50
+		errs := make(chan error, goroutines)
+
+		for range goroutines {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, err := pool.Get("http://127.0.0.1:0")
+				if err != nil {
+					errs <- err
+				}
+			}()
+		}
+
+		wg.Wait()
+		close(errs)
+
+		for err := range errs {
+			require.NoError(t, err)
+		}
+	})
+
+	t.Run("concurrent Get distributes across pool", func(t *testing.T) {
+		poolSize := 4
+		pool := NewClientPool(WithPoolSize(poolSize))
+		defer pool.Close()
+
+		var mu sync.Mutex
+		seen := make(map[*Client]int)
+
+		var wg sync.WaitGroup
+		const goroutines = 100
+
+		for range goroutines {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				client, err := pool.Get("http://127.0.0.1:0")
+				if err != nil {
+					return
+				}
+				mu.Lock()
+				seen[client]++
+				mu.Unlock()
+			}()
+		}
+
+		wg.Wait()
+
+		// All pool clients should have been used.
+		assert.Equal(t, poolSize, len(seen))
 	})
 }

--- a/cmd/yorkie/server.go
+++ b/cmd/yorkie/server.go
@@ -57,6 +57,7 @@ var (
 
 	clusterRPCTimeout        time.Duration
 	clusterClientTimeout     time.Duration
+	clusterClientPoolSize    int
 	maxConcurrentClusterRPCs int
 
 	housekeepingInterval time.Duration
@@ -121,6 +122,7 @@ func newServerCmd() *cobra.Command {
 			conf.Backend.ClusterRPCTimeout = clusterRPCTimeout.String()
 			conf.Backend.ClusterClientTimeout = clusterClientTimeout.String()
 			conf.Backend.MaxConcurrentClusterRPCs = maxConcurrentClusterRPCs
+			conf.Backend.ClusterClientPoolSize = clusterClientPoolSize
 
 			if mongoConnectionURI != "" {
 				conf.Mongo = &mongo.Config{
@@ -587,6 +589,12 @@ func init() {
 		"cluster-client-timeout",
 		server.DefaultClusterClientTimeout,
 		"The hard limit for the entire HTTP request lifecycle of cluster communication.",
+	)
+	cmd.Flags().IntVar(
+		&clusterClientPoolSize,
+		"cluster-client-pool-size",
+		server.DefaultClusterClientPoolSize,
+		"The number of connections per host in the cluster client pool.",
 	)
 	cmd.Flags().IntVar(
 		&maxConcurrentClusterRPCs,

--- a/server/backend/backend.go
+++ b/server/backend/backend.go
@@ -133,6 +133,7 @@ func New(
 	clusterClientPool := cluster.NewClientPool(
 		cluster.WithRPCTimeout(conf.ParseClusterRPCTimeout()),
 		cluster.WithClientTimeout(conf.ParseClusterClientTimeout()),
+		cluster.WithPoolSize(conf.ClusterClientPoolSize),
 	)
 
 	// 04. Create the database instance. If the MongoDB configuration is given,

--- a/server/backend/config.go
+++ b/server/backend/config.go
@@ -93,6 +93,11 @@ type Config struct {
 	// request and response. This acts as a safety net. Default is "30s".
 	ClusterClientTimeout string `yaml:"ClusterClientTimeout"`
 
+	// ClusterClientPoolSize is the number of connections per host in the cluster
+	// client pool. Multiple connections reduce HTTP/2 mutex contention under
+	// high concurrency. Default is 1.
+	ClusterClientPoolSize int `yaml:"ClusterClientPoolSize"`
+
 	// MaxConcurrentClusterRPCs is the maximum number of concurrent cluster
 	// RPC calls across the entire server. This prevents goroutine explosion
 	// when a cluster peer is slow or unresponsive. Default is 5000.
@@ -153,13 +158,24 @@ func (c *Config) Validate() error {
 			)
 		}
 	}
+	if c.ChannelSessionCountCacheSize <= 0 {
+		return fmt.Errorf(
+			`invalid argument "%d" for "--channel-session-count-cache-size"`,
+			c.ChannelSessionCountCacheSize,
+		)
+	}
 	if c.MaxConcurrentClusterRPCs <= 0 {
 		return fmt.Errorf(
 			`invalid argument "%d" for "--max-concurrent-cluster-rpcs"`,
 			c.MaxConcurrentClusterRPCs,
 		)
 	}
-
+	if c.ClusterClientPoolSize <= 0 {
+		return fmt.Errorf(
+			`invalid argument "%d" for "--cluster-client-pool-size"`,
+			c.ClusterClientPoolSize,
+		)
+	}
 	return nil
 }
 

--- a/server/backend/config_test.go
+++ b/server/backend/config_test.go
@@ -26,9 +26,11 @@ import (
 
 func newValidBackendConf() backend.Config {
 	return backend.Config{
-		AdminTokenDuration:       "24h",
-		AuthWebhookCacheTTL:      "10s",
-		MaxConcurrentClusterRPCs: 1,
+		AdminTokenDuration:           "24h",
+		AuthWebhookCacheTTL:          "10s",
+		ChannelSessionCountCacheSize: 1,
+		ClusterClientPoolSize:        1,
+		MaxConcurrentClusterRPCs:     1,
 	}
 }
 func TestConfig(t *testing.T) {
@@ -51,6 +53,17 @@ func TestConfig(t *testing.T) {
 
 		conf.MaxConcurrentClusterRPCs = 1
 		assert.NoError(t, conf.Validate())
+	})
+
+	t.Run("validate ChannelSessionCountCacheSize test", func(t *testing.T) {
+		conf := newValidBackendConf()
+		assert.Equal(t, 1, conf.ChannelSessionCountCacheSize)
+
+		conf.ChannelSessionCountCacheSize = 0
+		assert.Error(t, conf.Validate())
+
+		conf.ChannelSessionCountCacheSize = -1
+		assert.Error(t, conf.Validate())
 	})
 
 	t.Run("validate ClusterRPCTimeout test", func(t *testing.T) {
@@ -100,5 +113,14 @@ func TestConfig(t *testing.T) {
 
 		conf.ClusterClientTimeout = "1m"
 		assert.Equal(t, "1m0s", conf.ParseClusterClientTimeout().String())
+	})
+
+	t.Run("ClusterClientPoolSize field test", func(t *testing.T) {
+		conf := newValidBackendConf()
+		assert.Equal(t, 1, conf.ClusterClientPoolSize)
+
+		conf.ClusterClientPoolSize = 10
+		assert.Equal(t, 10, conf.ClusterClientPoolSize)
+		assert.NoError(t, conf.Validate())
 	})
 }

--- a/server/config.go
+++ b/server/config.go
@@ -71,6 +71,7 @@ const (
 
 	DefaultClusterRPCTimeout        = 10 * time.Second
 	DefaultClusterClientTimeout     = 30 * time.Second
+	DefaultClusterClientPoolSize    = 1
 	DefaultMaxConcurrentClusterRPCs = 5000
 
 	DefaultAdminUser     = "admin"
@@ -281,7 +282,7 @@ func (c *Config) ensureBackendDefaultValue() {
 	if c.Backend.ChannelSessionCountCacheTTL == "" {
 		c.Backend.ChannelSessionCountCacheTTL = DefaultChannelSessionCountCacheTTL.String()
 	}
-	if c.Backend.ChannelSessionCountCacheSize == 0 {
+	if c.Backend.ChannelSessionCountCacheSize <= 0 {
 		c.Backend.ChannelSessionCountCacheSize = DefaultChannelSessionCountCacheSize
 	}
 	if c.Backend.ClusterRPCTimeout == "" {
@@ -289,6 +290,9 @@ func (c *Config) ensureBackendDefaultValue() {
 	}
 	if c.Backend.ClusterClientTimeout == "" {
 		c.Backend.ClusterClientTimeout = DefaultClusterClientTimeout.String()
+	}
+	if c.Backend.ClusterClientPoolSize <= 0 {
+		c.Backend.ClusterClientPoolSize = DefaultClusterClientPoolSize
 	}
 	if c.Backend.MaxConcurrentClusterRPCs <= 0 {
 		c.Backend.MaxConcurrentClusterRPCs = DefaultMaxConcurrentClusterRPCs

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -63,6 +63,11 @@ func assertDefaultConfig(t *testing.T, conf *server.Config) {
 	assert.Equal(t, server.DefaultHostname, conf.Backend.Hostname)
 	assert.Equal(t, server.DefaultGatewayAddr, conf.Backend.GatewayAddr)
 
+	assertDurationEqual(t, server.DefaultClusterRPCTimeout, conf.Backend.ClusterRPCTimeout)
+	assertDurationEqual(t, server.DefaultClusterClientTimeout, conf.Backend.ClusterClientTimeout)
+	assert.Equal(t, server.DefaultClusterClientPoolSize, conf.Backend.ClusterClientPoolSize)
+	assert.Equal(t, server.DefaultMaxConcurrentClusterRPCs, conf.Backend.MaxConcurrentClusterRPCs)
+
 	if conf.Mongo != nil {
 		assertDurationEqual(t, server.DefaultMongoConnectionTimeout, conf.Mongo.ConnectionTimeout)
 		assert.Equal(t, server.DefaultMongoConnectionURI, conf.Mongo.ConnectionURI)

--- a/server/packs/pushpull_test.go
+++ b/server/packs/pushpull_test.go
@@ -109,6 +109,7 @@ func TestMain(m *testing.M) {
 			ChannelSessionCountCacheSize:  helper.ChannelSessionCountCacheSize,
 			ClusterRPCTimeout:             helper.ClusterRPCTimeout,
 			ClusterClientTimeout:          helper.ClusterClientTimeout,
+			ClusterClientPoolSize:         helper.ClusterClientPoolSize,
 			MaxConcurrentClusterRPCs:      helper.MaxConcurrentClusterRPCs,
 		}, &mongo.Config{
 			ConnectionURI:      helper.MongoConnectionURI,

--- a/server/rpc/server_test.go
+++ b/server/rpc/server_test.go
@@ -85,6 +85,7 @@ func TestMain(m *testing.M) {
 		ChannelSessionCountCacheSize:  helper.ChannelSessionCountCacheSize,
 		ClusterRPCTimeout:             helper.ClusterRPCTimeout,
 		ClusterClientTimeout:          helper.ClusterClientTimeout,
+		ClusterClientPoolSize:         helper.ClusterClientPoolSize,
 		MaxConcurrentClusterRPCs:      helper.MaxConcurrentClusterRPCs,
 	}, &mongo.Config{
 		ConnectionURI:      helper.MongoConnectionURI,

--- a/test/complex/main_test.go
+++ b/test/complex/main_test.go
@@ -91,6 +91,7 @@ func TestMain(m *testing.M) {
 		ChannelSessionCountCacheSize:  helper.ChannelSessionCountCacheSize,
 		ClusterRPCTimeout:             helper.ClusterRPCTimeout,
 		ClusterClientTimeout:          helper.ClusterClientTimeout,
+		ClusterClientPoolSize:         helper.ClusterClientPoolSize,
 		MaxConcurrentClusterRPCs:      helper.MaxConcurrentClusterRPCs,
 	}, &mongo.Config{
 		ConnectionTimeout:  helper.MongoConnectionTimeout,

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -88,6 +88,7 @@ var (
 
 	ClusterRPCTimeout        = "10s"
 	ClusterClientTimeout     = "30s"
+	ClusterClientPoolSize    = 1
 	MaxConcurrentClusterRPCs = 5000
 
 	AdminTokenDuration        = "10s"
@@ -318,6 +319,7 @@ func TestConfig() *server.Config {
 			ChannelSessionCountCacheSize:  ChannelSessionCountCacheSize,
 			ClusterRPCTimeout:             ClusterRPCTimeout,
 			ClusterClientTimeout:          ClusterClientTimeout,
+			ClusterClientPoolSize:         ClusterClientPoolSize,
 			MaxConcurrentClusterRPCs:      MaxConcurrentClusterRPCs,
 		},
 		Mongo: &mongo.Config{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

 - Introduces a new option to configure the number of connections per host in the cluster client pool through the `WithPoolSize` function. 
 - The `ClusterClientPoolSize` parameter is now part of the server configuration, allowing users to set this value via command-line flags. 
 - This enhancement aims to reduce HTTP/2 mutex contention under high concurrency, improving overall performance and stability of cluster communications.


**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable per-host connection pool with round‑robin distribution for cluster communications
  * New CLI/config option to set cluster client pool size

* **Bug Fixes**
  * Improved pool lifecycle: proper cleanup on creation failures and safer concurrent access

* **Tests**
  * Expanded test coverage for pool sizing, per-host isolation, round‑robin behavior, pruning, and concurrency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->