### PR TITLE
Acquire DocPushKey lock before epoch check in pushPack

### DIFF
--- a/server/packs/pushpull.go
+++ b/server/packs/pushpull.go
@@ -201,7 +201,17 @@ func pushPack(
 		pushables = append(pushables, info)
 	}
 
-	// 02. Discard stale-epoch changes before storing them.
+	// 02. Push the changes to the database.
+	// NOTE(hackerwins): The lock must be acquired before the epoch check
+	// because FindDocInfoByRefKey populates the docCache. Without the lock,
+	// a concurrent goroutine's stale MongoDB read can overwrite a fresher
+	// cache entry, causing ErrConflictOnUpdate in CreateChangeInfos.
+	if len(pushables) > 0 || reqPack.IsRemoved {
+		locker := be.Lockers.Locker(DocPushKey(docKey))
+		defer locker.Unlock()
+	}
+
+	// 03. Discard stale-epoch changes before storing them.
 	// pushPack runs before preparePack. Without this check, stale-epoch
 	// changes would be inserted into the in-memory changeCache, polluting
 	// it with operations that reference pre-compaction CRDT node IDs.
@@ -222,12 +232,6 @@ func pushPack(
 				pushables = nil
 			}
 		}
-	}
-
-	// 03. Push the changes to the database.
-	if len(pushables) > 0 || reqPack.IsRemoved {
-		locker := be.Lockers.Locker(DocPushKey(docKey))
-		defer locker.Unlock()
 	}
 	docInfo, cpAfterPush, err := be.DB.CreateChangeInfos(
 		ctx,


### PR DESCRIPTION
## Summary

- Fix `BenchmarkPresenceConcurrency/0-100-10` CI failure caused by docCache stale write race
- Move `DocPushKey` lock acquisition before the epoch check so that `FindDocInfoByRefKey` (which populates `docCache` on cache miss) is always called under the lock
- Revert the nil guard workaround (#1744) which is no longer needed with the root cause fixed

## Root Cause

`3c62acd4` added an epoch check in `pushPack` that calls `FindDocInfoByRefKey` **before** the `DocPushKey` lock. Under 100 concurrent attaches to a new document:

1. Goroutine A holds lock, pushes change (serverSeq 0→1), updates cache to 1
2. Goroutine B (no lock, epoch check) starts MongoDB query, gets stale serverSeq=0
3. Goroutine A releases lock
4. Goroutine B writes stale serverSeq=0 to cache, then acquires lock
5. Goroutine B's `CreateChangeInfos` reads stale cache → `UpdateOne` filter mismatches → `ErrConflictOnUpdate`

## Test plan

- [x] `make lint` passes
- [x] `make test` passes
- [x] `make bench` passes (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lock management during push operations to ensure data synchronization across multiple steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->