### PR TITLE
Fix split + delete divergence by skipping merge for concurrent elements

### DIFF
--- a/docs/design/concurrent-merge-split.md
+++ b/docs/design/concurrent-merge-split.md
@@ -99,7 +99,7 @@ All 27 cases from `tree.md` converge:
 | Contained | split + insert (into split node) | ✅ | existing |
 | Contained | split + insert (at split position) | ✅ | existing |
 | Contained | split + delete contents | ✅ | existing |
-| **Overlapping** | **split + delete (overlapping text)** | ❌ | see Remaining Issues |
+| Overlapping | split + delete (overlapping text) | ✅ | concurrent element merge skip (Fix 9) |
 | Contained | split + delete whole | ✅ | InsNextID cascade delete |
 | Contained | split + split (different levels) | ✅ | split sibling forwarding (Fix 7) |
 | Contained | multi-level split + cross-boundary merge | ✅ | SplitElement merge-moved children skip (Fix 8) |
@@ -121,9 +121,9 @@ All 27 cases from `tree.md` converge:
 |----------|-------|-------------|--------------|
 | Basic Edit + Edit | 27 | 27 | 0 |
 | Merge | 12 | 12 | 0 |
-| Split | 14 | 13 | 1 |
+| Split | 14 | 14 | 0 |
 | Style | 10 | 10 | 0 |
-| **Total** | **63** | **62** | **1** |
+| **Total** | **63** | **63** | **0** |
 
 ## Design
 
