### PR TITLE
Guard against nil client in BenchmarkPresenceConcurrency

### DIFF
--- a/test/bench/presence_concurrency_bench_test.go
+++ b/test/bench/presence_concurrency_bench_test.go
@@ -58,10 +58,14 @@ func benchmarkPresenceConcurrency(b *testing.B, svr *server.Yorkie, initialCnt i
 			go func() {
 				defer wg.Done()
 
-				client, doc, err := helper.ClientAndAttachedDoc(ctx, svr.RPCAddr(), docKey)
-				assert.NoError(b, err)
-				err = client.Sync(ctx)
-				assert.NoError(b, err)
+				cli, doc, err := helper.ClientAndAttachedDoc(ctx, svr.RPCAddr(), docKey)
+				if !assert.NoError(b, err) {
+					return
+				}
+
+				if !assert.NoError(b, cli.Sync(ctx)) {
+					return
+				}
 
 				for j := range syncCnt {
 					err := doc.Update(func(root *json.Object, p *presence.Presence) error {
@@ -70,8 +74,8 @@ func benchmarkPresenceConcurrency(b *testing.B, svr *server.Yorkie, initialCnt i
 					})
 					assert.NoError(b, err)
 				}
-				assert.NoError(b, client.Sync(ctx))
-				assert.NoError(b, client.Close())
+				assert.NoError(b, cli.Sync(ctx))
+				assert.NoError(b, cli.Close())
 			}()
 		}
 		wg.Wait()


### PR DESCRIPTION
## Summary

- Add early return on error in `BenchmarkPresenceConcurrency` goroutines to prevent nil pointer panic

## Motivation

`BenchmarkPresenceConcurrency/0-100-10` spawns 100 goroutines that concurrently attach to the same document. Under load, `ClientAndAttachedDoc` can intermittently fail. The benchmark was calling `client.Sync(ctx)` on the nil client, causing a panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
  client.(*Client).Sync(0x0, ...)
  presence_concurrency_bench_test.go:63
```

## Fix

Use `assert.NoError` return value to guard against nil client — return early from the goroutine if attach or initial sync fails.

## Test plan

- [x] `go test -tags bench -c -o /dev/null ./test/bench/` — compilation passes
- [x] CI bench job — no more nil pointer panics


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved error handling and control flow in concurrent benchmark tests to ensure proper failure detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->