### PR TITLE
Copy attributes to split node in TreeNode.SplitElement

### DIFF
--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -1503,6 +1503,34 @@ func (t *Tree) Style(
 					diff.Add(newNode.DataSize())
 				}
 			}
+
+			// Propagate style to unknown split siblings so that a
+			// style operation whose range was determined before the
+			// split also covers the right part of the split.
+			if token.TokenType == index.Start && !isVersionVectorEmpty {
+				current := node
+				for current.InsNextID != nil {
+					next := t.findFloorNode(current.InsNextID)
+					if next == nil || next.IsText() {
+						break
+					}
+					if ticketKnown(versionVector, next.id.CreatedAt) {
+						break
+					}
+					for key, value := range attrs {
+						if rhtNode := next.SetAttr(key, value, editedAt); rhtNode != nil {
+							pairs = append(pairs, GCPair{
+								Parent: next,
+								Child:  rhtNode,
+							})
+						}
+						if newNode, ok := next.Attrs.nodeMapByKey[key]; ok {
+							diff.Add(newNode.DataSize())
+						}
+					}
+					current = next
+				}
+			}
 		}
 	}); err != nil {
 		return nil, resource.DataSize{}, err
@@ -1576,6 +1604,30 @@ func (t *Tree) RemoveStyle(
 						Parent: node,
 						Child:  rhtNode,
 					})
+				}
+			}
+
+			// Propagate remove-style to unknown split siblings.
+			if token.TokenType == index.Start && !isVersionVectorEmpty {
+				current := node
+				for current.InsNextID != nil {
+					next := t.findFloorNode(current.InsNextID)
+					if next == nil || next.IsText() {
+						break
+					}
+					if ticketKnown(versionVector, next.id.CreatedAt) {
+						break
+					}
+					for _, attr := range attrs {
+						rhtNodes := next.RemoveAttr(attr, editedAt)
+						for _, rhtNode := range rhtNodes {
+							pairs = append(pairs, GCPair{
+								Parent: next,
+								Child:  rhtNode,
+							})
+						}
+					}
+					current = next
 				}
 			}
 		}

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -399,8 +399,11 @@ func (n *TreeNode) SplitElement(
 	// nodes could have arbitrary offset range. So, id could be duplicated
 	// and its order could be broken when concurrent editing happens.
 	// Currently, we use the similar IDString of split element with the split text.
-	// TODO(raararaara): We need to check if the attributes are copied correctly when splitting elements.
-	split := NewTreeNode(&TreeNodeID{CreatedAt: issueTimeTicket(), Offset: 0}, n.Type(), nil)
+	var splitAttrs *RHT
+	if n.Attrs != nil {
+		splitAttrs = n.Attrs.DeepCopy()
+	}
+	split := NewTreeNode(&TreeNodeID{CreatedAt: issueTimeTicket(), Offset: 0}, n.Type(), splitAttrs)
 	split.removedAt = n.removedAt
 	if err := n.Index.Parent.InsertAfterInternal(split.Index, n.Index); err != nil {
 		return nil, diff, err

--- a/pkg/document/crdt/tree_test.go
+++ b/pkg/document/crdt/tree_test.go
@@ -103,6 +103,31 @@ func TestTreeNode(t *testing.T) {
 		assert.Equal(t, `<span font-weight="bold">helloyorkie</span>`, crdt.ToXML(node))
 	})
 
+	t.Run("split element should copy attributes", func(t *testing.T) {
+		attrs := crdt.NewRHT()
+		attrs.Set("bold", "true", time.InitialTicket)
+
+		root := crdt.NewTreeNode(dummyTreeNodeID, "r", nil)
+		para := crdt.NewTreeNode(dummyTreeNodeID, "p", attrs)
+		assert.NoError(t, root.Append(para))
+		assert.NoError(t, para.Append(crdt.NewTreeNode(dummyTreeNodeID, "text", nil, "helloworld")))
+		assert.Equal(t, `<r><p bold="true">helloworld</p></r>`, crdt.ToXML(root))
+
+		// split text node
+		left, err := para.Child(0)
+		assert.NoError(t, err)
+		_, _, err = left.SplitText(5, 0)
+		assert.NoError(t, err)
+
+		// split element node
+		split, _, err := para.SplitElement(1, func() *time.Ticket {
+			return time.InitialTicket
+		}, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, `<p bold="true">hello</p>`, crdt.ToXML(para))
+		assert.Equal(t, `<p bold="true">world</p>`, crdt.ToXML(split))
+	})
+
 	t.Run("UTF-16 code unit test", func(t *testing.T) {
 		tests := []struct {
 			length int

--- a/pkg/document/size_test.go
+++ b/pkg/document/size_test.go
@@ -65,7 +65,6 @@ func TestTreeNodeSize(t *testing.T) {
 	})
 
 	t.Run("split tree node with attribute test", func(t *testing.T) {
-		t.Skip("TODO(raararaara): We need to check if the attributes are copied correctly when splitting elements.")
 		attributes := crdt.NewRHT()
 		attributes.Set("bold", "true", time.InitialTicket)
 


### PR DESCRIPTION
## Summary
- Fix attributes not being copied to the new (right) node during `TreeNode.SplitElement`
- Deep-copy the original node's `Attrs` so both halves retain the same attributes after split
- Propagate style/remove-style to unknown split siblings for convergence: when a style operation's range was determined before a concurrent split, the right part was missed
- 4 previously-skipped complex tests (`split-1 × style/remove-style` for `equal` and `B contains A` ranges) now pass

Fixes #1282

## Test plan
- [x] Unit test `split element should copy attributes` verifies both nodes have `bold="true"` after split
- [x] `TestTreeConcurrencySplitEdit` complex tests: 4 SKIP → PASS (equal/B-contains-A × style/remove-style)
- [x] All existing document tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed element attribute handling during split operations—document formatting and styling are preserved when elements are split.
  * Improved style propagation—style additions and removals now correctly propagate across connected elements, ensuring consistent appearance during collaborative edits.

* **Tests**
  * Re-enabled and added tests validating attribute preservation and sizing during split operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->