### PR TITLE
Refactor logging to use shared core for named loggers

### DIFF
--- a/server/backend/background/background.go
+++ b/server/backend/background/background.go
@@ -81,7 +81,7 @@ func (b *Background) Go(
 
 	// now safe to add since WaitGroup wait has not started yet
 	b.wg.Add(1)
-	routineLogger := logging.New(b.routineID.next())
+	routineLogger := logging.NewNamed(b.routineID.next())
 	b.metrics.AddBackgroundGoroutines(taskType)
 	go func() {
 		defer func() {

--- a/server/rpc/interceptors/admin.go
+++ b/server/rpc/interceptors/admin.go
@@ -182,7 +182,7 @@ func (i *AdminServiceInterceptor) buildContext(
 		ctx = newContext
 	}
 
-	ctx = logging.With(ctx, logging.New(i.requestID.next()))
+	ctx = logging.With(ctx, logging.NewNamed(i.requestID.next()))
 
 	return ctx, nil
 }

--- a/server/rpc/interceptors/cluster.go
+++ b/server/rpc/interceptors/cluster.go
@@ -126,5 +126,5 @@ func (i *ClusterServiceInterceptor) WrapStreamingHandler(
 
 // buildContext builds a context data for server-to-server RPC.
 func (i *ClusterServiceInterceptor) buildContext(ctx context.Context) context.Context {
-	return logging.With(ctx, logging.New(i.requestID.next()))
+	return logging.With(ctx, logging.NewNamed(i.requestID.next()))
 }

--- a/server/rpc/interceptors/yorkie.go
+++ b/server/rpc/interceptors/yorkie.go
@@ -185,7 +185,7 @@ func (i *YorkieServiceInterceptor) buildContext(ctx context.Context, header http
 	}
 
 	// 04. Build Logger with request ID
-	ctx = logging.With(ctx, logging.New(i.requestID.next()))
+	ctx = logging.With(ctx, logging.NewNamed(i.requestID.next()))
 
 	return ctx, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Add `NewNamed()` function that creates loggers by reusing a singleton `zapcore.Core`, avoiding per-call allocation of Core, Encoder, and EncoderConfig
  - Replace logging.New() with logging.NewNamed() in 4 hot paths (Yorkie/Admin/Cluster interceptors, Background goroutines)
  - Cold paths (monitor, publisher, cache) remain unchanged as they are called once at initialization

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized logging infrastructure to improve performance and reduce memory allocations across background and service processing.
  * Enhanced logger initialization with consistent naming patterns for better request tracing and debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->