### PR TITLE
Replace n8n webhook with inline CI result reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,6 +485,7 @@ jobs:
           ### Result
 
           <details>
+          <summary>Full k6 output</summary>
 
           ${RESULT}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,9 +187,10 @@ jobs:
         id: bench-analysis
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          PARSED: ${{ steps.bench-parse.outputs.PARSED }}
         run: |
-          SIGNIFICANT=$(echo '${{ steps.bench-parse.outputs.PARSED }}' | jq -r '.significantChangesTable // ""')
-          GROUPED=$(echo '${{ steps.bench-parse.outputs.PARSED }}' | jq -r '.groupedTable // ""')
+          SIGNIFICANT=$(echo "$PARSED" | jq -r '.significantChangesTable // ""')
+          GROUPED=$(echo "$PARSED" | jq -r '.groupedTable // ""')
 
           if [ -z "$SIGNIFICANT" ]; then
             echo "ANALYSIS=No significant benchmark changes detected." >> $GITHUB_OUTPUT
@@ -197,62 +198,78 @@ jobs:
             exit 0
           fi
 
-          PROMPT="Analyze these Go benchmark changes (≥20% difference). Write 2-3 key observations as markdown bullets. Be concise, data-driven.
+          # Write prompt to a file to avoid shell injection
+          cat > /tmp/bench-prompt.txt << 'PROMPT_EOF'
+          Analyze these Go benchmark changes (≥20% difference). Write 2-3 key observations as markdown bullets. Be concise, data-driven.
+          PROMPT_EOF
+          echo "" >> /tmp/bench-prompt.txt
+          echo "Significant changes:" >> /tmp/bench-prompt.txt
+          echo "$SIGNIFICANT" >> /tmp/bench-prompt.txt
+          echo "" >> /tmp/bench-prompt.txt
+          echo "Full data:" >> /tmp/bench-prompt.txt
+          echo "$GROUPED" >> /tmp/bench-prompt.txt
 
-          Significant changes:
-          ${SIGNIFICANT}
+          ANALYSIS=$(claude -p "$(cat /tmp/bench-prompt.txt)" --model claude-sonnet-4-20250514 2>/dev/null || echo "Analysis unavailable.")
 
-          Full data:
-          ${GROUPED}"
-
-          ANALYSIS=$(claude -p "$PROMPT" --model claude-sonnet-4-20250514 --max-tokens 1024 2>/dev/null || echo "Analysis unavailable.")
+          # Write analysis to file to avoid shell injection in later steps
+          echo "$ANALYSIS" > /tmp/bench-analysis.txt
 
           EOF_MARKER="ANALYSIS_EOF_$(date +%s)"
           echo "ANALYSIS<<${EOF_MARKER}" >> $GITHUB_OUTPUT
           echo "$ANALYSIS" >> $GITHUB_OUTPUT
           echo "${EOF_MARKER}" >> $GITHUB_OUTPUT
 
-          HAS_VV=$(echo '${{ steps.bench-parse.outputs.PARSED }}' | jq -r '.hasVersionVector // false')
+          HAS_VV=$(echo "$PARSED" | jq -r '.hasVersionVector // false')
           if [ "$HAS_VV" = "true" ]; then
-            VV_DATA=$(echo '${{ steps.bench-parse.outputs.PARSED }}' | jq -r '[.grouped | to_entries[] | select(.key | test("VersionVector|SyncConcurrency"))] | map("\(.key): \(.value | tostring)") | join("\n")')
-            VV_PROMPT="Compare Lamport vs VersionVector performance from this benchmark data. Provide a concise summary:
+            VV_DATA=$(echo "$PARSED" | jq -r '[.grouped | to_entries[] | select(.key | test("VersionVector|SyncConcurrency"))] | map("\(.key): \(.value | tostring)") | join("\n")')
 
-            ${VV_DATA}"
-            VV_ANALYSIS=$(claude -p "$VV_PROMPT" --model claude-sonnet-4-20250514 --max-tokens 1024 2>/dev/null || echo "")
+            cat > /tmp/vv-prompt.txt << 'PROMPT_EOF'
+          Compare Lamport vs VersionVector performance from this benchmark data. Provide a concise summary.
+          PROMPT_EOF
+            echo "" >> /tmp/vv-prompt.txt
+            echo "$VV_DATA" >> /tmp/vv-prompt.txt
+
+            VV_ANALYSIS=$(claude -p "$(cat /tmp/vv-prompt.txt)" --model claude-sonnet-4-20250514 2>/dev/null || echo "")
+            echo "$VV_ANALYSIS" > /tmp/vv-analysis.txt
+
             EOF_VV="VV_EOF_$(date +%s)"
             echo "VV_ANALYSIS<<${EOF_VV}" >> $GITHUB_OUTPUT
             echo "$VV_ANALYSIS" >> $GITHUB_OUTPUT
             echo "${EOF_VV}" >> $GITHUB_OUTPUT
           else
             echo "VV_ANALYSIS=" >> $GITHUB_OUTPUT
+            echo "" > /tmp/vv-analysis.txt
           fi
 
       - name: Post benchmark comment to PR
         if: github.event_name == 'pull_request' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PARSED: ${{ steps.bench-parse.outputs.PARSED }}
         run: |
-          SIGNIFICANT_TABLE=$(echo '${{ steps.bench-parse.outputs.PARSED }}' | jq -r '.significantChangesTable // ""')
-          GROUPED_TABLE=$(echo '${{ steps.bench-parse.outputs.PARSED }}' | jq -r '.groupedTable // ""')
+          SIGNIFICANT_TABLE=$(echo "$PARSED" | jq -r '.significantChangesTable // ""')
+          GROUPED_TABLE=$(echo "$PARSED" | jq -r '.groupedTable // ""')
           COMMIT_ID="${{ github.sha }}"
           PREV_COMMIT_ID="${{ steps.prev-bench.outputs.PREV_COMMIT }}"
 
+          # Read LLM outputs from files (safe, no shell injection)
+          ANALYSIS=$(cat /tmp/bench-analysis.txt 2>/dev/null || echo "")
+          VV_ANALYSIS=$(cat /tmp/vv-analysis.txt 2>/dev/null || echo "")
+
           VV_SECTION=""
