### PR TITLE
Add Istio ambient mode support to yorkie-cluster chart

### DIFF
--- a/build/charts/yorkie-cluster/templates/istio/waypoint.yaml
+++ b/build/charts/yorkie-cluster/templates/istio/waypoint.yaml
@@ -1,0 +1,15 @@
+{{- if eq .Values.istio.mode "ambient" }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ .Values.yorkie.name }}-waypoint
+  namespace: {{ .Values.yorkie.namespace }}
+  labels:
+    istio.io/waypoint-for: service
+spec:
+  gatewayClassName: istio-waypoint
+  listeners:
+    - name: mesh
+      port: 15008
+      protocol: HBONE
+{{- end }}

--- a/build/charts/yorkie-cluster/templates/yorkie/deployment.yaml
+++ b/build/charts/yorkie-cluster/templates/yorkie/deployment.yaml
@@ -31,6 +31,9 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.yorkie.ports.profilingPort }}"
         prometheus.io/path: "/metrics"
+        {{- if eq .Values.istio.mode "ambient" }}
+        sidecar.istio.io/inject: "false"
+        {{- end }}
         {{- with .Values.yorkie.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/build/charts/yorkie-cluster/templates/yorkie/service.yaml
+++ b/build/charts/yorkie-cluster/templates/yorkie/service.yaml
@@ -13,6 +13,9 @@ metadata:
     prometheus.io/scrape: "true"
     prometheus.io/port: "{{ .Values.yorkie.ports.profilingPort }}"
     prometheus.io/path: "/metrics"
+    {{- if eq .Values.istio.mode "ambient" }}
+    istio.io/use-waypoint: {{ .Values.yorkie.name }}-waypoint
+    {{- end }}
 spec:
   ports:
   # even when the port name is grpc-web,

--- a/build/charts/yorkie-cluster/values.yaml
+++ b/build/charts/yorkie-cluster/values.yaml
@@ -28,6 +28,11 @@ yorkie:
 
   resources: {}
 
+# Configuration for Istio service mesh
+istio:
+  # Istio data plane mode: "sidecar" or "ambient"
+  mode: sidecar
+
 # Configuration for istio ingress gateway
 ingressGateway:
   consistentHash:


### PR DESCRIPTION
## Summary
- Add `istio.mode` value (`sidecar` | `ambient`, default: `sidecar`)
- When ambient: disable sidecar injection, deploy waypoint proxy Gateway, annotate service with `istio.io/use-waypoint`
- Ingress gateway, VirtualService, DestinationRule, EnvoyFilters unchanged (all GATEWAY context, work as-is)

## Test plan
- [x] `helm template --set istio.mode=ambient` renders waypoint Gateway, sidecar disable annotation, use-waypoint annotation
- [x] `helm template --set istio.mode=sidecar` renders no ambient resources (backward compatible)
- [ ] Deploy with `istio.mode=ambient` on a cluster with Istio ambient mode installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Istio ambient mode configuration, allowing users to select between sidecar and ambient service mesh deployment modes for enhanced flexibility in cluster networking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->