### PR TITLE
Release v0.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and Yorkie adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## [v0.7.4] - 2026-04-09
+
+### Fixed
+
+- Fix tree divergence on concurrent split inside merge range by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1727
+- Fix split + delete divergence by skipping merge for concurrent elements by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1725
+- Fix multi-level split + merge divergence via mergedFrom by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1724
+- Fix split sibling convergence via position forwarding by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1723
+- Fix convergence bugs in concurrent tree merge/split by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1722
+
 ## [v0.7.3] - 2026-04-02
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-YORKIE_VERSION := 0.7.3
+YORKIE_VERSION := 0.7.4
 
 GO_PROJECT = github.com/yorkie-team/yorkie
 

--- a/api/docs/yorkie.base.yaml
+++ b/api/docs/yorkie.base.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Yorkie
   description: "Yorkie is an open source document store for building collaborative editing applications."
-  version: v0.7.3
+  version: v0.7.4
 servers:
   - url: https://api.yorkie.dev
     description: Production server

--- a/api/docs/yorkie/v1/admin.openapi.yaml
+++ b/api/docs/yorkie/v1/admin.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.3
+  version: v0.7.4
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/api/docs/yorkie/v1/resources.openapi.yaml
+++ b/api/docs/yorkie/v1/resources.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.3
+  version: v0.7.4
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/api/docs/yorkie/v1/yorkie.openapi.yaml
+++ b/api/docs/yorkie/v1/yorkie.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.3
+  version: v0.7.4
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/build/charts/yorkie-cluster/Chart.yaml
+++ b/build/charts/yorkie-cluster/Chart.yaml
@@ -9,8 +9,8 @@ maintainers:
 
 sources:
   - https://github.com/yorkie-team/yorkie
-version: 0.7.3
-appVersion: "0.7.3"
+version: 0.7.4
+appVersion: "0.7.4"
 kubeVersion: ">=1.28.0-0"
 
 dependencies:


### PR DESCRIPTION
## Summary
- Update version to 0.7.4 across Makefile, Helm charts, and API docs
- Add CHANGELOG entry for v0.7.4

## Changes
- `Makefile`: YORKIE_VERSION 0.7.3 → 0.7.4
- `build/charts/yorkie-cluster/Chart.yaml`: version/appVersion 0.7.4
- `api/docs/`: all OpenAPI spec versions → v0.7.4
- `CHANGELOG.md`: v0.7.4 section with tree convergence fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Tree data structure convergence and divergence issues in concurrent split/merge operations, including merge-range interactions, split+delete scenarios, and sibling synchronization.

* **Chores**
  * Version updated to v0.7.4 across project configuration and API specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->