### PR TITLE
Discard stale-epoch changes in pushPack before cache insertion

### DIFF
--- a/docs/design/document-epoch.md
+++ b/docs/design/document-epoch.md
@@ -114,20 +114,61 @@ Client: detach → re-attach (receives new epoch)
 
 ### Epoch Check Placement
 
-The epoch comparison must happen **before** the existing `serverSeq`
-validation in `preparePack`. Once epochs differ, comparing `serverSeq` values
-is meaningless — they belong to different generations.
+The epoch comparison must happen in **two places**: `pushPack` (before
+changes are stored) and `preparePack` (before pulling changes).
+
+#### pushPack (push-side guard)
+
+`PushPull` executes `pushPack` before `preparePack`. If the epoch check
+only exists in `preparePack`, stale-epoch changes are already inserted into
+the in-memory `changeCache` by the time the mismatch is detected. These
+cached changes reference pre-compaction CRDT node IDs that no longer exist
+in the post-compaction snapshot, causing `ErrNotApplicableDataType` on
+subsequent attach or compaction attempts.
+
+To prevent this, `pushPack` must check the epoch **before** calling
+`CreateChangeInfos`:
+
+```go
+func pushPack(...) {
+    // ...filter already-pushed changes...
+
+    if len(pushables) > 0 {
+        docInfo, err := be.DB.FindDocInfoByRefKey(ctx, docKey)
+        if err != nil {
+            return ..., err
+        }
+        if clientDocInfo := clientInfo.Documents[docKey.DocID];
+            clientDocInfo != nil && clientDocInfo.Epoch != docInfo.Epoch {
+            // Discard stale-epoch changes silently. preparePack will
+            // return ErrEpochMismatch (or allow detach) downstream.
+            pushables = nil
+        }
+    }
+
+    docInfo, cpAfterPush, err := be.DB.CreateChangeInfos(...)
+    // ...
+}
+```
+
+When the epoch mismatches, `pushPack` discards the pushable changes and
+proceeds with an empty push. This allows `PushPull` to continue into
+`pullPack`, where `preparePack` handles the epoch mismatch appropriately:
+returning `ErrEpochMismatch` for normal syncs, or allowing detach to
+proceed.
+
+#### preparePack (pull-side guard)
+
+The existing epoch check in `preparePack` remains unchanged. It compares
+epochs before the `serverSeq` validation and returns `ErrEpochMismatch`
+to the client:
 
 ```go
 func preparePack(...) {
-    // Compare epochs first: if the document has been compacted since the
-    // client last synced, serverSeq values from different epochs cannot be
-    // compared.
     if clientEpoch != docEpoch {
         return ErrEpochMismatch
     }
 
-    // Existing serverSeq validation.
     if initialServerSeq < reqPack.Checkpoint.ServerSeq {
         return ErrInvalidServerSeq
     }
@@ -143,11 +184,14 @@ func preparePack(...) {
 3. **`CompactChangeInfos`** (`server/backend/database/mongo/client.go`):
    Increment `doc.Epoch` alongside the `serverSeq` reset.
 4. **`AttachDocument`**: Set `ClientDocInfo.Epoch = DocInfo.Epoch` on attach.
-5. **`preparePack`** (`server/packs/pushpull.go`): Add epoch comparison before
+5. **`pushPack`** (`server/packs/pushpull.go`): Add epoch comparison before
+   `CreateChangeInfos` to prevent stale-epoch changes from polluting the
+   in-memory cache.
+6. **`preparePack`** (`server/packs/pushpull.go`): Add epoch comparison before
    the `serverSeq` check.
-6. **Error definition**: Add `ErrEpochMismatch` with an appropriate gRPC
+7. **Error definition**: Add `ErrEpochMismatch` with an appropriate gRPC
    status code mapping.
-7. **SDKs** (JS, iOS, Android): Handle `ErrEpochMismatch` by performing
+8. **SDKs** (JS, iOS, Android): Handle `ErrEpochMismatch` by performing
    detach → re-attach.
 
 ### Backward Compatibility
@@ -164,3 +208,4 @@ func preparePack(...) {
 | Client has unsent local changes when it receives `ErrEpochMismatch`; reattach discards them | Expose `ErrEpochMismatch` as an SDK event so the application can notify the user before reattaching |
 | Older SDK versions do not recognize `ErrEpochMismatch` | They fall through to the existing `ErrInvalidServerSeq` behavior — no worse than today |
 | Epoch counter overflows | `int64` supports over 9 × 10¹⁸ compactions — practically unlimited |
+| Stale-epoch push pollutes in-memory cache before `preparePack` detects mismatch | `pushPack` checks epoch before `CreateChangeInfos` and discards stale changes (see "Epoch Check Placement") |

--- a/server/packs/pushpull.go
+++ b/server/packs/pushpull.go
@@ -201,7 +201,30 @@ func pushPack(
 		pushables = append(pushables, info)
 	}
 
-	// 02. Push the changes to the database.
+	// 02. Discard stale-epoch changes before storing them.
+	// pushPack runs before preparePack. Without this check, stale-epoch
+	// changes would be inserted into the in-memory changeCache, polluting
+	// it with operations that reference pre-compaction CRDT node IDs.
+	// preparePack will return ErrEpochMismatch to the client downstream.
+	if len(pushables) > 0 {
+		if clientDocInfo := clientInfo.Documents[docKey.DocID]; clientDocInfo != nil {
+			currentDocInfo, err := be.DB.FindDocInfoByRefKey(ctx, docKey)
+			if err != nil {
+				return nil, nil, time.InitialLamport, change.InitialCheckpoint, err
+			}
+			if clientDocInfo.Epoch != currentDocInfo.Epoch {
+				logging.From(ctx).Warnf(
+					"discarding %d changes from stale epoch: client(%d) != doc(%d)",
+					len(pushables),
+					clientDocInfo.Epoch,
+					currentDocInfo.Epoch,
+				)
+				pushables = nil
+			}
+		}
+	}
+
+	// 03. Push the changes to the database.
 	if len(pushables) > 0 || reqPack.IsRemoved {
 		locker := be.Lockers.Locker(DocPushKey(docKey))
 		defer locker.Unlock()

--- a/test/integration/compaction_test.go
+++ b/test/integration/compaction_test.go
@@ -164,4 +164,41 @@ func TestDocumentCompaction(t *testing.T) {
 		}))
 		assert.NoError(t, c.Sync(ctx))
 	})
+
+	t.Run("stale epoch push does not corrupt document for other clients", func(t *testing.T) {
+		ctx := context.Background()
+
+		d1 := document.New(helper.TestKey(t))
+		assert.NoError(t, c1.Attach(ctx, d1, client.WithInitialRoot(
+			yson.ParseObject(`{"text": Text()}`),
+		)))
+		assert.NoError(t, d1.Update(func(r *json.Object, p *presence.Presence) error {
+			r.GetText("text").Edit(0, 0, "hello")
+			return nil
+		}))
+		assert.NoError(t, c1.Sync(ctx))
+
+		d2 := document.New(d1.Key())
+		assert.NoError(t, c2.Attach(ctx, d2))
+		assert.NoError(t, c2.Sync(ctx))
+
+		assert.NoError(t, defaultServer.CompactDocument(ctx, d1.Key(), true))
+
+		assert.NoError(t, d2.Update(func(r *json.Object, p *presence.Presence) error {
+			r.GetText("text").Edit(5, 5, " world")
+			return nil
+		}))
+		err := c2.Sync(ctx)
+		assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+		assert.Equal(t, "ErrEpochMismatch", converter.ErrorCodeOf(err))
+
+		assert.NoError(t, c2.Detach(ctx, d2))
+
+		d3 := document.New(d1.Key())
+		assert.NoError(t, c3.Attach(ctx, d3))
+		assert.Equal(t, `hello`, d3.Root().GetText("text").String())
+
+		assert.NoError(t, c1.Detach(ctx, d1))
+		assert.NoError(t, c3.Detach(ctx, d3))
+	})
 }


### PR DESCRIPTION
## Summary

- Add epoch check to `pushPack` before `CreateChangeInfos` to prevent stale-epoch changes from polluting the in-memory `changeCache`
- Update `document-epoch.md` design doc with the push-side guard rationale
- Add integration test verifying stale-epoch push doesn't corrupt document for other clients

## Motivation

After document compaction, clients from the previous epoch can still push changes via `pushPack` (which has no epoch check). These stale changes reference pre-compaction CRDT node IDs and get stored in the `changeCache`. When other clients attach, `BuildInternalDocForServerSeq` replays these cached changes against the post-compaction snapshot, causing `ErrNotApplicableDataType`.

The existing epoch check in `preparePack` runs *after* `pushPack`, so by the time it catches the mismatch, the cache is already polluted.

## Fix

`pushPack` now calls `FindDocInfoByRefKey` (docCache hit, cheap) and compares epochs before `CreateChangeInfos`. On mismatch, pushable changes are discarded silently. `preparePack` still returns `ErrEpochMismatch` to the client downstream.

## Test plan

- [x] `go test -tags integration ./test/integration/ -run TestDocumentCompaction -v`
  - New subtest: `stale epoch push does not corrupt document for other clients`
- [x] Existing epoch mismatch tests still pass (recovery flow unchanged)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Strengthened epoch consistency validation with enhanced guards to prevent stale-epoch cached changes from corrupting shared document state.
* Added safety checks that automatically discard stale changes before persisting them, ensuring data integrity in concurrent multi-client editing scenarios.
* Improved document synchronization to maintain consistent state across all connected clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->