### PR TITLE
Garbage collect before building snapshot response

### DIFF
--- a/docs/design/garbage-collection.md
+++ b/docs/design/garbage-collection.md
@@ -67,6 +67,15 @@ min([c1:2, c2:3, c3:4], [c1:3, c2:1, c3:5, c4:3])
 
 ```
 
+## GC Responsibility by Response Type
+
+GC responsibility is split between server and client depending on the response type:
+
+- **Snapshot response**: The server runs GC with `minVersionVector` before serializing the snapshot. The client receives a clean state and skips GC (`!pack.hasSnapshot()` guard in the SDK).
+- **Changes response**: The server sends `minVersionVector` in the response pack. The client runs GC locally using this vector after applying the changes.
+
+This means the server must always GC the document before building a snapshot response. Without this, tombstones from applied changes would leak into the snapshot and persist on the client, since the client does not run GC for snapshot responses by design.
+
 ## An example of garbage collection:
 
 ### State 1

--- a/server/packs/pushpull.go
+++ b/server/packs/pushpull.go
@@ -412,6 +412,16 @@ func pullSnapshot(
 
 	cpAfterPull := cpAfterPush.NextServerSeq(docInfo.ServerSeq)
 
+	if !be.Config.SnapshotDisableGC {
+		vector, err := be.DB.GetMinVersionVector(ctx, docInfo.RefKey(), doc.VersionVector())
+		if err != nil {
+			return nil, err
+		}
+		if _, err := doc.GarbageCollect(vector); err != nil {
+			return nil, err
+		}
+	}
+
 	snapshot, err := converter.SnapshotToBytes(doc.RootObject(), doc.AllPresences())
 	if err != nil {
 		return nil, err

--- a/test/integration/gc_test.go
+++ b/test/integration/gc_test.go
@@ -845,6 +845,39 @@ func TestGarbageCollection(t *testing.T) {
 		assert.Equal(t, int(helper.SnapshotInterval), d2.GarbageLen())
 	})
 
+	t.Run("snapshot response should not contain tombstones when GC is enabled", func(t *testing.T) {
+		ctx := context.Background()
+
+		// 01. c1 creates a document and generates tombstones by editing text.
+		d1 := document.New(helper.TestKey(t))
+		assert.NoError(t, c1.Attach(ctx, d1))
+		defer func() { assert.NoError(t, c1.Detach(ctx, d1)) }()
+
+		assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewText("text").Edit(0, 0, "-")
+			return nil
+		}))
+		for i := range int(helper.SnapshotThreshold) {
+			assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+				root.GetText("text").Edit(0, 1, strconv.Itoa(i))
+				return nil
+			}))
+		}
+		assert.Equal(t, int(helper.SnapshotThreshold), d1.GarbageLen())
+		assert.NoError(t, c1.Sync(ctx))
+
+		// 02. c2 attaches the same document. Because the number of changes
+		// exceeds SnapshotThreshold, the server responds with a snapshot.
+		// The snapshot should have no tombstones because the server runs GC
+		// with minVersionVector before building the snapshot.
+		d2 := document.New(helper.TestKey(t))
+		assert.NoError(t, c2.Attach(ctx, d2))
+		defer func() { assert.NoError(t, c2.Detach(ctx, d2)) }()
+
+		assert.Equal(t, d1.Marshal(), d2.Marshal())
+		assert.Equal(t, 0, d2.GarbageLen())
+	})
+
 	t.Run("concurrent garbage collection test", func(t *testing.T) {
 		ctx := context.Background()
 		d1 := document.New(helper.TestKey(t))


### PR DESCRIPTION
## Summary

- Run GC with `minVersionVector` before serializing snapshot in `pullSnapshot()`
- When `pullSnapshot` builds a snapshot for the client, it applies pushed changes on top of the cached document but does not run GC afterward. This leaves tombstones in the snapshot that the client cannot collect (client skips GC for snapshot responses by design)
- Fixes yorkie-team/yorkie-js-sdk#980

## Test plan

- [x] `make build` passes
- [x] `server/packs` unit tests pass
- [x] `test/integration` tests pass (2246 tests in JS SDK)
- [x] Manual test: CodeMirror dev example with low snapshot threshold, verify no tombstones after attach

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected snapshot synchronization to properly exclude deleted content markers, preventing unwanted residual data from persisting on client devices.
  * Improved garbage collection to run before snapshot serialization, ensuring cleaner data transfer between servers and clients.

* **Documentation**
  * Clarified garbage collection responsibilities between server and client for snapshot and incremental change responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->