### PR TITLE
Update undo-redo design doc: TreeStyleOperation support

### DIFF
--- a/docs/design/undo-redo.md
+++ b/docs/design/undo-redo.md
@@ -439,6 +439,7 @@ Oldest entries are evicted when the cap is reached.
 | Tree split L1 undo/redo | ✅ | Boundary-deletion reverse ops (PR #1219) |
 | Tree multi-client (non-overlapping) | ✅ | Cases 1, 2, 7 (left/right/adjacent) |
 | TreeStyleOperation single-client | ✅ | setStyle, removeStyle undo/redo (PR #1221) |
+| TreeStyleOperation multi-client | ✅ | style×style (18 tests), style×edit/split (24 tests), all converge (PR #1221) |
 
 #### Remaining Work
 
@@ -446,6 +447,5 @@ Oldest entries are evicted when the cap is reached.
 |----------|------|---------|
 | HIGH | Tree reconciliation Cases 3-6 | Overlapping range reconciliation. Text has it; Tree needs symmetric index computation or tree-native `normalizePos()`. 4 tests skipped. |
 | MED | Tree redo divergence | `insert-text + delete-text` redo combo diverges in multi-client. 1 test skipped. |
-| MED | TreeStyleOperation multi-client | Single-client undo works; multi-client reconciliation not yet tested. |
 | LOW | splitLevel≥2 undo/redo | Blocked by L2 forward convergence (68/320 concurrent tests fail). Fix forward first. |
 | LOW | History reconciliation performance | O(n) stack scan → indexed lookup (TODO in `history.ts`). |

--- a/docs/design/undo-redo.md
+++ b/docs/design/undo-redo.md
@@ -29,7 +29,7 @@ operations valid when remote edits arrive.
 - Undo/redo for `Tree.Edit` with `splitLevel >= 2` at the CRDT layer (deferred
   until L2 forward convergence is fixed; `splitLevel=1` is supported).
 - Overlapping range reconciliation for Tree (Cases 3–6, deferred to Phase 2).
-- Undo/redo for `TreeStyleOperation` (not yet implemented).
+- Undo/redo for `TreeStyleOperation` with multi-client reconciliation (single-client undo/redo is now supported via PR #1221).
 
 ## Proposal Details
 
@@ -81,6 +81,7 @@ mapping, and each subsection below explains the details.
 | `StyleOperation` (Text.style) | `StyleOperation` |
 | `TreeEditOperation` (Tree.edit, splitLevel=0) | `TreeEditOperation` |
 | `TreeEditOperation` (Tree.edit, splitLevel=1) | `TreeEditOperation` (boundary deletion) |
+| `TreeStyleOperation` (Tree.style) | `TreeStyleOperation` |
 
 #### Object.set → SetOperation
 
@@ -437,13 +438,14 @@ Oldest entries are evicted when the cap is reached.
 | Tree single-client (splitLevel=0) | ✅ | All op types + chained ops |
 | Tree split L1 undo/redo | ✅ | Boundary-deletion reverse ops (PR #1219) |
 | Tree multi-client (non-overlapping) | ✅ | Cases 1, 2, 7 (left/right/adjacent) |
+| TreeStyleOperation single-client | ✅ | setStyle, removeStyle undo/redo (PR #1221) |
 
 #### Remaining Work
 
 | Priority | Item | Details |
 |----------|------|---------|
 | HIGH | Tree reconciliation Cases 3-6 | Overlapping range reconciliation. Text has it; Tree needs symmetric index computation or tree-native `normalizePos()`. 4 tests skipped. |
-| HIGH | TreeStyleOperation undo | No `reverseOp` generated. Text's `StyleOperation` has full undo support, but `TreeStyleOperation` does not. |
 | MED | Tree redo divergence | `insert-text + delete-text` redo combo diverges in multi-client. 1 test skipped. |
+| MED | TreeStyleOperation multi-client | Single-client undo works; multi-client reconciliation not yet tested. |
 | LOW | splitLevel≥2 undo/redo | Blocked by L2 forward convergence (68/320 concurrent tests fail). Fix forward first. |
 | LOW | History reconciliation performance | O(n) stack scan → indexed lookup (TODO in `history.ts`). |

--- a/docs/design/undo-redo.md
+++ b/docs/design/undo-redo.md
@@ -446,6 +446,38 @@ Oldest entries are evicted when the cap is reached.
 | Priority | Item | Details |
 |----------|------|---------|
 | HIGH | Tree reconciliation Cases 3-6 | Overlapping range reconciliation. Text has it; Tree needs symmetric index computation or tree-native `normalizePos()`. 4 tests skipped. |
-| MED | Tree redo divergence | `insert-text + delete-text` redo combo diverges in multi-client. 1 test skipped. |
+| MED | Tree redo divergence | `insert-text + delete-text` redo combo diverges in multi-client. 1 test skipped. Same root cause as Cases 3-6: tree-native `normalizePos()` needed. See analysis below. |
 | LOW | splitLevel≥2 undo/redo | Blocked by L2 forward convergence (68/320 concurrent tests fail). Fix forward first. |
 | LOW | History reconciliation performance | O(n) stack scan → indexed lookup (TODO in `history.ts`). |
+
+#### Analysis: Tree Redo Divergence (insert-text + delete-text)
+
+This divergence shares the same root cause as Cases 3-6: Tree uses integer
+indices for redo positions, which are **asymmetric** across clients.
+
+```
+Initial:    <p>The fox jumped.</p>
+
+d1 forward: insert "X" at idx 16     → <p>The fox jumped.X</p>
+d2 forward: delete "." at idx 15-16  → <p>The fox jumped</p>
+Sync:       both converge to           <p>The fox jumpedX.</p>
+            (CRDT timestamp ordering: X before .)
+
+Both undo → sync → converge:          <p>The fox jumped.</p>
+
+d1 redo: insert "X" at idx 16        → <p>The fox jumped.X</p>  (X after .)
+d2 redo: delete "." at idx 15-16     → <p>The fox jumped.</p>
+Sync:    DIVERGE
+  d1: <p>The fox jumped.X</p>        (X after .)
+  d2: <p>The fox jumpedX.</p>        (X before .)
+```
+
+During forward execution, "X" and "." were concurrent inserts at the same
+position. The CRDT resolved their order by timestamp: `X` before `.`. On redo,
+"." has already been restored (via undo), so "X" is inserted sequentially
+**after** it — producing the opposite order.
+
+Text avoids this because `normalizePos()` walks the physical RGA chain, which is
+identical on all clients. Tree's integer-index-based redo does not have this
+guarantee. A tree-native `normalizePos()` that walks the CRDT node chain
+(analogous to Text's RGA chain walking) would fix both this issue and Cases 3-6.


### PR DESCRIPTION
## Summary

- Update undo-redo design doc to reflect TreeStyleOperation single-client undo/redo support (PR yorkie-team/yorkie-js-sdk#1221)

## Changes

- Add `TreeStyleOperation` to reverse operation table
- Update Non-Goals: TreeStyle single-client undo now works, multi-client reconciliation remains
- Add TreeStyleOperation to Completed status table
- Replace HIGH TreeStyleOperation item with MED multi-client reconciliation item in Remaining Work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised undo/redo design doc to mark style-operations as supported for single-client undo/redo and reconciled for multi-client scenarios; status matrix and reverse-operation table updated accordingly.
  * Removed style-operations from remaining work and expanded the analysis of redo divergence, linking the insert/delete redo case to the same root cause as other overlap cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->