-          if [ -n "${{ steps.bench-analysis.outputs.VV_ANALYSIS }}" ]; then
-            VV_SECTION="
-          ### Clock Analysis
+          if [ -n "$VV_ANALYSIS" ]; then
+            VV_SECTION="### Clock Analysis
 
           <details>
           <summary>Lamport vs VersionVector</summary>
 
-          ${{ steps.bench-analysis.outputs.VV_ANALYSIS }}
+          ${VV_ANALYSIS}
 
-          </details>
-          "
+          </details>"
           fi
 
-          cat > /tmp/bench-comment.md << EOF
-          <!-- yorkie-ci-benchmark n8n comment -->
+          cat > /tmp/bench-comment.md << COMMENT_EOF
+          <!-- yorkie-ci-benchmark comment -->
           ## Go Benchmark Analysis 📊
 
           This is a comparison result between the previous(${PREV_COMMIT_ID}) and the current commit(${COMMIT_ID}).
@@ -261,19 +278,19 @@ jobs:
 
           ${SIGNIFICANT_TABLE}
 
-          ${{ steps.bench-analysis.outputs.ANALYSIS }}
+          ${ANALYSIS}
 
           ${VV_SECTION}
 
           ### Detailed Test Results
 
           ${GROUPED_TABLE}
-          EOF
+          COMMENT_EOF
 
           bash repo/scripts/ci/post-comment.sh \
             "${{ github.repository }}" \
             "${{ github.event.pull_request.number }}" \
-            "<!-- yorkie-ci-benchmark n8n comment -->" \
+            "<!-- yorkie-ci-benchmark comment -->" \
             /tmp/bench-comment.md
 
       - name: Store benchmark result
@@ -443,9 +460,10 @@ jobs:
         if: github.event_name == 'pull_request' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PARSED: ${{ steps.load-parse.outputs.PARSED }}
         run: |
-          CHANGE_TABLE=$(echo '${{ steps.load-parse.outputs.PARSED }}' | jq -r '.table // ""')
-          RESULT=$(echo '${{ steps.load-parse.outputs.PARSED }}' | jq -r '.result // ""')
+          CHANGE_TABLE=$(echo "$PARSED" | jq -r '.table // ""')
+          RESULT=$(echo "$PARSED" | jq -r '.result // ""')
           COMMIT_ID="${{ github.sha }}"
           PREV_COMMIT_ID="${{ steps.prev-load.outputs.PREV_COMMIT }}"
 
@@ -456,8 +474,8 @@ jobs:
           ${CHANGE_TABLE}"
           fi
 
-          cat > /tmp/load-comment.md << EOF
-          <!-- yorkie-ci-load n8n comment -->
+          cat > /tmp/load-comment.md << COMMENT_EOF
+          <!-- yorkie-ci-load comment -->
           ## k6 Load Test 📊
 
           This is a comparison result between the previous(${PREV_COMMIT_ID}) and the current commit(${COMMIT_ID}).
@@ -471,12 +489,12 @@ jobs:
           ${RESULT}
 
           </details>
-          EOF
+          COMMENT_EOF
 
           bash repo/scripts/ci/post-comment.sh \
             "${{ github.repository }}" \
             "${{ github.event.pull_request.number }}" \
-            "<!-- yorkie-ci-load n8n comment -->" \
+            "<!-- yorkie-ci-load comment -->" \
             /tmp/load-comment.md
 
       - name: Store load result

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     needs: ci-target-check
     if: ${{ github.ref == 'refs/heads/main' || needs.ci-target-check.outputs.bench == 'true' }}
@@ -118,6 +119,16 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+
+      - name: Set up Node.js
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Claude Code CLI
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
+        run: npm install -g @anthropic-ai/claude-code
 
       - name: Checkout current repository
         uses: actions/checkout@v4
@@ -158,37 +169,112 @@ jobs:
           content=$(cat output.txt | jq -R -s .)
           echo "BENCH_RESULT=$content" >> $GITHUB_OUTPUT
 
-      - name: Trigger n8n webhook
+      - name: Parse benchmark results
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
+        id: bench-parse
+        env:
+          PREV_BENCH_RESULT: ${{ steps.prev-bench.outputs.PREV_BENCH_RESULT }}
+          CURR_BENCH_RESULT: ${{ steps.curr-bench.outputs.BENCH_RESULT }}
+        run: |
+          PARSED=$(node repo/scripts/ci/parse-bench.js)
+          EOF_MARKER="BENCH_PARSE_EOF_$(date +%s)"
+          echo "PARSED<<${EOF_MARKER}" >> $GITHUB_OUTPUT
+          echo "$PARSED" >> $GITHUB_OUTPUT
+          echo "${EOF_MARKER}" >> $GITHUB_OUTPUT
+
+      - name: Analyze benchmark with Claude
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
+        id: bench-analysis
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          SIGNIFICANT=$(echo '${{ steps.bench-parse.outputs.PARSED }}' | jq -r '.significantChangesTable // ""')
+          GROUPED=$(echo '${{ steps.bench-parse.outputs.PARSED }}' | jq -r '.groupedTable // ""')
+
+          if [ -z "$SIGNIFICANT" ]; then
+            echo "ANALYSIS=No significant benchmark changes detected." >> $GITHUB_OUTPUT
+            echo "VV_ANALYSIS=" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          PROMPT="Analyze these Go benchmark changes (≥20% difference). Write 2-3 key observations as markdown bullets. Be concise, data-driven.
+
+          Significant changes:
+          ${SIGNIFICANT}
+
+          Full data:
+          ${GROUPED}"
+
+          ANALYSIS=$(claude -p "$PROMPT" --model claude-sonnet-4-20250514 --max-tokens 1024 2>/dev/null || echo "Analysis unavailable.")
+
+          EOF_MARKER="ANALYSIS_EOF_$(date +%s)"
+          echo "ANALYSIS<<${EOF_MARKER}" >> $GITHUB_OUTPUT
+          echo "$ANALYSIS" >> $GITHUB_OUTPUT
+          echo "${EOF_MARKER}" >> $GITHUB_OUTPUT
+
+          HAS_VV=$(echo '${{ steps.bench-parse.outputs.PARSED }}' | jq -r '.hasVersionVector // false')
+          if [ "$HAS_VV" = "true" ]; then
+            VV_DATA=$(echo '${{ steps.bench-parse.outputs.PARSED }}' | jq -r '[.grouped | to_entries[] | select(.key | test("VersionVector|SyncConcurrency"))] | map("\(.key): \(.value | tostring)") | join("\n")')
+            VV_PROMPT="Compare Lamport vs VersionVector performance from this benchmark data. Provide a concise summary:
+
+            ${VV_DATA}"
+            VV_ANALYSIS=$(claude -p "$VV_PROMPT" --model claude-sonnet-4-20250514 --max-tokens 1024 2>/dev/null || echo "")
+            EOF_VV="VV_EOF_$(date +%s)"
+            echo "VV_ANALYSIS<<${EOF_VV}" >> $GITHUB_OUTPUT
+            echo "$VV_ANALYSIS" >> $GITHUB_OUTPUT
+            echo "${EOF_VV}" >> $GITHUB_OUTPUT
+          else
+            echo "VV_ANALYSIS=" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Post benchmark comment to PR
         if: github.event_name == 'pull_request' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
         env:
