### PR TITLE
Register LWW-losing element in gcElementPairMap on Set conflict

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -16,6 +16,7 @@
 - [VersionVector](version-vector.md): VersionVector for GC and Resolving conflicts in CRDT
 - [Garbage Collection](garbage-collection.md): Removing tombstones in CRDT
 - [Garbage Collection for Text Type](gc-for-text-type.md): Garbage collection for text type CRDT
+- [GC Registration on Set Conflict](gc-registration-on-set-conflict.md): Fix missing GC registration when new element loses LWW conflict
 - [Tree](tree.md): Tree data structure for tree-based rich text editor
 - [Concurrent Merge and Split](concurrent-merge-split.md): Fix convergence bugs in concurrent tree merge/split operations
 - [Range Deletion in SplayTree](range-deletion-in-splay-tree.md): Improving range deletion in SplayTree

--- a/docs/design/gc-registration-on-set-conflict.md
+++ b/docs/design/gc-registration-on-set-conflict.md
@@ -1,0 +1,134 @@
+---
+title: gc-registration-on-set-conflict
+target-version: 0.7.6
+---
+
+# GC Registration on Set Conflict
+
+## Problem
+
+When two clients simultaneously attach to a new document using `Attach` with
+`InitialRoot`, both generate `Set` operations for the same key. When these
+operations are applied on the server (or via remote sync), the LWW (Last Writer
+Wins) resolution in `ElementRHT.Set` correctly determines a winner and marks the
+loser as removed. However, when the **new element loses** the LWW conflict, it
+is not registered in `gcElementPairMap`, causing a GC mapping leak.
+
+### Root Cause
+
+In `ElementRHT.Set` (`element_rht.go:102-120`), there are two conflict
+outcomes:
+
+1. **New element wins** (higher CreatedAt): The old element is marked as removed
+   and returned as `removed`. The caller (`Set` operation in `set.go`) registers
+   it in `gcElementPairMap` via `RegisterRemovedElementPair`. This works
+   correctly.
+
+2. **New element loses** (lower CreatedAt): The new element is immediately
+   marked as removed (`v.Remove(node.elem.CreatedAt())`), but `Set` returns
+   `nil` for `removed` because the old element was not displaced. The caller
+   sees `removed == nil` and skips GC registration. The new element exists in
+   `nodeMapByCreatedAt` with `removedAt` set but has no entry in
+   `gcElementPairMap`.
+
+```
+// Conflict timeline example:
+// Client A: Set("content", valueA) — createdAt=(1, actorA)
+// Client B: Set("content", valueB) — createdAt=(1, actorB)
+// If actorA > actorB, valueB loses LWW:
+//   - valueB added to nodeMapByCreatedAt ✓
+//   - valueB.removedAt set              ✓
+//   - gcElementPairMap entry for valueB  ✗ ← MISSING
+```
+
+### Impact
+
+- `ElementsMapByCreatedAt` contains two elements for the same key (winner +
+  tombstoned loser)
+- `gcElementPairMap` is missing the entry for the loser
+- The loser element is never garbage collected, causing a memory leak
+- Reported in [#1300](https://github.com/yorkie-team/yorkie/issues/1300)
+
+### Goals
+
+- Register LWW-losing elements in `gcElementPairMap` so they are garbage
+  collected
+
+### Non-Goals
+
+- Changing the LWW resolution logic in `ElementRHT`
+- Modifying the `ElementRHT.Set` return type or signature
+
+## Design
+
+Add a post-check in `Set.Execute` (`operations/set.go`) after `obj.Set()`. If
+the newly added value has been immediately marked as removed (i.e., it lost the
+LWW conflict), register it in `gcElementPairMap`:
+
+```go
+func (o *Set) Execute(root *crdt.Root, _ time.VersionVector) error {
+    parent := root.FindByCreatedAt(o.parentCreatedAt)
+
+    obj, ok := parent.(*crdt.Object)
+    if !ok {
+        return ErrNotApplicableDataType
+    }
+
+    value, err := o.value.DeepCopy()
+    if err != nil {
+        return err
+    }
+    removed := obj.Set(o.key, value)
+    root.RegisterElement(value)
+    if removed != nil {
+        root.RegisterRemovedElementPair(obj, removed)
+    }
+    if value.RemovedAt() != nil {
+        root.RegisterRemovedElementPair(obj, value)
+    }
+    return nil
+}
+```
+
+The added check (`value.RemovedAt() != nil`) catches the case where
+`ElementRHT.Set` marks the new element as removed due to LWW loss. This is safe
+because:
+
+- A freshly created element always has `RemovedAt() == nil`
+- `RemovedAt()` is only set during `ElementRHT.Set` when the element loses LWW
+- The check does not interfere with the existing `removed != nil` path — these
+  are mutually exclusive (if the old element is removed, the new one wins; if
+  the new one is removed, the old one stays)
+
+### Affected Call Sites
+
+| Call site | Impact |
+|-----------|--------|
+| `operations/set.go:68` | **Bug site** — LWW loser not registered in GC |
+| `converter/from_bytes.go:137` | Not affected — `NewRoot` traverses all descendants and registers removed elements |
+| `object.go:134` (`DeepCopy`) | Not affected — rebuilt via `NewRoot` |
+| `object.go:37` (`NewObject`) | Not affected — empty RHT, no conflict possible |
+
+### Risks and Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| Double registration if both `removed` and `value` are non-nil | Mutually exclusive by LWW logic — only one of old/new can be the loser |
+
+### Design Decisions
+
+| Decision | Reason |
+|----------|--------|
+| Fix in `set.go` rather than changing `ElementRHT.Set` signature | Minimal change, no API breakage, all callers would need updating otherwise |
+| Post-check on `value.RemovedAt()` rather than new return value | Simpler, no signature change, the information is already on the element |
+
+## Alternatives Considered
+
+| Alternative | Why not |
+|-------------|---------|
+| Change `ElementRHT.Set` to return `(removed, loser)` tuple | Breaks API for all callers, larger change for same result |
+| Register inside `ElementRHT.Set` directly | `ElementRHT` has no access to `Root` or `gcElementPairMap` |
+
+## Tasks
+
+Track execution plans in `docs/tasks/active/` as separate task documents.

--- a/pkg/document/operations/set.go
+++ b/pkg/document/operations/set.go
@@ -70,6 +70,9 @@ func (o *Set) Execute(root *crdt.Root, _ time.VersionVector) error {
 	if removed != nil {
 		root.RegisterRemovedElementPair(obj, removed)
 	}
+	if value.RemovedAt() != nil {
+		root.RegisterRemovedElementPair(obj, value)
+	}
 	return nil
 }
 

--- a/pkg/document/operations/set_test.go
+++ b/pkg/document/operations/set_test.go
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package operations_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/pkg/document/crdt"
+	"github.com/yorkie-team/yorkie/pkg/document/operations"
+	"github.com/yorkie-team/yorkie/pkg/document/time"
+)
+
+func TestSet(t *testing.T) {
+	t.Run("LWW loser should be registered in gcElementPairMap", func(t *testing.T) {
+		// Setup: create root with an empty object.
+		root := crdt.NewRoot(crdt.NewObject(crdt.NewElementRHT(), time.InitialTicket))
+
+		actorA, _ := time.ActorIDFromHex("aaaaaaaaaaaaaaaaaaaaaaaa")
+		actorB, _ := time.ActorIDFromHex("bbbbbbbbbbbbbbbbbbbbbbbb")
+
+		// actorB > actorA, so actorB wins LWW when lamport is equal.
+		ticketA := time.NewTicket(1, 0, actorA)
+		ticketB := time.NewTicket(1, 0, actorB)
+
+		// First Set: actorA sets "key" = 1.
+		valueA, err := crdt.NewPrimitive(1, ticketA)
+		assert.NoError(t, err)
+		setA := operations.NewSet(time.InitialTicket, "key", valueA, ticketA)
+		err = setA.Execute(root, time.NewVersionVector())
+		assert.NoError(t, err)
+		assert.Equal(t, 0, root.GarbageLen())
+
+		// Second Set: actorB sets "key" = 2 (actorB wins, actorA loses).
+		valueB, err := crdt.NewPrimitive(2, ticketB)
+		assert.NoError(t, err)
+		setB := operations.NewSet(time.InitialTicket, "key", valueB, ticketB)
+		err = setB.Execute(root, time.NewVersionVector())
+		assert.NoError(t, err)
+		// valueA should be registered as garbage (it was removed by the winner).
+		assert.Equal(t, 1, root.GarbageLen())
+		assert.Equal(t, `{"key":2}`, root.Object().Marshal())
+
+		// Third Set: actorA sets "key" = 3 (actorA loses to actorB's value).
+		ticketA2 := time.NewTicket(1, 1, actorA)
+		valueA2, err := crdt.NewPrimitive(3, ticketA2)
+		assert.NoError(t, err)
+		setA2 := operations.NewSet(time.InitialTicket, "key", valueA2, ticketA2)
+		err = setA2.Execute(root, time.NewVersionVector())
+		assert.NoError(t, err)
+		// valueA2 should also be registered as garbage (it lost LWW to valueB).
+		// Before the fix, this was 1 because the LWW loser was not registered.
+		assert.Equal(t, 2, root.GarbageLen())
+		assert.Equal(t, `{"key":2}`, root.Object().Marshal())
+	})
+}


### PR DESCRIPTION
## Summary

- When two clients simultaneously attach with `InitialRoot`, both generate `Set` operations for the same key. The LWW loser is marked as removed but **not registered in `gcElementPairMap`**, causing a memory leak.
- Add a post-check in `Set.Execute`: if the new value has `RemovedAt` set (lost LWW), register it for GC.
- Add test covering the LWW conflict GC registration scenario.

Design doc: `docs/design/gc-registration-on-set-conflict.md`

Fixes #1300

## Test plan

- [x] New test `TestSet/LWW_loser_should_be_registered_in_gcElementPairMap` passes
- [x] All existing `pkg/document/...` tests pass
- [x] `make lint` passes
- [ ] Integration test with two clients doing concurrent `Attach` with `InitialRoot`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a garbage collection memory leak in conflict resolution when newly inserted elements lose in concurrent set operations.

* **Documentation**
  * Added detailed design documentation explaining the issue and the implemented solution.

* **Tests**
  * Added comprehensive test coverage validating set operation behavior under concurrent conflict resolution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->