### PR TITLE
Rename DisableWebhookValidation to EnableWebhookValidation

### DIFF
--- a/cmd/yorkie/server.go
+++ b/cmd/yorkie/server.go
@@ -471,10 +471,10 @@ func init() {
 		"The cache size of the snapshots.",
 	)
 	cmd.Flags().BoolVar(
-		&conf.Backend.DisableWebhookValidation,
-		"backend-disable-webhook-validation",
+		&conf.Backend.EnableWebhookValidation,
+		"backend-enable-webhook-validation",
 		false,
-		"Whether to disable webhook validation. This is useful for testing purposes.",
+		"Whether to enable webhook URL validation to prevent SSRF attacks.",
 	)
 	cmd.Flags().IntVar(
 		&conf.Backend.AuthWebhookCacheSize,

--- a/pkg/webhook/client.go
+++ b/pkg/webhook/client.go
@@ -57,16 +57,16 @@ type Options struct {
 
 // Client is a httpClient for the webhook.
 type Client[Req any, Res any] struct {
-	httpClient        *http.Client
-	disableValidation bool
+	httpClient       *http.Client
+	enableValidation bool
 }
 
 // NewClient creates a new instance of Client. If you only want to get the status code,
 // then set Res to int.
-func NewClient[Req any, Res any](disableValidation bool) *Client[Req, Res] {
+func NewClient[Req any, Res any](enableValidation bool) *Client[Req, Res] {
 	return &Client[Req, Res]{
-		httpClient:        &http.Client{},
-		disableValidation: disableValidation,
+		httpClient:       &http.Client{},
+		enableValidation: enableValidation,
 	}
 }
 
@@ -78,7 +78,7 @@ func (c *Client[Req, Res]) Send(
 	options Options,
 ) (*Res, int, error) {
 	// Validate webhook URL early to prevent SSRF attacks before any processing
-	if err := ValidateWebhookURL(url, c.disableValidation); err != nil {
+	if err := ValidateWebhookURL(url, c.enableValidation); err != nil {
 		return nil, 0, fmt.Errorf("send webhook: %w", err)
 	}
 

--- a/pkg/webhook/client_test.go
+++ b/pkg/webhook/client_test.go
@@ -90,7 +90,7 @@ func TestHMAC(t *testing.T) {
 	testServer := newHMACTestServer(t, validSecret, expectedResponse)
 	defer testServer.Close()
 
-	client := webhook.NewClient[testRequest, testResponse](true)
+	client := webhook.NewClient[testRequest, testResponse](false)
 	options := webhook.Options{
 		MaxRetries:      0,
 		MinWaitInterval: 0,
@@ -155,7 +155,7 @@ func TestBackoff(t *testing.T) {
 	server := newRetryServer(t, replyAfter, expectedResponse)
 	defer server.Close()
 
-	webhookClient := webhook.NewClient[testRequest, testResponse](true)
+	webhookClient := webhook.NewClient[testRequest, testResponse](false)
 	t.Run("retry fail test", func(t *testing.T) {
 		reqPayload := testRequest{Name: "retry fails"}
 		body, err := json.Marshal(reqPayload)
@@ -197,7 +197,7 @@ func TestRequestTimeout(t *testing.T) {
 	server := newDelayServer(t, delayTime, expectedResponse)
 	defer server.Close()
 
-	webhookClient := webhook.NewClient[testRequest, testResponse](true)
+	webhookClient := webhook.NewClient[testRequest, testResponse](false)
 	t.Run("request succeed after timeout", func(t *testing.T) {
 		reqPayload := testRequest{Name: "TimeoutTest"}
 		body, err := json.Marshal(reqPayload)
@@ -243,7 +243,7 @@ func TestErrorHandling(t *testing.T) {
 		MaxWaitInterval: 0,
 		RequestTimeout:  50 * time.Millisecond,
 	}
-	unreachableClient := webhook.NewClient[testRequest, testResponse](true)
+	unreachableClient := webhook.NewClient[testRequest, testResponse](false)
 
 	t.Run("request fails with context done test", func(t *testing.T) {
 		reqPayload := testRequest{Name: "ContextDone"}

--- a/pkg/webhook/validator.go
+++ b/pkg/webhook/validator.go
@@ -30,9 +30,9 @@ var (
 )
 
 // ValidateWebhookURL validates the webhook URL to prevent SSRF attacks.
-func ValidateWebhookURL(rawURL string, disabled bool) error {
-	// If validation is disabled, skip the validation.
-	if disabled {
+func ValidateWebhookURL(rawURL string, enabled bool) error {
+	// If validation is not enabled, skip the validation.
+	if !enabled {
 		return nil
 	}
 

--- a/pkg/webhook/validator_test.go
+++ b/pkg/webhook/validator_test.go
@@ -62,7 +62,7 @@ func TestValidateWebhookURL_SSRF(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			err := webhook.ValidateWebhookURL(tc.url, false)
+			err := webhook.ValidateWebhookURL(tc.url, true)
 			if tc.wantErr {
 				assert.Error(t, err)
 				assert.ErrorContains(t, err, webhook.ErrInvalidWebhookURL.Error())
@@ -74,8 +74,8 @@ func TestValidateWebhookURL_SSRF(t *testing.T) {
 }
 
 func TestValidateWebhookURL_Disabled(t *testing.T) {
-	t.Run("allow blocked url if validation is disabled", func(t *testing.T) {
-		err := webhook.ValidateWebhookURL("http://localhost/webhook", true)
+	t.Run("allow blocked url if validation is not enabled", func(t *testing.T) {
+		err := webhook.ValidateWebhookURL("http://localhost/webhook", false)
 		assert.NoError(t, err)
 	})
 }

--- a/server/backend/backend.go
+++ b/server/backend/backend.go
@@ -125,10 +125,10 @@ func New(
 
 	// 03. Create webhook clients and cluster client pool.
 	authWebhookClient := pkgwebhook.NewClient[types.AuthWebhookRequest, types.AuthWebhookResponse](
-		conf.DisableWebhookValidation,
+		conf.EnableWebhookValidation,
 	)
 	eventWebhookManger := webhook.NewManager(
-		pkgwebhook.NewClient[types.EventWebhookRequest, int](conf.DisableWebhookValidation),
+		pkgwebhook.NewClient[types.EventWebhookRequest, int](conf.EnableWebhookValidation),
 	)
 	clusterClientPool := cluster.NewClientPool(
 		cluster.WithRPCTimeout(conf.ParseClusterRPCTimeout()),

--- a/server/backend/config.go
+++ b/server/backend/config.go
@@ -80,8 +80,10 @@ type Config struct {
 	// messages to other nodes in the cluster.
 	RPCAddr string `yaml:"RPCAddr"`
 
-	// DisableWebhookValidation is whether to disable webhook validation.
-	DisableWebhookValidation bool `yaml:"DisableWebhookValidation"`
+	// EnableWebhookValidation is whether to enable webhook URL validation
+	// to prevent SSRF attacks. If false (default), webhook URL validation
+	// is skipped.
+	EnableWebhookValidation bool `yaml:"EnableWebhookValidation"`
 
 	// ClusterRPCTimeout is the timeout for individual cluster RPC calls.
 	// If a cluster peer does not respond within this duration, the call

--- a/test/bench/webhook_bench_test.go
+++ b/test/bench/webhook_bench_test.go
@@ -108,7 +108,7 @@ func benchmarkSendWebhook(b *testing.B, webhookNum, endpointNum int) {
 		}
 	}()
 
-	cli := pkgwebhook.NewClient[types.EventWebhookRequest, int](true)
+	cli := pkgwebhook.NewClient[types.EventWebhookRequest, int](false)
 	for b.Loop() {
 		for range webhookNum {
 			for i := range endpointNum {
@@ -148,7 +148,7 @@ func benchmarkSendWebhookWithLimits(b *testing.B, webhookNum, endpointNum int) {
 		}
 	}()
 
-	cli := pkgwebhook.NewClient[types.EventWebhookRequest, int](true)
+	cli := pkgwebhook.NewClient[types.EventWebhookRequest, int](false)
 
 	logging.DefaultLogger()
 

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -310,7 +310,7 @@ func TestConfig() *server.Config {
 			SnapshotCacheSize:             SnapshotCacheSize,
 			AuthWebhookCacheSize:          AuthWebhookSize,
 			AuthWebhookCacheTTL:           AuthWebhookCacheTTL.String(),
-			DisableWebhookValidation:      true,
+			EnableWebhookValidation:       false,
 			GatewayAddr:                   fmt.Sprintf("localhost:%d", RPCPort+portOffset),
 			RPCAddr:                       fmt.Sprintf("localhost:%d", RPCPort+portOffset),
 			ChannelSessionTTL:             ChannelSessionTTL,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Reverse the webhook validation flag so that validation is opt-in rather than opt-out. This makes the default behavior less aggressive by skipping SSRF validation unless explicitly enabled.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched webhook validation to an enable-first model so URL validation is active by default, improving protection against SSRF attacks.

* **Tests**
  * Updated tests and benchmarks to reflect the new validation default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->