-          BENCH_RESULT: ${{ steps.curr-bench.outputs.BENCH_RESULT }}
-          PREV_BENCH_RESULT: ${{ steps.prev-bench.outputs.PREV_BENCH_RESULT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          payload=$(jq -n \
-           --arg repo "${{ github.repository }}" \
-           --arg pr_number "${{ github.event.pull_request.number }}" \
-           --arg commit_id "${{ github.sha }}" \
-           --arg prev_commit_id "${{ steps.prev-bench.outputs.PREV_COMMIT }}" \
-           --arg bench_result "$BENCH_RESULT" \
-           --arg prev_bench_result "$PREV_BENCH_RESULT" \
-           '{
-               target: "bench",
-               repo: $repo,
-               pr_number: $pr_number,
-               commit_id: $commit_id,
-               prev_commit_id: $prev_commit_id,
-               bench_result: $bench_result,
-               prev_bench_result: $prev_bench_result,
-           }')
+          SIGNIFICANT_TABLE=$(echo '${{ steps.bench-parse.outputs.PARSED }}' | jq -r '.significantChangesTable // ""')
+          GROUPED_TABLE=$(echo '${{ steps.bench-parse.outputs.PARSED }}' | jq -r '.groupedTable // ""')
+          COMMIT_ID="${{ github.sha }}"
+          PREV_COMMIT_ID="${{ steps.prev-bench.outputs.PREV_COMMIT }}"
 
-          response=$(curl -f -X POST ${{ secrets.N8N_WEBHOOK_URL }} \
-          -H "Content-Type: application/json" \
-          -d "$payload" || echo "CURL_ERROR")
+          VV_SECTION=""
+          if [ -n "${{ steps.bench-analysis.outputs.VV_ANALYSIS }}" ]; then
+            VV_SECTION="
+          ### Clock Analysis
 
-          if [ "$response" = "CURL_ERROR" ]; then
-            echo "::error::Failed to trigger n8n webhook"
-            exit 1
+          <details>
+          <summary>Lamport vs VersionVector</summary>
+
+          ${{ steps.bench-analysis.outputs.VV_ANALYSIS }}
+
+          </details>
+          "
           fi
+
+          cat > /tmp/bench-comment.md << EOF
+          <!-- yorkie-ci-benchmark n8n comment -->
+          ## Go Benchmark Analysis 📊
+
+          This is a comparison result between the previous(${PREV_COMMIT_ID}) and the current commit(${COMMIT_ID}).
+
+          ### Significant Changes (≥20% difference)
+
+          ${SIGNIFICANT_TABLE}
+
+          ${{ steps.bench-analysis.outputs.ANALYSIS }}
+
+          ${VV_SECTION}
+
+          ### Detailed Test Results
+
+          ${GROUPED_TABLE}
+          EOF
+
+          bash repo/scripts/ci/post-comment.sh \
+            "${{ github.repository }}" \
+            "${{ github.event.pull_request.number }}" \
+            "<!-- yorkie-ci-benchmark n8n comment -->" \
+            /tmp/bench-comment.md
 
       - name: Store benchmark result
         if: github.ref == 'refs/heads/main'
@@ -260,6 +346,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     needs: ci-target-check
     if: ${{ github.ref == 'refs/heads/main' || needs.ci-target-check.outputs.load-test == 'true' }}
@@ -269,6 +356,12 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+
+      - name: Set up Node.js
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
 
       - name: Checkout current repository
         uses: actions/checkout@v4
@@ -332,43 +425,59 @@ jobs:
       - name: Stop the server
         run: cd repo && make stop
 
-      - name: Trigger n8n webhook
+      - name: Parse load test results
         if: github.event_name == 'pull_request' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
+        id: load-parse
         env:
-          LOAD_RESULT: ${{ steps.curr-load.outputs.LOAD_RESULT }}
-          PREV_LOAD_RESULT: ${{ steps.prev-load.outputs.PREV_LOAD_RESULT }}
-          LOAD_SUMMARY: ${{ steps.curr-load.outputs.LOAD_SUMMARY }}
+          CURR_LOAD_RESULT: ${{ steps.curr-load.outputs.LOAD_RESULT }}
+          CURR_LOAD_SUMMARY: ${{ steps.curr-load.outputs.LOAD_SUMMARY }}
           PREV_LOAD_SUMMARY: ${{ steps.prev-load.outputs.PREV_LOAD_SUMMARY }}
         run: |
-          payload=$(jq -n \
-           --arg repo "${{ github.repository }}" \
-           --arg pr_number "${{ github.event.pull_request.number }}" \
-           --arg commit_id "${{ github.sha }}" \
-           --arg prev_commit_id "${{ steps.prev-load.outputs.PREV_COMMIT }}" \
-           --arg load_result "$LOAD_RESULT" \
-           --arg prev_load_result "$PREV_LOAD_RESULT" \
-           --arg load_summary "$LOAD_SUMMARY" \
-           --arg prev_load_summary "$PREV_LOAD_SUMMARY" \
-           '{
-               target: "load",
-               repo: $repo,
-               pr_number: $pr_number,
-               commit_id: $commit_id,
-               prev_commit_id: $prev_commit_id,
-               load_result: $load_result,
-               prev_load_result: $prev_load_result,
-               load_summary: $load_summary,
-               prev_load_summary: $prev_load_summary
-           }')
+          PARSED=$(node repo/scripts/ci/parse-load.js)
+          EOF_MARKER="LOAD_PARSE_EOF_$(date +%s)"
+          echo "PARSED<<${EOF_MARKER}" >> $GITHUB_OUTPUT
+          echo "$PARSED" >> $GITHUB_OUTPUT
+          echo "${EOF_MARKER}" >> $GITHUB_OUTPUT
 
-           response=$(curl -f -X POST ${{ secrets.N8N_WEBHOOK_URL }} \
-           -H "Content-Type: application/json" \
-           -d "$payload" || echo "CURL_ERROR")
+      - name: Post load test comment to PR
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CHANGE_TABLE=$(echo '${{ steps.load-parse.outputs.PARSED }}' | jq -r '.table // ""')
+          RESULT=$(echo '${{ steps.load-parse.outputs.PARSED }}' | jq -r '.result // ""')
+          COMMIT_ID="${{ github.sha }}"
+          PREV_COMMIT_ID="${{ steps.prev-load.outputs.PREV_COMMIT }}"
 
-           if [ "$response" = "CURL_ERROR" ]; then
-               echo "::error::Failed to trigger n8n webhook"
-               exit 1
-           fi
+          CHANGE_SECTION=""
+          if [ -n "$CHANGE_TABLE" ] && [ "$CHANGE_TABLE" != "null" ]; then
+            CHANGE_SECTION="### Change
+
+          ${CHANGE_TABLE}"
+          fi
+
+          cat > /tmp/load-comment.md << EOF
+          <!-- yorkie-ci-load n8n comment -->
+          ## k6 Load Test 📊
+
+          This is a comparison result between the previous(${PREV_COMMIT_ID}) and the current commit(${COMMIT_ID}).
+
+          ${CHANGE_SECTION}
+
+          ### Result
+
+          <details>
+
+          ${RESULT}
+
+          </details>
+          EOF
+
+          bash repo/scripts/ci/post-comment.sh \
+            "${{ github.repository }}" \
+            "${{ github.event.pull_request.number }}" \
+            "<!-- yorkie-ci-load n8n comment -->" \
+            /tmp/load-comment.md
 
       - name: Store load result
         if: github.ref == 'refs/heads/main'

--- a/scripts/ci/parse-bench.js
+++ b/scripts/ci/parse-bench.js
@@ -148,8 +148,9 @@ function isSignificant(pct, absChange, unit) {
   return true;
 }
 
-// Build comparison rows for a set of benchmark names
-// Returns array of { name, metrics: [{ unit, prev, curr, pct, significant }] }
+// Build comparison rows for a set of benchmark names.
+// Returns { rows: [{ name, metrics: [{ unit, prevVal, currVal, pct, absChange, significant }] }],
+//           sortedUnits: string[] }
 function buildRows(names, prevData, currData) {
   // Collect all units seen across these benchmarks
   const allUnits = new Set();

--- a/scripts/ci/parse-bench.js
+++ b/scripts/ci/parse-bench.js
@@ -31,6 +31,8 @@ const BENCH_LINE_RE =
 const TIME_UNITS = new Set(['ns/op', '(ns)', '(ms)', '(s)']);
 const MEMORY_UNITS = new Set(['B/op', '(bytes)']);
 const ALLOC_UNITS = new Set(['allocs/op', '(allocs)']);
+// Throughput units where higher is better (e.g. MB/s, ops/s)
+const THROUGHPUT_UNITS = new Set(['MB/s', 'ops/s', 'docs/s', 'req/s']);
 
 // Significant change thresholds
 const SIG_PCT = 20; // percent
@@ -130,13 +132,15 @@ function pctChange(prev, curr) {
   return ((curr - prev) / prev) * 100;
 }
 
-// Indicator emoji
-function indicator(pct) {
+// Indicator emoji.
+// For most units (time, memory, allocs): lower is better (negative % = 🟢).
+// For throughput units (MB/s, ops/s): higher is better (positive % = 🟢).
+function indicator(pct, unit) {
   if (pct === null) return '⚪';
-  // For time and memory: negative pct = improvement (green)
-  // For allocs: negative pct = improvement (green)
   if (Math.abs(pct) < 0.5) return '⚪';
-  return pct < 0 ? '🟢' : '🔴';
+  const higherBetter = THROUGHPUT_UNITS.has(unit);
+  const improved = higherBetter ? pct > 0 : pct < 0;
+  return improved ? '🟢' : '🔴';
 }
 
 // Determine if a change is significant
@@ -233,7 +237,7 @@ function buildGroupTable(groupName, names, prevData, currData) {
       const currStr = currVal !== null ? formatValue(currVal, unit) : 'N/A';
       let changeStr = '⚪ N/A';
       if (pct !== null) {
-        const icon = indicator(pct);
+        const icon = indicator(pct, unit);
         const sign = pct > 0 ? '+' : '';
         changeStr = `${icon} ${sign}${pct.toFixed(1)}%`;
       }
@@ -271,7 +275,7 @@ function buildSignificantTable(grouped, prevData, currData) {
   for (const { name, unit, prevVal, currVal, pct } of sigRows) {
     const prevStr = prevVal !== null ? formatValue(prevVal, unit) : 'N/A';
     const currStr = currVal !== null ? formatValue(currVal, unit) : 'N/A';
-    const icon = indicator(pct);
+    const icon = indicator(pct, unit);
     const sign = pct > 0 ? '+' : '';
     const changeStr = `${icon} ${sign}${pct.toFixed(1)}%`;
     lines.push(`| ${name} | ${unitLabel(unit)} | ${prevStr} | ${currStr} | ${changeStr} |`);

--- a/scripts/ci/parse-bench.js
+++ b/scripts/ci/parse-bench.js
@@ -1,0 +1,356 @@
+#!/usr/bin/env node
+// Copyright 2026 The Yorkie Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// parse-bench.js — parses Go benchmark output and computes percentage changes.
+//
+// Input (env vars):
+//   PREV_BENCH_RESULT  JSON-encoded string of previous Go benchmark output
+//   CURR_BENCH_RESULT  JSON-encoded string of current Go benchmark output
+//
+// Output (stdout):
+//   JSON: { groupedTable, significantChangesTable, hasVersionVector, grouped }
+
+const BENCH_LINE_RE =
+  /^(?<name>Benchmark[\w/()$%^&*\-=|,[\]{}\"#]*?)(?<procs>-\d+)?\s+(?<times>\d+)\s+(?<remainder>.+)$/;
+
+// Unit classification
+const TIME_UNITS = new Set(['ns/op', '(ns)', '(ms)', '(s)']);
+const MEMORY_UNITS = new Set(['B/op', '(bytes)']);
+const ALLOC_UNITS = new Set(['allocs/op', '(allocs)']);
+
+// Significant change thresholds
+const SIG_PCT = 20; // percent
+const SIG_TIME_NS = 1000; // 1 µs
+const SIG_BYTES = 8;
+const SIG_ALLOCS = 1;
+
+// Convert raw value to nanoseconds for time comparison
+function toNs(value, unit) {
+  switch (unit) {
+    case 'ns/op':
+    case '(ns)':
+      return value;
+    case '(ms)':
+      return value * 1e6;
+    case '(s)':
+      return value * 1e9;
+    default:
+      return value;
+  }
+}
+
+// Format nanoseconds to human-readable string
+function formatTime(ns) {
+  if (ns >= 1e9) return (ns / 1e9).toFixed(3) + ' s';
+  if (ns >= 1e6) return (ns / 1e6).toFixed(3) + ' ms';
+  if (ns >= 1e3) return (ns / 1e3).toFixed(3) + ' µs';
+  return ns.toFixed(3) + ' ns';
+}
+
+// Format bytes to human-readable string
+function formatBytes(b) {
+  if (b >= 1024 ** 3) return (b / 1024 ** 3).toFixed(2) + ' GB';
+  if (b >= 1024 ** 2) return (b / 1024 ** 2).toFixed(2) + ' MB';
+  if (b >= 1024) return (b / 1024).toFixed(2) + ' KB';
+  return b.toFixed(0) + ' B';
+}
+
+// Format allocation count
+function formatAllocs(n) {
+  return n.toFixed(0);
+}
+
+// Format a metric value given its unit
+function formatValue(value, unit) {
+  if (TIME_UNITS.has(unit)) return formatTime(toNs(value, unit));
+  if (MEMORY_UNITS.has(unit)) return formatBytes(value);
+  if (ALLOC_UNITS.has(unit)) return formatAllocs(value);
+  return value.toString();
+}
+
+// Determine unit category label for table headers
+function unitLabel(unit) {
+  if (TIME_UNITS.has(unit)) return 'Time';
+  if (MEMORY_UNITS.has(unit)) return 'Memory';
+  if (ALLOC_UNITS.has(unit)) return 'Allocs';
+  return unit;
+}
+
+// Parse a single Go benchmark output string into a map:
+//   { benchmarkName => { metricUnit => value } }
+function parseBenchOutput(text) {
+  const results = {};
+  for (const line of text.split(/\r?\n/)) {
+    const m = BENCH_LINE_RE.exec(line.trim());
+    if (!m) continue;
+
+    const { name, remainder } = m.groups;
+    const parts = remainder.trim().split(/\s+/);
+    const metrics = {};
+
+    for (let i = 0; i + 1 < parts.length; i += 2) {
+      const val = parseFloat(parts[i]);
+      const unit = parts[i + 1];
+      if (!isNaN(val)) {
+        metrics[unit] = val;
+      }
+    }
+
+    if (Object.keys(metrics).length > 0) {
+      results[name] = metrics;
+    }
+  }
+  return results;
+}
+
+// Extract group prefix from a benchmark name.
+// e.g. BenchmarkDocument/constructor => BenchmarkDocument
+function groupPrefix(name) {
+  const slash = name.indexOf('/');
+  return slash !== -1 ? name.slice(0, slash) : name;
+}
+
+// Compute percentage change: (curr - prev) / prev * 100
+function pctChange(prev, curr) {
+  if (prev === 0) return null;
+  return ((curr - prev) / prev) * 100;
+}
+
+// Indicator emoji
+function indicator(pct) {
+  if (pct === null) return '⚪';
+  // For time and memory: negative pct = improvement (green)
+  // For allocs: negative pct = improvement (green)
+  if (Math.abs(pct) < 0.5) return '⚪';
+  return pct < 0 ? '🟢' : '🔴';
+}
+
+// Determine if a change is significant
+function isSignificant(pct, absChange, unit) {
+  if (pct === null || Math.abs(pct) < SIG_PCT) return false;
+  if (TIME_UNITS.has(unit)) return absChange >= SIG_TIME_NS;
+  if (MEMORY_UNITS.has(unit)) return absChange >= SIG_BYTES;
+  if (ALLOC_UNITS.has(unit)) return absChange >= SIG_ALLOCS;
+  return true;
+}
+
+// Build comparison rows for a set of benchmark names
+// Returns array of { name, metrics: [{ unit, prev, curr, pct, significant }] }
+function buildRows(names, prevData, currData) {
+  // Collect all units seen across these benchmarks
+  const allUnits = new Set();
+  for (const name of names) {
+    for (const unit of Object.keys(currData[name] || {})) allUnits.add(unit);
+    for (const unit of Object.keys(prevData[name] || {})) allUnits.add(unit);
+  }
+
+  // Sort units: time first, then memory, then allocs, then others
+  const unitOrder = (u) => {
+    if (TIME_UNITS.has(u)) return 0;
+    if (MEMORY_UNITS.has(u)) return 1;
+    if (ALLOC_UNITS.has(u)) return 2;
+    return 3;
+  };
+  const sortedUnits = [...allUnits].sort((a, b) => unitOrder(a) - unitOrder(b));
+
+  const rows = [];
+  for (const name of names) {
+    const prev = prevData[name] || {};
+    const curr = currData[name] || {};
+    const metrics = [];
+
+    for (const unit of sortedUnits) {
+      const prevVal = prev[unit] ?? null;
+      const currVal = curr[unit] ?? null;
+
+      let pct = null;
+      let absChange = null;
+
+      if (prevVal !== null && currVal !== null) {
+        pct = pctChange(
+          TIME_UNITS.has(unit) ? toNs(prevVal, unit) : prevVal,
+          TIME_UNITS.has(unit) ? toNs(currVal, unit) : currVal,
+        );
+        absChange = Math.abs(
+          (TIME_UNITS.has(unit) ? toNs(currVal, unit) : currVal) -
+            (TIME_UNITS.has(unit) ? toNs(prevVal, unit) : prevVal),
+        );
+      }
+
+      metrics.push({
+        unit,
+        prevVal,
+        currVal,
+        pct,
+        absChange,
+        significant: isSignificant(pct, absChange, unit),
+      });
+    }
+
+    rows.push({ name, metrics });
+  }
+
+  return { rows, sortedUnits };
+}
+
+// Render a short display name: strip the group prefix
+function shortName(name) {
+  const slash = name.indexOf('/');
+  return slash !== -1 ? name.slice(slash + 1) : name;
+}
+
+// Build markdown table for a group of benchmarks
+function buildGroupTable(groupName, names, prevData, currData) {
+  const { rows, sortedUnits } = buildRows(names, prevData, currData);
+  if (rows.length === 0) return '';
+
+  // Build header columns
+  const metricCols = sortedUnits.map((u) => unitLabel(u));
+  const header = ['Benchmark', ...metricCols.flatMap((l) => [`Prev ${l}`, `Curr ${l}`, 'Change'])];
+  const sep = header.map(() => '---');
+
+  const lines = [`| ${header.join(' | ')} |`, `| ${sep.join(' | ')} |`];
+
+  for (const { name, metrics } of rows) {
+    const cells = [shortName(name)];
+    for (const { unit, prevVal, currVal, pct, significant } of metrics) {
+      const prevStr = prevVal !== null ? formatValue(prevVal, unit) : 'N/A';
+      const currStr = currVal !== null ? formatValue(currVal, unit) : 'N/A';
+      let changeStr = '⚪ N/A';
+      if (pct !== null) {
+        const icon = indicator(pct);
+        const sign = pct > 0 ? '+' : '';
+        changeStr = `${icon} ${sign}${pct.toFixed(1)}%`;
+      }
+      cells.push(prevStr, currStr, changeStr);
+    }
+    lines.push(`| ${cells.join(' | ')} |`);
+  }
+
+  return lines.join('\n');
+}
+
+// Build significant changes table across all groups.
+// Returns { table, hasVersionVector }.
+function buildSignificantTable(grouped, prevData, currData) {
+  const sigRows = [];
+  let hasVV = false;
+
+  for (const [groupName, names] of Object.entries(grouped)) {
+    const { rows } = buildRows(names, prevData, currData);
+    for (const { name, metrics } of rows) {
+      for (const { unit, prevVal, currVal, pct, significant } of metrics) {
+        if (!significant) continue;
+        sigRows.push({ name, unit, prevVal, currVal, pct });
+        if (name.includes('VersionVector')) hasVV = true;
+      }
+    }
+  }
+
+  if (sigRows.length === 0) return { table: '', hasVersionVector: hasVV };
+
+  const header = ['Benchmark', 'Metric', 'Prev', 'Curr', 'Change'];
+  const sep = header.map(() => '---');
+  const lines = [`| ${header.join(' | ')} |`, `| ${sep.join(' | ')} |`];
+
+  for (const { name, unit, prevVal, currVal, pct } of sigRows) {
+    const prevStr = prevVal !== null ? formatValue(prevVal, unit) : 'N/A';
+    const currStr = currVal !== null ? formatValue(currVal, unit) : 'N/A';
+    const icon = indicator(pct);
+    const sign = pct > 0 ? '+' : '';
+    const changeStr = `${icon} ${sign}${pct.toFixed(1)}%`;
+    lines.push(`| ${name} | ${unitLabel(unit)} | ${prevStr} | ${currStr} | ${changeStr} |`);
+  }
+
+  return { table: lines.join('\n'), hasVersionVector: hasVV };
+}
+
+const EMPTY_RESULT = JSON.stringify({
+  groupedTable: '',
+  significantChangesTable: '',
+  hasVersionVector: false,
+  grouped: {},
+});
+
+function main() {
+  const prevEnv = process.env.PREV_BENCH_RESULT;
+  const currEnv = process.env.CURR_BENCH_RESULT;
+
+  // If either is missing or null, output empty result and exit
+  if (!prevEnv || !currEnv) {
+    process.stdout.write(EMPTY_RESULT);
+    process.exit(0);
+  }
+
+  let prevText, currText;
+  try {
+    prevText = JSON.parse(prevEnv);
+    currText = JSON.parse(currEnv);
+  } catch (e) {
+    process.stderr.write('Failed to parse input JSON: ' + e.message + '\n');
+    process.exit(1);
+  }
+
+  if (!prevText || prevText === 'null' || !currText || currText === 'null') {
+    process.stdout.write(EMPTY_RESULT);
+    process.exit(0);
+  }
+
+  const prevData = parseBenchOutput(prevText);
+  const currData = parseBenchOutput(currText);
+
+  // Group benchmark names by prefix
+  const grouped = {};
+  const allNames = new Set([...Object.keys(prevData), ...Object.keys(currData)]);
+
+  for (const name of allNames) {
+    const prefix = groupPrefix(name);
+    if (!grouped[prefix]) grouped[prefix] = [];
+    if (!grouped[prefix].includes(name)) grouped[prefix].push(name);
+  }
+
+  // Sort names within each group
+  for (const names of Object.values(grouped)) {
+    names.sort();
+  }
+
+  // Build grouped table with <details> sections
+  const groupSections = [];
+  for (const [groupName, names] of Object.entries(grouped)) {
+    const table = buildGroupTable(groupName, names, prevData, currData);
+    if (!table) continue;
+    groupSections.push(
+      `<details>\n<summary>${groupName}</summary>\n\n${table}\n\n</details>`,
+    );
+  }
+  const groupedTable = groupSections.join('\n\n');
+
+  // Build significant changes table and check for VersionVector
+  const { table: significantChangesTable, hasVersionVector } =
+    buildSignificantTable(grouped, prevData, currData);
+
+  process.stdout.write(
+    JSON.stringify({
+      groupedTable,
+      significantChangesTable,
+      hasVersionVector,
+      grouped,
+    }),
+  );
+}
+
+main();

--- a/scripts/ci/parse-load.js
+++ b/scripts/ci/parse-load.js
@@ -39,14 +39,14 @@ const NOISE_RES = [
 ];
 
 // Target metrics to extract from the k6 summary JSON
-// Format: [dotPath, displayLabel, isCount]
+// Format: [dotPath, displayLabel, isCount, higherIsBetter]
 const TARGET_METRICS = [
-  ['transaction_time.avg', 'Transaction Time (avg)', false],
-  ['http_req_duration.avg', 'HTTP Req Duration (avg)', false],
-  ['http_req_duration.p(95)', 'HTTP Req Duration (p95)', false],
-  ['iteration_duration.avg', 'Iteration Duration (avg)', false],
-  ['data_received.count', 'Data Received', true],
-  ['data_sent.count', 'Data Sent', true],
+  ['transaction_time.avg', 'Transaction Time (avg)', false, false],
+  ['http_req_duration.avg', 'HTTP Req Duration (avg)', false, false],
+  ['http_req_duration.p(95)', 'HTTP Req Duration (p95)', false, false],
+  ['iteration_duration.avg', 'Iteration Duration (avg)', false, false],
+  ['data_received.count', 'Data Received', true, true],
+  ['data_sent.count', 'Data Sent', true, true],
 ];
 
 // Filter noise lines from k6 output
@@ -62,7 +62,7 @@ function filterOutput(text) {
 }
 
 // Resolve a dot-path like "http_req_duration.p(95)" from the k6 metrics object.
-// k6 summary structure: { metrics: { <name>: { values: { avg, "p(95)", ... } } } }
+// k6 --summary-export shape: { metrics: { <name>: { avg, "p(95)", count, ... } } }
 function resolveMetric(summary, path) {
   if (!summary || !summary.metrics) return null;
   const dot = path.indexOf('.');
@@ -95,12 +95,12 @@ function pctChange(prev, curr) {
 }
 
 // Change indicator emoji.
-// For load metrics: lower is generally better (time, bytes transferred).
-// Negative pct (curr < prev) = improvement = 🟢
-// Positive pct (curr > prev) = regression = 🔴
-function indicator(pct) {
+// higherIsBetter=false (default): negative pct = improvement = 🟢
+// higherIsBetter=true (throughput): positive pct = improvement = 🟢
+function indicator(pct, higherIsBetter) {
   if (pct === null) return '⚪';
   if (Math.abs(pct) < 0.5) return '⚪';
+  if (higherIsBetter) return pct > 0 ? '🟢' : '🔴';
   return pct < 0 ? '🟢' : '🔴';
 }
 
@@ -110,7 +110,7 @@ function buildTable(prevSummary, currSummary) {
   const sep = header.map(() => '---');
   const lines = [`| ${header.join(' | ')} |`, `| ${sep.join(' | ')} |`];
 
-  for (const [path, label, isCount] of TARGET_METRICS) {
+  for (const [path, label, isCount, higherIsBetter] of TARGET_METRICS) {
     const prevVal = resolveMetric(prevSummary, path);
     const currVal = resolveMetric(currSummary, path);
 
@@ -122,7 +122,7 @@ function buildTable(prevSummary, currSummary) {
     if (pct === null) {
       changeStr = '⚪ –';
     } else {
-      const icon = indicator(pct);
+      const icon = indicator(pct, higherIsBetter);
       const sign = pct > 0 ? '+' : '';
       changeStr = `${icon} ${sign}${pct.toFixed(1)}%`;
     }
@@ -148,7 +148,7 @@ function main() {
       process.stderr.write('Failed to parse CURR_LOAD_RESULT JSON: ' + e.message + '\n');
       process.exit(1);
     }
-    if (text && text !== 'null') {
+    if (text) {
       result = filterOutput(text);
     }
   }
@@ -165,7 +165,7 @@ function main() {
       process.exit(1);
     }
 
-    if (currSummary && currSummary !== 'null' && prevSummary && prevSummary !== 'null') {
+    if (currSummary && prevSummary) {
       table = buildTable(prevSummary, currSummary);
     }
   }

--- a/scripts/ci/parse-load.js
+++ b/scripts/ci/parse-load.js
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+// Copyright 2026 The Yorkie Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// parse-load.js — parses k6 load test output and summary JSON, computes
+// metric diffs, and generates a markdown comparison table.
+//
+// Input (env vars):
+//   CURR_LOAD_RESULT    JSON-encoded string of k6 console output
+//   CURR_LOAD_SUMMARY   JSON-encoded k6 summary object
+//   PREV_LOAD_SUMMARY   JSON-encoded previous k6 summary object
+//
+// Output (stdout):
+//   JSON: { result, table }
+//     result  filtered k6 output (null if no input)
+//     table   markdown comparison table (null if no prev/curr summaries)
+
+// Regexes for filtering k6 progress noise from console output
+const NOISE_RES = [
+  /^\s*script:\s*(.+)$/m,
+  /^\s*output:\s*(.+)$/m,
+  /^\s*execution:\s*(.+)$/m,
+  /running \(.*\), \d+\/\d+ VUs, \d+ complete and \d+ interrupted iterations/,
+  /\[\s*(\d+)%\s*\]\s*\d+(\/\d+)? VUs/,
+  /^(?:\|| |\n|\/|\u203e|\(|\)|_|\\|Grafana)+$/,
+];
+
+// Target metrics to extract from the k6 summary JSON
+// Format: [dotPath, displayLabel, isCount]
+const TARGET_METRICS = [
+  ['transaction_time.avg', 'Transaction Time (avg)', false],
+  ['http_req_duration.avg', 'HTTP Req Duration (avg)', false],
+  ['http_req_duration.p(95)', 'HTTP Req Duration (p95)', false],
+  ['iteration_duration.avg', 'Iteration Duration (avg)', false],
+  ['data_received.count', 'Data Received', true],
+  ['data_sent.count', 'Data Sent', true],
+];
+
+// Filter noise lines from k6 output
+function filterOutput(text) {
+  const lines = text.split(/\r?\n/);
+  const kept = lines.filter((line) => !NOISE_RES.some((re) => re.test(line)));
+  // Trim leading/trailing blank lines
+  let start = 0;
+  let end = kept.length - 1;
+  while (start <= end && kept[start].trim() === '') start++;
+  while (end >= start && kept[end].trim() === '') end--;
+  return kept.slice(start, end + 1).join('\n');
+}
+
+// Resolve a dot-path like "http_req_duration.p(95)" from the k6 metrics object.
+// k6 summary structure: { metrics: { <name>: { values: { avg, "p(95)", ... } } } }
+function resolveMetric(summary, path) {
+  if (!summary || !summary.metrics) return null;
+  const dot = path.indexOf('.');
+  if (dot === -1) return null;
+
+  const metricName = path.slice(0, dot);
+  const valuePath = path.slice(dot + 1);
+
+  const metric = summary.metrics[metricName];
+  if (!metric || !metric.values) return null;
+  const val = metric.values[valuePath];
+  return val !== undefined ? val : null;
+}
+
+// Format a numeric value: integers with locale formatting, floats with 2 dp
+function formatNum(value, isCount) {
+  if (value === null || value === undefined) return '–';
+  if (isCount) {
+    // Byte counts — show as locale integer
+    return Number(value).toLocaleString('en-US');
+  }
+  // Time values (ms) — float with 2 dp
+  return Number(value).toFixed(2);
+}
+
+// Compute percentage change: (curr - prev) / prev * 100
+function pctChange(prev, curr) {
+  if (prev === 0 || prev === null || curr === null) return null;
+  return ((curr - prev) / prev) * 100;
+}
+
+// Change indicator emoji.
+// For load metrics: lower is generally better (time, bytes transferred).
+// Negative pct (curr < prev) = improvement = 🟢
+// Positive pct (curr > prev) = regression = 🔴
+function indicator(pct) {
+  if (pct === null) return '⚪';
+  if (Math.abs(pct) < 0.5) return '⚪';
+  return pct < 0 ? '🟢' : '🔴';
+}
+
+// Build the markdown comparison table
+function buildTable(prevSummary, currSummary) {
+  const header = ['Metric', 'Previous', 'Current', 'Change'];
+  const sep = header.map(() => '---');
+  const lines = [`| ${header.join(' | ')} |`, `| ${sep.join(' | ')} |`];
+
+  for (const [path, label, isCount] of TARGET_METRICS) {
+    const prevVal = resolveMetric(prevSummary, path);
+    const currVal = resolveMetric(currSummary, path);
+
+    const prevStr = formatNum(prevVal, isCount);
+    const currStr = formatNum(currVal, isCount);
+
+    const pct = pctChange(prevVal, currVal);
+    let changeStr;
+    if (pct === null) {
+      changeStr = '⚪ –';
+    } else {
+      const icon = indicator(pct);
+      const sign = pct > 0 ? '+' : '';
+      changeStr = `${icon} ${sign}${pct.toFixed(1)}%`;
+    }
+
+    lines.push(`| ${label} | ${prevStr} | ${currStr} | ${changeStr} |`);
+  }
+
+  return lines.join('\n');
+}
+
+function main() {
+  const currResultEnv = process.env.CURR_LOAD_RESULT;
+  const currSummaryEnv = process.env.CURR_LOAD_SUMMARY;
+  const prevSummaryEnv = process.env.PREV_LOAD_SUMMARY;
+
+  // Filter k6 output
+  let result = null;
+  if (currResultEnv) {
+    let text;
+    try {
+      text = JSON.parse(currResultEnv);
+    } catch (e) {
+      process.stderr.write('Failed to parse CURR_LOAD_RESULT JSON: ' + e.message + '\n');
+      process.exit(1);
+    }
+    if (text && text !== 'null') {
+      result = filterOutput(text);
+    }
+  }
+
+  // Build comparison table if both summaries are available
+  let table = null;
+  if (currSummaryEnv && prevSummaryEnv) {
+    let currSummary, prevSummary;
+    try {
+      currSummary = JSON.parse(currSummaryEnv);
+      prevSummary = JSON.parse(prevSummaryEnv);
+    } catch (e) {
+      process.stderr.write('Failed to parse summary JSON: ' + e.message + '\n');
+      process.exit(1);
+    }
+
+    if (currSummary && currSummary !== 'null' && prevSummary && prevSummary !== 'null') {
+      table = buildTable(prevSummary, currSummary);
+    }
+  }
+
+  process.stdout.write(JSON.stringify({ result, table }));
+}
+
+main();

--- a/scripts/ci/parse-load.js
+++ b/scripts/ci/parse-load.js
@@ -72,8 +72,8 @@ function resolveMetric(summary, path) {
   const valuePath = path.slice(dot + 1);
 
   const metric = summary.metrics[metricName];
-  if (!metric || !metric.values) return null;
-  const val = metric.values[valuePath];
+  if (!metric) return null;
+  const val = metric[valuePath];
   return val !== undefined ? val : null;
 }
 


### PR DESCRIPTION
## Summary

- Add `scripts/ci/parse-bench.js`, `parse-load.js`, `post-comment.sh` to handle benchmark and load test result analysis inline
- Replace the n8n webhook calls in bench and load-test jobs with local parsing, Claude Code CLI analysis, and direct PR comment posting via `gh api`
- Fix k6 summary metric extraction (remove incorrect `.values` indirection)

### Motivation

The n8n instance (`n8n.yorkie.dev`) currently receives CI results via webhook, processes them with OpenAI, and posts PR comments. This adds external infrastructure dependency (n8n + PostgreSQL on K8s) for a task that can be done inline in GitHub Actions.

After this change:
- No external n8n dependency for CI
- Analysis uses Claude Code CLI (already used in `second-brain` repo)
- Comment create/update logic is a simple shell script using `gh api`
- `N8N_WEBHOOK_URL` secret can be removed, `CLAUDE_CODE_OAUTH_TOKEN` secret needs to be added

### Follow-up (after merge)

1. Add `CLAUDE_CODE_OAUTH_TOKEN` secret to this repo
2. Remove `N8N_WEBHOOK_URL` secret
3. Remove `k8s/n8n/` from devops repo (frees n8n namespace, PostgreSQL, 12Gi PVC)

## Test plan

- [ ] Verify `parse-bench.js` parses Go benchmark output correctly
- [ ] Verify `parse-load.js` parses k6 output and summary JSON correctly
- [ ] Verify `post-comment.sh` syntax is valid
- [ ] Verify `ci.yml` step ID references are all valid
- [ ] Trigger bench CI on a test PR to confirm end-to-end flow
- [ ] Trigger load-test CI on a test PR to confirm end-to-end flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * PRs now include formatted benchmark comparison tables with percent-change indicators, highlighting significant regressions or improvements.
  * Benchmark PR comments include automated analysis sections and optional expanded “Clock” details when relevant.
  * Load test PR comments show cleaned output, metric comparisons to baseline, and emoji-style indicators for change magnitude.
  * Comments are now generated and posted automatically for bench and load-test PR runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->