### PR TITLE
Add podAnnotations support to Helm deployment template

### DIFF
--- a/build/charts/yorkie-cluster/templates/yorkie/deployment.yaml
+++ b/build/charts/yorkie-cluster/templates/yorkie/deployment.yaml
@@ -31,6 +31,9 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.yorkie.ports.profilingPort }}"
         prometheus.io/path: "/metrics"
+        {{- with .Values.yorkie.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{ if index .Values "mongodb" "enabled"}}
       initContainers:


### PR DESCRIPTION
## Summary
- Add `podAnnotations` support to the yorkie-cluster Helm chart deployment template
- Allows users to pass custom pod annotations (e.g., `sidecar.istio.io/inject: "false"`) via `values.yaml` without modifying the chart template

## Context
To disable Istio sidecar injection on yorkie pods while keeping the gateway-level consistent hashing, we need to set `sidecar.istio.io/inject: "false"` as a pod annotation. The current chart template only has hardcoded prometheus annotations.

## Test plan
- [x] `helm template` renders correctly with and without `podAnnotations` set
- [x] Deploy with `sidecar.istio.io/inject: "false"` — pods should start without sidecar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom pod annotations in Helm chart deployments. Users can now configure and inject custom annotations into pod template metadata alongside default monitoring annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->