### PR TITLE
Remove t.Skip in Update doc size test

### DIFF
--- a/test/integration/limit_test.go
+++ b/test/integration/limit_test.go
@@ -76,7 +76,6 @@ func TestDocSize(t *testing.T) {
 	})
 
 	t.Run("Update doc size test", func(t *testing.T) {
-		t.Skip("TODO(raararaara): Remove this after resolving inter-node projectCache invalidataion")
 		ctx := context.Background()
 
 		sizeLimit := 100


### PR DESCRIPTION
## Summary
- Remove `t.Skip` in `TestDocSize/Update_doc_size_test` that was waiting for inter-node projectCache invalidation to be resolved
- The issue was resolved by `BroadcastCacheInvalidation` added in #1553, which broadcasts cache invalidation to all cluster nodes on `UpdateProject`

## Test plan
- [x] `go test -tags integration -run "TestDocSize/Update_doc_size_test" ./test/integration/ -v` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Re-enabled document size limit validation test to ensure proper enforcement of project document size configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->