### PR TITLE
Simplify Counter interface with type inference

### DIFF
--- a/api/converter/converter_test.go
+++ b/api/converter/converter_test.go
@@ -105,7 +105,7 @@ func TestConverter(t *testing.T) {
 				Style(0, 5, map[string]string{"b": "1"})
 
 			// a counter
-			root.SetNewCounter("k5", crdt.LongCnt, 0).
+			root.SetNewCounter("k5", int64(0)).
 				Increase(10).
 				Increase(math.MaxInt64)
 
@@ -176,7 +176,7 @@ func TestConverter(t *testing.T) {
 				Style(0, 5, map[string]string{"b": "1"})
 
 			// counter
-			root.SetNewCounter("k4", crdt.IntegerCnt, 0).Increase(5)
+			root.SetNewCounter("k4", 0).Increase(5)
 
 			return nil
 		})

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -69,8 +69,6 @@ const (
 // Root represents the root of a document.
 type Root = json.Object
 
-// Int represents an integer type in the document.
-const Int = crdt.IntegerCnt
 
 // Presence represents the presence of a client editing the document.
 type Presence = presence.Presence

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -69,7 +69,6 @@ const (
 // Root represents the root of a document.
 type Root = json.Object
 
-
 // Presence represents the presence of a client editing the document.
 type Presence = presence.Presence
 

--- a/pkg/document/document_test.go
+++ b/pkg/document/document_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/yorkie-team/yorkie/pkg/document"
 	"github.com/yorkie-team/yorkie/pkg/document/change"
-	"github.com/yorkie-team/yorkie/pkg/document/crdt"
 	"github.com/yorkie-team/yorkie/pkg/document/json"
 	"github.com/yorkie-team/yorkie/pkg/document/presence"
 	"github.com/yorkie-team/yorkie/pkg/document/time"
@@ -361,7 +360,7 @@ func TestDocument(t *testing.T) {
 
 		// integer type test
 		err := doc.Update(func(root *json.Object, p *presence.Presence) error {
-			root.SetNewCounter("age", crdt.IntegerCnt, 5)
+			root.SetNewCounter("age", 5)
 
 			age := root.GetCounter("age")
 			age.Increase(long)
@@ -378,7 +377,7 @@ func TestDocument(t *testing.T) {
 
 		// long type test
 		err = doc.Update(func(root *json.Object, p *presence.Presence) error {
-			root.SetNewCounter("price", crdt.LongCnt, 9000000000000000000)
+			root.SetNewCounter("price", int64(9000000000000000000))
 			price := root.GetCounter("price")
 			println(price.ValueType())
 			price.Increase(long)

--- a/pkg/document/json/counter.go
+++ b/pkg/document/json/counter.go
@@ -52,10 +52,13 @@ func (p *Counter) Initialize(ctx *change.Context, counter *crdt.Counter) *Counte
 	return p
 }
 
-// Increase adds an increase operations.
+// Increase adds an increase operation. Only valid for non-dedup counters.
 // Only numeric types are allowed as operand values, excluding
 // uint64 and uintptr.
 func (p *Counter) Increase(v interface{}) *Counter {
+	if p.Counter.IsDedup() {
+		panic("dedup counter does not support Increase(), use Add(actor)")
+	}
 	if !isAllowedOperand(v) {
 		panic("unsupported type")
 	}
@@ -132,6 +135,15 @@ func (p *Counter) Add(actor string) *Counter {
 	))
 
 	return p
+}
+
+// inferCounterType infers the CounterType from the Go value type.
+// int64 maps to LongCnt; all other numeric types map to IntegerCnt.
+func inferCounterType(v interface{}) crdt.CounterType {
+	if reflect.ValueOf(v).Kind() == reflect.Int64 {
+		return crdt.LongCnt
+	}
+	return crdt.IntegerCnt
 }
 
 // isAllowedOperand indicates whether

--- a/pkg/document/json/object.go
+++ b/pkg/document/json/object.go
@@ -98,8 +98,22 @@ func (p *Object) SetNewText(k string) *Text {
 	return v.(*Text)
 }
 
-// SetNewCounter sets a new NewCounter for the given key.
-func (p *Object) SetNewCounter(k string, t crdt.CounterType, n any) *Counter {
+// SetNewCounter sets a new Counter for the given key. The counter type is
+// inferred from the value: int/int32 → IntegerCnt, int64 → LongCnt.
+func (p *Object) SetNewCounter(k string, n any) *Counter {
+	t := inferCounterType(n)
+	return p.setNewCounter(k, t, n)
+}
+
+// SetNewDedupCounter sets a new dedup Counter for the given key. Dedup
+// counters use HyperLogLog to count unique actors. Use counter.Add(actor)
+// to record a unique visitor.
+func (p *Object) SetNewDedupCounter(k string) *Counter {
+	return p.setNewCounter(k, crdt.IntegerDedupCnt, 0)
+}
+
+// setNewCounter is the internal constructor that accepts an explicit type.
+func (p *Object) setNewCounter(k string, t crdt.CounterType, n any) *Counter {
 	v := p.setInternal(k, func(ticket *time.Ticket) crdt.Element {
 		crdtCounter, err := crdt.NewCounter(t, n, ticket)
 		if err != nil {
@@ -110,13 +124,6 @@ func (p *Object) SetNewCounter(k string, t crdt.CounterType, n any) *Counter {
 	})
 
 	return v.(*Counter)
-}
-
-// SetNewDedupCounter sets a new dedup Counter for the given key. Dedup
-// counters use HyperLogLog to count unique actors. Use counter.Add(actor)
-// to record a unique visitor.
-func (p *Object) SetNewDedupCounter(k string) *Counter {
-	return p.SetNewCounter(k, crdt.IntegerDedupCnt, 0)
 }
 
 // SetNewTree sets a new Tree for the given key.
@@ -241,7 +248,7 @@ func (p *Object) SetDate(k string, v gotime.Time) *Object {
 func (p *Object) SetYSONElement(k string, v interface{}) *Object {
 	switch y := v.(type) {
 	case yson.Counter:
-		p.SetNewCounter(k, y.Type, y.Value)
+		p.setNewCounter(k, y.Type, y.Value)
 	case yson.Array:
 		arr := p.SetNewArray(k)
 		for _, elem := range y {

--- a/pkg/document/size_test.go
+++ b/pkg/document/size_test.go
@@ -175,7 +175,7 @@ func TestDocumentSize(t *testing.T) {
 		doc := document.New("doc")
 
 		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
-			root.SetNewCounter("counter", crdt.IntegerCnt, 0)
+			root.SetNewCounter("counter", 0)
 			return nil
 		}))
 		assert.Equal(t, resource.DataSize{Data: 4, Meta: 72}, doc.DocSize().Live)
@@ -328,7 +328,7 @@ func TestDocumentSize(t *testing.T) {
 		doc := document.New("doc")
 
 		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
-			root.SetNewCounter("counter", crdt.IntegerCnt, 0)
+			root.SetNewCounter("counter", 0)
 			return nil
 		}))
 		clone, err := doc.InternalDocument().DeepCopy()

--- a/pkg/document/yson/yson_test.go
+++ b/pkg/document/yson/yson_test.go
@@ -77,11 +77,11 @@ func TestYSONConversion(t *testing.T) {
 				Style(6, 9, map[string]string{"color": "blue"})
 
 			// long counter
-			r.SetNewCounter("k5", crdt.LongCnt, 0).
+			r.SetNewCounter("k5", int64(0)).
 				Increase(10)
 
 			// integer counter
-			r.SetNewCounter("k6", crdt.IntegerCnt, 0).
+			r.SetNewCounter("k6", 0).
 				Increase(10)
 
 			// tree
@@ -130,7 +130,7 @@ func TestYSONConversion(t *testing.T) {
 			// Add nested object
 			obj := arr.AddNewObject()
 			obj.SetString("key", "value")
-			obj.SetNewCounter("counter", crdt.IntegerCnt, 10)
+			obj.SetNewCounter("counter", 10)
 
 			text := arr.AddNewText()
 			text.Edit(0, 0, "Hello")

--- a/pkg/schema/ruleset_validator_test.go
+++ b/pkg/schema/ruleset_validator_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/yorkie-team/yorkie/api/types"
 	"github.com/yorkie-team/yorkie/pkg/document"
-	"github.com/yorkie-team/yorkie/pkg/document/crdt"
 	"github.com/yorkie-team/yorkie/pkg/document/json"
 	"github.com/yorkie-team/yorkie/pkg/document/presence"
 	"github.com/yorkie-team/yorkie/pkg/schema"
@@ -156,7 +155,7 @@ func TestRulesetValidator(t *testing.T) {
 		assert.NoError(t, doc.Update(func(r *json.Object, p *presence.Presence) error {
 			r.SetNewText("text")
 			r.SetNewTree("tree", json.TreeNode{Type: "doc"})
-			r.SetNewCounter("counter", crdt.IntegerCnt, 0)
+			r.SetNewCounter("counter", 0)
 			return nil
 		}))
 		result := schema.ValidateYorkieRuleset(doc.RootObject(), ruleset)

--- a/test/bench/document_bench_test.go
+++ b/test/bench/document_bench_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/yorkie-team/yorkie/pkg/document"
 	"github.com/yorkie-team/yorkie/pkg/document/change"
-	"github.com/yorkie-team/yorkie/pkg/document/crdt"
 	"github.com/yorkie-team/yorkie/pkg/document/json"
 	"github.com/yorkie-team/yorkie/pkg/document/presence"
 	"github.com/yorkie-team/yorkie/test/helper"
@@ -343,7 +342,7 @@ func BenchmarkDocument(b *testing.B) {
 
 			// integer type test
 			err := doc.Update(func(root *json.Object, p *presence.Presence) error {
-				root.SetNewCounter("age", crdt.IntegerCnt, 5)
+				root.SetNewCounter("age", 5)
 
 				age := root.GetCounter("age")
 				age.Increase(long)
@@ -359,7 +358,7 @@ func BenchmarkDocument(b *testing.B) {
 
 			// long type test
 			err = doc.Update(func(root *json.Object, p *presence.Presence) error {
-				root.SetNewCounter("price", crdt.LongCnt, 9000000000000000000)
+				root.SetNewCounter("price", int64(9000000000000000000))
 				price := root.GetCounter("price")
 				price.Increase(long)
 				price.Increase(double)
@@ -737,7 +736,7 @@ func benchmarkCounter(cnt int, b *testing.B) {
 		doc := document.New("d1")
 
 		err := doc.Update(func(root *json.Object, p *presence.Presence) error {
-			counter := root.SetNewCounter("k1", crdt.IntegerCnt, 0)
+			counter := root.SetNewCounter("k1", 0)
 			for c := range cnt {
 				counter.Increase(c)
 			}

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -188,7 +188,7 @@ func TestClient(t *testing.T) {
 		// 02. cli update the document with creating a counter
 		//     and sync with push-pull mode: CP(1, 1) -> CP(2, 2)
 		assert.NoError(t, doc.Update(func(root *document.Root, p *document.Presence) error {
-			root.SetNewCounter("counter", document.Int, 0)
+			root.SetNewCounter("counter", 0)
 			return nil
 		}))
 		assert.Equal(t, change.Checkpoint{ClientSeq: 1, ServerSeq: 1}, doc.Checkpoint())

--- a/test/integration/counter_test.go
+++ b/test/integration/counter_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/yorkie-team/yorkie/pkg/document"
-	"github.com/yorkie-team/yorkie/pkg/document/crdt"
 	"github.com/yorkie-team/yorkie/pkg/document/json"
 	"github.com/yorkie-team/yorkie/pkg/document/presence"
 	"github.com/yorkie-team/yorkie/test/helper"
@@ -44,7 +43,7 @@ func TestCounter(t *testing.T) {
 		assert.NoError(t, err)
 
 		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
-			root.SetNewCounter("age", crdt.LongCnt, 1).
+			root.SetNewCounter("age", int64(1)).
 				Increase(2).
 				Increase(2.5).
 				Increase(-100000000).
@@ -68,9 +67,9 @@ func TestCounter(t *testing.T) {
 		assert.NoError(t, err)
 
 		err = d1.Update(func(root *json.Object, p *presence.Presence) error {
-			root.SetNewCounter("age", crdt.IntegerCnt, 0)
-			root.SetNewCounter("width", crdt.LongCnt, 0)
-			root.SetNewCounter("height", crdt.LongCnt, 0)
+			root.SetNewCounter("age", 0)
+			root.SetNewCounter("width", int64(0))
+			root.SetNewCounter("height", int64(0))
 			return nil
 		})
 		assert.NoError(t, err)

--- a/test/integration/yson_test.go
+++ b/test/integration/yson_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/yorkie-team/yorkie/pkg/document"
-	"github.com/yorkie-team/yorkie/pkg/document/crdt"
 	"github.com/yorkie-team/yorkie/pkg/document/json"
 	"github.com/yorkie-team/yorkie/pkg/document/presence"
 	"github.com/yorkie-team/yorkie/pkg/document/yson"
@@ -63,7 +62,7 @@ func TestObjectWithYSON(t *testing.T) {
 			root.SetNewObject("obj").SetString("str", "v")
 			root.GetObject("obj").SetNewArray("arr").AddInteger(1).AddString("str")
 			root.GetObject("obj").SetNewObject("obj").SetDouble("key3", 42.2)
-			root.GetObject("obj").SetNewCounter("cnt", crdt.LongCnt, 0)
+			root.GetObject("obj").SetNewCounter("cnt", int64(0))
 			root.GetObject("obj").SetNewText("txt")
 			root.GetObject("obj").SetNewTree("tree", json.TreeNode{
 				Type: "doc",


### PR DESCRIPTION
## Summary

- `SetNewCounter` infers `CounterType` from value: `SetNewCounter("k", 0)` → Int, `SetNewCounter("k", int64(0))` → Long
- Add dedup guard in JSON proxy `Increase()` for early error with actionable message
- Remove `document.Int` alias — callers no longer need to import `crdt.CounterType`

## Breaking Changes

| Before | After |
|--------|-------|
| `root.SetNewCounter("k", crdt.IntegerCnt, 5)` | `root.SetNewCounter("k", 5)` |
| `root.SetNewCounter("k", crdt.LongCnt, 0)` | `root.SetNewCounter("k", int64(0))` |
| `root.SetNewCounter("k", document.Int, 0)` | `root.SetNewCounter("k", 0)` |
| `Increase()` on dedup → error in CRDT layer | `Increase()` on dedup → **panic in JSON proxy** with guidance |

## Related

- JS SDK counterpart: yorkie-team/yorkie-js-sdk#1216
- Context: [#765](https://github.com/yorkie-team/yorkie/issues/765) — Counter generics discussion

## Test plan

- [x] `make build` passes
- [x] `make test` passes (all unit + integration)
- [x] `go vet` clean
- [x] `make lint` (golangci-lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a convenience method to create dedup counters with a simpler call.

* **Breaking Changes**
  * Counter creation now infers counter type from the provided numeric value instead of an explicit type parameter.
  * Removed the public numeric-type alias; use numeric values directly when creating counters.

* **Behavior Change**
  * Incrementing dedup counters is now disallowed (use the dedup-specific add operation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->