### PR TITLE
Add StyleByPath and RemoveStyleByPath for Tree

### DIFF
--- a/docs/design/tree.md
+++ b/docs/design/tree.md
@@ -17,7 +17,7 @@ This document aims to help new SDK contributors understand the overall `Tree` da
 
 ### Non-Goals
 
-This document focuses on `Tree.Edit` operations rather than `Tree.Style`.
+This document does not cover the internal CRDT conflict resolution of `Tree.Style`, which follows the same coordinate system as `Tree.Edit`.
 
 ## Proposal Details
 
@@ -58,6 +58,31 @@ https://github.com/yorkie-team/yorkie/blob/fd3b15c7d2c482464b6c8470339bcc4972041
 Users can use the `Style` operation to specify attributes for the element nodes in the `Tree`.
 
 https://github.com/yorkie-team/yorkie/blob/fd3b15c7d2c482464b6c8470339bcc497204114e/pkg/document/json/tree.go#L239-L268
+
+Similarly, users can specify the styling range using a `path` with `StyleByPath` and `RemoveStyleByPath`:
+
+```go
+// StyleByPath sets attributes on element nodes in the given path range.
+func (t *Tree) StyleByPath(fromPath []int, toPath []int, attributes map[string]string) bool
+
+// RemoveStyleByPath removes attributes from element nodes in the given path range.
+func (t *Tree) RemoveStyleByPath(fromPath []int, toPath []int, attributesToRemove []string) bool
+```
+
+These follow the same pattern as `EditByPath`: convert two paths to CRDT positions via `PathToPos`, then delegate to the existing CRDT `Style`/`RemoveStyle` operations. The CRDT layer is unchanged — only the JSON layer gains path-based entry points.
+
+Note that `Style` applies attributes to **element nodes only**. Text nodes in the range are traversed but not styled (`canStyle` returns false for text nodes). This is the same behavior for both index-based and path-based variants.
+
+In the JS SDK, `styleByPath` is overloaded to support both single-path (existing) and range (new) signatures:
+
+```typescript
+// Single element (existing, backward-compatible)
+styleByPath(path: Array<number>, attributes: { [key: string]: any }): void;
+// Range (new)
+styleByPath(fromPath: Array<number>, toPath: Array<number>, attributes: { [key: string]: any }): void;
+```
+
+`removeStyleByPath` is new in both SDKs and only has the range signature.
 
 ### Implementation of Edit Operation
 

--- a/docs/tasks/active/20260402-style-by-path-range-lessons.md
+++ b/docs/tasks/active/20260402-style-by-path-range-lessons.md
@@ -1,0 +1,5 @@
+**Created**: 2026-04-02
+
+# Lessons: range-based StyleByPath and RemoveStyleByPath
+
+(Record lessons learned during implementation here)

--- a/docs/tasks/active/20260402-style-by-path-range-todo.md
+++ b/docs/tasks/active/20260402-style-by-path-range-todo.md
@@ -1,0 +1,27 @@
+**Created**: 2026-04-02
+
+# Add range-based StyleByPath and RemoveStyleByPath
+
+Related issue: https://github.com/yorkie-team/yorkie-js-sdk/issues/1197
+
+## Summary
+
+Add range signatures to `styleByPath` (JS) / `StyleByPath` (Go). The CRDT layer
+is unchanged — the JSON layer converts paths to positions via `PathToPos` and
+delegates to the existing `Style`/`RemoveStyle` operations.
+
+## Go SDK
+
+- [ ] Add `StyleByPath(fromPath, toPath, attributes)` to `pkg/document/json/tree.go`
+- [ ] Add `RemoveStyleByPath(fromPath, toPath, attributesToRemove)` to the same file
+- [ ] Add integration tests in `test/integration/tree_test.go`
+- [ ] Verify `make lint && make test` passes
+
+## JS SDK
+
+- [ ] Overload `styleByPath`: support both `(path, attrs)` and `(fromPath, toPath, attrs)`
+      in `packages/sdk/src/document/json/tree.ts`
+- [ ] Add `removeStyleByPath(fromPath, toPath, keys)` to the same file
+- [ ] Add integration tests in `packages/sdk/test/integration/tree_test.ts`
+- [ ] Verify existing single-path `styleByPath` tests still pass
+- [ ] Verify `pnpm lint && pnpm sdk build && pnpm sdk test` passes

--- a/docs/tasks/active/README.md
+++ b/docs/tasks/active/README.md
@@ -1,7 +1,7 @@
 ---
-updated: 2026-03-27
+updated: 2026-04-02
 ---
 
 # Active Tasks
 
-(none)
+- [StyleByPath range support](20260402-style-by-path-range-todo.md) — Add range-based StyleByPath and RemoveStyleByPath to Go/JS SDK

