### PR TITLE
Remove hardcoded healthcheck-port from Ingress template

### DIFF
--- a/build/charts/yorkie-cluster/templates/istio/ingress.yaml
+++ b/build/charts/yorkie-cluster/templates/istio/ingress.yaml
@@ -18,7 +18,6 @@ metadata:
     alb.ingress.kubernetes.io/group.name: {{ .Values.ingress.hosts.apiHost }}
     alb.ingress.kubernetes.io/group.order: '10'
     alb.ingress.kubernetes.io/healthcheck-path: /healthz/ready
-    alb.ingress.kubernetes.io/healthcheck-port: "32442"
   {{ end }}
   {{ if .Values.ingress.ncpAlb.enabled }}
   annotations:


### PR DESCRIPTION
## Summary

- Remove hardcoded `alb.ingress.kubernetes.io/healthcheck-port: "32442"` from the yorkie-cluster Helm chart Ingress template

## Motivation

The healthcheck-port was hardcoded to `32442`, which was the NodePort from a previous Istio gateway installation via IstioOperator. Since the gateway is now installed separately via Helm (as of #1709), the NodePort changes on every reinstall. Hardcoding this value causes ALB health checks to fail after gateway recreation, leading to 504 Gateway Timeout.

Without this annotation, ALB uses `traffic-port` by default. Operators can override the healthcheck-port via Ingress annotation after deployment if needed.

## Test plan

- [x] Verified on production cluster: removing hardcoded port and setting correct value via annotation restores ALB health checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified load balancer configuration settings in Kubernetes deployments by removing a redundant health check port annotation from the ingress configuration. The essential health check path configuration remains in place to ensure proper cluster health monitoring, endpoint verification, and load balancer operation without unnecessary port-specific constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->