### PR TITLE
Add mongodb-exporter to yorkie-monitoring chart

### DIFF
--- a/build/charts/yorkie-monitoring/Chart.yaml
+++ b/build/charts/yorkie-monitoring/Chart.yaml
@@ -11,8 +11,8 @@ maintainers:
 
 sources:
   - https://github.com/yorkie-team/yorkie
-version: 0.7.3
-appVersion: "0.7.3"
+version: 0.7.5
+appVersion: "0.7.5"
 kubeVersion: ">=1.24.0-0"
 
 keywords:

--- a/build/charts/yorkie-monitoring/templates/mongodb-exporter/dashboard-configmap.yaml
+++ b/build/charts/yorkie-monitoring/templates/mongodb-exporter/dashboard-configmap.yaml
@@ -1,0 +1,121 @@
+{{- if .Values.mongodbExporter.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.monitoring.name }}-mongodb-dashboard
+  namespace: {{ .Values.monitoring.namespace }}
+  labels:
+    app.kubernetes.io/name: mongodb-exporter
+    app.kubernetes.io/instance: {{ .Values.monitoring.name }}
+    app.kubernetes.io/component: mongodb-exporter
+    app.kubernetes.io/part-of: {{ .Values.monitoring.name }}
+    app.kubernetes.io/managed-by: Helm
+    grafana_dashboard: "1"
+data:
+  mongodb-mongos-overview.json: |-
+    {
+      "uid": "mongodb-yorkie",
+      "title": "MongoDB Mongos Overview",
+      "tags": ["mongodb", "yorkie"],
+      "timezone": "utc",
+      "refresh": "30s",
+      "time": { "from": "now-1h", "to": "now" },
+      "panels": [
+        {
+          "id": 1, "type": "stat", "title": "MongoDB Up",
+          "gridPos": { "h": 4, "w": 4, "x": 0, "y": 0 },
+          "targets": [{ "expr": "mongodb_up", "legendFormat": "up", "refId": "A" }],
+          "fieldConfig": { "defaults": { "mappings": [{"type": "value", "options": {"0": {"text": "DOWN", "color": "red"}, "1": {"text": "UP", "color": "green"}}}] } },
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        },
+        {
+          "id": 2, "type": "stat", "title": "Shards",
+          "gridPos": { "h": 4, "w": 4, "x": 4, "y": 0 },
+          "targets": [{ "expr": "mongodb_mongos_sharding_shards_total", "legendFormat": "shards", "refId": "A" }],
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        },
+        {
+          "id": 3, "type": "stat", "title": "Chunks",
+          "gridPos": { "h": 4, "w": 4, "x": 8, "y": 0 },
+          "targets": [{ "expr": "mongodb_mongos_sharding_chunks_total", "legendFormat": "chunks", "refId": "A" }],
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        },
+        {
+          "id": 4, "type": "stat", "title": "Balancer",
+          "gridPos": { "h": 4, "w": 4, "x": 12, "y": 0 },
+          "targets": [{ "expr": "mongodb_mongos_sharding_balancer_enabled", "legendFormat": "enabled", "refId": "A" }],
+          "fieldConfig": { "defaults": { "mappings": [{"type": "value", "options": {"0": {"text": "OFF", "color": "red"}, "1": {"text": "ON", "color": "green"}}}] } },
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        },
+        {
+          "id": 5, "type": "stat", "title": "DB Data Size",
+          "gridPos": { "h": 4, "w": 4, "x": 16, "y": 0 },
+          "targets": [{ "expr": "mongodb_dbstats_dataSize{database=\"yorkie-meta\"}", "legendFormat": "data", "refId": "A" }],
+          "fieldConfig": { "defaults": { "unit": "bytes" } },
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        },
+        {
+          "id": 6, "type": "stat", "title": "DB Index Size",
+          "gridPos": { "h": 4, "w": 4, "x": 20, "y": 0 },
+          "targets": [{ "expr": "mongodb_dbstats_indexSize{database=\"yorkie-meta\"}", "legendFormat": "index", "refId": "A" }],
+          "fieldConfig": { "defaults": { "unit": "bytes" } },
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        },
+        {
+          "id": 10, "type": "timeseries", "title": "Read Ops by Collection",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+          "targets": [{ "expr": "rate(mongodb_collstats_latencyStats_reads_ops[5m])", "legendFormat": "{{ "{{" }}database{{ "}}" }}.{{ "{{" }}collection{{ "}}" }} ({{ "{{" }}shard{{ "}}" }})", "refId": "A" }],
+          "fieldConfig": { "defaults": { "unit": "ops" } },
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        },
+        {
+          "id": 11, "type": "timeseries", "title": "Write Ops by Collection",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+          "targets": [{ "expr": "rate(mongodb_collstats_latencyStats_writes_ops[5m])", "legendFormat": "{{ "{{" }}database{{ "}}" }}.{{ "{{" }}collection{{ "}}" }} ({{ "{{" }}shard{{ "}}" }})", "refId": "A" }],
+          "fieldConfig": { "defaults": { "unit": "ops" } },
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        },
+        {
+          "id": 12, "type": "timeseries", "title": "Read Latency by Collection (avg)",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+          "targets": [{ "expr": "rate(mongodb_collstats_latencyStats_reads_latency[5m]) / rate(mongodb_collstats_latencyStats_reads_ops[5m])", "legendFormat": "{{ "{{" }}database{{ "}}" }}.{{ "{{" }}collection{{ "}}" }} ({{ "{{" }}shard{{ "}}" }})", "refId": "A" }],
+          "fieldConfig": { "defaults": { "unit": "\u00b5s" } },
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        },
+        {
+          "id": 13, "type": "timeseries", "title": "Write Latency by Collection (avg)",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+          "targets": [{ "expr": "rate(mongodb_collstats_latencyStats_writes_latency[5m]) / rate(mongodb_collstats_latencyStats_writes_ops[5m])", "legendFormat": "{{ "{{" }}database{{ "}}" }}.{{ "{{" }}collection{{ "}}" }} ({{ "{{" }}shard{{ "}}" }})", "refId": "A" }],
+          "fieldConfig": { "defaults": { "unit": "\u00b5s" } },
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        },
+        {
+          "id": 20, "type": "timeseries", "title": "Collection Document Count",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
+          "targets": [{ "expr": "mongodb_collstats_storageStats_count", "legendFormat": "{{ "{{" }}database{{ "}}" }}.{{ "{{" }}collection{{ "}}" }} ({{ "{{" }}shard{{ "}}" }})", "refId": "A" }],
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        },
+        {
+          "id": 21, "type": "timeseries", "title": "Collection Storage Size",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 20 },
+          "targets": [{ "expr": "mongodb_collstats_storageStats_storageSize", "legendFormat": "{{ "{{" }}database{{ "}}" }}.{{ "{{" }}collection{{ "}}" }} ({{ "{{" }}shard{{ "}}" }})", "refId": "A" }],
+          "fieldConfig": { "defaults": { "unit": "bytes" } },
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        },
+        {
+          "id": 30, "type": "timeseries", "title": "Shard Chunk Distribution",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 28 },
+          "targets": [{ "expr": "mongodb_mongos_sharding_shard_chunks_total", "legendFormat": "{{ "{{" }}shard{{ "}}" }}", "refId": "A" }],
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        },
+        {
+          "id": 31, "type": "timeseries", "title": "Command Ops by Collection",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 28 },
+          "targets": [{ "expr": "rate(mongodb_collstats_latencyStats_commands_ops[5m])", "legendFormat": "{{ "{{" }}database{{ "}}" }}.{{ "{{" }}collection{{ "}}" }} ({{ "{{" }}shard{{ "}}" }})", "refId": "A" }],
+          "fieldConfig": { "defaults": { "unit": "ops" } },
+          "datasource": { "type": "prometheus", "uid": "prometheus" }
+        }
+      ],
+      "schemaVersion": 39
+    }
+{{- end }}

