### PR TITLE
Fix inverted revision sort order in memory database

### DIFF
--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -2567,9 +2567,9 @@ func (d *DB) FindRevisionInfosByPaging(
 	// Sort by ID descending (newest first, since ID contains timestamp)
 	sort.Slice(revisions, func(i, j int) bool {
 		if paging.IsForward {
-			return revisions[i].ID > revisions[j].ID
+			return revisions[i].ID < revisions[j].ID
 		}
-		return revisions[i].ID < revisions[j].ID
+		return revisions[i].ID > revisions[j].ID
 	})
 
 	// Apply paging


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The memory backend's FindRevisionInfosByPaging had its sort comparisons swapped, causing it to return oldest-first when IsForward=false (default) instead of newest-first like the MongoDB backend.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed revision pagination ordering to display items in the correct sequence for both forward and backward navigation through results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->