### PR TITLE
Bump version to v0.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and Yorkie adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## [v0.7.5] - 2026-04-20
+
+### Added
+
+- Add Counter dedup mode with HyperLogLog for UV measurement by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1733
+- Add podAnnotations support to Helm deployment template by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1746
+
+### Changed
+
+- Simplify Counter interface with type inference by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1738
+- Remove hardcoded healthcheck-port from Ingress template by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1739
+- Remove deprecated yorkie-argocd Helm chart by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1748
+- Replace n8n webhook with inline CI result reporting by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1749
+
+### Fixed
+
+- Discard stale-epoch changes in pushPack before cache insertion by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1742
+- Acquire DocPushKey lock before epoch check in pushPack by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1745
+
 ## [v0.7.4] - 2026-04-11
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-YORKIE_VERSION := 0.7.4
+YORKIE_VERSION := 0.7.5
 
 GO_PROJECT = github.com/yorkie-team/yorkie
 

--- a/api/docs/yorkie.base.yaml
+++ b/api/docs/yorkie.base.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Yorkie
   description: "Yorkie is an open source document store for building collaborative editing applications."
-  version: v0.7.4
+  version: v0.7.5
 servers:
   - url: https://api.yorkie.dev
     description: Production server

--- a/api/docs/yorkie/v1/admin.openapi.yaml
+++ b/api/docs/yorkie/v1/admin.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.4
+  version: v0.7.5
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/api/docs/yorkie/v1/resources.openapi.yaml
+++ b/api/docs/yorkie/v1/resources.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.4
+  version: v0.7.5
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/api/docs/yorkie/v1/yorkie.openapi.yaml
+++ b/api/docs/yorkie/v1/yorkie.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.4
+  version: v0.7.5
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/build/charts/yorkie-cluster/Chart.yaml
+++ b/build/charts/yorkie-cluster/Chart.yaml
@@ -9,8 +9,8 @@ maintainers:
 
 sources:
   - https://github.com/yorkie-team/yorkie
-version: 0.7.5-rc2
-appVersion: "0.7.4"
+version: 0.7.5
+appVersion: "0.7.5"
 kubeVersion: ">=1.28.0-0"
 
 dependencies:


### PR DESCRIPTION
## Summary
- Bump `YORKIE_VERSION` in Makefile to 0.7.5
- Bump yorkie-cluster Helm chart version and appVersion to 0.7.5
- Bump API docs version to v0.7.5

## Test plan
- [x] Verify CI passes
- [x] After merge: create GitHub Release with changelog and binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Project version bumped to 0.7.5 across build config, release metadata, and charts; Helm chart and app version updated.
  * CHANGELOG updated with a new v0.7.5 release notes section.

* **Documentation**
  * API/OpenAPI documentation version metadata updated to v0.7.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->