### PR TITLE
Unify presence event emission with ReconcilePresence

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -999,37 +999,26 @@ func handleWatchResponse(pbResp *api.WatchResponse, d *document.Document) (*Watc
 			case events.DocChanged:
 				return &WatchDocResponse{Type: DocumentChanged}, nil
 			case events.DocWatched:
-				d.AddOnlineClient(cli.String())
-
-				// NOTE(hackerwins): If the presence does not exist, it means that
-				// PushPull is not received before watching. In that case, the 'watched'
-				// event is ignored here, and it will be triggered by PushPull.
-				if d.Presence(cli.String()) == nil {
+				event := d.AddOnlineClientAndReconcile(cli.String())
+				if event == nil {
 					return nil, nil
 				}
-
+				t := PresenceChanged
+				if event.Type == document.WatchedEvent {
+					t = DocumentWatched
+				}
 				return &WatchDocResponse{
-					Type: DocumentWatched,
-					Presences: map[string]document.PresenceData{
-						cli.String(): d.Presence(cli.String()),
-					},
+					Type:      t,
+					Presences: event.Presences,
 				}, nil
 			case events.DocUnwatched:
-				p := d.Presence(cli.String())
-				d.RemoveOnlineClient(cli.String())
-
-				// NOTE(hackerwins): If the presence does not exist, it means that
-				// PushPull is already received before unwatching. In that case, the
-				// 'unwatched' event is ignored here, and it was triggered by PushPull.
-				if p == nil {
+				event := d.RemoveOnlineClientAndReconcile(cli.String())
+				if event == nil {
 					return nil, nil
 				}
-
 				return &WatchDocResponse{
-					Type: DocumentUnwatched,
-					Presences: map[string]document.PresenceData{
-						cli.String(): p,
-					},
+					Type:      DocumentUnwatched,
+					Presences: event.Presences,
 				}, nil
 			}
 		}

--- a/docs/design/doc-presence.md
+++ b/docs/design/doc-presence.md
@@ -329,3 +329,201 @@ public applyChanges(changes: Array<Change<P>>): void {
   - Client, Document → MongoDB (Document DB or RDB)
   - Change → HBase (Wide column store)
   - Snapshot, Presence → Redis (key-value store, In-memory DB)
+
+## Presence Event Reconciliation
+
+> target-version: 0.7.6
+
+### Summary
+
+The current presence event system has a structural problem: the same event type is emitted from multiple code paths with conditional logic to handle event reordering between two independent server channels (PushPull and Watch Stream). This leads to bugs when new cases arise (e.g., [yorkie-js-sdk#729](https://github.com/yorkie-team/yorkie-js-sdk/issues/729) — missing presence value for initial presence).
+
+This section describes a redesign that separates data updates from event emission by introducing a single reconciliation function.
+
+### Problem
+
+Presence events (`watched`, `unwatched`, `presence-changed`) are emitted from 8 places across the JS SDK codebase:
+
+| # | Location | Event | Trigger |
+|---|----------|-------|---------|
+| 1 | `update()` | presence-changed | Local presence change |
+| 2 | `applyChange()` | watched or presence-changed | Remote PresenceChange.Put |
+| 3 | `applyChange()` | unwatched | Remote PresenceChange.Clear |
+| 4 | `applyWatchInit()` | initialized | Watch stream init |
+| 5 | `applyDocEvent()` | watched | DOCUMENT_WATCHED from watch stream |
+| 6 | `applyDocEvent()` | unwatched | DOCUMENT_UNWATCHED from watch stream |
+| 7 | `executeUndoRedo()` | presence-changed | Undo/redo with presence |
+
+The root cause: data updates and event emission are coupled. Each handler that receives data also tries to emit events, requiring every handler to check whether data from the other channel has already arrived. This creates scattered conditional logic that breaks when new cases appear.
+
+For example, in [yorkie-js-sdk#729](https://github.com/yorkie-team/yorkie-js-sdk/issues/729), when a client sets initial presence during `attach()`, `doc.update()` emits a `presence-changed` event immediately. At this point, the document status is not yet `Attached` and the client is not yet in `onlineClients`, so `getPresence()` returns `undefined`. The event fires with a missing presence value.
+
+### Design
+
+#### Principle: Separate data updates from event emission
+
+Each channel handler updates only its own data store. After updating, it calls a single `reconcilePresence()` function that compares the previous state with the current state and decides which event (if any) to emit.
+
+```
+[Data Layer]
+  PushPull handler:  updates presences Map     → reconcile()
+  Watch handler:     updates onlineClients Set → reconcile()
+  Local update():    updates presences Map     → reconcile()
+
+[Event Layer]
+  reconcilePresence(): (prev state, current state) → event decision
+```
+
+#### Per-client state model
+
+For each client, two independent boolean states are tracked:
+
+| State | Source | Meaning |
+|-------|--------|---------|
+| `hasPresence` | PushPull (ChangePack) | Client has presence data in presences Map |
+| `isOnline` | Watch Stream | Client is in onlineClients Set |
+
+#### State transition table
+
+The reconcile function maps `(previous, current)` state pairs to events:
+
+```
+Previous → Current                    Event
+──────────────────────────────────────────────────────
+(!hasP, !isOn) → (hasP, isOn)        watched
+(hasP, isOn)   → (hasP, isOn)        presence-changed (if value changed)
+(hasP, isOn)   → (!hasP, _)          unwatched (clear)
+(hasP, isOn)   → (_, !isOn)          unwatched (unwatch)
+(_, _)         → (hasP, !isOn)       no event (waiting for online)
+(_, _)         → (!hasP, isOn)       no event (waiting for presence)
+```
+
+Events are emitted only when both conditions are met (`hasPresence` AND `isOnline`), or when transitioning out of a state where both were met.
+
+#### reconcilePresence function
+
+```typescript
+type PrevState = { hadPresence: boolean; wasOnline: boolean };
+
+private reconcilePresence(
+  actorID: ActorID,
+  prev: PrevState,
+  source: OpSource,
+): DocEvent | undefined {
+  const hasPresence = this.presences.has(actorID);
+  const isOnline = this.onlineClients.has(actorID);
+
+  if (!hasPresence || !isOnline) {
+    if (prev.hadPresence && prev.wasOnline) {
+      return {
+        type: DocEventType.Unwatched,
+        source,
+        value: { clientID: actorID, presence: prev.presence },
+      };
+    }
+    return undefined;
+  }
+
+  if (!prev.hadPresence || !prev.wasOnline) {
+    return {
+      type: DocEventType.Watched,
+      source,
+      value: {
+        clientID: actorID,
+        presence: this.presences.get(actorID)!,
+      },
+    };
+  }
+
+  return {
+    type: DocEventType.PresenceChanged,
+    source,
+    value: {
+      clientID: actorID,
+      presence: this.presences.get(actorID)!,
+    },
+  };
+}
+```
+
+The caller knows what it changed, so it captures previous state before the update and passes it as a hint. No separate snapshot Map is needed.
+
+Event payloads read from `presences.get()` directly, not through `getPresence()` public API, to avoid the status/onlineClients guards that exist for external callers.
+
+#### Call sites
+
+Each call site follows the same pattern: capture prev → update data → reconcile → publish.
+
+```
+applyChange (remote Put):
+  prev = { hadPresence: presences.has(id), wasOnline: onlineClients.has(id) }
+  presences.set(id, newPresence)
+  event = reconcile(id, prev, OpSource.Remote)
+
+applyDocEvent (DOCUMENT_WATCHED):
+  prev = { hadPresence: presences.has(id), wasOnline: onlineClients.has(id) }
+  onlineClients.add(id)
+  event = reconcile(id, prev, OpSource.Remote)
+
+applyDocEvent (DOCUMENT_UNWATCHED):
+  prev = { hadPresence: presences.has(id), wasOnline: onlineClients.has(id) }
+  onlineClients.delete(id)
+  presences.delete(id)
+  event = reconcile(id, prev, OpSource.Remote)
+
+applyChange (remote Clear):
+  prev = { hadPresence: presences.has(id), wasOnline: onlineClients.has(id) }
+  onlineClients.delete(id)
+  presences.delete(id)
+  event = reconcile(id, prev, OpSource.Remote)
+
+update (local):
+  prev = { hadPresence: presences.has(myID), wasOnline: onlineClients.has(myID) }
+  presences.set(myID, newPresence)
+  event = reconcile(myID, prev, OpSource.Local)
+
+executeUndoRedo:
+  prev = { hadPresence: presences.has(myID), wasOnline: onlineClients.has(myID) }
+  presences.set(myID, newPresence)
+  event = reconcile(myID, prev, OpSource.UndoRedo)
+```
+
+#### initialized event
+
+The `initialized` event is not part of reconciliation. It is emitted once during `applyWatchInit()` and serves a different purpose (full list of current participants). This remains unchanged.
+
+### How this resolves yorkie-js-sdk#729
+
+With the current code:
+1. `doc.update(initialPresence)` → emits `presence-changed` → `getPresence()` returns `undefined` (not yet Attached)
+
+With reconciliation:
+1. `doc.update(initialPresence)` → sets presences → reconcile → `isOnline` is false → **no event (waiting)**
+2. Attach completes → `applyWatchInit()` → sets onlineClients → reconcile → both ready → **`watched` event with correct presence value**
+
+### Event reordering handled uniformly
+
+The existing event reordering scenarios (documented above in "Presence Events") are handled uniformly:
+
+**watched (PushPull first):**
+1. `applyChange(Put)` → presences set → reconcile → not online yet → no event
+2. `applyDocEvent(WATCHED)` → onlineClients add → reconcile → both ready → `watched`
+
+**watched (Watch first):**
+1. `applyDocEvent(WATCHED)` → onlineClients add → reconcile → no presence yet → no event
+2. `applyChange(Put)` → presences set → reconcile → both ready → `watched`
+
+Both orderings produce the same result through the same code path.
+
+### Implementation plan
+
+1. **JS SDK first:** Implement reconcile pattern in `yorkie-js-sdk`. Validate with existing integration tests + new test for #729.
+2. **Go SDK alignment:** Apply the same reconcile pattern to the Go SDK to maintain consistency across SDKs.
+
+### Risks and Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| Existing tests depend on current (buggy) event timing | Update tests to expect correct behavior — old timing was a bug |
+| Edge cases missed in reconcile | State space is small (2 bits × 2 bits = 16 transitions) — exhaustive verification possible |
+| Behavioral difference between JS and Go SDK during rollout | JS SDK ships first as reference implementation; Go SDK follows with same pattern |

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -461,6 +461,37 @@ func (d *Document) RemoveOnlineClient(clientID string) {
 	d.doc.RemoveOnlineClient(clientID)
 }
 
+// AddOnlineClientAndReconcile adds the given client to the online clients
+// and returns the appropriate presence event based on the state transition.
+func (d *Document) AddOnlineClientAndReconcile(clientID string) *DocEvent {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	hadPresence := d.doc.presences.Has(clientID)
+	_, wasOnline := d.doc.onlineClients[clientID]
+	prevPresence := d.doc.Presence(clientID)
+
+	d.doc.AddOnlineClient(clientID)
+
+	return d.doc.ReconcilePresence(clientID, hadPresence, wasOnline, prevPresence)
+}
+
+// RemoveOnlineClientAndReconcile removes the given client from the online
+// clients and returns the appropriate presence event based on the state
+// transition.
+func (d *Document) RemoveOnlineClientAndReconcile(clientID string) *DocEvent {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	hadPresence := d.doc.presences.Has(clientID)
+	_, wasOnline := d.doc.onlineClients[clientID]
+	prevPresence := d.doc.Presence(clientID)
+
+	d.doc.RemoveOnlineClient(clientID)
+
+	return d.doc.ReconcilePresence(clientID, hadPresence, wasOnline, prevPresence)
+}
+
 // Events returns the events of this document.
 func (d *Document) Events() <-chan DocEvent {
 	return d.events

--- a/pkg/document/internal_document.go
+++ b/pkg/document/internal_document.go
@@ -281,45 +281,27 @@ func (d *InternalDocument) applySnapshot(snapshot []byte, vector time.VersionVec
 func (d *InternalDocument) ApplyChanges(changes ...*change.Change) ([]DocEvent, error) {
 	var events []DocEvent
 	for _, c := range changes {
+		var hadPresence, wasOnline bool
+		var prevPresence presence.Data
+		clientID := c.ID().ActorID().String()
+
 		if c.PresenceChange() != nil {
-			clientID := c.ID().ActorID().String()
-			if _, ok := d.onlineClients[clientID]; ok {
-				switch c.PresenceChange().ChangeType {
-				case presence.Put:
-					// NOTE(chacha912): When the user exists in onlineClients, but
-					// their presence was initially absent, we can consider that we have
-					// received their initial presence, so trigger the 'watched' event.
-					eventType := PresenceChangedEvent
-					if !d.presences.Has(clientID) {
-						eventType = WatchedEvent
-					}
-					event := DocEvent{
-						Type: eventType,
-						Presences: map[string]presence.Data{
-							clientID: c.PresenceChange().Presence,
-						},
-					}
-					events = append(events, event)
-				case presence.Clear:
-					// NOTE(chacha912): When the user exists in onlineClients, but
-					// PresenceChange(clear) is received, we can consider it as detachment
-					// occurring before unwatch.
-					// Detached user is no longer participating in the document, we remove
-					// them from the online clients and trigger the 'unwatched' event.
-					event := DocEvent{
-						Type: UnwatchedEvent,
-						Presences: map[string]presence.Data{
-							clientID: d.Presence(clientID),
-						},
-					}
-					events = append(events, event)
-					d.RemoveOnlineClient(clientID)
-				}
-			}
+			hadPresence = d.presences.Has(clientID)
+			_, wasOnline = d.onlineClients[clientID]
+			prevPresence = d.Presence(clientID)
 		}
 
 		if err := c.Execute(d.root, d.presences); err != nil {
 			return nil, err
+		}
+
+		if c.PresenceChange() != nil {
+			if c.PresenceChange().ChangeType == presence.Clear {
+				d.RemoveOnlineClient(clientID)
+			}
+			if event := d.ReconcilePresence(clientID, hadPresence, wasOnline, prevPresence); event != nil {
+				events = append(events, *event)
+			}
 		}
 
 		d.changeID = d.changeID.SyncClocks(c.ID())
@@ -389,6 +371,53 @@ func (d *InternalDocument) AddOnlineClient(clientID string) {
 // RemoveOnlineClient removes the given client from the online clients.
 func (d *InternalDocument) RemoveOnlineClient(clientID string) {
 	delete(d.onlineClients, clientID)
+}
+
+// ReconcilePresence compares the previous and current state of a client's
+// presence/online status and returns the appropriate event to emit.
+//
+// State transition table:
+//
+//	(!hadP || !wasOn) → (hasP && isOn)  : WatchedEvent
+//	(hadP && wasOn)   → (hasP && isOn)  : PresenceChangedEvent
+//	(hadP && wasOn)   → (!hasP || !isOn): UnwatchedEvent
+//	otherwise                           : no event (waiting)
+func (d *InternalDocument) ReconcilePresence(
+	clientID string,
+	hadPresence bool,
+	wasOnline bool,
+	prevPresence presence.Data,
+) *DocEvent {
+	hasPresence := d.presences.Has(clientID)
+	_, isOnline := d.onlineClients[clientID]
+
+	if !hasPresence || !isOnline {
+		if hadPresence && wasOnline {
+			return &DocEvent{
+				Type: UnwatchedEvent,
+				Presences: map[string]presence.Data{
+					clientID: prevPresence,
+				},
+			}
+		}
+		return nil
+	}
+
+	if !hadPresence || !wasOnline {
+		return &DocEvent{
+			Type: WatchedEvent,
+			Presences: map[string]presence.Data{
+				clientID: d.Presence(clientID),
+			},
+		}
+	}
+
+	return &DocEvent{
+		Type: PresenceChangedEvent,
+		Presences: map[string]presence.Data{
+			clientID: d.Presence(clientID),
+		},
+	}
 }
 
 // ToDocument converts this document to Document.


### PR DESCRIPTION
## Summary

- Add `ReconcilePresence` method to `InternalDocument` that determines presence events based on per-client state transitions `(hasPresence, isOnline)`
- Refactor `ApplyChanges` to capture prev state before execute, then reconcile after
- Refactor `handleWatchResponse` to use `AddOnlineClientAndReconcile` / `RemoveOnlineClientAndReconcile` instead of inline conditional logic
- Design doc updated in `docs/design/doc-presence.md` ("Presence Event Reconciliation" section, target-version: 0.7.6)

## Context

This is the Go SDK counterpart to yorkie-team/yorkie-js-sdk#1229. The JS SDK had 7 scattered presence event emission points; the Go SDK had the same pattern in 2 locations (`ApplyChanges` and `handleWatchResponse`). Both now use a single reconcile function.

The state transition table:

| Previous → Current | Event |
|---|---|
| not-ready → both ready | `watched` |
| both ready → both ready | `presence-changed` |
| both ready → not-ready | `unwatched` |
| not-ready → still not-ready | no event (waiting) |

## Test plan

- [x] `make build` passes
- [ ] CI lint + tests (observing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency and reliability of presence event emission when users join or leave document watch sessions.

* **Documentation**
  * Added detailed design documentation for presence event reconciliation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->