### PR TITLE
Fix tree divergence on concurrent split inside merge range

### DIFF
--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -413,22 +413,30 @@ func (n *TreeNode) SplitElement(
 	leftChildren := allChildren[0:offset]
 	rightChildren := allChildren[offset:]
 
-	// Fix 8: Keep merge-moved children in the original node when the
-	// merge is concurrent and the split boundary is not itself within
-	// merged content. If the boundary node (last left child) has
-	// mergedFrom, the split is operating within merged content and
-	// all children should move normally.
-	boundaryIsMerged := len(leftChildren) > 0 &&
-		leftChildren[len(leftChildren)-1].Value.mergedFrom != nil
+	// Fix 8: Handle concurrent merge-moved children during split.
+	// When a child was merge-moved from a source that is itself a child
+	// of the node being split, the content was local to this level and
+	// should stay in the original (left) node. When the source is
+	// external (e.g., a sibling element that was merged), the content
+	// should flow naturally to the split (right) node.
 	var actualRight []*index.Node[*TreeNode]
 	for _, child := range rightChildren {
-		if !boundaryIsMerged &&
-			child.Value.mergedFrom != nil && child.Value.mergedAt != nil &&
+		if child.Value.mergedFrom != nil && child.Value.mergedAt != nil &&
 			len(versionVector) > 0 {
 			actorID := child.Value.mergedAt.ActorID()
 			if l, ok := versionVector.Get(actorID); !ok || l < child.Value.mergedAt.Lamport() {
-				leftChildren = append(leftChildren, child)
-				continue
+				// Check if the merge source is a child of this node.
+				sourceIsChild := false
+				for _, sibling := range allChildren {
+					if sibling.Value.id.Equal(child.Value.mergedFrom) {
+						sourceIsChild = true
+						break
+					}
+				}
+				if sourceIsChild {
+					leftChildren = append(leftChildren, child)
+					continue
+				}
 			}
 		}
 		actualRight = append(actualRight, child)

--- a/test/integration/tree_test.go
+++ b/test/integration/tree_test.go
@@ -2123,6 +2123,51 @@ func TestTree(t *testing.T) {
 		assert.Equal(t, "<root><p>ab</p><p>c</p></root>", d1.Root().GetTree("t").ToXML())
 	})
 
+	t.Run("contained-split-and-merge-same-block", func(t *testing.T) {
+		// Regression test for https://github.com/yorkie-team/yorkie/issues/1726
+		// When one client splits inside a block that the other client merges,
+		// replicas must converge.
+		ctx := context.Background()
+		d1 := document.New(helper.TestKey(t))
+		assert.NoError(t, c1.Attach(ctx, d1))
+		d2 := document.New(helper.TestKey(t))
+		assert.NoError(t, c2.Attach(ctx, d2))
+
+		assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewTree("t", json.TreeNode{
+				Type: "root",
+				Children: []json.TreeNode{{
+					Type:     "p",
+					Children: []json.TreeNode{{Type: "text", Value: "ab"}},
+				}, {
+					Type:     "p",
+					Children: []json.TreeNode{{Type: "text", Value: "cd"}},
+				}},
+			})
+			return nil
+		}))
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+		assert.Equal(t, "<root><p>ab</p><p>cd</p></root>", d1.Root().GetTree("t").ToXML())
+		assert.Equal(t, "<root><p>ab</p><p>cd</p></root>", d2.Root().GetTree("t").ToXML())
+
+		// d1: split first paragraph at a|b
+		assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetTree("t").Edit(2, 2, nil, 1)
+			return nil
+		}))
+		// d2: merge both paragraphs (delete boundary)
+		assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetTree("t").Edit(3, 5, nil, 0)
+			return nil
+		}))
+		assert.Equal(t, "<root><p>a</p><p>b</p><p>cd</p></root>", d1.Root().GetTree("t").ToXML())
+		assert.Equal(t, "<root><p>abcd</p></root>", d2.Root().GetTree("t").ToXML())
+
+		syncClientsThenAssertEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
+		assert.Equal(t, "<root><p>a</p><p>bcd</p></root>", d1.Root().GetTree("t").ToXML())
+	})
+
 	t.Run("contained-merge-and-split-at-multi-levels", func(t *testing.T) {
 		ctx := context.Background()
 		d1 := document.New(helper.TestKey(t))


### PR DESCRIPTION
## Summary

- Fix divergence when one client splits a block while another merges that block with its neighbor (#1726)
- Replace `boundaryIsMerged` heuristic in SplitElement's Fix 8 with `sourceIsChild` check: merge-moved children from external sources flow to the split (right) node, while locally-sourced children stay in the original (left) node
- Add `contained-split-and-merge-same-block` integration test (64th convergence case)

## Test plan

- [x] New test `contained-split-and-merge-same-block` passes
- [x] All 64 existing convergence tests in `TestTree` pass
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of concurrent split and merge operations in document trees to ensure consistent synchronization across replicas.

* **Tests**
  * Added integration test for concurrent split and merge scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->