### PR TITLE
Add attributes_to_remove support to Operation.Style for text undo/redo

### DIFF
--- a/api/converter/from_pb.go
+++ b/api/converter/from_pb.go
@@ -528,6 +528,17 @@ func fromStyle(pbStyle *api.Operation_Style) (*operations.Style, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if len(pbStyle.AttributesToRemove) > 0 {
+		return operations.NewStyleRemove(
+			parentCreatedAt,
+			from,
+			to,
+			pbStyle.AttributesToRemove,
+			executedAt,
+		), nil
+	}
+
 	return operations.NewStyle(
 		parentCreatedAt,
 		from,

--- a/api/converter/to_pb.go
+++ b/api/converter/to_pb.go
@@ -442,11 +442,12 @@ func toEdit(e *operations.Edit) (*api.Operation_Edit_, error) {
 func toStyle(style *operations.Style) (*api.Operation_Style_, error) {
 	return &api.Operation_Style_{
 		Style: &api.Operation_Style{
-			ParentCreatedAt: ToTimeTicket(style.ParentCreatedAt()),
-			From:            toTextNodePos(style.From()),
-			To:              toTextNodePos(style.To()),
-			Attributes:      style.Attributes(),
-			ExecutedAt:      ToTimeTicket(style.ExecutedAt()),
+			ParentCreatedAt:    ToTimeTicket(style.ParentCreatedAt()),
+			From:               toTextNodePos(style.From()),
+			To:                 toTextNodePos(style.To()),
+			Attributes:         style.Attributes(),
+			ExecutedAt:         ToTimeTicket(style.ExecutedAt()),
+			AttributesToRemove: style.AttributesToRemove(),
 		},
 	}, nil
 }

--- a/api/docs/yorkie/v1/admin.openapi.yaml
+++ b/api/docs/yorkie/v1/admin.openapi.yaml
@@ -2756,6 +2756,13 @@ components:
           description: ""
           title: attributes
           type: object
+        attributesToRemove:
+          additionalProperties: false
+          description: ""
+          items:
+            type: string
+          title: attributes_to_remove
+          type: array
         createdAtMapByActor:
           additionalProperties: false
           description: deprecated

--- a/api/docs/yorkie/v1/resources.openapi.yaml
+++ b/api/docs/yorkie/v1/resources.openapi.yaml
@@ -1257,6 +1257,13 @@ components:
           description: ""
           title: attributes
           type: object
+        attributesToRemove:
+          additionalProperties: false
+          description: ""
+          items:
+            type: string
+          title: attributes_to_remove
+          type: array
         createdAtMapByActor:
           additionalProperties: false
           description: deprecated

--- a/api/docs/yorkie/v1/yorkie.openapi.yaml
+++ b/api/docs/yorkie/v1/yorkie.openapi.yaml
@@ -1703,6 +1703,13 @@ components:
           description: ""
           title: attributes
           type: object
+        attributesToRemove:
+          additionalProperties: false
+          description: ""
+          items:
+            type: string
+          title: attributes_to_remove
+          type: array
         createdAtMapByActor:
           additionalProperties: false
           description: deprecated

--- a/api/yorkie/v1/resources.pb.go
+++ b/api/yorkie/v1/resources.pb.go
@@ -3562,6 +3562,7 @@ type Operation_Style struct {
 	Attributes          map[string]string      `protobuf:"bytes,4,rep,name=attributes,proto3" json:"attributes,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	ExecutedAt          *TimeTicket            `protobuf:"bytes,5,opt,name=executed_at,json=executedAt,proto3" json:"executed_at,omitempty"`
 	CreatedAtMapByActor map[string]*TimeTicket `protobuf:"bytes,6,rep,name=created_at_map_by_actor,json=createdAtMapByActor,proto3" json:"created_at_map_by_actor,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // deprecated
+	AttributesToRemove  []string               `protobuf:"bytes,7,rep,name=attributes_to_remove,json=attributesToRemove,proto3" json:"attributes_to_remove,omitempty"`
 	unknownFields       protoimpl.UnknownFields
 	sizeCache           protoimpl.SizeCache
 }
@@ -3634,6 +3635,13 @@ func (x *Operation_Style) GetExecutedAt() *TimeTicket {
 func (x *Operation_Style) GetCreatedAtMapByActor() map[string]*TimeTicket {
 	if x != nil {
 		return x.CreatedAtMapByActor
+	}
+	return nil
+}
+
+func (x *Operation_Style) GetAttributesToRemove() []string {
+	if x != nil {
+		return x.AttributesToRemove
 	}
 	return nil
 }
@@ -4548,7 +4556,7 @@ const file_yorkie_v1_resources_proto_rawDesc = "" +
 	"\x06vector\x18\x01 \x03(\v2$.yorkie.v1.VersionVector.VectorEntryR\x06vector\x1a9\n" +
 	"\vVectorEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\x03R\x05value:\x028\x01\"\xa3 \n" +
+	"\x05value\x18\x02 \x01(\x03R\x05value:\x028\x01\"\xd5 \n" +
 	"\tOperation\x12,\n" +
 	"\x03set\x18\x01 \x01(\v2\x18.yorkie.v1.Operation.SetH\x00R\x03set\x12,\n" +
 	"\x03add\x18\x02 \x01(\v2\x18.yorkie.v1.Operation.AddH\x00R\x03add\x12/\n" +
@@ -4603,7 +4611,7 @@ const file_yorkie_v1_resources_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\v2\x15.yorkie.v1.TimeTicketR\x05value:\x028\x01\x1a=\n" +
 	"\x0fAttributesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a\xab\x04\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a\xdd\x04\n" +
 	"\x05Style\x12A\n" +
 	"\x11parent_created_at\x18\x01 \x01(\v2\x15.yorkie.v1.TimeTicketR\x0fparentCreatedAt\x12*\n" +
 	"\x04from\x18\x02 \x01(\v2\x16.yorkie.v1.TextNodePosR\x04from\x12&\n" +
@@ -4613,7 +4621,8 @@ const file_yorkie_v1_resources_proto_rawDesc = "" +
 	"attributes\x126\n" +
 	"\vexecuted_at\x18\x05 \x01(\v2\x15.yorkie.v1.TimeTicketR\n" +
 	"executedAt\x12i\n" +
-	"\x17created_at_map_by_actor\x18\x06 \x03(\v23.yorkie.v1.Operation.Style.CreatedAtMapByActorEntryR\x13createdAtMapByActor\x1a=\n" +
+	"\x17created_at_map_by_actor\x18\x06 \x03(\v23.yorkie.v1.Operation.Style.CreatedAtMapByActorEntryR\x13createdAtMapByActor\x120\n" +
+	"\x14attributes_to_remove\x18\a \x03(\tR\x12attributesToRemove\x1a=\n" +
 	"\x0fAttributesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a]\n" +

--- a/api/yorkie/v1/resources.proto
+++ b/api/yorkie/v1/resources.proto
@@ -108,6 +108,7 @@ message Operation {
     map<string, string> attributes = 4;
     TimeTicket executed_at = 5;
     map<string, TimeTicket> created_at_map_by_actor = 6; // deprecated
+    repeated string attributes_to_remove = 7;
   }
   message Increase {
     TimeTicket parent_created_at = 1;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add the ability to remove text style attributes via Operation.Style, enabling undo/redo of text style operations in the JS SDK. This follows the existing TreeStyle pattern with attributesToRemove.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Addresses #652

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remove specific text styling attributes from a selected range, letting users strip chosen formatting while keeping other styles.
* **Documentation**
  * Public API and docs updated to expose a new attributesToRemove field for edit/style operations so clients can request or observe attribute removals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->