@@ -259,6 +259,62 @@ d2 (merge → split): merge moves "cd" to outer_p, sets mergedFrom.
 Both: <root><p>cd</p><p></p></root> ✅
 ```
 
+### Fix 9: Skip merge for concurrent elements
+
+**Location**: `CRDTTree.collectBetween`
+
+When a delete range crosses into an element that was created by a concurrent
+operation (not covered by the editor's version vector), the delete should not
+trigger a merge. The element boundary was unknown to the editor, so the range
+crossing is an artifact of the concurrent split, not an intentional merge.
+
+In `collectBetween`, at the merge detection point (`Start && !ended`), check
+whether the element's `CreatedAt` is covered by the editor's version vector.
+If not, skip adding it to `toBeMergedNodes` and `toBeMovedToFromParents`.
+Text content inside the concurrent element is still tombstoned individually
+via the existing `canDelete` check.
+
+**Convergence proof**:
+
+```text
+Initial: <root><p>abcd</p></root>
+d1: Edit(2,4,nil,0) — delete "bc"
+d2: Edit(3,3,nil,1) — split at b|c with splitLevel=1
+
+d1 (delete → split): "bc" tombstoned. d2 split resolves at tombstone
+  boundary, SplitElement partitions ["a",†"b"] | [†"c","d"].
+  Result: <p>a</p><p>d</p>.
+
+d2 (split → delete): split creates <p>ab</p><p'>cd</p'>.
+  d1 delete: collectBetween(p,"a" → p',"c").
+  p' Start: p'.CreatedAt not in d1's VV → skip merge.
+  "b" canDelete → tombstoned. "c" canDelete → tombstoned.
+  "d" outside range → survives in p'.
+  Result: <p>a</p><p>d</p>.
+
+Both: <root><p>a</p><p>d</p></root> ✅
+```
+
+Intentional merges are unaffected: the target element existed when the editor
+created the operation, so its `CreatedAt` is always covered by the editor's
+version vector.
+
+### Fix 10: JS splitElement preserves tombstoned children
+
+**Location**: `IndexTreeNode.splitElement` in `index_tree.ts`
+
+The `children` getter filters out removed nodes. `splitElement` used this
+getter to partition children, then reassigned `_children` from the filtered
+result. Tombstoned children were silently dropped from the tree structure.
+
+**Fix**: Use `_children` (raw array) instead of `children` (filtered getter)
+in `splitElement`. This matches Go's `Children(true)` behavior and preserves
+tombstoned children across splits.
+
+Additionally fixed `clone.visibleSize` calculation: was using
+`paddedSize(true)` (total) instead of `paddedSize()` (visible), diverging
+from Go's `PaddedLength()` usage for visible length.
+
 ### Risks and Mitigation
 
 | Risk | Mitigation |
@@ -269,6 +325,8 @@ Both: <root><p>cd</p><p></p></root> ✅
 | Fix 5 propagation deletes too much | Skip when mergedInto == fromParent (concurrent merge, not delete) |
 | Fix 7 advances past known siblings | Version vector check ensures only unknown siblings are skipped. `leftNode == parent` guard preserves leftmost-child semantics |
 | Fix 8 skips too many children | Only children with `mergedFrom` set are skipped. `mergedFrom` is only set during merge, so normal children are unaffected |
+| Fix 9 skips merge for known elements | Only elements whose CreatedAt is not covered by editor's VV are skipped. Intentional merges target elements the editor knew about |
+| Fix 10 changes splitElement child visibility | Uses raw `_children` array matching Go's `Children(true)`. Tombstoned children were already invisible in toXML output |
 
 ### Design Decisions
 
@@ -281,58 +339,12 @@ Both: <root><p>cd</p><p></p></root> ✅
 | No undo/redo in scope | Consistent with undo-redo.md Phase 2 deferral |
 | Runtime-only `mergedFrom` on child nodes | Same pattern as `mergedInto`/`mergedChildIDs`. No protobuf change needed |
 | Skip in SplitElement rather than post-reconciliation | Filtering during partition is simpler and preserves child ordering naturally |
+| VV check in collectBetween for Fix 9 | Same pattern as other fixes. Cleanly distinguishes intentional merge (editor knew the element) from accidental boundary crossing (concurrent split) |
+| Fix split position resolution instead of merge skip (Fix 9 alt) | Changing offset semantics in FindTreeNodesWithSplitText affects all text operations. collectBetween-level fix is more isolated |
 
 ## Remaining Issues
 
-### Split + delete on overlapping text content
-
-**Test**: `split-with-concurrent-delete-overlapping-content`
-
-When one client deletes text and another concurrently splits the same
-paragraph at a position inside the deleted range, the replicas diverge.
-
-**Scenario**:
-```text
-Initial: <root><p>abcd</p></root>
-d1: Edit(2,4,nil,0) — delete "bc"
-d2: Edit(3,3,nil,1) — split at b|c with splitLevel=1
-```
-
-**Root cause**: The split position (between 'b' and 'c') resolves inside
-tombstoned content on the replica that applied the delete first. The
-position resolution and offset calculation produce different structural
-splits depending on operation order:
-
-| Replica | Delete first? | Result |
-|---------|--------------|--------|
-| d1 | ✅ yes | `<root><p>a</p><p>d</p></root>` |
-| d2 | ❌ no | `<root><p>ad</p><p></p></root>` |
-
-### JS SDK: splitElement drops tombstoned children
-
-**Location**: `IndexTreeNode.splitElement` in `index_tree.ts`
-
-The `children` getter (line 323) filters out removed nodes:
-```typescript
-get children(): Array<T> {
-  return this._children.filter((child) => !child.isRemoved);
-}
-```
-
-`splitElement` uses this getter to partition children, then reassigns
-`_children` from the filtered result. Tombstoned children are silently
-dropped from the tree structure. In Go, `Children(true)` includes removed
-nodes so they survive the split.
-
-This does not cause visible divergence (tombstoned nodes are invisible in
-`toXML()`), but it can affect:
-- GC bookkeeping: orphaned tombstones cannot be collected
-- Subsequent operations that reference tombstoned nodes by ID
-- Tree size/index calculations
-
-**Fix approach**: Use `_children` (raw array) instead of `children` (filtered
-getter) in `splitElement`, and compute the split offset against the full
-child list including removed nodes.
+All 63 convergence cases now pass. No remaining convergence issues.
 
 ## Alternatives Considered
 
@@ -348,3 +360,6 @@ child list including removed nodes.
 | Merge redirects to split sibling (Fix 8 alt) | Merge would need structural awareness of splits. Direction ambiguous when multiple siblings exist |
 | Deterministic container selection (Fix 8 alt) | Requires generic comparison rule that interacts with all other fixes. Broad change surface |
 | Post-split reconciliation (move children back) | Error-prone ordering, harder to reason about than filtering during partition |
+| Fix split position resolution for overlapping delete (Fix 9 alt) | Changing offset semantics in SplitText/FindTreeNodesWithSplitText affects all text operations. Broad change surface with high regression risk |
+| Post-reconciliation for split boundaries (Fix 9 alt) | Does not fit the operation-based model. Complex correctness proof |
+| JS splitElement with visible-to-all offset conversion (Fix 10 alt) | Adds complexity without benefit. Go uses same visible offset with Children(true) and passes all tests |

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -1110,6 +1110,20 @@ func (t *Tree) propagateMergeDeletes(
 	return pairs
 }
 
+// ticketKnown returns true if the given ticket is causally known to the
+// editor, i.e. the editor's version vector covers the ticket's lamport
+// clock for the same actor. For local operations (empty version vector),
+// all tickets are considered known.
+func ticketKnown(vv time.VersionVector, ticket *time.Ticket) bool {
+	if len(vv) == 0 {
+		return true
+	}
+	if l, ok := vv.Get(ticket.ActorID()); ok && l >= ticket.Lamport() {
+		return true
+	}
+	return false
+}
+
 // collectBetween collects nodes that are marked as removed or moved.
 func (t *Tree) collectBetween(
 	fromParent *TreeNode, fromLeft *TreeNode,
@@ -1145,17 +1159,7 @@ func (t *Tree) collectBetween(
 				// operations. The editor didn't know about this element,
 				// so crossing into it is an artifact of a concurrent split,
 				// not an intentional merge.
-				isLocal := len(versionVector) == 0
-				elementKnown := false
-				if isLocal {
-					elementKnown = true
-				} else if l, ok := versionVector.Get(
-					node.id.CreatedAt.ActorID(),
-				); ok && l >= node.id.CreatedAt.Lamport() {
-					elementKnown = true
-				}
-
-				if elementKnown {
+				if ticketKnown(versionVector, node.id.CreatedAt) {
 					toBeMergedNodes = append(toBeMergedNodes, node)
 					for _, child := range node.Index.Children() {
 						toBeMovedToFromParents = append(toBeMovedToFromParents, child.Value)
@@ -1164,23 +1168,10 @@ func (t *Tree) collectBetween(
 			}
 
 			// NOTE(sigmaith): Determine if the node's creation event was visible.
-			isLocal := len(versionVector) == 0
-			creationKnown := false
-			if isLocal {
-				creationKnown = true
-			} else if l, ok := versionVector.Get(node.id.CreatedAt.ActorID()); ok && l >= node.id.CreatedAt.Lamport() {
-				creationKnown = true
-			}
+			creationKnown := ticketKnown(versionVector, node.id.CreatedAt)
 
 			// NOTE(sigmaith): Determine if existing tombstone was already causally known.
-			tombstoneKnown := false
-			if node.removedAt != nil {
-				if isLocal {
-					tombstoneKnown = true
-				} else if l, ok := versionVector.Get(node.removedAt.ActorID()); ok && l >= node.removedAt.Lamport() {
-					tombstoneKnown = true
-				}
-			}
+			tombstoneKnown := node.removedAt != nil && ticketKnown(versionVector, node.removedAt)
 
 			// NOTE(sejongk): If the node is removable or its parent is going to
 			// be removed, then this node should be removed.
@@ -1206,15 +1197,7 @@ func (t *Tree) collectBetween(
 						!slices.Contains(toBeMergedNodes, node) {
 						next := t.findFloorNode(node.InsNextID)
 						for next != nil {
-							splitCreationKnown := false
-							if isLocal {
-								splitCreationKnown = true
-							} else if l, ok := versionVector.Get(
-								next.ID().CreatedAt.ActorID(),
-							); ok && l >= next.ID().CreatedAt.Lamport() {
-								splitCreationKnown = true
-							}
-							if !splitCreationKnown {
+							if !ticketKnown(versionVector, next.ID().CreatedAt) {
 								toBeRemoveds = append(toBeRemoveds, next)
 								// Cascade through the full subtree, not just immediate children.
 								index.TraverseNode(next.Index, func(n *index.Node[*TreeNode], _ int) {

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -1141,9 +1141,25 @@ func (t *Tree) collectBetween(
 				// 	return
 				// }
 
-				toBeMergedNodes = append(toBeMergedNodes, node)
-				for _, child := range node.Index.Children() {
-					toBeMovedToFromParents = append(toBeMovedToFromParents, child.Value)
+				// Fix 9: Skip merge for elements created by concurrent
+				// operations. The editor didn't know about this element,
+				// so crossing into it is an artifact of a concurrent split,
+				// not an intentional merge.
+				isLocal := len(versionVector) == 0
+				elementKnown := false
+				if isLocal {
+					elementKnown = true
+				} else if l, ok := versionVector.Get(
+					node.id.CreatedAt.ActorID(),
+				); ok && l >= node.id.CreatedAt.Lamport() {
+					elementKnown = true
+				}
+
+				if elementKnown {
+					toBeMergedNodes = append(toBeMergedNodes, node)
+					for _, child := range node.Index.Children() {
+						toBeMovedToFromParents = append(toBeMovedToFromParents, child.Value)
+					}
 				}
 			}
 

--- a/test/integration/tree_test.go
+++ b/test/integration/tree_test.go
@@ -2983,7 +2983,7 @@ func TestTree(t *testing.T) {
 	// This structural difference could cause issues with GC and subsequent
 	// operations that reference tombstoned nodes by ID.
 	t.Run("split-with-concurrent-delete-overlapping-content", func(t *testing.T) {
-		t.Skip("TODO(hackerwins): fix concurrent delete + split convergence on overlapping content")
+		// Fixed by Fix 9: skip merge for concurrent elements in collectBetween.
 		ctx := context.Background()
 		d1 := document.New(helper.TestKey(t))
 		assert.NoError(t, c1.Attach(ctx, d1))
@@ -3018,6 +3018,7 @@ func TestTree(t *testing.T) {
 		assert.Equal(t, "<root><p>ab</p><p>cd</p></root>", d2.Root().GetTree("t").ToXML())
 
 		syncClientsThenAssertEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
+		assert.Equal(t, "<root><p>a</p><p>d</p></root>", d1.Root().GetTree("t").ToXML())
 	})
 
 	// Issue B: merge with concurrent delete of content inside merge source.


### PR DESCRIPTION
## Summary

- Add version vector check in `collectBetween` merge detection: when a delete range crosses into an element created by a concurrent split, skip merge behavior (Fix 9)
- The editor never intended to merge paragraphs — the boundary crossing is an artifact of the concurrent split
- Resolves the last remaining convergence case: 63/63 in the coverage table
- Update design doc with Fix 9/10 descriptions, mark all cases resolved

## What changed

- `pkg/document/crdt/tree.go`: VV check at `Start && !ended` merge detection point in `collectBetween`
- `test/integration/tree_test.go`: Enable `split-with-concurrent-delete-overlapping-content` test, add post-sync XML assertion
- `docs/design/concurrent-merge-split.md`: Add Fix 9/10, update convergence table to 63/63

## Test plan

- [x] `split-with-concurrent-delete-overlapping-content` integration test passes (was skipped)
- [x] All 102 tree integration tests pass (101 + 1 newly enabled)
- [x] Build passes
- [x] CI: complex-test, load-test, bench

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved converging failures for split+delete overlapping cases so all tree-edit convergence cases now pass.

* **Documentation**
  * Updated design doc with the fixes' behavior, risks, mitigations, and alternatives; removed previous "Remaining Issues" entries.

* **Tests**
  * Re-enabled and expanded the integration test for concurrent split with delete, asserting full convergence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->