--- a/build/charts/yorkie-monitoring/templates/mongodb-exporter/deployment.yaml
+++ b/build/charts/yorkie-monitoring/templates/mongodb-exporter/deployment.yaml
@@ -28,9 +28,14 @@ spec:
           image: "{{ .Values.mongodbExporter.image.repository }}:{{ .Values.mongodbExporter.image.tag }}"
           imagePullPolicy: {{ .Values.mongodbExporter.image.pullPolicy }}
           args:
-            - --mongodb.uri={{ .Values.mongodbExporter.mongodb.uri }}
             - --collect-all
             - --compatible-mode
+          env:
+            - name: MONGODB_URI
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.mongodbExporter.mongodb.existingSecret | default (printf "%s-mongodb-exporter" .Values.monitoring.name) }}
+                  key: mongodb-uri
           ports:
             - name: metrics
               containerPort: 9216
@@ -45,6 +50,13 @@ spec:
               path: /
               port: metrics
             initialDelaySeconds: 10
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           resources:
             {{- toYaml .Values.mongodbExporter.resources | nindent 12 }}
 {{- end }}

--- a/build/charts/yorkie-monitoring/templates/mongodb-exporter/deployment.yaml
+++ b/build/charts/yorkie-monitoring/templates/mongodb-exporter/deployment.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.mongodbExporter.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.monitoring.name }}-mongodb-exporter
+  namespace: {{ .Values.monitoring.yorkieNamespace }}
+  labels:
+    app.kubernetes.io/name: mongodb-exporter
+    app.kubernetes.io/instance: {{ .Values.monitoring.name }}
+    app.kubernetes.io/component: mongodb-exporter
+    app.kubernetes.io/part-of: {{ .Values.monitoring.name }}
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mongodb-exporter
+      app.kubernetes.io/instance: {{ .Values.monitoring.name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mongodb-exporter
+        app.kubernetes.io/instance: {{ .Values.monitoring.name }}
+        app.kubernetes.io/component: mongodb-exporter
+    spec:
+      containers:
+        - name: mongodb-exporter
+          image: "{{ .Values.mongodbExporter.image.repository }}:{{ .Values.mongodbExporter.image.tag }}"
+          imagePullPolicy: {{ .Values.mongodbExporter.image.pullPolicy }}
+          args:
+            - --mongodb.uri={{ .Values.mongodbExporter.mongodb.uri }}
+            - --collect-all
+            - --compatible-mode
+          ports:
+            - name: metrics
+              containerPort: 9216
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: metrics
+            initialDelaySeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: metrics
+            initialDelaySeconds: 10
+          resources:
+            {{- toYaml .Values.mongodbExporter.resources | nindent 12 }}
+{{- end }}

--- a/build/charts/yorkie-monitoring/templates/mongodb-exporter/deployment.yaml
+++ b/build/charts/yorkie-monitoring/templates/mongodb-exporter/deployment.yaml
@@ -42,12 +42,12 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /metrics
               port: metrics
             initialDelaySeconds: 10
           readinessProbe:
             httpGet:
-              path: /
+              path: /metrics
               port: metrics
             initialDelaySeconds: 10
           securityContext:

--- a/build/charts/yorkie-monitoring/templates/mongodb-exporter/secret.yaml
+++ b/build/charts/yorkie-monitoring/templates/mongodb-exporter/secret.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.mongodbExporter.enabled (not .Values.mongodbExporter.mongodb.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.monitoring.name }}-mongodb-exporter
+  namespace: {{ .Values.monitoring.yorkieNamespace }}
+  labels:
+    app.kubernetes.io/name: mongodb-exporter
+    app.kubernetes.io/instance: {{ .Values.monitoring.name }}
+    app.kubernetes.io/component: mongodb-exporter
+    app.kubernetes.io/part-of: {{ .Values.monitoring.name }}
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+stringData:
+  mongodb-uri: {{ required "mongodbExporter.mongodb.uri is required when mongodbExporter.enabled is true and no existingSecret is set" .Values.mongodbExporter.mongodb.uri | quote }}
+{{- end }}

--- a/build/charts/yorkie-monitoring/templates/mongodb-exporter/service.yaml
+++ b/build/charts/yorkie-monitoring/templates/mongodb-exporter/service.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.mongodbExporter.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.monitoring.name }}-mongodb-exporter
+  namespace: {{ .Values.monitoring.yorkieNamespace }}
+  labels:
+    app.kubernetes.io/name: mongodb-exporter
+    app.kubernetes.io/instance: {{ .Values.monitoring.name }}
+    app.kubernetes.io/component: mongodb-exporter
+    app.kubernetes.io/part-of: {{ .Values.monitoring.name }}
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: metrics
+      port: 9216
+      targetPort: metrics
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: mongodb-exporter
+    app.kubernetes.io/instance: {{ .Values.monitoring.name }}
+{{- end }}

