### PR TITLE
Introduce treelist to optimize random access in Array

### DIFF
--- a/docs/design/data-structure.md
+++ b/docs/design/data-structure.md
@@ -73,17 +73,18 @@ CRDT data structures are used by JSON-like group to resolve conflicts in concurr
 
 - `RHT`(Replicated Hash Table): similar to hash table, but resolves concurrent-editing conflicts.
 - `ElementRHT`: similar to `RHT`, but has elements as values.
-- `RGATreeList`: extended `RGA(Replicated Growable Array)` with an additional index tree. The index tree manages the indices of elements and provides faster access to elements at the int-based index.
+- `RGATreeList`: extended `RGA(Replicated Growable Array)` with an additional index tree. The index tree manages the indices of elements and provides faster access to elements at the int-based index. It uses `TreeList` as the index tree to guarantee O(log N) worst-case for all operations.
 - `RGATreeSplit`: extended `RGATreeList` allowing characters to be represented as blocks rather than each single character.
 - `CRDTTree`: represents the CRDT tree with an index tree structure'. It resolves conflicts arising from concurrent editing.
 ### Common Group
 
 Common data structures can be used for general purposes.
 
-- [`SplayTree`](https://en.wikipedia.org/wiki/Splay_tree): A tree that moves nodes to the root by splaying. This is effective when user frequently access the same location, such as text editing. We use `SplayTree` as an index tree to give each node a weight, and to quickly access the node based on the index.
+- [`SplayTree`](https://en.wikipedia.org/wiki/Splay_tree): A tree that moves nodes to the root by splaying. This is effective when user frequently access the same location, such as text editing. We use `SplayTree` as an index tree in `RGATreeSplit` to give each node a weight, and to quickly access the node based on the index.
 - [`LLRBTree`](https://en.wikipedia.org/wiki/Left-leaning_red%E2%80%93black_tree): A tree simpler than Red-Black Tree. Newly added `floor` method finds the node of the largest key less than or equal to the given key.
+- `TreeList`: An order-statistic tree built on Left-leaning Red-Black Tree. It maintains both a live-node weight (for index-based lookup over non-removed elements) and a structural count (including tombstones), guaranteeing O(log N) worst-case for insert, delete, and index-based access. Used as the index tree of `RGATreeList`.
 - `IndexTree`: A tree implementation to represent a document of text-based editors.
   
 ### Risks and Mitigation
 
-We can replace the data structures with better ones for some reason, such as performance. For example, `SplayTree` used in `RGATreeList` can be replaced with [TreeList](https://commons.apache.org/proper/commons-collections/apidocs/org/apache/commons/collections4/list/TreeList.html).
+We can replace the data structures with better ones for some reason, such as performance. For example, the `SplayTree` previously used in `RGATreeList` has been replaced with `TreeList` to guarantee O(log N) worst-case for random access, which is more predictable for non-locality workloads.

--- a/pkg/document/crdt/array.go
+++ b/pkg/document/crdt/array.go
@@ -103,7 +103,7 @@ func (a *Array) RGATreeList() *RGATreeList {
 func (a *Array) Elements() []Element {
 	var elements []Element
 	for _, node := range a.elements.Nodes() {
-		if node.isRemoved() {
+		if node.IsRemoved() {
 			continue
 		}
 		elements = append(elements, node.Element())

--- a/pkg/document/crdt/rga_tree_list.go
+++ b/pkg/document/crdt/rga_tree_list.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/yorkie-team/yorkie/pkg/document/resource"
 	"github.com/yorkie-team/yorkie/pkg/document/time"
-	"github.com/yorkie-team/yorkie/pkg/splay"
+	"github.com/yorkie-team/yorkie/pkg/treelist"
 )
 
 // ElementEntry is the stable identity of an element in the RGATreeList.
@@ -36,7 +36,7 @@ type ElementEntry struct {
 // RGATreeListNode is a position slot in the RGA linked list.
 // When elementEntry is nil, it is a dead slot abandoned by a move.
 type RGATreeListNode struct {
-	indexNode    *splay.Node[*RGATreeListNode]
+	indexNode    *treelist.Node[*RGATreeListNode]
 	elementEntry *ElementEntry
 	createdAt    *time.Ticket
 	removedAt    *time.Ticket
@@ -56,7 +56,7 @@ func newRGATreeListNode(elem Element) *RGATreeListNode {
 		createdAt:    elem.CreatedAt(),
 	}
 	entry.positionNode = node
-	node.indexNode = splay.NewNode(node)
+	node.indexNode = treelist.NewNode(node)
 
 	return node
 }
@@ -68,7 +68,7 @@ func newBarePositionNode(createdAt *time.Ticket) *RGATreeListNode {
 		next:      nil,
 		createdAt: createdAt,
 	}
-	node.indexNode = splay.NewNode(node)
+	node.indexNode = treelist.NewNode(node)
 
 	return node
 }
@@ -129,15 +129,6 @@ func (n *RGATreeListNode) PositionedAt() *time.Ticket {
 	return n.createdAt
 }
 
-// Len returns the length of this node.
-// Dead nodes (no element) return 0, removed elements return 0.
-func (n *RGATreeListNode) Len() int {
-	if n.elementEntry == nil || n.isRemoved() {
-		return 0
-	}
-	return 1
-}
-
 // String returns the string representation of this node.
 func (n *RGATreeListNode) String() string {
 	if n.elementEntry == nil {
@@ -146,7 +137,8 @@ func (n *RGATreeListNode) String() string {
 	return n.elementEntry.elem.Marshal()
 }
 
-func (n *RGATreeListNode) isRemoved() bool {
+// IsRemoved returns true if this node is a dead position (no element) or its element was deleted.
+func (n *RGATreeListNode) IsRemoved() bool {
 	if n.elementEntry == nil {
 		return true
 	}
@@ -196,7 +188,7 @@ func (n *RGATreeListNode) DataSize() resource.DataSize {
 type RGATreeList struct {
 	dummyHead             *RGATreeListNode
 	last                  *RGATreeListNode
-	nodeMapByIndex        *splay.Tree[*RGATreeListNode]
+	nodeMapByIndex        *treelist.Tree[*RGATreeListNode]
 	nodeMapByCreatedAt    map[string]*RGATreeListNode
 	elementMapByCreatedAt map[string]*ElementEntry
 }
@@ -209,7 +201,7 @@ func NewRGATreeList() *RGATreeList {
 
 	dummyValue.SetRemovedAt(time.InitialTicket)
 	dummyHead := newRGATreeListNode(dummyValue)
-	nodeMapByIndex := splay.NewTree(dummyHead.indexNode)
+	nodeMapByIndex := treelist.NewTree(dummyHead.indexNode)
 	nodeMapByCreatedAt := make(map[string]*RGATreeListNode)
 	nodeMapByCreatedAt[dummyHead.CreatedAt().Key()] = dummyHead
 	elementMapByCreatedAt := make(map[string]*ElementEntry)
@@ -231,7 +223,7 @@ func (a *RGATreeList) Marshal() string {
 	current := a.dummyHead.next
 	isFirst := true
 	for current != nil {
-		if current.elementEntry != nil && !current.isRemoved() {
+		if !current.IsRemoved() {
 			if isFirst {
 				isFirst = false
 			} else {
@@ -329,11 +321,11 @@ func (a *RGATreeList) InsertAfter(prevCreatedAt *time.Ticket, elem Element, exec
 
 // Get returns the element of the given index.
 func (a *RGATreeList) Get(idx int) (*RGATreeListNode, error) {
-	splayNode, err := a.nodeMapByIndex.FindForArray(idx)
+	treelistNode, err := a.nodeMapByIndex.Find(idx)
 	if err != nil {
 		return nil, err
 	}
-	return splayNode.Value(), nil
+	return treelistNode.Value(), nil
 }
 
 // DeleteByCreatedAt deletes the given element.
@@ -345,9 +337,9 @@ func (a *RGATreeList) DeleteByCreatedAt(createdAt *time.Ticket, deletedAt *time.
 
 	node := entry.positionNode
 
-	alreadyRemoved := node.isRemoved()
+	alreadyRemoved := node.IsRemoved()
 	if entry.elem.Remove(deletedAt) && !alreadyRemoved {
-		a.nodeMapByIndex.Splay(node.indexNode)
+		a.nodeMapByIndex.UpdateWeight(node.indexNode)
 	}
 	return node, nil
 }
@@ -398,7 +390,7 @@ func (a *RGATreeList) MoveAfter(prevCreatedAt, createdAt, executedAt *time.Ticke
 			return nil, err
 		}
 		deadPosNode.removedAt = executedAt
-		a.nodeMapByIndex.Splay(deadPosNode.indexNode)
+		a.nodeMapByIndex.UpdateWeight(deadPosNode.indexNode)
 		return deadPosNode, nil
 	}
 
@@ -412,7 +404,7 @@ func (a *RGATreeList) MoveAfter(prevCreatedAt, createdAt, executedAt *time.Ticke
 	oldPosNode := entry.positionNode
 	oldPosNode.elementEntry = nil
 	oldPosNode.removedAt = executedAt
-	a.nodeMapByIndex.Splay(oldPosNode.indexNode)
+	a.nodeMapByIndex.UpdateWeight(oldPosNode.indexNode)
 
 	// NOTE: We do NOT delete/reassign nodeMapByCreatedAt[createdAt] here.
 	// The old position node keeps its key in nodeMapByCreatedAt (dead but findable).
@@ -425,7 +417,7 @@ func (a *RGATreeList) MoveAfter(prevCreatedAt, createdAt, executedAt *time.Ticke
 	entry.posMovedAt = executedAt
 	entry.elem.SetMovedAt(executedAt)
 
-	a.nodeMapByIndex.Splay(newPosNode.indexNode)
+	a.nodeMapByIndex.UpdateWeight(newPosNode.indexNode)
 
 	return oldPosNode, nil
 }
@@ -446,7 +438,7 @@ func (a *RGATreeList) FindPrevCreatedAt(createdAt *time.Ticket) (*time.Ticket, e
 		if node.elementEntry == nil {
 			continue
 		}
-		if a.dummyHead == node || !node.isRemoved() {
+		if a.dummyHead == node || !node.IsRemoved() {
 			break
 		}
 	}

--- a/pkg/document/document_test.go
+++ b/pkg/document/document_test.go
@@ -130,22 +130,22 @@ func TestDocument(t *testing.T) {
 			root.SetNewArray("k1").AddInteger(1).AddInteger(2).AddInteger(3)
 			assert.Equal(t, 3, root.GetArray("k1").Len())
 			assert.Equal(t, `{"k1":[1,2,3]}`, root.Marshal())
-			assert.Equal(t, "[0,0]0[1,1]1[2,1]2[3,1]3", root.GetArray("k1").ToTestString())
+			assert.Equal(t, "[0,0]0[3,1]1[1,1]2[2,1]3", root.GetArray("k1").ToTestString())
 
 			root.GetArray("k1").Delete(1)
 			assert.Equal(t, `{"k1":[1,3]}`, root.Marshal())
 			assert.Equal(t, 2, root.GetArray("k1").Len())
-			assert.Equal(t, "[0,0]0[1,1]1[2,0]2[1,1]3", root.GetArray("k1").ToTestString())
+			assert.Equal(t, "[0,0]0[2,1]1[0,0]2[1,1]3", root.GetArray("k1").ToTestString())
 
 			root.GetArray("k1").InsertIntegerAfter(0, 2)
 			assert.Equal(t, `{"k1":[1,2,3]}`, root.Marshal())
 			assert.Equal(t, 3, root.GetArray("k1").Len())
-			assert.Equal(t, "[0,0]0[1,1]1[3,1]2[1,0]2[1,1]3", root.GetArray("k1").ToTestString())
+			assert.Equal(t, "[0,0]0[2,1]1[1,1]2[3,0]2[1,1]3", root.GetArray("k1").ToTestString())
 
 			root.GetArray("k1").InsertIntegerAfter(2, 4)
 			assert.Equal(t, `{"k1":[1,2,3,4]}`, root.Marshal())
 			assert.Equal(t, 4, root.GetArray("k1").Len())
-			assert.Equal(t, "[0,0]0[1,1]1[2,1]2[2,0]2[3,1]3[4,1]4", root.GetArray("k1").ToTestString())
+			assert.Equal(t, "[0,0]0[2,1]1[1,1]2[4,0]2[1,1]3[2,1]4", root.GetArray("k1").ToTestString())
 
 			for i := range root.GetArray("k1").Len() {
 				assert.Equal(

--- a/pkg/treelist/treelist.go
+++ b/pkg/treelist/treelist.go
@@ -1,0 +1,454 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package treelist provides a Tree List implementation using Left-leaning Red-Black Tree.
+// It is an order-statistic tree that supports index-based operations for RGATreeList.
+// Unlike splay trees, it guarantees O(log N) worst-case for all operations.
+package treelist
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ErrOutOfIndex is returned when the given index is out of index.
+var ErrOutOfIndex = fmt.Errorf("out of index")
+
+// Value represents the data stored in the nodes of Tree.
+type Value interface {
+	IsRemoved() bool
+	String() string
+}
+
+// Node is a node of Tree.
+type Node[V Value] struct {
+	value  V
+	left   *Node[V]
+	right  *Node[V]
+	parent *Node[V]
+
+	// weight is the number of non-removed (live) nodes in this subtree.
+	// Used for logical index-based operations
+	weight int
+
+	// count is the total number of nodes in this subtree (including tombstones).
+	// Used for structural position-based operations
+	count int
+
+	isRed bool
+}
+
+// NewNode creates a new instance of Node.
+func NewNode[V Value](value V) *Node[V] {
+	n := &Node[V]{
+		value: value,
+		isRed: true,
+	}
+	n.weight = n.Size()
+	n.count = 1
+	return n
+}
+
+// Value returns the value of this Node.
+func (n *Node[V]) Value() V {
+	return n.value
+}
+
+// Size returns 1 if the node is live, 0 if removed (tombstone).
+func (n *Node[V]) Size() int {
+	if n.value.IsRemoved() {
+		return 0
+	}
+	return 1
+}
+
+// Tree is an order-statistic tree based on Left-leaning Red-Black Tree.
+// It maintains two weights per node:
+//   - weight: count of non-removed nodes (for index-based lookup)
+//   - count: total nodes including tombstones (for structural operations)
+type Tree[V Value] struct {
+	root *Node[V]
+}
+
+// NewTree creates a new instance of Tree.
+func NewTree[V Value](root *Node[V]) *Tree[V] {
+	if root != nil {
+		root.isRed = false
+	}
+	return &Tree[V]{root: root}
+}
+
+// InsertAfter inserts the target node right after prev in the in-order traversal.
+// It uses structural (count-based) indexing to correctly handle tombstone nodes.
+func (t *Tree[V]) InsertAfter(prev *Node[V], target *Node[V]) {
+	if prev == nil || target == nil {
+		return
+	}
+
+	target.left = nil
+	target.right = nil
+	target.parent = nil
+	target.isRed = true
+	target.weight = target.Size()
+	target.count = 1
+
+	idx := t.structuralIndexOf(prev)
+	t.root = t.insertByCount(t.root, idx+1, target)
+	t.root.isRed = false
+	t.root.parent = nil
+}
+
+// insertByCount inserts newNode at the given structural index within the
+// subtree rooted at node, descending the tree using each node's left count
+// (tombstones included) and rebalancing on the way back up.
+func (t *Tree[V]) insertByCount(node *Node[V], index int, newNode *Node[V]) *Node[V] {
+	if node == nil {
+		return newNode
+	}
+
+	if index <= node.leftCount() {
+		node.left = t.insertByCount(node.left, index, newNode)
+		node.left.parent = node
+	} else {
+		node.right = t.insertByCount(node.right, index-node.leftCount()-1, newNode)
+		node.right.parent = node
+	}
+
+	return fixUp(node)
+}
+
+// Len returns the number of non-removed (live) nodes.
+func (t *Tree[V]) Len() int {
+	if t.root == nil {
+		return 0
+	}
+	return t.root.weight
+}
+
+// Find returns the node at the given logical index (among non-removed nodes).
+func (t *Tree[V]) Find(index int) (*Node[V], error) {
+	if t.root == nil || index < 0 || index >= t.Len() {
+		return nil, fmt.Errorf("tree size %d, index %d: %w", t.Len(), index, ErrOutOfIndex)
+	}
+
+	node := t.root
+	for {
+		if index < node.leftWeight() {
+			node = node.left
+		} else if index < node.leftWeight()+node.Size() {
+			break
+		} else {
+			index -= node.leftWeight() + node.Size()
+			node = node.right
+		}
+	}
+	return node, nil
+}
+
+// Delete physically removes a node from the tree.
+// Unlike tombstoning, this completely removes the node from the tree structure.
+// It uses structural (count-based) indexing and swaps the node structure
+// (not values) with its successor to preserve node identity.
+func (t *Tree[V]) Delete(node *Node[V]) {
+	if node == nil || t.root == nil {
+		return
+	}
+
+	if !isRed(t.root.left) && !isRed(t.root.right) {
+		t.root.isRed = true
+	}
+
+	idx := t.structuralIndexOf(node)
+	t.root = t.deleteByCount(t.root, idx)
+
+	if t.root != nil {
+		t.root.isRed = false
+		t.root.parent = nil
+	}
+}
+
+// deleteByCount removes the node at the given structural index within the
+// subtree rooted at node. When deleting an internal node, it swaps in the
+// in-order successor by re-parenting rather than copying values so external
+// references to the surviving node remain valid.
+func (t *Tree[V]) deleteByCount(node *Node[V], index int) *Node[V] {
+	if index < node.leftCount() {
+		if !isRed(node.left) && !isRed(node.left.left) {
+			node = moveRedLeft(node)
+		}
+		node.left = t.deleteByCount(node.left, index)
+		if node.left != nil {
+			node.left.parent = node
+		}
+	} else {
+		if isRed(node.left) {
+			node = rotateRight(node)
+		}
+
+		if index == node.leftCount() && node.right == nil {
+			return nil
+		}
+
+		if !isRed(node.right) && !isRed(node.right.left) {
+			node = moveRedRight(node)
+		}
+
+		if index == node.leftCount() {
+			// Swap the successor into this position instead of copying values.
+			// This preserves node identity so external references remain valid.
+			successor := min(node.right)
+			newRight := removeMin(node.right)
+
+			successor.left = node.left
+			successor.right = newRight
+			successor.isRed = node.isRed
+			if successor.left != nil {
+				successor.left.parent = successor
+			}
+			if successor.right != nil {
+				successor.right.parent = successor
+			}
+
+			node.left = nil
+			node.right = nil
+			node.parent = nil
+
+			node = successor
+		} else {
+			node.right = t.deleteByCount(node.right, index-node.leftCount()-1)
+			if node.right != nil {
+				node.right.parent = node
+			}
+		}
+	}
+
+	return fixUp(node)
+}
+
+// UpdateWeight propagates weight changes from the given node up to the root.
+// Call this after a node's IsRemoved() status changes (i.e., after tombstoning).
+func (t *Tree[V]) UpdateWeight(node *Node[V]) {
+	for cur := node; cur != nil; cur = cur.parent {
+		cur.weight = cur.leftWeight() + cur.Size() + cur.rightWeight()
+	}
+}
+
+// ToTestString returns a String containing the metadata of the node
+// for debugging purpose.
+func (t *Tree[V]) ToTestString() string {
+	var b strings.Builder
+	traverseInOrder(t.root, func(node *Node[V]) {
+		b.WriteString(fmt.Sprintf("[%d,%d]%s", node.weight, node.Size(), node.value.String()))
+	})
+	return b.String()
+}
+
+// structuralIndexOf returns the structural position of the node,
+// counting all nodes including tombstones.
+func (t *Tree[V]) structuralIndexOf(node *Node[V]) int {
+	index := node.leftCount()
+	for cur := node; cur.parent != nil; cur = cur.parent {
+		if cur == cur.parent.right {
+			index += cur.parent.leftCount() + 1
+		}
+	}
+	return index
+}
+
+// leftWeight returns the live-node weight of the left subtree, or 0 if absent.
+func (n *Node[V]) leftWeight() int {
+	if n.left != nil {
+		return n.left.weight
+	}
+	return 0
+}
+
+// rightWeight returns the live-node weight of the right subtree, or 0 if absent.
+func (n *Node[V]) rightWeight() int {
+	if n.right != nil {
+		return n.right.weight
+	}
+	return 0
+}
+
+// leftCount returns the total node count (including tombstones) of the left
+// subtree, or 0 if absent.
+func (n *Node[V]) leftCount() int {
+	if n.left != nil {
+		return n.left.count
+	}
+	return 0
+}
+
+// rightCount returns the total node count (including tombstones) of the right
+// subtree, or 0 if absent.
+func (n *Node[V]) rightCount() int {
+	if n.right != nil {
+		return n.right.count
+	}
+	return 0
+}
+
+// isRed reports whether the given node is a red link. A nil node is treated
+// as black, matching the standard LLRB convention.
+func isRed[V Value](node *Node[V]) bool {
+	return node != nil && node.isRed
+}
+
+// updateNode recomputes the cached weight and count aggregates of node from
+// its children. Call this whenever the structure or liveness of a child
+// changes.
+func updateNode[V Value](node *Node[V]) {
+	node.weight = node.leftWeight() + node.Size() + node.rightWeight()
+	node.count = node.leftCount() + 1 + node.rightCount()
+}
+
+// rotateLeft performs a standard LLRB left rotation around node, promoting
+// its right child. Parent pointers and aggregate counters are refreshed and
+// the new subtree root is returned.
+func rotateLeft[V Value](node *Node[V]) *Node[V] {
+	right := node.right
+
+	node.right = right.left
+	if node.right != nil {
+		node.right.parent = node
+	}
+
+	right.left = node
+	right.parent = node.parent
+	node.parent = right
+
+	right.isRed = node.isRed
+	node.isRed = true
+
+	updateNode(node)
+	updateNode(right)
+	return right
+}
+
+// rotateRight performs a standard LLRB right rotation around node, promoting
+// its left child. Parent pointers and aggregate counters are refreshed and
+// the new subtree root is returned.
+func rotateRight[V Value](node *Node[V]) *Node[V] {
+	left := node.left
+
+	node.left = left.right
+	if node.left != nil {
+		node.left.parent = node
+	}
+
+	left.right = node
+	left.parent = node.parent
+	node.parent = left
+
+	left.isRed = node.isRed
+	node.isRed = true
+
+	updateNode(node)
+	updateNode(left)
+	return left
+}
+
+// flipColors toggles the colors of node and both of its children, used during
+// LLRB splits and merges.
+func flipColors[V Value](node *Node[V]) {
+	node.isRed = !node.isRed
+	node.left.isRed = !node.left.isRed
+	node.right.isRed = !node.right.isRed
+}
+
+// moveRedLeft ensures the left child or one of its children is red so a
+// deletion descending to the left can proceed without violating LLRB
+// invariants. The new subtree root is returned.
+func moveRedLeft[V Value](node *Node[V]) *Node[V] {
+	flipColors(node)
+	if isRed(node.right.left) {
+		node.right = rotateRight(node.right)
+		node.right.parent = node
+		node = rotateLeft(node)
+		flipColors(node)
+	}
+	return node
+}
+
+// moveRedRight ensures the right child or one of its children is red so a
+// deletion descending to the right can proceed without violating LLRB
+// invariants. The new subtree root is returned.
+func moveRedRight[V Value](node *Node[V]) *Node[V] {
+	flipColors(node)
+	if isRed(node.left.left) {
+		node = rotateRight(node)
+		flipColors(node)
+	}
+	return node
+}
+
+// removeMin removes the minimum (left-most) node from the subtree rooted at
+// node and returns the rebalanced subtree root. Used by Delete when splicing
+// in the in-order successor.
+func removeMin[V Value](node *Node[V]) *Node[V] {
+	if node.left == nil {
+		return nil
+	}
+
+	if !isRed(node.left) && !isRed(node.left.left) {
+		node = moveRedLeft(node)
+	}
+
+	node.left = removeMin(node.left)
+	if node.left != nil {
+		node.left.parent = node
+	}
+
+	return fixUp(node)
+}
+
+// min returns the left-most node of the subtree rooted at node, which is the
+// in-order successor used during deletion.
+func min[V Value](node *Node[V]) *Node[V] {
+	for node.left != nil {
+		node = node.left
+	}
+	return node
+}
+
+// fixUp restores LLRB invariants on the way back up after an insertion or
+// deletion: it leans right-red links left, splits 4-nodes, and refreshes the
+// node's aggregate counters.
+func fixUp[V Value](node *Node[V]) *Node[V] {
+	if isRed(node.right) && !isRed(node.left) {
+		node = rotateLeft(node)
+	}
+	if isRed(node.left) && isRed(node.left.left) {
+		node = rotateRight(node)
+	}
+	if isRed(node.left) && isRed(node.right) {
+		flipColors(node)
+	}
+	updateNode(node)
+	return node
+}
+
+// traverseInOrder walks the subtree rooted at node in left-root-right order,
+// invoking cb on every node (live and tombstoned).
+func traverseInOrder[V Value](node *Node[V], cb func(*Node[V])) {
+	if node == nil {
+		return
+	}
+	traverseInOrder(node.left, cb)
+	cb(node)
+	traverseInOrder(node.right, cb)
+}

--- a/pkg/treelist/treelist_test.go
+++ b/pkg/treelist/treelist_test.go
@@ -1,0 +1,605 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package treelist_test
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/pkg/treelist"
+)
+
+type testValue struct {
+	content string
+	removed bool
+}
+
+func (v *testValue) IsRemoved() bool {
+	return v.removed
+}
+
+func (v *testValue) String() string {
+	return v.content
+}
+
+func newNode(content string) *treelist.Node[*testValue] {
+	return treelist.NewNode(&testValue{content: content})
+}
+
+func newRemovedNode(content string) *treelist.Node[*testValue] {
+	return treelist.NewNode(&testValue{content: content, removed: true})
+}
+
+func TestTreeList(t *testing.T) {
+	t.Run("insert and find test", func(t *testing.T) {
+		dummyHead := newRemovedNode("dummy")
+		tree := treelist.NewTree(dummyHead)
+
+		assert.Equal(t, 0, tree.Len())
+
+		nodeA := newNode("A")
+		tree.InsertAfter(dummyHead, nodeA)
+		assert.Equal(t, 1, tree.Len())
+
+		nodeB := newNode("B")
+		tree.InsertAfter(nodeA, nodeB)
+		assert.Equal(t, 2, tree.Len())
+
+		nodeC := newNode("C")
+		tree.InsertAfter(nodeB, nodeC)
+		assert.Equal(t, 3, tree.Len())
+
+		found, err := tree.Find(0)
+		assert.NoError(t, err)
+		assert.Equal(t, nodeA, found)
+
+		found, err = tree.Find(1)
+		assert.NoError(t, err)
+		assert.Equal(t, nodeB, found)
+
+		found, err = tree.Find(2)
+		assert.NoError(t, err)
+		assert.Equal(t, nodeC, found)
+	})
+
+	t.Run("insert in the middle test", func(t *testing.T) {
+		dummyHead := newRemovedNode("dummy")
+		tree := treelist.NewTree(dummyHead)
+
+		nodeA := newNode("A")
+		tree.InsertAfter(dummyHead, nodeA)
+		nodeC := newNode("C")
+		tree.InsertAfter(nodeA, nodeC)
+
+		// Insert B between A and C
+		nodeB := newNode("B")
+		tree.InsertAfter(nodeA, nodeB)
+		assert.Equal(t, 3, tree.Len())
+
+		found, err := tree.Find(0)
+		assert.NoError(t, err)
+		assert.Equal(t, nodeA, found)
+
+		found, err = tree.Find(1)
+		assert.NoError(t, err)
+		assert.Equal(t, nodeB, found)
+
+		found, err = tree.Find(2)
+		assert.NoError(t, err)
+		assert.Equal(t, nodeC, found)
+	})
+
+	t.Run("insert after tombstone test", func(t *testing.T) {
+		dummyHead := newRemovedNode("dummy")
+		tree := treelist.NewTree(dummyHead)
+
+		nodeA := newNode("A")
+		tree.InsertAfter(dummyHead, nodeA)
+		nodeB := newNode("B")
+		tree.InsertAfter(nodeA, nodeB)
+
+		// Tombstone A
+		nodeA.Value().removed = true
+		tree.UpdateWeight(nodeA)
+		assert.Equal(t, 1, tree.Len())
+
+		// Insert C after tombstoned A — should appear before B
+		nodeC := newNode("C")
+		tree.InsertAfter(nodeA, nodeC)
+		assert.Equal(t, 2, tree.Len())
+
+		found, err := tree.Find(0)
+		assert.NoError(t, err)
+		assert.Equal(t, nodeC, found)
+
+		found, err = tree.Find(1)
+		assert.NoError(t, err)
+		assert.Equal(t, nodeB, found)
+	})
+
+	t.Run("delete test", func(t *testing.T) {
+		dummyHead := newRemovedNode("dummy")
+		tree := treelist.NewTree(dummyHead)
+
+		nodeA := newNode("A")
+		tree.InsertAfter(dummyHead, nodeA)
+		nodeB := newNode("B")
+		tree.InsertAfter(nodeA, nodeB)
+		nodeC := newNode("C")
+		tree.InsertAfter(nodeB, nodeC)
+		assert.Equal(t, 3, tree.Len())
+
+		// Delete middle node
+		tree.Delete(nodeB)
+		assert.Equal(t, 2, tree.Len())
+
+		found, err := tree.Find(0)
+		assert.NoError(t, err)
+		assert.Equal(t, nodeA, found)
+
+		found, err = tree.Find(1)
+		assert.NoError(t, err)
+		assert.Equal(t, nodeC, found)
+	})
+
+	t.Run("delete preserves node identity test", func(t *testing.T) {
+		dummyHead := newRemovedNode("dummy")
+		tree := treelist.NewTree(dummyHead)
+
+		nodes := make([]*treelist.Node[*testValue], 5)
+		prev := dummyHead
+		for i := 0; i < 5; i++ {
+			nodes[i] = newNode(fmt.Sprintf("%c", 'A'+i))
+			tree.InsertAfter(prev, nodes[i])
+			prev = nodes[i]
+		}
+		assert.Equal(t, 5, tree.Len())
+
+		// Delete C (index 2). After deletion, remaining nodes should
+		// still be findable and point to the same original node objects.
+		tree.Delete(nodes[2])
+		assert.Equal(t, 4, tree.Len())
+
+		found, err := tree.Find(0)
+		assert.NoError(t, err)
+		assert.Equal(t, nodes[0], found) // A
+
+		found, err = tree.Find(1)
+		assert.NoError(t, err)
+		assert.Equal(t, nodes[1], found) // B
+
+		found, err = tree.Find(2)
+		assert.NoError(t, err)
+		assert.Equal(t, nodes[3], found) // D
+
+		found, err = tree.Find(3)
+		assert.NoError(t, err)
+		assert.Equal(t, nodes[4], found) // E
+	})
+
+	t.Run("delete first and last nodes test", func(t *testing.T) {
+		dummyHead := newRemovedNode("dummy")
+		tree := treelist.NewTree(dummyHead)
+
+		nodeA := newNode("A")
+		tree.InsertAfter(dummyHead, nodeA)
+		nodeB := newNode("B")
+		tree.InsertAfter(nodeA, nodeB)
+		nodeC := newNode("C")
+		tree.InsertAfter(nodeB, nodeC)
+
+		// Delete first live node
+		tree.Delete(nodeA)
+		assert.Equal(t, 2, tree.Len())
+		found, err := tree.Find(0)
+		assert.NoError(t, err)
+		assert.Equal(t, nodeB, found)
+
+		// Delete last live node
+		tree.Delete(nodeC)
+		assert.Equal(t, 1, tree.Len())
+		found, err = tree.Find(0)
+		assert.NoError(t, err)
+		assert.Equal(t, nodeB, found)
+	})
+
+	t.Run("delete tombstoned node test", func(t *testing.T) {
+		dummyHead := newRemovedNode("dummy")
+		tree := treelist.NewTree(dummyHead)
+
+		nodeA := newNode("A")
+		tree.InsertAfter(dummyHead, nodeA)
+		nodeB := newNode("B")
+		tree.InsertAfter(nodeA, nodeB)
+		nodeC := newNode("C")
+		tree.InsertAfter(nodeB, nodeC)
+
+		// Tombstone B, then physically delete it
+		nodeB.Value().removed = true
+		tree.UpdateWeight(nodeB)
+		assert.Equal(t, 2, tree.Len())
+
+		tree.Delete(nodeB)
+		assert.Equal(t, 2, tree.Len()) // Still 2 live nodes (A, C)
+
+		found, err := tree.Find(0)
+		assert.NoError(t, err)
+		assert.Equal(t, nodeA, found)
+
+		found, err = tree.Find(1)
+		assert.NoError(t, err)
+		assert.Equal(t, nodeC, found)
+	})
+
+	t.Run("delete all nodes test", func(t *testing.T) {
+		dummyHead := newRemovedNode("dummy")
+		tree := treelist.NewTree(dummyHead)
+
+		nodeA := newNode("A")
+		tree.InsertAfter(dummyHead, nodeA)
+		nodeB := newNode("B")
+		tree.InsertAfter(nodeA, nodeB)
+
+		tree.Delete(nodeA)
+		tree.Delete(nodeB)
+		tree.Delete(dummyHead)
+
+		assert.Equal(t, 0, tree.Len())
+	})
+
+	t.Run("tombstone and update weight test", func(t *testing.T) {
+		dummyHead := newRemovedNode("dummy")
+		tree := treelist.NewTree(dummyHead)
+
+		nodeA := newNode("A")
+		tree.InsertAfter(dummyHead, nodeA)
+		nodeB := newNode("B")
+		tree.InsertAfter(nodeA, nodeB)
+		nodeC := newNode("C")
+		tree.InsertAfter(nodeB, nodeC)
+		assert.Equal(t, 3, tree.Len())
+
+		// Tombstone B
+		nodeB.Value().removed = true
+		tree.UpdateWeight(nodeB)
+		assert.Equal(t, 2, tree.Len())
+
+		// Find should skip B
+		found, err := tree.Find(0)
+		assert.NoError(t, err)
+		assert.Equal(t, nodeA, found)
+
+		found, err = tree.Find(1)
+		assert.NoError(t, err)
+		assert.Equal(t, nodeC, found)
+
+		_, err = tree.Find(2)
+		assert.Error(t, err)
+	})
+
+	t.Run("multiple tombstones test", func(t *testing.T) {
+		dummyHead := newRemovedNode("dummy")
+		tree := treelist.NewTree(dummyHead)
+
+		nodes := make([]*treelist.Node[*testValue], 6)
+		prev := dummyHead
+		for i := 0; i < 6; i++ {
+			nodes[i] = newNode(fmt.Sprintf("%c", 'A'+i))
+			tree.InsertAfter(prev, nodes[i])
+			prev = nodes[i]
+		}
+		// In-order: dummy, A, B, C, D, E, F
+		assert.Equal(t, 6, tree.Len())
+
+		// Tombstone B, D, F (odd-indexed live nodes)
+		nodes[1].Value().removed = true // B
+		tree.UpdateWeight(nodes[1])
+		nodes[3].Value().removed = true // D
+		tree.UpdateWeight(nodes[3])
+		nodes[5].Value().removed = true // F
+		tree.UpdateWeight(nodes[5])
+		assert.Equal(t, 3, tree.Len())
+
+		// Only A, C, E remain
+		found, err := tree.Find(0)
+		assert.NoError(t, err)
+		assert.Equal(t, nodes[0], found) // A
+
+		found, err = tree.Find(1)
+		assert.NoError(t, err)
+		assert.Equal(t, nodes[2], found) // C
+
+		found, err = tree.Find(2)
+		assert.NoError(t, err)
+		assert.Equal(t, nodes[4], found) // E
+	})
+
+	t.Run("find out of bounds test", func(t *testing.T) {
+		dummyHead := newRemovedNode("dummy")
+		tree := treelist.NewTree(dummyHead)
+
+		_, err := tree.Find(0)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, treelist.ErrOutOfIndex)
+
+		nodeA := newNode("A")
+		tree.InsertAfter(dummyHead, nodeA)
+
+		_, err = tree.Find(-1)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, treelist.ErrOutOfIndex)
+
+		_, err = tree.Find(1)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, treelist.ErrOutOfIndex)
+	})
+
+	t.Run("insert after nil is no-op test", func(t *testing.T) {
+		dummyHead := newRemovedNode("dummy")
+		tree := treelist.NewTree(dummyHead)
+		assert.Equal(t, 0, tree.Len())
+
+		tree.InsertAfter(nil, newNode("A"))
+		assert.Equal(t, 0, tree.Len())
+
+		tree.InsertAfter(dummyHead, nil)
+		assert.Equal(t, 0, tree.Len())
+	})
+
+	t.Run("delete nil is no-op test", func(t *testing.T) {
+		dummyHead := newRemovedNode("dummy")
+		tree := treelist.NewTree(dummyHead)
+		nodeA := newNode("A")
+		tree.InsertAfter(dummyHead, nodeA)
+
+		tree.Delete(nil)
+		assert.Equal(t, 1, tree.Len())
+	})
+
+	t.Run("single live node tree test", func(t *testing.T) {
+		node := newNode("A")
+		tree := treelist.NewTree(node)
+		assert.Equal(t, 1, tree.Len())
+
+		found, err := tree.Find(0)
+		assert.NoError(t, err)
+		assert.Equal(t, node, found)
+
+		tree.Delete(node)
+		assert.Equal(t, 0, tree.Len())
+	})
+
+	t.Run("large sequential insert and find test", func(t *testing.T) {
+		dummyHead := newRemovedNode("dummy")
+		tree := treelist.NewTree(dummyHead)
+
+		const n = 100
+		nodes := make([]*treelist.Node[*testValue], n)
+		prev := dummyHead
+		for i := 0; i < n; i++ {
+			nodes[i] = newNode(fmt.Sprintf("%d", i))
+			tree.InsertAfter(prev, nodes[i])
+			prev = nodes[i]
+		}
+		assert.Equal(t, n, tree.Len())
+
+		// Verify all nodes are findable at correct index
+		for i := 0; i < n; i++ {
+			found, err := tree.Find(i)
+			assert.NoError(t, err)
+			assert.Equal(t, nodes[i], found, "mismatch at index %d", i)
+		}
+	})
+
+	t.Run("large sequential insert, tombstone, and find test", func(t *testing.T) {
+		dummyHead := newRemovedNode("dummy")
+		tree := treelist.NewTree(dummyHead)
+
+		const n = 100
+		nodes := make([]*treelist.Node[*testValue], n)
+		prev := dummyHead
+		for i := 0; i < n; i++ {
+			nodes[i] = newNode(fmt.Sprintf("%d", i))
+			tree.InsertAfter(prev, nodes[i])
+			prev = nodes[i]
+		}
+
+		// Tombstone even-indexed nodes
+		for i := 0; i < n; i += 2 {
+			nodes[i].Value().removed = true
+			tree.UpdateWeight(nodes[i])
+		}
+		assert.Equal(t, n/2, tree.Len())
+
+		// Verify odd-indexed nodes are at correct positions
+		idx := 0
+		for i := 1; i < n; i += 2 {
+			found, err := tree.Find(idx)
+			assert.NoError(t, err)
+			assert.Equal(t, nodes[i], found, "mismatch at logical index %d (node %d)", idx, i)
+			idx++
+		}
+	})
+
+	t.Run("large sequential insert and delete test", func(t *testing.T) {
+		dummyHead := newRemovedNode("dummy")
+		tree := treelist.NewTree(dummyHead)
+
+		const n = 100
+		nodes := make([]*treelist.Node[*testValue], n)
+		prev := dummyHead
+		for i := 0; i < n; i++ {
+			nodes[i] = newNode(fmt.Sprintf("%d", i))
+			tree.InsertAfter(prev, nodes[i])
+			prev = nodes[i]
+		}
+
+		// Delete even-indexed nodes
+		for i := 0; i < n; i += 2 {
+			tree.Delete(nodes[i])
+		}
+		assert.Equal(t, n/2, tree.Len())
+
+		// Verify remaining nodes
+		idx := 0
+		for i := 1; i < n; i += 2 {
+			found, err := tree.Find(idx)
+			assert.NoError(t, err)
+			assert.Equal(t, nodes[i], found, "mismatch at logical index %d (node %d)", idx, i)
+			idx++
+		}
+	})
+
+	t.Run("interleaved insert and delete test", func(t *testing.T) {
+		dummyHead := newRemovedNode("dummy")
+		tree := treelist.NewTree(dummyHead)
+
+		nodeA := newNode("A")
+		tree.InsertAfter(dummyHead, nodeA)
+		nodeB := newNode("B")
+		tree.InsertAfter(nodeA, nodeB)
+		nodeC := newNode("C")
+		tree.InsertAfter(nodeB, nodeC)
+
+		// Delete B, insert D after A (where B was)
+		tree.Delete(nodeB)
+		nodeD := newNode("D")
+		tree.InsertAfter(nodeA, nodeD)
+		assert.Equal(t, 3, tree.Len())
+
+		found, err := tree.Find(0)
+		assert.NoError(t, err)
+		assert.Equal(t, nodeA, found)
+
+		found, err = tree.Find(1)
+		assert.NoError(t, err)
+		assert.Equal(t, nodeD, found)
+
+		found, err = tree.Find(2)
+		assert.NoError(t, err)
+		assert.Equal(t, nodeC, found)
+	})
+
+	t.Run("insert after dummy head with existing nodes test", func(t *testing.T) {
+		dummyHead := newRemovedNode("dummy")
+		tree := treelist.NewTree(dummyHead)
+
+		nodeB := newNode("B")
+		tree.InsertAfter(dummyHead, nodeB)
+		nodeC := newNode("C")
+		tree.InsertAfter(nodeB, nodeC)
+
+		// Insert A right after dummy (before B)
+		nodeA := newNode("A")
+		tree.InsertAfter(dummyHead, nodeA)
+		assert.Equal(t, 3, tree.Len())
+
+		found, err := tree.Find(0)
+		assert.NoError(t, err)
+		assert.Equal(t, nodeA, found)
+
+		found, err = tree.Find(1)
+		assert.NoError(t, err)
+		assert.Equal(t, nodeB, found)
+
+		found, err = tree.Find(2)
+		assert.NoError(t, err)
+		assert.Equal(t, nodeC, found)
+	})
+
+	t.Run("ToTestString test", func(t *testing.T) {
+		dummyHead := newRemovedNode("dummy")
+		tree := treelist.NewTree(dummyHead)
+
+		nodeA := newNode("A")
+		tree.InsertAfter(dummyHead, nodeA)
+		nodeB := newNode("B")
+		tree.InsertAfter(nodeA, nodeB)
+
+		str := tree.ToTestString()
+		assert.Contains(t, str, "dummy")
+		assert.Contains(t, str, "A")
+		assert.Contains(t, str, "B")
+	})
+
+	t.Run("stress test with random operations", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(42)) //nolint:gosec
+		dummyHead := newRemovedNode("dummy")
+		tree := treelist.NewTree(dummyHead)
+
+		// Track live nodes in a slice for reference
+		var liveNodes []*treelist.Node[*testValue]
+		allNodes := []*treelist.Node[*testValue]{dummyHead}
+
+		const ops = 500
+		for i := 0; i < ops; i++ {
+			op := rng.Intn(3)
+
+			switch {
+			case op == 0 || len(allNodes) < 3:
+				// Insert after a random existing node
+				prevIdx := rng.Intn(len(allNodes))
+				prev := allNodes[prevIdx]
+				node := newNode(fmt.Sprintf("n%d", i))
+				tree.InsertAfter(prev, node)
+				allNodes = append(allNodes, node)
+				// Update liveNodes from scratch
+				liveNodes = rebuildLiveList(tree, len(allNodes))
+
+			case op == 1 && len(liveNodes) > 0:
+				// Tombstone a random live node
+				idx := rng.Intn(len(liveNodes))
+				liveNodes[idx].Value().removed = true
+				tree.UpdateWeight(liveNodes[idx])
+				liveNodes = rebuildLiveList(tree, len(allNodes))
+
+			case op == 2 && len(allNodes) > 1:
+				// Delete a random non-dummy node
+				delIdx := 1 + rng.Intn(len(allNodes)-1)
+				tree.Delete(allNodes[delIdx])
+				allNodes = append(allNodes[:delIdx], allNodes[delIdx+1:]...)
+				liveNodes = rebuildLiveList(tree, len(allNodes))
+			}
+
+			// Verify tree length matches live node count
+			assert.Equal(t, len(liveNodes), tree.Len(), "iteration %d", i)
+
+			// Verify all live nodes are findable
+			for j, node := range liveNodes {
+				found, err := tree.Find(j)
+				assert.NoError(t, err, "iteration %d, find index %d", i, j)
+				assert.Equal(t, node, found, "iteration %d, find index %d", i, j)
+			}
+		}
+	})
+}
+
+// rebuildLiveList reconstructs the list of live nodes by using Find.
+func rebuildLiveList(tree *treelist.Tree[*testValue], _ int) []*treelist.Node[*testValue] {
+	var result []*treelist.Node[*testValue]
+	for i := 0; i < tree.Len(); i++ {
+		node, err := tree.Find(i)
+		if err != nil {
+			break
+		}
+		result = append(result, node)
+	}
+	return result
+}

--- a/test/bench/array_bench_test.go
+++ b/test/bench/array_bench_test.go
@@ -1,0 +1,311 @@
+//go:build bench
+
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bench
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/pkg/document/change"
+	"github.com/yorkie-team/yorkie/pkg/document/crdt"
+	"github.com/yorkie-team/yorkie/pkg/document/json"
+	"github.com/yorkie-team/yorkie/pkg/document/time"
+)
+
+// OpType represents the type of array operation.
+type OpType uint8
+
+const (
+	Insert OpType = iota
+	Delete
+	Move
+	Set
+	Get
+)
+
+// newArray creates a json.Array with a minimal change.Context for benchmarking.
+func newArray() *json.Array {
+	root := crdt.NewRoot(crdt.NewObject(crdt.NewElementRHT(), time.InitialTicket))
+	ctx := change.NewContext(change.InitialID(), "", root)
+	return json.NewArray(ctx, crdt.NewArray(crdt.NewRGATreeList(), ctx.IssueTimeTicket()))
+}
+
+// setupBenchArray creates a json.Array pre-populated with `size` integers.
+func setupBenchArray(size int) *json.Array {
+	arr := newArray()
+	for i := range size {
+		arr.AddInteger(i)
+	}
+	return arr
+}
+
+// generateOps creates a deterministic sequence of operations for benchmarking.
+// Distribution: 40% Insert, 20% Delete, 15% Move, 15% Set, 10% Get.
+func generateOps(rng *rand.Rand, count int) []OpType {
+	ops := make([]OpType, count)
+	for i := range ops {
+		r := rng.Intn(100)
+		switch {
+		case r < 40:
+			ops[i] = Insert
+		case r < 60:
+			ops[i] = Delete
+		case r < 75:
+			ops[i] = Move
+		case r < 90:
+			ops[i] = Set
+		default:
+			ops[i] = Get
+		}
+	}
+	return ops
+}
+
+func BenchmarkArray(b *testing.B) {
+	b.Run("sequential insert 10000", func(b *testing.B) {
+		benchmarkArraySequentialInsert(10000, b)
+	})
+	b.Run("sequential insert 100000", func(b *testing.B) {
+		benchmarkArraySequentialInsert(100000, b)
+	})
+	b.Run("random insert 10000", func(b *testing.B) {
+		benchmarkArrayRandomInsert(10000, b)
+	})
+	b.Run("random insert 100000", func(b *testing.B) {
+		benchmarkArrayRandomInsert(100000, b)
+	})
+	b.Run("random delete 10000", func(b *testing.B) {
+		benchmarkArrayRandomDelete(10000, b)
+	})
+	b.Run("random delete 100000", func(b *testing.B) {
+		benchmarkArrayRandomDelete(100000, b)
+	})
+	b.Run("random access 10000", func(b *testing.B) {
+		benchmarkArrayRandomAccess(10000, b)
+	})
+	b.Run("random access 100000", func(b *testing.B) {
+		benchmarkArrayRandomAccess(100000, b)
+	})
+	b.Run("random move 10000", func(b *testing.B) {
+		benchmarkArrayRandomMove(10000, b)
+	})
+	b.Run("random set 10000", func(b *testing.B) {
+		benchmarkArrayRandomSet(10000, b)
+	})
+	b.Run("random set 100000", func(b *testing.B) {
+		benchmarkArrayRandomSet(100000, b)
+	})
+	b.Run("mixed workload 10000", func(b *testing.B) {
+		benchmarkArrayMixedWorkload(10000, b)
+	})
+	b.Run("mixed workload 100000", func(b *testing.B) {
+		benchmarkArrayMixedWorkload(100000, b)
+	})
+	b.Run("heavy delete then insert 50000", func(b *testing.B) {
+		benchmarkArrayHeavyDeleteThenInsert(50000, b)
+	})
+	b.Run("move heavy 10000", func(b *testing.B) {
+		benchmarkArrayMoveHeavy(10000, b)
+	})
+}
+
+func benchmarkArraySequentialInsert(size int, b *testing.B) {
+	for b.Loop() {
+		arr := newArray()
+		for i := range size {
+			arr.AddInteger(i)
+		}
+		assert.Equal(b, size, arr.Len())
+	}
+}
+
+func benchmarkArrayRandomInsert(size int, b *testing.B) {
+	for b.Loop() {
+		rng := rand.New(rand.NewSource(42)) //nolint:gosec
+		arr := newArray()
+		arr.AddInteger(0)
+		for i := 1; i < size; i++ {
+			idx := rng.Intn(arr.Len())
+			arr.InsertIntegerAfter(idx, i)
+		}
+		assert.Equal(b, size, arr.Len())
+	}
+}
+
+func benchmarkArrayRandomDelete(size int, b *testing.B) {
+	for b.Loop() {
+		b.StopTimer()
+		arr := setupBenchArray(size)
+		rng := rand.New(rand.NewSource(42)) //nolint:gosec
+		b.StartTimer()
+
+		for arr.Len() > 0 {
+			idx := rng.Intn(arr.Len())
+			arr.Delete(idx)
+		}
+		assert.Equal(b, 0, arr.Len())
+	}
+}
+
+func benchmarkArrayRandomAccess(size int, b *testing.B) {
+	for b.Loop() {
+		b.StopTimer()
+		arr := setupBenchArray(size)
+		rng := rand.New(rand.NewSource(42)) //nolint:gosec
+		b.StartTimer()
+
+		for range size {
+			idx := rng.Intn(arr.Len())
+			_ = arr.Get(idx)
+		}
+		assert.Equal(b, size, arr.Len())
+	}
+}
+
+func benchmarkArrayRandomMove(size int, b *testing.B) {
+	for b.Loop() {
+		b.StopTimer()
+		arr := setupBenchArray(size)
+		rng := rand.New(rand.NewSource(42)) //nolint:gosec
+		moveCount := size / 2
+		b.StartTimer()
+
+		for range moveCount {
+			n := arr.Len()
+			from := rng.Intn(n)
+			to := rng.Intn(n)
+			for to == from {
+				to = rng.Intn(n)
+			}
+			arr.MoveAfterByIndex(to, from)
+		}
+		assert.Equal(b, size, arr.Len())
+	}
+}
+
+func benchmarkArrayRandomSet(size int, b *testing.B) {
+	for b.Loop() {
+		b.StopTimer()
+		arr := setupBenchArray(size)
+		rng := rand.New(rand.NewSource(42)) //nolint:gosec
+		b.StartTimer()
+
+		for range size {
+			idx := rng.Intn(arr.Len())
+			arr.SetInteger(idx, rng.Int())
+		}
+		assert.Equal(b, size, arr.Len())
+	}
+}
+
+func benchmarkArrayMixedWorkload(size int, b *testing.B) {
+	for b.Loop() {
+		b.StopTimer()
+		arr := setupBenchArray(size)
+		rng := rand.New(rand.NewSource(42)) //nolint:gosec
+		ops := generateOps(rng, size)
+		b.StartTimer()
+
+		for _, op := range ops {
+			n := arr.Len()
+			if n == 0 {
+				arr.AddInteger(rng.Int())
+				continue
+			}
+			switch op {
+			case Insert:
+				idx := rng.Intn(n)
+				arr.InsertIntegerAfter(idx, rng.Int())
+			case Delete:
+				idx := rng.Intn(n)
+				arr.Delete(idx)
+			case Move:
+				if n < 2 {
+					arr.AddInteger(rng.Int())
+					continue
+				}
+				from := rng.Intn(n)
+				to := rng.Intn(n)
+				for to == from {
+					to = rng.Intn(n)
+				}
+				arr.MoveAfterByIndex(to, from)
+			case Set:
+				idx := rng.Intn(n)
+				arr.SetInteger(idx, rng.Int())
+			case Get:
+				idx := rng.Intn(n)
+				_ = arr.Get(idx)
+			}
+		}
+		assert.True(b, arr.Len() > 0)
+	}
+}
+
+func benchmarkArrayHeavyDeleteThenInsert(size int, b *testing.B) {
+	for b.Loop() {
+		b.StopTimer()
+		arr := setupBenchArray(size)
+		rng := rand.New(rand.NewSource(42)) //nolint:gosec
+		b.StartTimer()
+
+		deleteCount := size / 2
+		for range deleteCount {
+			idx := rng.Intn(arr.Len())
+			arr.Delete(idx)
+		}
+		remaining := arr.Len()
+		for range deleteCount {
+			idx := rng.Intn(arr.Len())
+			arr.InsertIntegerAfter(idx, rng.Int())
+		}
+		assert.Equal(b, remaining+deleteCount, arr.Len())
+	}
+}
+
+func benchmarkArrayMoveHeavy(size int, b *testing.B) {
+	for b.Loop() {
+		b.StopTimer()
+		arr := setupBenchArray(size)
+		rng := rand.New(rand.NewSource(42)) //nolint:gosec
+		b.StartTimer()
+
+		for range size {
+			n := arr.Len()
+			targetIdx := rng.Intn(n)
+			target := arr.Get(targetIdx)
+			r := rng.Intn(3)
+			switch r {
+			case 0:
+				arr.MoveFront(target.CreatedAt())
+			case 1:
+				arr.MoveLast(target.CreatedAt())
+			case 2:
+				to := rng.Intn(n)
+				for to == targetIdx {
+					to = rng.Intn(n)
+				}
+				arr.MoveAfterByIndex(to, targetIdx)
+			}
+		}
+		assert.Equal(b, size, arr.Len())
+	}
+}

--- a/test/bench/document_bench_test.go
+++ b/test/bench/document_bench_test.go
@@ -141,22 +141,22 @@ func BenchmarkDocument(b *testing.B) {
 				root.SetNewArray("k1").AddInteger(1).AddInteger(2).AddInteger(3)
 				assert.Equal(b, 3, root.GetArray("k1").Len())
 				assert.Equal(b, `{"k1":[1,2,3]}`, root.Marshal())
-				assert.Equal(b, "[0,0]0[1,1]1[2,1]2[3,1]3", root.GetArray("k1").ToTestString())
+				assert.Equal(b, "[0,0]0[3,1]1[1,1]2[2,1]3", root.GetArray("k1").ToTestString())
 
 				root.GetArray("k1").Delete(1)
 				assert.Equal(b, `{"k1":[1,3]}`, root.Marshal())
 				assert.Equal(b, 2, root.GetArray("k1").Len())
-				assert.Equal(b, "[0,0]0[1,1]1[2,0]2[1,1]3", root.GetArray("k1").ToTestString())
+				assert.Equal(b, "[0,0]0[2,1]1[0,0]2[1,1]3", root.GetArray("k1").ToTestString())
 
 				root.GetArray("k1").InsertIntegerAfter(0, 2)
 				assert.Equal(b, `{"k1":[1,2,3]}`, root.Marshal())
 				assert.Equal(b, 3, root.GetArray("k1").Len())
-				assert.Equal(b, "[0,0]0[1,1]1[3,1]2[1,0]2[1,1]3", root.GetArray("k1").ToTestString())
+				assert.Equal(b, "[0,0]0[2,1]1[1,1]2[3,0]2[1,1]3", root.GetArray("k1").ToTestString())
 
 				root.GetArray("k1").InsertIntegerAfter(2, 4)
 				assert.Equal(b, `{"k1":[1,2,3,4]}`, root.Marshal())
 				assert.Equal(b, 4, root.GetArray("k1").Len())
-				assert.Equal(b, "[0,0]0[1,1]1[2,1]2[2,0]2[3,1]3[4,1]4", root.GetArray("k1").ToTestString())
+				assert.Equal(b, "[0,0]0[2,1]1[1,1]2[4,0]2[1,1]3[2,1]4", root.GetArray("k1").ToTestString())
 
 				for i := range root.GetArray("k1").Len() {
 					assert.Equal(


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
In Json Array, it uses SplayTree for tree structure. It's locality is great, but Array operation is usually random workload unlike Text. So, implementing treelist (llrb with index-based search) for Array will be great.

**Which issue(s) this PR fixes**: 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #980  

**Special notes for your reviewer**:
Here is the `Json.Array` and `Document.Update` benchmark comparison between Before (SplayTree) and After (TreeList) with an in-depth analysis of the execution time (ns/op) differences.

Benchmark Category | Workload | Before: SplayTree (ns/op) | After: TreeList (ns/op) | Performance Delta | Result
-- | -- | -- | -- | -- | --
Array | sequential_insert_10000 | 4,747,789 | 6,343,121 | -33.6% | 🔻 Slower
Array | sequential_insert_100000 | 51,334,977 | 69,058,875 | -34.5% | 🔻 Slower
Array | random_insert_10000 | 11,173,106 | 9,374,565 | +16.1% | ✅ Faster
Array | random_insert_100000 | 173,668,646 | 144,012,815 | +17.1% | ✅ Faster
Array | random_delete_10000 | 8,534,321 | 5,105,108 | +40.2% | ✅ Faster
Array | random_delete_100000 | 145,310,340 | 117,300,292 | +19.3% | ✅ Faster
Array | random_access_10000 | 5,335,426 | 1,611,727 | +69.8% | 🚀 Excellent
Array | random_access_100000 | 83,197,000 | 39,124,542 | +53.0% | 🚀 Excellent
Array | random_move_10000 | 8,945,756 | 7,246,307 | +19.0% | ✅ Faster
Array | random_set_10000 | 15,645,432 | 11,500,425 | +26.5% | ✅ Faster
Array | random_set_100000 | 267,809,635 | 201,791,125 | +24.7% | ✅ Faster
Array | mixed_workload_10000 | 14,444,686 | 10,611,689 | +26.5% | ✅ Faster
Array | mixed_workload_100000 | 244,393,558 | 181,858,347 | +25.6% | ✅ Faster
Array | heavy_delete_then_insert_50000 | 78,244,911 | 58,025,077 | +25.8% | ✅ Faster
Array | move_heavy_10000 | 14,672,739 | 13,845,337 | +5.6% | ✅ Faster
Document | array_test | 16,727 | 16,620 | +0.6% | ➖ Neutral
Document | array_1000 | 712,538 | 931,809 | -30.8% | 🔻 Slower
Document | array_10000 | 7,079,611 | 10,008,653 | -41.4% | 🔻 Slower
Document | array_gc_100 | 78,739 | 95,600 | -21.4% | 🔻 Slower
Document | array_gc_1000 | 835,801 | 1,038,336 | -24.2% | 🔻 Slower

As we can expect, random workload is faster in `TreeList`, sequential insert is faster in `SplayTree`. Document tests are all sequential operations except `array_test`.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new ordered index structure with tombstone-aware indexing for efficient indexed lookups, insertion and deletion; integrated as the index tree for the array/sequence CRDT.

* **Breaking / API**
  * Exposed removal predicate renamed and a previously-unused length helper removed to align with tombstone semantics.

* **Bug Fixes**
  * Array element iteration now properly filters out removed entries.

* **Tests**
  * Added comprehensive unit tests and a randomized stress test for the new index structure.
  * Added and updated benchmarks to reflect new internal ordering and test-string formatting.

* **Docs**
  * Updated design docs to describe the new index/tree components and rationale.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yorkie-team/yorkie/pull/1685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->