--- a/pkg/document/json/tree.go
+++ b/pkg/document/json/tree.go
@@ -270,6 +270,99 @@ func (t *Tree) RemoveStyle(fromIdx, toIdx int, attributesToRemove []string) bool
 	return true
 }
 
+// StyleByPath sets the attributes to the elements of the given path range.
+func (t *Tree) StyleByPath(fromPath []int, toPath []int, attributes map[string]string) bool {
+	if len(fromPath) != len(toPath) {
+		panic(ErrPathLenDiff)
+	}
+
+	if len(fromPath) == 0 || len(toPath) == 0 {
+		panic(ErrEmptyPath)
+	}
+
+	if len(attributes) == 0 {
+		return true
+	}
+
+	fromPos, err := t.Tree.PathToPos(fromPath)
+	if err != nil {
+		panic(err)
+	}
+	toPos, err := t.Tree.PathToPos(toPath)
+	if err != nil {
+		panic(err)
+	}
+
+	ticket := t.context.IssueTimeTicket()
+	pairs, diff, err := t.Tree.Style(fromPos, toPos, attributes, ticket, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, pair := range pairs {
+		t.context.RegisterGCPair(pair)
+		t.context.AdjustDiffForGCPair(&diff, pair)
+	}
+
+	t.context.Acc(diff)
+
+	t.context.Push(operations.NewTreeStyle(
+		t.CreatedAt(),
+		fromPos,
+		toPos,
+		attributes,
+		ticket,
+	))
+
+	return true
+}
+
+// RemoveStyleByPath removes the attributes from the elements of the given path range.
+func (t *Tree) RemoveStyleByPath(fromPath []int, toPath []int, attributesToRemove []string) bool {
+	if len(fromPath) != len(toPath) {
+		panic(ErrPathLenDiff)
+	}
+
+	if len(fromPath) == 0 || len(toPath) == 0 {
+		panic(ErrEmptyPath)
+	}
+
+	if len(attributesToRemove) == 0 {
+		return true
+	}
+
+	fromPos, err := t.Tree.PathToPos(fromPath)
+	if err != nil {
+		panic(err)
+	}
+	toPos, err := t.Tree.PathToPos(toPath)
+	if err != nil {
+		panic(err)
+	}
+
+	ticket := t.context.IssueTimeTicket()
+	pairs, diff, err := t.Tree.RemoveStyle(fromPos, toPos, attributesToRemove, ticket, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	t.context.Acc(diff)
+
+	for _, pair := range pairs {
+		t.context.RegisterGCPair(pair)
+	}
+
+	t.context.Push(operations.NewTreeStyleRemove(
+		t.CreatedAt(),
+		fromPos,
+		toPos,
+		attributesToRemove,
+		ticket,
+	))
+
+	return true
+}
+
 // Len returns the length of this tree.
 func (t *Tree) Len() int {
 	return t.IndexTree.Root().Len()

--- a/test/integration/tree_test.go
+++ b/test/integration/tree_test.go
@@ -873,6 +873,150 @@ func TestTree(t *testing.T) {
 		assert.Equal(t, `{"type":"root","children":[{"type":"p","children":[{"type":"text","value":"ab"}]},{"type":"p","children":[{"type":"text","value":"cd"}]}]}`, doc.Root().GetTree("t").Marshal())
 	})
 
+	t.Run("style by path test", func(t *testing.T) {
+		doc := document.New(helper.TestKey(t))
+
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewTree("t", json.TreeNode{
+				Type: "root",
+				Children: []json.TreeNode{
+					{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "ab"}}},
+					{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "cd"}}},
+				},
+			})
+			return nil
+		}))
+		assert.Equal(t, `<root><p>ab</p><p>cd</p></root>`, doc.Root().GetTree("t").ToXML())
+
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetTree("t").StyleByPath([]int{0}, []int{1}, map[string]string{"bold": "true"})
+			return nil
+		}))
+		assert.Equal(t, `<root><p bold="true">ab</p><p>cd</p></root>`, doc.Root().GetTree("t").ToXML())
+	})
+
+	t.Run("remove style by path test", func(t *testing.T) {
+		doc := document.New(helper.TestKey(t))
+
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewTree("t", json.TreeNode{
+				Type: "root",
+				Children: []json.TreeNode{
+					{Type: "p", Attributes: map[string]string{"bold": "true"}, Children: []json.TreeNode{{Type: "text", Value: "ab"}}},
+					{Type: "p", Attributes: map[string]string{"italic": "true"}, Children: []json.TreeNode{{Type: "text", Value: "cd"}}},
+				},
+			})
+			return nil
+		}))
+		assert.Equal(t, `<root><p bold="true">ab</p><p italic="true">cd</p></root>`, doc.Root().GetTree("t").ToXML())
+
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetTree("t").RemoveStyleByPath([]int{0}, []int{1}, []string{"bold"})
+			return nil
+		}))
+		assert.Equal(t, `<root><p>ab</p><p italic="true">cd</p></root>`, doc.Root().GetTree("t").ToXML())
+	})
+
+	t.Run("multi-element style by path test", func(t *testing.T) {
+		doc := document.New(helper.TestKey(t))
+
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewTree("t", json.TreeNode{
+				Type: "root",
+				Children: []json.TreeNode{
+					{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "ab"}}},
+					{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "cd"}}},
+				},
+			})
+			return nil
+		}))
+		assert.Equal(t, `<root><p>ab</p><p>cd</p></root>`, doc.Root().GetTree("t").ToXML())
+
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetTree("t").StyleByPath([]int{0}, []int{2}, map[string]string{"bold": "true"})
+			return nil
+		}))
+		assert.Equal(t, `<root><p bold="true">ab</p><p bold="true">cd</p></root>`, doc.Root().GetTree("t").ToXML())
+	})
+
+	t.Run("multi-element remove style by path test", func(t *testing.T) {
+		doc := document.New(helper.TestKey(t))
+
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewTree("t", json.TreeNode{
+				Type: "root",
+				Children: []json.TreeNode{
+					{Type: "p", Attributes: map[string]string{"bold": "true"}, Children: []json.TreeNode{{Type: "text", Value: "ab"}}},
+					{Type: "p", Attributes: map[string]string{"bold": "true"}, Children: []json.TreeNode{{Type: "text", Value: "cd"}}},
+				},
+			})
+			return nil
+		}))
+		assert.Equal(t, `<root><p bold="true">ab</p><p bold="true">cd</p></root>`, doc.Root().GetTree("t").ToXML())
+
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetTree("t").RemoveStyleByPath([]int{0}, []int{2}, []string{"bold"})
+			return nil
+		}))
+		assert.Equal(t, `<root><p>ab</p><p>cd</p></root>`, doc.Root().GetTree("t").ToXML())
+	})
+
+	t.Run("style by path with mismatched path lengths", func(t *testing.T) {
+		doc := document.New(helper.TestKey(t))
+
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewTree("t", json.TreeNode{
+				Type: "root",
+				Children: []json.TreeNode{
+					{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "ab"}}},
+				},
+			})
+			return nil
+		}))
+
+		assert.Panics(t, func() {
+			assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+				root.GetTree("t").StyleByPath([]int{0}, []int{0, 1}, map[string]string{"bold": "true"})
+				return nil
+			}))
+		})
+
+		assert.Panics(t, func() {
+			assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+				root.GetTree("t").RemoveStyleByPath([]int{0}, []int{0, 1}, []string{"bold"})
+				return nil
+			}))
+		})
+	})
+
+	t.Run("style by path with empty paths", func(t *testing.T) {
+		doc := document.New(helper.TestKey(t))
+
+		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewTree("t", json.TreeNode{
+				Type: "root",
+				Children: []json.TreeNode{
+					{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "ab"}}},
+				},
+			})
+			return nil
+		}))
+
+		assert.Panics(t, func() {
+			assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+				root.GetTree("t").StyleByPath([]int{}, []int{}, map[string]string{"bold": "true"})
+				return nil
+			}))
+		})
+
+		assert.Panics(t, func() {
+			assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+				root.GetTree("t").RemoveStyleByPath([]int{}, []int{}, []string{"bold"})
+				return nil
+			}))
+		})
+	})
+
 	// Concurrent editing, overlapping range test
 	t.Run("concurrently delete overlapping elements test", func(t *testing.T) {
 		ctx := context.Background()


### PR DESCRIPTION
## Summary

- Add `StyleByPath(fromPath, toPath, attributes)` to set attributes on element nodes in a path range
- Add `RemoveStyleByPath(fromPath, toPath, attributesToRemove)` to remove attributes from element nodes in a path range
- Both follow the `EditByPath` pattern: convert paths to CRDT positions via `PathToPos`, then delegate to existing `Style`/`RemoveStyle` operations
- CRDT layer is unchanged — only the JSON layer gains path-based entry points

Related issue: https://github.com/yorkie-team/yorkie-js-sdk/issues/1197

## Test plan

- [x] Single-element `StyleByPath` test
- [x] Single-element `RemoveStyleByPath` test
- [x] Multi-element range `StyleByPath` test
- [x] Multi-element range `RemoveStyleByPath` test
- [x] Error case: mismatched path lengths
- [x] Error case: empty paths
- [x] `go build` and `go vet` pass
- [x] Unit tests pass (`go test ./pkg/document/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `StyleByPath` and `RemoveStyleByPath` methods to the Tree API for path-based styling
  * Support for both single-path and range-based styling operations

* **Documentation**
  * Updated Tree API documentation with path-based styling specifications and behavior constraints
  * Added implementation roadmap for SDK enhancements

* **Tests**
  * Added integration tests for path-based styling operations and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->