--- a/build/charts/yorkie-monitoring/templates/mongodb-exporter/servicemonitor.yaml
+++ b/build/charts/yorkie-monitoring/templates/mongodb-exporter/servicemonitor.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.mongodbExporter.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Values.monitoring.name }}-mongodb-exporter
+  namespace: {{ .Values.monitoring.namespace }}
+  labels:
+    app.kubernetes.io/name: mongodb-exporter
+    app.kubernetes.io/instance: {{ .Values.monitoring.name }}
+    app.kubernetes.io/component: mongodb-exporter
+    app.kubernetes.io/part-of: {{ .Values.monitoring.name }}
+    app.kubernetes.io/managed-by: Helm
+    prometheus: monitoring
+spec:
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+  namespaceSelector:
+    matchNames:
+      - {{ .Values.monitoring.yorkieNamespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mongodb-exporter
+      app.kubernetes.io/instance: {{ .Values.monitoring.name }}
+{{- end }}

--- a/build/charts/yorkie-monitoring/values.yaml
+++ b/build/charts/yorkie-monitoring/values.yaml
@@ -207,3 +207,23 @@ loki-stack:
     config:
       clients:
         - url: http://yorkie-monitoring-loki:3100/loki/api/v1/push
+
+# Configuration for MongoDB exporter
+mongodbExporter:
+  enabled: false
+
+  image:
+    repository: percona/mongodb_exporter
+    tag: "0.44.0"
+    pullPolicy: IfNotPresent
+
+  mongodb:
+    uri: ""
+
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi

--- a/build/charts/yorkie-monitoring/values.yaml
+++ b/build/charts/yorkie-monitoring/values.yaml
@@ -219,6 +219,7 @@ mongodbExporter:
 
   mongodb:
     uri: ""
+    existingSecret: ""
 
   resources:
     requests:


### PR DESCRIPTION
## Summary
- Add mongodb-exporter templates (Deployment, Service, ServiceMonitor, dashboard ConfigMap) to yorkie-monitoring chart
- Exporter connects to mongos and exposes metrics for Prometheus scraping
- Custom Grafana dashboard with collection-level read/write ops, latency, storage, and shard distribution
- Disabled by default (`mongodbExporter.enabled: false`), bump chart to 0.7.5

## Test plan
- [x] `helm template` renders correctly with enabled/disabled flag
- [x] Deployed on minikube with Percona MongoDB cluster
- [x] Verified `mongodb_up=1` in Prometheus
- [x] Verified MongoDB metrics (collstats, dbstats, sharding) exposed
- [x] Verified Grafana dashboard displays data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart version and appVersion to 0.7.5

* **New Features**
  * Optional MongoDB exporter integration for metrics collection (deployment, service, and service monitor)
  * Grafana dashboard added with comprehensive MongoDB metrics (uptime, shards, DB/collection sizes, ops, latencies)
  * Configurable settings for enabling the exporter, connection credentials, image, and resource limits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->