### PR TITLE
Remove detached client's lamport from version vectors

### DIFF
--- a/api/converter/converter_test.go
+++ b/api/converter/converter_test.go
@@ -361,7 +361,7 @@ func TestConverter(t *testing.T) {
 
 		// 05. Serialize docA's post-merge state via SnapshotToBytes -
 		//     this is exactly what the server stores as a snapshot.
-		snapshot, err := converter.SnapshotToBytes(docA.RootObject(), docA.AllPresences())
+		snapshot, err := converter.SnapshotToBytes(docA.RootObject(), docA.AllPresences(), nil)
 		assert.NoError(t, err)
 
 		// 06. docB loads the snapshot. mergedInto/mergedChildIDs/mergedAt
@@ -448,7 +448,7 @@ func TestConverter(t *testing.T) {
 		assert.Equal(t, "<root><p>a</p><p>bc</p></root>", docC.Root().GetTree("t").ToXML())
 
 		// 04. Snapshot docA, load into docB.
-		snapshot, err := converter.SnapshotToBytes(docA.RootObject(), docA.AllPresences())
+		snapshot, err := converter.SnapshotToBytes(docA.RootObject(), docA.AllPresences(), nil)
 		assert.NoError(t, err)
 		docB := document.New(helper.TestKey(t))
 		docB.SetActor(actorB)

--- a/api/converter/from_bytes.go
+++ b/api/converter/from_bytes.go
@@ -32,23 +32,33 @@ import (
 var ErrUnmarshallFailed = errors.Internal("unmarshal failed")
 
 // BytesToSnapshot creates a Snapshot from the given byte array.
-func BytesToSnapshot(snapshot []byte) (*crdt.Object, *presence.Map, error) {
+func BytesToSnapshot(snapshot []byte) (*crdt.Object, *presence.Map, map[time.ActorID]int64, error) {
 	if len(snapshot) == 0 {
-		return crdt.NewObject(crdt.NewElementRHT(), time.InitialTicket), presence.NewMap(), nil
+		return crdt.NewObject(crdt.NewElementRHT(), time.InitialTicket), presence.NewMap(), nil, nil
 	}
 
 	pbSnapshot := &api.Snapshot{}
 	if err := proto.Unmarshal(snapshot, pbSnapshot); err != nil {
-		return nil, nil, fmt.Errorf("unmarshal snapshot: %w", err)
+		return nil, nil, nil, fmt.Errorf("unmarshal snapshot: %w", err)
 	}
 
 	obj, err := fromJSONElement(pbSnapshot.GetRoot())
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	presences := fromPresences(pbSnapshot.GetPresences())
-	return obj.(*crdt.Object), presences, nil
+
+	detachedActors := make(map[time.ActorID]int64)
+	for actorIDStr, lamport := range pbSnapshot.GetDetachedActors() {
+		actorID, err := time.ActorIDFromHex(actorIDStr)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		detachedActors[actorID] = lamport
+	}
+
+	return obj.(*crdt.Object), presences, detachedActors, nil
 }
 
 // BytesToObject creates an Object from the given byte array.

--- a/api/converter/from_bytes.go
+++ b/api/converter/from_bytes.go
@@ -34,7 +34,8 @@ var ErrUnmarshallFailed = errors.Internal("unmarshal failed")
 // BytesToSnapshot creates a Snapshot from the given byte array.
 func BytesToSnapshot(snapshot []byte) (*crdt.Object, *presence.Map, map[time.ActorID]int64, error) {
 	if len(snapshot) == 0 {
-		return crdt.NewObject(crdt.NewElementRHT(), time.InitialTicket), presence.NewMap(), nil, nil
+		return crdt.NewObject(crdt.NewElementRHT(), time.InitialTicket),
+			presence.NewMap(), make(map[time.ActorID]int64), nil
 	}
 
 	pbSnapshot := &api.Snapshot{}

--- a/api/converter/from_pb.go
+++ b/api/converter/from_pb.go
@@ -188,13 +188,23 @@ func FromChangePack(pbPack *api.ChangePack) (*change.Pack, error) {
 		return nil, err
 	}
 
+	detachedActors := make(map[time.ActorID]int64)
+	for actorIDStr, lamport := range pbPack.DetachedActors {
+		actorID, err := time.ActorIDFromHex(actorIDStr)
+		if err != nil {
+			return nil, err
+		}
+		detachedActors[actorID] = lamport
+	}
+
 	pack := &change.Pack{
-		DocumentKey:   key.Key(pbPack.DocumentKey),
-		Checkpoint:    fromCheckpoint(pbPack.Checkpoint),
-		Changes:       changes,
-		Snapshot:      pbPack.Snapshot,
-		IsRemoved:     pbPack.IsRemoved,
-		VersionVector: versionVector,
+		DocumentKey:    key.Key(pbPack.DocumentKey),
+		Checkpoint:     fromCheckpoint(pbPack.Checkpoint),
+		Changes:        changes,
+		Snapshot:       pbPack.Snapshot,
+		IsRemoved:      pbPack.IsRemoved,
+		VersionVector:  versionVector,
+		DetachedActors: detachedActors,
 	}
 
 	return pack, nil

--- a/api/converter/to_bytes.go
+++ b/api/converter/to_bytes.go
@@ -25,11 +25,16 @@ import (
 	api "github.com/yorkie-team/yorkie/api/yorkie/v1"
 	"github.com/yorkie-team/yorkie/pkg/document/crdt"
 	"github.com/yorkie-team/yorkie/pkg/document/presence"
+	"github.com/yorkie-team/yorkie/pkg/document/time"
 	"github.com/yorkie-team/yorkie/pkg/index"
 )
 
 // SnapshotToBytes converts the given document to byte array.
-func SnapshotToBytes(obj *crdt.Object, presences map[string]presence.Data) ([]byte, error) {
+func SnapshotToBytes(
+	obj *crdt.Object,
+	presences map[string]presence.Data,
+	detachedActors map[time.ActorID]int64,
+) ([]byte, error) {
 	pbElem, err := toJSONElement(obj)
 	if err != nil {
 		return nil, err
@@ -37,9 +42,15 @@ func SnapshotToBytes(obj *crdt.Object, presences map[string]presence.Data) ([]by
 
 	pbPresences := ToPresences(presences)
 
+	pbDetachedActors := make(map[string]int64)
+	for actorID, lamport := range detachedActors {
+		pbDetachedActors[actorID.String()] = lamport
+	}
+
 	bytes, err := proto.Marshal(&api.Snapshot{
-		Root:      pbElem,
-		Presences: pbPresences,
+		Root:           pbElem,
+		Presences:      pbPresences,
+		DetachedActors: pbDetachedActors,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("marshal Snapshot to bytes: %w", err)

--- a/api/converter/to_pb.go
+++ b/api/converter/to_pb.go
@@ -216,13 +216,19 @@ func ToChangePack(pack *change.Pack) (*api.ChangePack, error) {
 		return nil, err
 	}
 
+	pbDetachedActors := make(map[string]int64)
+	for actorID, lamport := range pack.DetachedActors {
+		pbDetachedActors[actorID.String()] = lamport
+	}
+
 	return &api.ChangePack{
-		DocumentKey:   pack.DocumentKey.String(),
-		Checkpoint:    ToCheckpoint(pack.Checkpoint),
-		Changes:       pbChanges,
-		Snapshot:      pack.Snapshot,
-		VersionVector: pbVersionVector,
-		IsRemoved:     pack.IsRemoved,
+		DocumentKey:    pack.DocumentKey.String(),
+		Checkpoint:     ToCheckpoint(pack.Checkpoint),
+		Changes:        pbChanges,
+		Snapshot:       pack.Snapshot,
+		VersionVector:  pbVersionVector,
+		IsRemoved:      pack.IsRemoved,
+		DetachedActors: pbDetachedActors,
 	}, nil
 }
 

--- a/api/docs/yorkie/v1/resources.openapi.yaml
+++ b/api/docs/yorkie/v1/resources.openapi.yaml
@@ -306,6 +306,13 @@ components:
           description: ""
           title: checkpoint
           type: object
+        detachedActors:
+          additionalProperties: false
+          description: |-
+            detached_actors contains actors safe to remove from VV.
+             Server signals this when all clients have caught up.
+          title: detached_actors
+          type: object
         documentKey:
           additionalProperties: false
           description: ""
@@ -335,6 +342,24 @@ components:
           title: version_vector
           type: object
       title: ChangePack
+      type: object
+    yorkie.v1.ChangePack.DetachedActorsEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          additionalProperties: false
+          description: ""
+          oneOf:
+          - type: string
+          - type: number
+          title: value
+      title: DetachedActorsEntry
       type: object
     yorkie.v1.ChannelEvent:
       additionalProperties: false
@@ -1854,6 +1879,13 @@ components:
          Messages for Snapshot               //
         ///////////////////////////////////////
       properties:
+        detachedActors:
+          additionalProperties: false
+          description: |-
+            detached_actors preserves removed actor lamports for VV
+             augmentation when restoring from snapshot.
+          title: detached_actors
+          type: object
         presences:
           additionalProperties: false
           description: ""
@@ -1866,6 +1898,24 @@ components:
           title: root
           type: object
       title: Snapshot
+      type: object
+    yorkie.v1.Snapshot.DetachedActorsEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          additionalProperties: false
+          description: ""
+          oneOf:
+          - type: string
+          - type: number
+          title: value
+      title: DetachedActorsEntry
       type: object
     yorkie.v1.Snapshot.PresencesEntry:
       additionalProperties: false

--- a/api/docs/yorkie/v1/yorkie.openapi.yaml
+++ b/api/docs/yorkie/v1/yorkie.openapi.yaml
@@ -865,6 +865,13 @@ components:
           description: ""
           title: checkpoint
           type: object
+        detachedActors:
+          additionalProperties: false
+          description: |-
+            detached_actors contains actors safe to remove from VV.
+             Server signals this when all clients have caught up.
+          title: detached_actors
+          type: object
         documentKey:
           additionalProperties: false
           description: ""
@@ -894,6 +901,24 @@ components:
           title: version_vector
           type: object
       title: ChangePack
+      type: object
+    yorkie.v1.ChangePack.DetachedActorsEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          additionalProperties: false
+          description: ""
+          oneOf:
+          - type: string
+          - type: number
+          title: value
+      title: DetachedActorsEntry
       type: object
     yorkie.v1.ChannelDescriptor:
       additionalProperties: false

--- a/api/yorkie/v1/resources.pb.go
+++ b/api/yorkie/v1/resources.pb.go
@@ -280,11 +280,14 @@ func (ChannelEvent_Type) EnumDescriptor() ([]byte, []int) {
 // Messages for Snapshot               //
 // ///////////////////////////////////////
 type Snapshot struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Root          *JSONElement           `protobuf:"bytes,1,opt,name=root,proto3" json:"root,omitempty"`
-	Presences     map[string]*Presence   `protobuf:"bytes,2,rep,name=presences,proto3" json:"presences,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	Root      *JSONElement           `protobuf:"bytes,1,opt,name=root,proto3" json:"root,omitempty"`
+	Presences map[string]*Presence   `protobuf:"bytes,2,rep,name=presences,proto3" json:"presences,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// detached_actors preserves removed actor lamports for VV
+	// augmentation when restoring from snapshot.
+	DetachedActors map[string]int64 `protobuf:"bytes,3,rep,name=detached_actors,json=detachedActors,proto3" json:"detached_actors,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *Snapshot) Reset() {
@@ -331,6 +334,13 @@ func (x *Snapshot) GetPresences() map[string]*Presence {
 	return nil
 }
 
+func (x *Snapshot) GetDetachedActors() map[string]int64 {
+	if x != nil {
+		return x.DetachedActors
+	}
+	return nil
+}
+
 // ChangePack is a message that contains all changes that occurred in a document.
 // It is used to synchronize changes between clients and servers.
 type ChangePack struct {
@@ -342,8 +352,11 @@ type ChangePack struct {
 	MinSyncedTicket *TimeTicket            `protobuf:"bytes,5,opt,name=min_synced_ticket,json=minSyncedTicket,proto3" json:"min_synced_ticket,omitempty"` // deprecated
 	IsRemoved       bool                   `protobuf:"varint,6,opt,name=is_removed,json=isRemoved,proto3" json:"is_removed,omitempty"`
 	VersionVector   *VersionVector         `protobuf:"bytes,7,opt,name=version_vector,json=versionVector,proto3" json:"version_vector,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// detached_actors contains actors safe to remove from VV.
+	// Server signals this when all clients have caught up.
+	DetachedActors map[string]int64 `protobuf:"bytes,8,rep,name=detached_actors,json=detachedActors,proto3" json:"detached_actors,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *ChangePack) Reset() {
@@ -421,6 +434,13 @@ func (x *ChangePack) GetIsRemoved() bool {
 func (x *ChangePack) GetVersionVector() *VersionVector {
 	if x != nil {
 		return x.VersionVector
+	}
+	return nil
+}
+
+func (x *ChangePack) GetDetachedActors() map[string]int64 {
+	if x != nil {
+		return x.DetachedActors
 	}
 	return nil
 }
@@ -3336,7 +3356,7 @@ type Operation_Set struct {
 
 func (x *Operation_Set) Reset() {
 	*x = Operation_Set{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[40]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3348,7 +3368,7 @@ func (x *Operation_Set) String() string {
 func (*Operation_Set) ProtoMessage() {}
 
 func (x *Operation_Set) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[40]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3404,7 +3424,7 @@ type Operation_Add struct {
 
 func (x *Operation_Add) Reset() {
 	*x = Operation_Add{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[41]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3416,7 +3436,7 @@ func (x *Operation_Add) String() string {
 func (*Operation_Add) ProtoMessage() {}
 
 func (x *Operation_Add) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[41]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3472,7 +3492,7 @@ type Operation_Move struct {
 
 func (x *Operation_Move) Reset() {
 	*x = Operation_Move{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[42]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3484,7 +3504,7 @@ func (x *Operation_Move) String() string {
 func (*Operation_Move) ProtoMessage() {}
 
 func (x *Operation_Move) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[42]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3539,7 +3559,7 @@ type Operation_Remove struct {
 
 func (x *Operation_Remove) Reset() {
 	*x = Operation_Remove{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[43]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3551,7 +3571,7 @@ func (x *Operation_Remove) String() string {
 func (*Operation_Remove) ProtoMessage() {}
 
 func (x *Operation_Remove) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[43]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3603,7 +3623,7 @@ type Operation_Edit struct {
 
 func (x *Operation_Edit) Reset() {
 	*x = Operation_Edit{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[44]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3615,7 +3635,7 @@ func (x *Operation_Edit) String() string {
 func (*Operation_Edit) ProtoMessage() {}
 
 func (x *Operation_Edit) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[44]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3695,7 +3715,7 @@ type Operation_Style struct {
 
 func (x *Operation_Style) Reset() {
 	*x = Operation_Style{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[45]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3707,7 +3727,7 @@ func (x *Operation_Style) String() string {
 func (*Operation_Style) ProtoMessage() {}
 
 func (x *Operation_Style) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[45]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3784,7 +3804,7 @@ type Operation_Increase struct {
 
 func (x *Operation_Increase) Reset() {
 	*x = Operation_Increase{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[46]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3796,7 +3816,7 @@ func (x *Operation_Increase) String() string {
 func (*Operation_Increase) ProtoMessage() {}
 
 func (x *Operation_Increase) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[46]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3855,7 +3875,7 @@ type Operation_TreeEdit struct {
 
 func (x *Operation_TreeEdit) Reset() {
 	*x = Operation_TreeEdit{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[47]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3867,7 +3887,7 @@ func (x *Operation_TreeEdit) String() string {
 func (*Operation_TreeEdit) ProtoMessage() {}
 
 func (x *Operation_TreeEdit) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[47]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3947,7 +3967,7 @@ type Operation_TreeStyle struct {
 
 func (x *Operation_TreeStyle) Reset() {
 	*x = Operation_TreeStyle{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[48]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3959,7 +3979,7 @@ func (x *Operation_TreeStyle) String() string {
 func (*Operation_TreeStyle) ProtoMessage() {}
 
 func (x *Operation_TreeStyle) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[48]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4036,7 +4056,7 @@ type Operation_ArraySet struct {
 
 func (x *Operation_ArraySet) Reset() {
 	*x = Operation_ArraySet{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[49]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4048,7 +4068,7 @@ func (x *Operation_ArraySet) String() string {
 func (*Operation_ArraySet) ProtoMessage() {}
 
 func (x *Operation_ArraySet) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[49]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4104,7 +4124,7 @@ type JSONElement_JSONObject struct {
 
 func (x *JSONElement_JSONObject) Reset() {
 	*x = JSONElement_JSONObject{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[57]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4116,7 +4136,7 @@ func (x *JSONElement_JSONObject) String() string {
 func (*JSONElement_JSONObject) ProtoMessage() {}
 
 func (x *JSONElement_JSONObject) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[57]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4172,7 +4192,7 @@ type JSONElement_JSONArray struct {
 
 func (x *JSONElement_JSONArray) Reset() {
 	*x = JSONElement_JSONArray{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[58]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4184,7 +4204,7 @@ func (x *JSONElement_JSONArray) String() string {
 func (*JSONElement_JSONArray) ProtoMessage() {}
 
 func (x *JSONElement_JSONArray) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[58]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4241,7 +4261,7 @@ type JSONElement_Primitive struct {
 
 func (x *JSONElement_Primitive) Reset() {
 	*x = JSONElement_Primitive{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[59]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4253,7 +4273,7 @@ func (x *JSONElement_Primitive) String() string {
 func (*JSONElement_Primitive) ProtoMessage() {}
 
 func (x *JSONElement_Primitive) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[59]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4316,7 +4336,7 @@ type JSONElement_Text struct {
 
 func (x *JSONElement_Text) Reset() {
 	*x = JSONElement_Text{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[60]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4328,7 +4348,7 @@ func (x *JSONElement_Text) String() string {
 func (*JSONElement_Text) ProtoMessage() {}
 
 func (x *JSONElement_Text) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[60]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4386,7 +4406,7 @@ type JSONElement_Counter struct {
 
 func (x *JSONElement_Counter) Reset() {
 	*x = JSONElement_Counter{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[61]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4398,7 +4418,7 @@ func (x *JSONElement_Counter) String() string {
 func (*JSONElement_Counter) ProtoMessage() {}
 
 func (x *JSONElement_Counter) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[61]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4468,7 +4488,7 @@ type JSONElement_Tree struct {
 
 func (x *JSONElement_Tree) Reset() {
 	*x = JSONElement_Tree{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[62]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4480,7 +4500,7 @@ func (x *JSONElement_Tree) String() string {
 func (*JSONElement_Tree) ProtoMessage() {}
 
 func (x *JSONElement_Tree) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[62]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4533,7 +4553,7 @@ type UpdatableProjectFields_AuthWebhookMethods struct {
 
 func (x *UpdatableProjectFields_AuthWebhookMethods) Reset() {
 	*x = UpdatableProjectFields_AuthWebhookMethods{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[65]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4545,7 +4565,7 @@ func (x *UpdatableProjectFields_AuthWebhookMethods) String() string {
 func (*UpdatableProjectFields_AuthWebhookMethods) ProtoMessage() {}
 
 func (x *UpdatableProjectFields_AuthWebhookMethods) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[65]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4577,7 +4597,7 @@ type UpdatableProjectFields_EventWebhookEvents struct {
 
 func (x *UpdatableProjectFields_EventWebhookEvents) Reset() {
 	*x = UpdatableProjectFields_EventWebhookEvents{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[66]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4589,7 +4609,7 @@ func (x *UpdatableProjectFields_EventWebhookEvents) String() string {
 func (*UpdatableProjectFields_EventWebhookEvents) ProtoMessage() {}
 
 func (x *UpdatableProjectFields_EventWebhookEvents) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[66]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4621,7 +4641,7 @@ type UpdatableProjectFields_AllowedOrigins struct {
 
 func (x *UpdatableProjectFields_AllowedOrigins) Reset() {
 	*x = UpdatableProjectFields_AllowedOrigins{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[67]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4633,7 +4653,7 @@ func (x *UpdatableProjectFields_AllowedOrigins) String() string {
 func (*UpdatableProjectFields_AllowedOrigins) ProtoMessage() {}
 
 func (x *UpdatableProjectFields_AllowedOrigins) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[67]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4660,13 +4680,17 @@ var File_yorkie_v1_resources_proto protoreflect.FileDescriptor
 
 const file_yorkie_v1_resources_proto_rawDesc = "" +
 	"\n" +
-	"\x19yorkie/v1/resources.proto\x12\tyorkie.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/wrappers.proto\"\xcb\x01\n" +
+	"\x19yorkie/v1/resources.proto\x12\tyorkie.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/wrappers.proto\"\xe0\x02\n" +
 	"\bSnapshot\x12*\n" +
 	"\x04root\x18\x01 \x01(\v2\x16.yorkie.v1.JSONElementR\x04root\x12@\n" +
-	"\tpresences\x18\x02 \x03(\v2\".yorkie.v1.Snapshot.PresencesEntryR\tpresences\x1aQ\n" +
+	"\tpresences\x18\x02 \x03(\v2\".yorkie.v1.Snapshot.PresencesEntryR\tpresences\x12P\n" +
+	"\x0fdetached_actors\x18\x03 \x03(\v2'.yorkie.v1.Snapshot.DetachedActorsEntryR\x0edetachedActors\x1aQ\n" +
 	"\x0ePresencesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12)\n" +
-	"\x05value\x18\x02 \x01(\v2\x13.yorkie.v1.PresenceR\x05value:\x028\x01\"\xd2\x02\n" +
+	"\x05value\x18\x02 \x01(\v2\x13.yorkie.v1.PresenceR\x05value:\x028\x01\x1aA\n" +
+	"\x13DetachedActorsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\x03R\x05value:\x028\x01\"\xe9\x03\n" +
 	"\n" +
 	"ChangePack\x12!\n" +
 	"\fdocument_key\x18\x01 \x01(\tR\vdocumentKey\x125\n" +
@@ -4678,7 +4702,11 @@ const file_yorkie_v1_resources_proto_rawDesc = "" +
 	"\x11min_synced_ticket\x18\x05 \x01(\v2\x15.yorkie.v1.TimeTicketR\x0fminSyncedTicket\x12\x1d\n" +
 	"\n" +
 	"is_removed\x18\x06 \x01(\bR\tisRemoved\x12?\n" +
-	"\x0eversion_vector\x18\a \x01(\v2\x18.yorkie.v1.VersionVectorR\rversionVector\"\xc1\x01\n" +
+	"\x0eversion_vector\x18\a \x01(\v2\x18.yorkie.v1.VersionVectorR\rversionVector\x12R\n" +
+	"\x0fdetached_actors\x18\b \x03(\v2).yorkie.v1.ChangePack.DetachedActorsEntryR\x0edetachedActors\x1aA\n" +
+	"\x13DetachedActorsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\x03R\x05value:\x028\x01\"\xc1\x01\n" +
 	"\x06Change\x12#\n" +
 	"\x02id\x18\x01 \x01(\v2\x13.yorkie.v1.ChangeIDR\x02id\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x124\n" +
@@ -5160,7 +5188,7 @@ func file_yorkie_v1_resources_proto_rawDescGZIP() []byte {
 }
 
 var file_yorkie_v1_resources_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_yorkie_v1_resources_proto_msgTypes = make([]protoimpl.MessageInfo, 70)
+var file_yorkie_v1_resources_proto_msgTypes = make([]protoimpl.MessageInfo, 72)
 var file_yorkie_v1_resources_proto_goTypes = []any{
 	(ValueType)(0),                 // 0: yorkie.v1.ValueType
 	(DocEventType)(0),              // 1: yorkie.v1.DocEventType
@@ -5205,225 +5233,229 @@ var file_yorkie_v1_resources_proto_goTypes = []any{
 	(*Rule)(nil),                   // 40: yorkie.v1.Rule
 	(*RevisionSummary)(nil),        // 41: yorkie.v1.RevisionSummary
 	nil,                            // 42: yorkie.v1.Snapshot.PresencesEntry
-	nil,                            // 43: yorkie.v1.VersionVector.VectorEntry
-	(*Operation_Set)(nil),          // 44: yorkie.v1.Operation.Set
-	(*Operation_Add)(nil),          // 45: yorkie.v1.Operation.Add
-	(*Operation_Move)(nil),         // 46: yorkie.v1.Operation.Move
-	(*Operation_Remove)(nil),       // 47: yorkie.v1.Operation.Remove
-	(*Operation_Edit)(nil),         // 48: yorkie.v1.Operation.Edit
-	(*Operation_Style)(nil),        // 49: yorkie.v1.Operation.Style
-	(*Operation_Increase)(nil),     // 50: yorkie.v1.Operation.Increase
-	(*Operation_TreeEdit)(nil),     // 51: yorkie.v1.Operation.TreeEdit
-	(*Operation_TreeStyle)(nil),    // 52: yorkie.v1.Operation.TreeStyle
-	(*Operation_ArraySet)(nil),     // 53: yorkie.v1.Operation.ArraySet
-	nil,                            // 54: yorkie.v1.Operation.Edit.CreatedAtMapByActorEntry
-	nil,                            // 55: yorkie.v1.Operation.Edit.AttributesEntry
-	nil,                            // 56: yorkie.v1.Operation.Style.AttributesEntry
-	nil,                            // 57: yorkie.v1.Operation.Style.CreatedAtMapByActorEntry
-	nil,                            // 58: yorkie.v1.Operation.TreeEdit.CreatedAtMapByActorEntry
-	nil,                            // 59: yorkie.v1.Operation.TreeStyle.AttributesEntry
-	nil,                            // 60: yorkie.v1.Operation.TreeStyle.CreatedAtMapByActorEntry
-	(*JSONElement_JSONObject)(nil), // 61: yorkie.v1.JSONElement.JSONObject
-	(*JSONElement_JSONArray)(nil),  // 62: yorkie.v1.JSONElement.JSONArray
-	(*JSONElement_Primitive)(nil),  // 63: yorkie.v1.JSONElement.Primitive
-	(*JSONElement_Text)(nil),       // 64: yorkie.v1.JSONElement.Text
-	(*JSONElement_Counter)(nil),    // 65: yorkie.v1.JSONElement.Counter
-	(*JSONElement_Tree)(nil),       // 66: yorkie.v1.JSONElement.Tree
-	nil,                            // 67: yorkie.v1.TextNode.AttributesEntry
-	nil,                            // 68: yorkie.v1.TreeNode.AttributesEntry
-	(*UpdatableProjectFields_AuthWebhookMethods)(nil), // 69: yorkie.v1.UpdatableProjectFields.AuthWebhookMethods
-	(*UpdatableProjectFields_EventWebhookEvents)(nil), // 70: yorkie.v1.UpdatableProjectFields.EventWebhookEvents
-	(*UpdatableProjectFields_AllowedOrigins)(nil),     // 71: yorkie.v1.UpdatableProjectFields.AllowedOrigins
-	nil,                            // 72: yorkie.v1.DocumentSummary.PresencesEntry
-	nil,                            // 73: yorkie.v1.Presence.DataEntry
-	(*timestamppb.Timestamp)(nil),  // 74: google.protobuf.Timestamp
-	(*wrapperspb.StringValue)(nil), // 75: google.protobuf.StringValue
-	(*wrapperspb.UInt64Value)(nil), // 76: google.protobuf.UInt64Value
-	(*wrapperspb.Int64Value)(nil),  // 77: google.protobuf.Int64Value
-	(*wrapperspb.Int32Value)(nil),  // 78: google.protobuf.Int32Value
-	(*wrapperspb.BoolValue)(nil),   // 79: google.protobuf.BoolValue
+	nil,                            // 43: yorkie.v1.Snapshot.DetachedActorsEntry
+	nil,                            // 44: yorkie.v1.ChangePack.DetachedActorsEntry
+	nil,                            // 45: yorkie.v1.VersionVector.VectorEntry
+	(*Operation_Set)(nil),          // 46: yorkie.v1.Operation.Set
+	(*Operation_Add)(nil),          // 47: yorkie.v1.Operation.Add
+	(*Operation_Move)(nil),         // 48: yorkie.v1.Operation.Move
+	(*Operation_Remove)(nil),       // 49: yorkie.v1.Operation.Remove
+	(*Operation_Edit)(nil),         // 50: yorkie.v1.Operation.Edit
+	(*Operation_Style)(nil),        // 51: yorkie.v1.Operation.Style
+	(*Operation_Increase)(nil),     // 52: yorkie.v1.Operation.Increase
+	(*Operation_TreeEdit)(nil),     // 53: yorkie.v1.Operation.TreeEdit
+	(*Operation_TreeStyle)(nil),    // 54: yorkie.v1.Operation.TreeStyle
+	(*Operation_ArraySet)(nil),     // 55: yorkie.v1.Operation.ArraySet
+	nil,                            // 56: yorkie.v1.Operation.Edit.CreatedAtMapByActorEntry
+	nil,                            // 57: yorkie.v1.Operation.Edit.AttributesEntry
+	nil,                            // 58: yorkie.v1.Operation.Style.AttributesEntry
+	nil,                            // 59: yorkie.v1.Operation.Style.CreatedAtMapByActorEntry
+	nil,                            // 60: yorkie.v1.Operation.TreeEdit.CreatedAtMapByActorEntry
+	nil,                            // 61: yorkie.v1.Operation.TreeStyle.AttributesEntry
+	nil,                            // 62: yorkie.v1.Operation.TreeStyle.CreatedAtMapByActorEntry
+	(*JSONElement_JSONObject)(nil), // 63: yorkie.v1.JSONElement.JSONObject
+	(*JSONElement_JSONArray)(nil),  // 64: yorkie.v1.JSONElement.JSONArray
+	(*JSONElement_Primitive)(nil),  // 65: yorkie.v1.JSONElement.Primitive
+	(*JSONElement_Text)(nil),       // 66: yorkie.v1.JSONElement.Text
+	(*JSONElement_Counter)(nil),    // 67: yorkie.v1.JSONElement.Counter
+	(*JSONElement_Tree)(nil),       // 68: yorkie.v1.JSONElement.Tree
+	nil,                            // 69: yorkie.v1.TextNode.AttributesEntry
+	nil,                            // 70: yorkie.v1.TreeNode.AttributesEntry
+	(*UpdatableProjectFields_AuthWebhookMethods)(nil), // 71: yorkie.v1.UpdatableProjectFields.AuthWebhookMethods
+	(*UpdatableProjectFields_EventWebhookEvents)(nil), // 72: yorkie.v1.UpdatableProjectFields.EventWebhookEvents
+	(*UpdatableProjectFields_AllowedOrigins)(nil),     // 73: yorkie.v1.UpdatableProjectFields.AllowedOrigins
+	nil,                            // 74: yorkie.v1.DocumentSummary.PresencesEntry
+	nil,                            // 75: yorkie.v1.Presence.DataEntry
+	(*timestamppb.Timestamp)(nil),  // 76: google.protobuf.Timestamp
+	(*wrapperspb.StringValue)(nil), // 77: google.protobuf.StringValue
+	(*wrapperspb.UInt64Value)(nil), // 78: google.protobuf.UInt64Value
+	(*wrapperspb.Int64Value)(nil),  // 79: google.protobuf.Int64Value
+	(*wrapperspb.Int32Value)(nil),  // 80: google.protobuf.Int32Value
+	(*wrapperspb.BoolValue)(nil),   // 81: google.protobuf.BoolValue
 }
 var file_yorkie_v1_resources_proto_depIdxs = []int32{
 	11,  // 0: yorkie.v1.Snapshot.root:type_name -> yorkie.v1.JSONElement
 	42,  // 1: yorkie.v1.Snapshot.presences:type_name -> yorkie.v1.Snapshot.PresencesEntry
-	30,  // 2: yorkie.v1.ChangePack.checkpoint:type_name -> yorkie.v1.Checkpoint
-	6,   // 3: yorkie.v1.ChangePack.changes:type_name -> yorkie.v1.Change
-	32,  // 4: yorkie.v1.ChangePack.min_synced_ticket:type_name -> yorkie.v1.TimeTicket
-	8,   // 5: yorkie.v1.ChangePack.version_vector:type_name -> yorkie.v1.VersionVector
-	7,   // 6: yorkie.v1.Change.id:type_name -> yorkie.v1.ChangeID
-	9,   // 7: yorkie.v1.Change.operations:type_name -> yorkie.v1.Operation
-	27,  // 8: yorkie.v1.Change.presence_change:type_name -> yorkie.v1.PresenceChange
-	8,   // 9: yorkie.v1.ChangeID.version_vector:type_name -> yorkie.v1.VersionVector
-	43,  // 10: yorkie.v1.VersionVector.vector:type_name -> yorkie.v1.VersionVector.VectorEntry
-	44,  // 11: yorkie.v1.Operation.set:type_name -> yorkie.v1.Operation.Set
-	45,  // 12: yorkie.v1.Operation.add:type_name -> yorkie.v1.Operation.Add
-	46,  // 13: yorkie.v1.Operation.move:type_name -> yorkie.v1.Operation.Move
-	47,  // 14: yorkie.v1.Operation.remove:type_name -> yorkie.v1.Operation.Remove
-	48,  // 15: yorkie.v1.Operation.edit:type_name -> yorkie.v1.Operation.Edit
-	49,  // 16: yorkie.v1.Operation.style:type_name -> yorkie.v1.Operation.Style
-	50,  // 17: yorkie.v1.Operation.increase:type_name -> yorkie.v1.Operation.Increase
-	51,  // 18: yorkie.v1.Operation.tree_edit:type_name -> yorkie.v1.Operation.TreeEdit
-	52,  // 19: yorkie.v1.Operation.tree_style:type_name -> yorkie.v1.Operation.TreeStyle
-	53,  // 20: yorkie.v1.Operation.array_set:type_name -> yorkie.v1.Operation.ArraySet
-	32,  // 21: yorkie.v1.JSONElementSimple.created_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 22: yorkie.v1.JSONElementSimple.moved_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 23: yorkie.v1.JSONElementSimple.removed_at:type_name -> yorkie.v1.TimeTicket
-	0,   // 24: yorkie.v1.JSONElementSimple.type:type_name -> yorkie.v1.ValueType
-	61,  // 25: yorkie.v1.JSONElement.json_object:type_name -> yorkie.v1.JSONElement.JSONObject
-	62,  // 26: yorkie.v1.JSONElement.json_array:type_name -> yorkie.v1.JSONElement.JSONArray
-	63,  // 27: yorkie.v1.JSONElement.primitive:type_name -> yorkie.v1.JSONElement.Primitive
-	64,  // 28: yorkie.v1.JSONElement.text:type_name -> yorkie.v1.JSONElement.Text
-	65,  // 29: yorkie.v1.JSONElement.counter:type_name -> yorkie.v1.JSONElement.Counter
-	66,  // 30: yorkie.v1.JSONElement.tree:type_name -> yorkie.v1.JSONElement.Tree
-	11,  // 31: yorkie.v1.RHTNode.element:type_name -> yorkie.v1.JSONElement
-	13,  // 32: yorkie.v1.RGANode.next:type_name -> yorkie.v1.RGANode
-	11,  // 33: yorkie.v1.RGANode.element:type_name -> yorkie.v1.JSONElement
-	32,  // 34: yorkie.v1.RGANode.position_created_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 35: yorkie.v1.RGANode.position_moved_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 36: yorkie.v1.RGANode.position_removed_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 37: yorkie.v1.NodeAttr.updated_at:type_name -> yorkie.v1.TimeTicket
-	16,  // 38: yorkie.v1.TextNode.id:type_name -> yorkie.v1.TextNodeID
-	32,  // 39: yorkie.v1.TextNode.removed_at:type_name -> yorkie.v1.TimeTicket
-	16,  // 40: yorkie.v1.TextNode.ins_prev_id:type_name -> yorkie.v1.TextNodeID
-	67,  // 41: yorkie.v1.TextNode.attributes:type_name -> yorkie.v1.TextNode.AttributesEntry
-	32,  // 42: yorkie.v1.TextNodeID.created_at:type_name -> yorkie.v1.TimeTicket
-	19,  // 43: yorkie.v1.TreeNode.id:type_name -> yorkie.v1.TreeNodeID
-	32,  // 44: yorkie.v1.TreeNode.removed_at:type_name -> yorkie.v1.TimeTicket
-	19,  // 45: yorkie.v1.TreeNode.ins_prev_id:type_name -> yorkie.v1.TreeNodeID
-	19,  // 46: yorkie.v1.TreeNode.ins_next_id:type_name -> yorkie.v1.TreeNodeID
-	68,  // 47: yorkie.v1.TreeNode.attributes:type_name -> yorkie.v1.TreeNode.AttributesEntry
-	19,  // 48: yorkie.v1.TreeNode.merged_from:type_name -> yorkie.v1.TreeNodeID
-	32,  // 49: yorkie.v1.TreeNode.merged_at:type_name -> yorkie.v1.TimeTicket
-	17,  // 50: yorkie.v1.TreeNodes.content:type_name -> yorkie.v1.TreeNode
-	32,  // 51: yorkie.v1.TreeNodeID.created_at:type_name -> yorkie.v1.TimeTicket
-	19,  // 52: yorkie.v1.TreePos.parent_id:type_name -> yorkie.v1.TreeNodeID
-	19,  // 53: yorkie.v1.TreePos.left_sibling_id:type_name -> yorkie.v1.TreeNodeID
-	74,  // 54: yorkie.v1.User.created_at:type_name -> google.protobuf.Timestamp
-	74,  // 55: yorkie.v1.Member.invited_at:type_name -> google.protobuf.Timestamp
-	74,  // 56: yorkie.v1.Project.created_at:type_name -> google.protobuf.Timestamp
-	74,  // 57: yorkie.v1.Project.updated_at:type_name -> google.protobuf.Timestamp
-	75,  // 58: yorkie.v1.UpdatableProjectFields.name:type_name -> google.protobuf.StringValue
-	75,  // 59: yorkie.v1.UpdatableProjectFields.auth_webhook_url:type_name -> google.protobuf.StringValue
-	69,  // 60: yorkie.v1.UpdatableProjectFields.auth_webhook_methods:type_name -> yorkie.v1.UpdatableProjectFields.AuthWebhookMethods
-	76,  // 61: yorkie.v1.UpdatableProjectFields.auth_webhook_max_retries:type_name -> google.protobuf.UInt64Value
-	75,  // 62: yorkie.v1.UpdatableProjectFields.auth_webhook_min_wait_interval:type_name -> google.protobuf.StringValue
-	75,  // 63: yorkie.v1.UpdatableProjectFields.auth_webhook_max_wait_interval:type_name -> google.protobuf.StringValue
-	75,  // 64: yorkie.v1.UpdatableProjectFields.auth_webhook_request_timeout:type_name -> google.protobuf.StringValue
-	75,  // 65: yorkie.v1.UpdatableProjectFields.event_webhook_url:type_name -> google.protobuf.StringValue
-	70,  // 66: yorkie.v1.UpdatableProjectFields.event_webhook_events:type_name -> yorkie.v1.UpdatableProjectFields.EventWebhookEvents
-	76,  // 67: yorkie.v1.UpdatableProjectFields.event_webhook_max_retries:type_name -> google.protobuf.UInt64Value
-	75,  // 68: yorkie.v1.UpdatableProjectFields.event_webhook_min_wait_interval:type_name -> google.protobuf.StringValue
-	75,  // 69: yorkie.v1.UpdatableProjectFields.event_webhook_max_wait_interval:type_name -> google.protobuf.StringValue
-	75,  // 70: yorkie.v1.UpdatableProjectFields.event_webhook_request_timeout:type_name -> google.protobuf.StringValue
-	77,  // 71: yorkie.v1.UpdatableProjectFields.snapshot_threshold:type_name -> google.protobuf.Int64Value
-	77,  // 72: yorkie.v1.UpdatableProjectFields.snapshot_interval:type_name -> google.protobuf.Int64Value
-	75,  // 73: yorkie.v1.UpdatableProjectFields.client_deactivate_threshold:type_name -> google.protobuf.StringValue
-	78,  // 74: yorkie.v1.UpdatableProjectFields.max_subscribers_per_document:type_name -> google.protobuf.Int32Value
-	78,  // 75: yorkie.v1.UpdatableProjectFields.max_attachments_per_document:type_name -> google.protobuf.Int32Value
-	78,  // 76: yorkie.v1.UpdatableProjectFields.max_size_per_document:type_name -> google.protobuf.Int32Value
-	79,  // 77: yorkie.v1.UpdatableProjectFields.remove_on_detach:type_name -> google.protobuf.BoolValue
-	79,  // 78: yorkie.v1.UpdatableProjectFields.auto_revision_enabled:type_name -> google.protobuf.BoolValue
-	71,  // 79: yorkie.v1.UpdatableProjectFields.allowed_origins:type_name -> yorkie.v1.UpdatableProjectFields.AllowedOrigins
-	37,  // 80: yorkie.v1.DocumentSummary.document_size:type_name -> yorkie.v1.DocSize
-	72,  // 81: yorkie.v1.DocumentSummary.presences:type_name -> yorkie.v1.DocumentSummary.PresencesEntry
-	74,  // 82: yorkie.v1.DocumentSummary.created_at:type_name -> google.protobuf.Timestamp
-	74,  // 83: yorkie.v1.DocumentSummary.accessed_at:type_name -> google.protobuf.Timestamp
-	74,  // 84: yorkie.v1.DocumentSummary.updated_at:type_name -> google.protobuf.Timestamp
-	2,   // 85: yorkie.v1.PresenceChange.type:type_name -> yorkie.v1.PresenceChange.ChangeType
-	28,  // 86: yorkie.v1.PresenceChange.presence:type_name -> yorkie.v1.Presence
-	73,  // 87: yorkie.v1.Presence.data:type_name -> yorkie.v1.Presence.DataEntry
-	32,  // 88: yorkie.v1.TextNodePos.created_at:type_name -> yorkie.v1.TimeTicket
-	1,   // 89: yorkie.v1.DocEvent.type:type_name -> yorkie.v1.DocEventType
-	33,  // 90: yorkie.v1.DocEvent.body:type_name -> yorkie.v1.DocEventBody
-	3,   // 91: yorkie.v1.ChannelEvent.type:type_name -> yorkie.v1.ChannelEvent.Type
-	36,  // 92: yorkie.v1.DocSize.live:type_name -> yorkie.v1.DataSize
-	36,  // 93: yorkie.v1.DocSize.gc:type_name -> yorkie.v1.DataSize
-	40,  // 94: yorkie.v1.Schema.rules:type_name -> yorkie.v1.Rule
-	74,  // 95: yorkie.v1.Schema.created_at:type_name -> google.protobuf.Timestamp
-	39,  // 96: yorkie.v1.Rule.tree_nodes:type_name -> yorkie.v1.TreeNodeRule
-	74,  // 97: yorkie.v1.RevisionSummary.created_at:type_name -> google.protobuf.Timestamp
-	28,  // 98: yorkie.v1.Snapshot.PresencesEntry.value:type_name -> yorkie.v1.Presence
-	32,  // 99: yorkie.v1.Operation.Set.parent_created_at:type_name -> yorkie.v1.TimeTicket
-	10,  // 100: yorkie.v1.Operation.Set.value:type_name -> yorkie.v1.JSONElementSimple
-	32,  // 101: yorkie.v1.Operation.Set.executed_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 102: yorkie.v1.Operation.Add.parent_created_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 103: yorkie.v1.Operation.Add.prev_created_at:type_name -> yorkie.v1.TimeTicket
-	10,  // 104: yorkie.v1.Operation.Add.value:type_name -> yorkie.v1.JSONElementSimple
-	32,  // 105: yorkie.v1.Operation.Add.executed_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 106: yorkie.v1.Operation.Move.parent_created_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 107: yorkie.v1.Operation.Move.prev_created_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 108: yorkie.v1.Operation.Move.created_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 109: yorkie.v1.Operation.Move.executed_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 110: yorkie.v1.Operation.Remove.parent_created_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 111: yorkie.v1.Operation.Remove.created_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 112: yorkie.v1.Operation.Remove.executed_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 113: yorkie.v1.Operation.Edit.parent_created_at:type_name -> yorkie.v1.TimeTicket
-	31,  // 114: yorkie.v1.Operation.Edit.from:type_name -> yorkie.v1.TextNodePos
-	31,  // 115: yorkie.v1.Operation.Edit.to:type_name -> yorkie.v1.TextNodePos
-	54,  // 116: yorkie.v1.Operation.Edit.created_at_map_by_actor:type_name -> yorkie.v1.Operation.Edit.CreatedAtMapByActorEntry
-	32,  // 117: yorkie.v1.Operation.Edit.executed_at:type_name -> yorkie.v1.TimeTicket
-	55,  // 118: yorkie.v1.Operation.Edit.attributes:type_name -> yorkie.v1.Operation.Edit.AttributesEntry
-	32,  // 119: yorkie.v1.Operation.Style.parent_created_at:type_name -> yorkie.v1.TimeTicket
-	31,  // 120: yorkie.v1.Operation.Style.from:type_name -> yorkie.v1.TextNodePos
-	31,  // 121: yorkie.v1.Operation.Style.to:type_name -> yorkie.v1.TextNodePos
-	56,  // 122: yorkie.v1.Operation.Style.attributes:type_name -> yorkie.v1.Operation.Style.AttributesEntry
-	32,  // 123: yorkie.v1.Operation.Style.executed_at:type_name -> yorkie.v1.TimeTicket
-	57,  // 124: yorkie.v1.Operation.Style.created_at_map_by_actor:type_name -> yorkie.v1.Operation.Style.CreatedAtMapByActorEntry
-	32,  // 125: yorkie.v1.Operation.Increase.parent_created_at:type_name -> yorkie.v1.TimeTicket
-	10,  // 126: yorkie.v1.Operation.Increase.value:type_name -> yorkie.v1.JSONElementSimple
-	32,  // 127: yorkie.v1.Operation.Increase.executed_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 128: yorkie.v1.Operation.TreeEdit.parent_created_at:type_name -> yorkie.v1.TimeTicket
-	20,  // 129: yorkie.v1.Operation.TreeEdit.from:type_name -> yorkie.v1.TreePos
-	20,  // 130: yorkie.v1.Operation.TreeEdit.to:type_name -> yorkie.v1.TreePos
-	58,  // 131: yorkie.v1.Operation.TreeEdit.created_at_map_by_actor:type_name -> yorkie.v1.Operation.TreeEdit.CreatedAtMapByActorEntry
-	18,  // 132: yorkie.v1.Operation.TreeEdit.contents:type_name -> yorkie.v1.TreeNodes
-	32,  // 133: yorkie.v1.Operation.TreeEdit.executed_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 134: yorkie.v1.Operation.TreeStyle.parent_created_at:type_name -> yorkie.v1.TimeTicket
-	20,  // 135: yorkie.v1.Operation.TreeStyle.from:type_name -> yorkie.v1.TreePos
-	20,  // 136: yorkie.v1.Operation.TreeStyle.to:type_name -> yorkie.v1.TreePos
-	59,  // 137: yorkie.v1.Operation.TreeStyle.attributes:type_name -> yorkie.v1.Operation.TreeStyle.AttributesEntry
-	32,  // 138: yorkie.v1.Operation.TreeStyle.executed_at:type_name -> yorkie.v1.TimeTicket
-	60,  // 139: yorkie.v1.Operation.TreeStyle.created_at_map_by_actor:type_name -> yorkie.v1.Operation.TreeStyle.CreatedAtMapByActorEntry
-	32,  // 140: yorkie.v1.Operation.ArraySet.parent_created_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 141: yorkie.v1.Operation.ArraySet.created_at:type_name -> yorkie.v1.TimeTicket
-	10,  // 142: yorkie.v1.Operation.ArraySet.value:type_name -> yorkie.v1.JSONElementSimple
-	32,  // 143: yorkie.v1.Operation.ArraySet.executed_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 144: yorkie.v1.Operation.Edit.CreatedAtMapByActorEntry.value:type_name -> yorkie.v1.TimeTicket
-	32,  // 145: yorkie.v1.Operation.Style.CreatedAtMapByActorEntry.value:type_name -> yorkie.v1.TimeTicket
-	32,  // 146: yorkie.v1.Operation.TreeEdit.CreatedAtMapByActorEntry.value:type_name -> yorkie.v1.TimeTicket
-	32,  // 147: yorkie.v1.Operation.TreeStyle.CreatedAtMapByActorEntry.value:type_name -> yorkie.v1.TimeTicket
-	12,  // 148: yorkie.v1.JSONElement.JSONObject.nodes:type_name -> yorkie.v1.RHTNode
-	32,  // 149: yorkie.v1.JSONElement.JSONObject.created_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 150: yorkie.v1.JSONElement.JSONObject.moved_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 151: yorkie.v1.JSONElement.JSONObject.removed_at:type_name -> yorkie.v1.TimeTicket
-	13,  // 152: yorkie.v1.JSONElement.JSONArray.nodes:type_name -> yorkie.v1.RGANode
-	32,  // 153: yorkie.v1.JSONElement.JSONArray.created_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 154: yorkie.v1.JSONElement.JSONArray.moved_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 155: yorkie.v1.JSONElement.JSONArray.removed_at:type_name -> yorkie.v1.TimeTicket
-	0,   // 156: yorkie.v1.JSONElement.Primitive.type:type_name -> yorkie.v1.ValueType
-	32,  // 157: yorkie.v1.JSONElement.Primitive.created_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 158: yorkie.v1.JSONElement.Primitive.moved_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 159: yorkie.v1.JSONElement.Primitive.removed_at:type_name -> yorkie.v1.TimeTicket
-	15,  // 160: yorkie.v1.JSONElement.Text.nodes:type_name -> yorkie.v1.TextNode
-	32,  // 161: yorkie.v1.JSONElement.Text.created_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 162: yorkie.v1.JSONElement.Text.moved_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 163: yorkie.v1.JSONElement.Text.removed_at:type_name -> yorkie.v1.TimeTicket
-	0,   // 164: yorkie.v1.JSONElement.Counter.type:type_name -> yorkie.v1.ValueType
-	32,  // 165: yorkie.v1.JSONElement.Counter.created_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 166: yorkie.v1.JSONElement.Counter.moved_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 167: yorkie.v1.JSONElement.Counter.removed_at:type_name -> yorkie.v1.TimeTicket
-	17,  // 168: yorkie.v1.JSONElement.Tree.nodes:type_name -> yorkie.v1.TreeNode
-	32,  // 169: yorkie.v1.JSONElement.Tree.created_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 170: yorkie.v1.JSONElement.Tree.moved_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 171: yorkie.v1.JSONElement.Tree.removed_at:type_name -> yorkie.v1.TimeTicket
-	14,  // 172: yorkie.v1.TextNode.AttributesEntry.value:type_name -> yorkie.v1.NodeAttr
-	14,  // 173: yorkie.v1.TreeNode.AttributesEntry.value:type_name -> yorkie.v1.NodeAttr
-	28,  // 174: yorkie.v1.DocumentSummary.PresencesEntry.value:type_name -> yorkie.v1.Presence
-	175, // [175:175] is the sub-list for method output_type
-	175, // [175:175] is the sub-list for method input_type
-	175, // [175:175] is the sub-list for extension type_name
-	175, // [175:175] is the sub-list for extension extendee
-	0,   // [0:175] is the sub-list for field type_name
+	43,  // 2: yorkie.v1.Snapshot.detached_actors:type_name -> yorkie.v1.Snapshot.DetachedActorsEntry
+	30,  // 3: yorkie.v1.ChangePack.checkpoint:type_name -> yorkie.v1.Checkpoint
+	6,   // 4: yorkie.v1.ChangePack.changes:type_name -> yorkie.v1.Change
+	32,  // 5: yorkie.v1.ChangePack.min_synced_ticket:type_name -> yorkie.v1.TimeTicket
+	8,   // 6: yorkie.v1.ChangePack.version_vector:type_name -> yorkie.v1.VersionVector
+	44,  // 7: yorkie.v1.ChangePack.detached_actors:type_name -> yorkie.v1.ChangePack.DetachedActorsEntry
+	7,   // 8: yorkie.v1.Change.id:type_name -> yorkie.v1.ChangeID
+	9,   // 9: yorkie.v1.Change.operations:type_name -> yorkie.v1.Operation
+	27,  // 10: yorkie.v1.Change.presence_change:type_name -> yorkie.v1.PresenceChange
+	8,   // 11: yorkie.v1.ChangeID.version_vector:type_name -> yorkie.v1.VersionVector
+	45,  // 12: yorkie.v1.VersionVector.vector:type_name -> yorkie.v1.VersionVector.VectorEntry
+	46,  // 13: yorkie.v1.Operation.set:type_name -> yorkie.v1.Operation.Set
+	47,  // 14: yorkie.v1.Operation.add:type_name -> yorkie.v1.Operation.Add
+	48,  // 15: yorkie.v1.Operation.move:type_name -> yorkie.v1.Operation.Move
+	49,  // 16: yorkie.v1.Operation.remove:type_name -> yorkie.v1.Operation.Remove
+	50,  // 17: yorkie.v1.Operation.edit:type_name -> yorkie.v1.Operation.Edit
+	51,  // 18: yorkie.v1.Operation.style:type_name -> yorkie.v1.Operation.Style
+	52,  // 19: yorkie.v1.Operation.increase:type_name -> yorkie.v1.Operation.Increase
+	53,  // 20: yorkie.v1.Operation.tree_edit:type_name -> yorkie.v1.Operation.TreeEdit
+	54,  // 21: yorkie.v1.Operation.tree_style:type_name -> yorkie.v1.Operation.TreeStyle
+	55,  // 22: yorkie.v1.Operation.array_set:type_name -> yorkie.v1.Operation.ArraySet
+	32,  // 23: yorkie.v1.JSONElementSimple.created_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 24: yorkie.v1.JSONElementSimple.moved_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 25: yorkie.v1.JSONElementSimple.removed_at:type_name -> yorkie.v1.TimeTicket
+	0,   // 26: yorkie.v1.JSONElementSimple.type:type_name -> yorkie.v1.ValueType
+	63,  // 27: yorkie.v1.JSONElement.json_object:type_name -> yorkie.v1.JSONElement.JSONObject
+	64,  // 28: yorkie.v1.JSONElement.json_array:type_name -> yorkie.v1.JSONElement.JSONArray
+	65,  // 29: yorkie.v1.JSONElement.primitive:type_name -> yorkie.v1.JSONElement.Primitive
+	66,  // 30: yorkie.v1.JSONElement.text:type_name -> yorkie.v1.JSONElement.Text
+	67,  // 31: yorkie.v1.JSONElement.counter:type_name -> yorkie.v1.JSONElement.Counter
+	68,  // 32: yorkie.v1.JSONElement.tree:type_name -> yorkie.v1.JSONElement.Tree
+	11,  // 33: yorkie.v1.RHTNode.element:type_name -> yorkie.v1.JSONElement
+	13,  // 34: yorkie.v1.RGANode.next:type_name -> yorkie.v1.RGANode
+	11,  // 35: yorkie.v1.RGANode.element:type_name -> yorkie.v1.JSONElement
+	32,  // 36: yorkie.v1.RGANode.position_created_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 37: yorkie.v1.RGANode.position_moved_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 38: yorkie.v1.RGANode.position_removed_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 39: yorkie.v1.NodeAttr.updated_at:type_name -> yorkie.v1.TimeTicket
+	16,  // 40: yorkie.v1.TextNode.id:type_name -> yorkie.v1.TextNodeID
+	32,  // 41: yorkie.v1.TextNode.removed_at:type_name -> yorkie.v1.TimeTicket
+	16,  // 42: yorkie.v1.TextNode.ins_prev_id:type_name -> yorkie.v1.TextNodeID
+	69,  // 43: yorkie.v1.TextNode.attributes:type_name -> yorkie.v1.TextNode.AttributesEntry
+	32,  // 44: yorkie.v1.TextNodeID.created_at:type_name -> yorkie.v1.TimeTicket
+	19,  // 45: yorkie.v1.TreeNode.id:type_name -> yorkie.v1.TreeNodeID
+	32,  // 46: yorkie.v1.TreeNode.removed_at:type_name -> yorkie.v1.TimeTicket
+	19,  // 47: yorkie.v1.TreeNode.ins_prev_id:type_name -> yorkie.v1.TreeNodeID
+	19,  // 48: yorkie.v1.TreeNode.ins_next_id:type_name -> yorkie.v1.TreeNodeID
+	70,  // 49: yorkie.v1.TreeNode.attributes:type_name -> yorkie.v1.TreeNode.AttributesEntry
+	19,  // 50: yorkie.v1.TreeNode.merged_from:type_name -> yorkie.v1.TreeNodeID
+	32,  // 51: yorkie.v1.TreeNode.merged_at:type_name -> yorkie.v1.TimeTicket
+	17,  // 52: yorkie.v1.TreeNodes.content:type_name -> yorkie.v1.TreeNode
+	32,  // 53: yorkie.v1.TreeNodeID.created_at:type_name -> yorkie.v1.TimeTicket
+	19,  // 54: yorkie.v1.TreePos.parent_id:type_name -> yorkie.v1.TreeNodeID
+	19,  // 55: yorkie.v1.TreePos.left_sibling_id:type_name -> yorkie.v1.TreeNodeID
+	76,  // 56: yorkie.v1.User.created_at:type_name -> google.protobuf.Timestamp
+	76,  // 57: yorkie.v1.Member.invited_at:type_name -> google.protobuf.Timestamp
+	76,  // 58: yorkie.v1.Project.created_at:type_name -> google.protobuf.Timestamp
+	76,  // 59: yorkie.v1.Project.updated_at:type_name -> google.protobuf.Timestamp
+	77,  // 60: yorkie.v1.UpdatableProjectFields.name:type_name -> google.protobuf.StringValue
+	77,  // 61: yorkie.v1.UpdatableProjectFields.auth_webhook_url:type_name -> google.protobuf.StringValue
+	71,  // 62: yorkie.v1.UpdatableProjectFields.auth_webhook_methods:type_name -> yorkie.v1.UpdatableProjectFields.AuthWebhookMethods
+	78,  // 63: yorkie.v1.UpdatableProjectFields.auth_webhook_max_retries:type_name -> google.protobuf.UInt64Value
+	77,  // 64: yorkie.v1.UpdatableProjectFields.auth_webhook_min_wait_interval:type_name -> google.protobuf.StringValue
+	77,  // 65: yorkie.v1.UpdatableProjectFields.auth_webhook_max_wait_interval:type_name -> google.protobuf.StringValue
+	77,  // 66: yorkie.v1.UpdatableProjectFields.auth_webhook_request_timeout:type_name -> google.protobuf.StringValue
+	77,  // 67: yorkie.v1.UpdatableProjectFields.event_webhook_url:type_name -> google.protobuf.StringValue
+	72,  // 68: yorkie.v1.UpdatableProjectFields.event_webhook_events:type_name -> yorkie.v1.UpdatableProjectFields.EventWebhookEvents
+	78,  // 69: yorkie.v1.UpdatableProjectFields.event_webhook_max_retries:type_name -> google.protobuf.UInt64Value
+	77,  // 70: yorkie.v1.UpdatableProjectFields.event_webhook_min_wait_interval:type_name -> google.protobuf.StringValue
+	77,  // 71: yorkie.v1.UpdatableProjectFields.event_webhook_max_wait_interval:type_name -> google.protobuf.StringValue
+	77,  // 72: yorkie.v1.UpdatableProjectFields.event_webhook_request_timeout:type_name -> google.protobuf.StringValue
+	79,  // 73: yorkie.v1.UpdatableProjectFields.snapshot_threshold:type_name -> google.protobuf.Int64Value
+	79,  // 74: yorkie.v1.UpdatableProjectFields.snapshot_interval:type_name -> google.protobuf.Int64Value
+	77,  // 75: yorkie.v1.UpdatableProjectFields.client_deactivate_threshold:type_name -> google.protobuf.StringValue
+	80,  // 76: yorkie.v1.UpdatableProjectFields.max_subscribers_per_document:type_name -> google.protobuf.Int32Value
+	80,  // 77: yorkie.v1.UpdatableProjectFields.max_attachments_per_document:type_name -> google.protobuf.Int32Value
+	80,  // 78: yorkie.v1.UpdatableProjectFields.max_size_per_document:type_name -> google.protobuf.Int32Value
+	81,  // 79: yorkie.v1.UpdatableProjectFields.remove_on_detach:type_name -> google.protobuf.BoolValue
+	81,  // 80: yorkie.v1.UpdatableProjectFields.auto_revision_enabled:type_name -> google.protobuf.BoolValue
+	73,  // 81: yorkie.v1.UpdatableProjectFields.allowed_origins:type_name -> yorkie.v1.UpdatableProjectFields.AllowedOrigins
+	37,  // 82: yorkie.v1.DocumentSummary.document_size:type_name -> yorkie.v1.DocSize
+	74,  // 83: yorkie.v1.DocumentSummary.presences:type_name -> yorkie.v1.DocumentSummary.PresencesEntry
+	76,  // 84: yorkie.v1.DocumentSummary.created_at:type_name -> google.protobuf.Timestamp
+	76,  // 85: yorkie.v1.DocumentSummary.accessed_at:type_name -> google.protobuf.Timestamp
+	76,  // 86: yorkie.v1.DocumentSummary.updated_at:type_name -> google.protobuf.Timestamp
+	2,   // 87: yorkie.v1.PresenceChange.type:type_name -> yorkie.v1.PresenceChange.ChangeType
+	28,  // 88: yorkie.v1.PresenceChange.presence:type_name -> yorkie.v1.Presence
+	75,  // 89: yorkie.v1.Presence.data:type_name -> yorkie.v1.Presence.DataEntry
+	32,  // 90: yorkie.v1.TextNodePos.created_at:type_name -> yorkie.v1.TimeTicket
+	1,   // 91: yorkie.v1.DocEvent.type:type_name -> yorkie.v1.DocEventType
+	33,  // 92: yorkie.v1.DocEvent.body:type_name -> yorkie.v1.DocEventBody
+	3,   // 93: yorkie.v1.ChannelEvent.type:type_name -> yorkie.v1.ChannelEvent.Type
+	36,  // 94: yorkie.v1.DocSize.live:type_name -> yorkie.v1.DataSize
+	36,  // 95: yorkie.v1.DocSize.gc:type_name -> yorkie.v1.DataSize
+	40,  // 96: yorkie.v1.Schema.rules:type_name -> yorkie.v1.Rule
+	76,  // 97: yorkie.v1.Schema.created_at:type_name -> google.protobuf.Timestamp
+	39,  // 98: yorkie.v1.Rule.tree_nodes:type_name -> yorkie.v1.TreeNodeRule
+	76,  // 99: yorkie.v1.RevisionSummary.created_at:type_name -> google.protobuf.Timestamp
+	28,  // 100: yorkie.v1.Snapshot.PresencesEntry.value:type_name -> yorkie.v1.Presence
+	32,  // 101: yorkie.v1.Operation.Set.parent_created_at:type_name -> yorkie.v1.TimeTicket
+	10,  // 102: yorkie.v1.Operation.Set.value:type_name -> yorkie.v1.JSONElementSimple
+	32,  // 103: yorkie.v1.Operation.Set.executed_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 104: yorkie.v1.Operation.Add.parent_created_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 105: yorkie.v1.Operation.Add.prev_created_at:type_name -> yorkie.v1.TimeTicket
+	10,  // 106: yorkie.v1.Operation.Add.value:type_name -> yorkie.v1.JSONElementSimple
+	32,  // 107: yorkie.v1.Operation.Add.executed_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 108: yorkie.v1.Operation.Move.parent_created_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 109: yorkie.v1.Operation.Move.prev_created_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 110: yorkie.v1.Operation.Move.created_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 111: yorkie.v1.Operation.Move.executed_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 112: yorkie.v1.Operation.Remove.parent_created_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 113: yorkie.v1.Operation.Remove.created_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 114: yorkie.v1.Operation.Remove.executed_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 115: yorkie.v1.Operation.Edit.parent_created_at:type_name -> yorkie.v1.TimeTicket
+	31,  // 116: yorkie.v1.Operation.Edit.from:type_name -> yorkie.v1.TextNodePos
+	31,  // 117: yorkie.v1.Operation.Edit.to:type_name -> yorkie.v1.TextNodePos
+	56,  // 118: yorkie.v1.Operation.Edit.created_at_map_by_actor:type_name -> yorkie.v1.Operation.Edit.CreatedAtMapByActorEntry
+	32,  // 119: yorkie.v1.Operation.Edit.executed_at:type_name -> yorkie.v1.TimeTicket
+	57,  // 120: yorkie.v1.Operation.Edit.attributes:type_name -> yorkie.v1.Operation.Edit.AttributesEntry
+	32,  // 121: yorkie.v1.Operation.Style.parent_created_at:type_name -> yorkie.v1.TimeTicket
+	31,  // 122: yorkie.v1.Operation.Style.from:type_name -> yorkie.v1.TextNodePos
+	31,  // 123: yorkie.v1.Operation.Style.to:type_name -> yorkie.v1.TextNodePos
+	58,  // 124: yorkie.v1.Operation.Style.attributes:type_name -> yorkie.v1.Operation.Style.AttributesEntry
+	32,  // 125: yorkie.v1.Operation.Style.executed_at:type_name -> yorkie.v1.TimeTicket
+	59,  // 126: yorkie.v1.Operation.Style.created_at_map_by_actor:type_name -> yorkie.v1.Operation.Style.CreatedAtMapByActorEntry
+	32,  // 127: yorkie.v1.Operation.Increase.parent_created_at:type_name -> yorkie.v1.TimeTicket
+	10,  // 128: yorkie.v1.Operation.Increase.value:type_name -> yorkie.v1.JSONElementSimple
+	32,  // 129: yorkie.v1.Operation.Increase.executed_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 130: yorkie.v1.Operation.TreeEdit.parent_created_at:type_name -> yorkie.v1.TimeTicket
+	20,  // 131: yorkie.v1.Operation.TreeEdit.from:type_name -> yorkie.v1.TreePos
+	20,  // 132: yorkie.v1.Operation.TreeEdit.to:type_name -> yorkie.v1.TreePos
+	60,  // 133: yorkie.v1.Operation.TreeEdit.created_at_map_by_actor:type_name -> yorkie.v1.Operation.TreeEdit.CreatedAtMapByActorEntry
+	18,  // 134: yorkie.v1.Operation.TreeEdit.contents:type_name -> yorkie.v1.TreeNodes
+	32,  // 135: yorkie.v1.Operation.TreeEdit.executed_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 136: yorkie.v1.Operation.TreeStyle.parent_created_at:type_name -> yorkie.v1.TimeTicket
+	20,  // 137: yorkie.v1.Operation.TreeStyle.from:type_name -> yorkie.v1.TreePos
+	20,  // 138: yorkie.v1.Operation.TreeStyle.to:type_name -> yorkie.v1.TreePos
+	61,  // 139: yorkie.v1.Operation.TreeStyle.attributes:type_name -> yorkie.v1.Operation.TreeStyle.AttributesEntry
+	32,  // 140: yorkie.v1.Operation.TreeStyle.executed_at:type_name -> yorkie.v1.TimeTicket
+	62,  // 141: yorkie.v1.Operation.TreeStyle.created_at_map_by_actor:type_name -> yorkie.v1.Operation.TreeStyle.CreatedAtMapByActorEntry
+	32,  // 142: yorkie.v1.Operation.ArraySet.parent_created_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 143: yorkie.v1.Operation.ArraySet.created_at:type_name -> yorkie.v1.TimeTicket
+	10,  // 144: yorkie.v1.Operation.ArraySet.value:type_name -> yorkie.v1.JSONElementSimple
+	32,  // 145: yorkie.v1.Operation.ArraySet.executed_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 146: yorkie.v1.Operation.Edit.CreatedAtMapByActorEntry.value:type_name -> yorkie.v1.TimeTicket
+	32,  // 147: yorkie.v1.Operation.Style.CreatedAtMapByActorEntry.value:type_name -> yorkie.v1.TimeTicket
+	32,  // 148: yorkie.v1.Operation.TreeEdit.CreatedAtMapByActorEntry.value:type_name -> yorkie.v1.TimeTicket
+	32,  // 149: yorkie.v1.Operation.TreeStyle.CreatedAtMapByActorEntry.value:type_name -> yorkie.v1.TimeTicket
+	12,  // 150: yorkie.v1.JSONElement.JSONObject.nodes:type_name -> yorkie.v1.RHTNode
+	32,  // 151: yorkie.v1.JSONElement.JSONObject.created_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 152: yorkie.v1.JSONElement.JSONObject.moved_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 153: yorkie.v1.JSONElement.JSONObject.removed_at:type_name -> yorkie.v1.TimeTicket
+	13,  // 154: yorkie.v1.JSONElement.JSONArray.nodes:type_name -> yorkie.v1.RGANode
+	32,  // 155: yorkie.v1.JSONElement.JSONArray.created_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 156: yorkie.v1.JSONElement.JSONArray.moved_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 157: yorkie.v1.JSONElement.JSONArray.removed_at:type_name -> yorkie.v1.TimeTicket
+	0,   // 158: yorkie.v1.JSONElement.Primitive.type:type_name -> yorkie.v1.ValueType
+	32,  // 159: yorkie.v1.JSONElement.Primitive.created_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 160: yorkie.v1.JSONElement.Primitive.moved_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 161: yorkie.v1.JSONElement.Primitive.removed_at:type_name -> yorkie.v1.TimeTicket
+	15,  // 162: yorkie.v1.JSONElement.Text.nodes:type_name -> yorkie.v1.TextNode
+	32,  // 163: yorkie.v1.JSONElement.Text.created_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 164: yorkie.v1.JSONElement.Text.moved_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 165: yorkie.v1.JSONElement.Text.removed_at:type_name -> yorkie.v1.TimeTicket
+	0,   // 166: yorkie.v1.JSONElement.Counter.type:type_name -> yorkie.v1.ValueType
+	32,  // 167: yorkie.v1.JSONElement.Counter.created_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 168: yorkie.v1.JSONElement.Counter.moved_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 169: yorkie.v1.JSONElement.Counter.removed_at:type_name -> yorkie.v1.TimeTicket
+	17,  // 170: yorkie.v1.JSONElement.Tree.nodes:type_name -> yorkie.v1.TreeNode
+	32,  // 171: yorkie.v1.JSONElement.Tree.created_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 172: yorkie.v1.JSONElement.Tree.moved_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 173: yorkie.v1.JSONElement.Tree.removed_at:type_name -> yorkie.v1.TimeTicket
+	14,  // 174: yorkie.v1.TextNode.AttributesEntry.value:type_name -> yorkie.v1.NodeAttr
+	14,  // 175: yorkie.v1.TreeNode.AttributesEntry.value:type_name -> yorkie.v1.NodeAttr
+	28,  // 176: yorkie.v1.DocumentSummary.PresencesEntry.value:type_name -> yorkie.v1.Presence
+	177, // [177:177] is the sub-list for method output_type
+	177, // [177:177] is the sub-list for method input_type
+	177, // [177:177] is the sub-list for extension type_name
+	177, // [177:177] is the sub-list for extension extendee
+	0,   // [0:177] is the sub-list for field type_name
 }
 
 func init() { file_yorkie_v1_resources_proto_init() }
@@ -5457,7 +5489,7 @@ func file_yorkie_v1_resources_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_yorkie_v1_resources_proto_rawDesc), len(file_yorkie_v1_resources_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   70,
+			NumMessages:   72,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/yorkie/v1/resources.proto
+++ b/api/yorkie/v1/resources.proto
@@ -31,6 +31,9 @@ option java_package = "dev.yorkie.api.v1";
 message Snapshot {
   JSONElement root = 1;
   map<string, Presence> presences = 2;
+  // detached_actors preserves removed actor lamports for VV
+  // augmentation when restoring from snapshot.
+  map<string, int64> detached_actors = 3;
 }
 
 /////////////////////////////////////////
@@ -47,6 +50,9 @@ message ChangePack {
   TimeTicket min_synced_ticket = 5; // deprecated
   bool is_removed = 6;
   VersionVector version_vector = 7;
+  // detached_actors contains actors safe to remove from VV.
+  // Server signals this when all clients have caught up.
+  map<string, int64> detached_actors = 8;
 }
 
 message Change {

--- a/docs/design/vv-cleanup.md
+++ b/docs/design/vv-cleanup.md
@@ -21,10 +21,10 @@ unknown concurrent actor").
 - Remove detached client lamport entries from VV without losing causality information
 - Define a safe removal point that all clients agree on
 - Maintain correct GC and concurrent operation handling after removal
+- Apply changes to both Go server and JS SDK
 
 ### Non-Goals
 
-- JS SDK changes (separate task; proto changes are additive and backward-compatible)
 - Automatic cleanup of the client-side `detachedActors` map (deferred to Compaction)
 - Optimizing minVV computation itself
 
@@ -62,7 +62,7 @@ Both need to handle the case where a detached actor's entry has been removed.
 Client detaches
   │
   ▼
-Server records {actorID, detachedLamport} in detached_clients table
+Server stores DetachedLamport in ClientDocInfo (existing clients collection)
   │
   ▼
 On each PushPull, server computes minVV and checks:
@@ -70,16 +70,17 @@ On each PushPull, server computes minVV and checks:
   │
   ├─ No  → do nothing (not all clients have caught up)
   │
-  └─ Yes → include actorID in response's removable_actors field
+  └─ Yes → include actorID in response's detached_actors field
+            Reset DetachedLamport to 0 after all clients notified
 ```
 
 ### Client-Side Flow
 
 ```
-Receive removable_actors in ChangePack response
+Receive detached_actors in ChangePack response
   │
   ▼
-For each removable actor:
+For each detached actor:
   1. Add to document's detachedActors map (actorID → lamport)
   2. Remove from document's VV (Unset)
   │
@@ -112,31 +113,74 @@ in their VV because the server only signals removal after all clients have caugh
 message ChangePack {
   ...
   VersionVector version_vector = 7;
-  map<string, int64> removable_actors = 8;  // NEW
+  // detached_actors contains actors safe to remove from VV.
+  // Server signals this when all clients have caught up.
+  map<string, int64> detached_actors = 8;  // NEW
 }
 
 message Snapshot {
   JSONElement root = 1;
   map<string, Presence> presences = 2;
-  map<string, int64> detached_actors = 3;   // NEW
+  // detached_actors preserves removed actor lamports for VV
+  // augmentation when restoring from snapshot.
+  map<string, int64> detached_actors = 3;  // NEW
 }
 ```
 
-Both fields are additive — old clients ignore them, maintaining backward compatibility.
+Both fields use the same name and data shape (`actorID → lamport`). The role differs
+by context: ChangePack carries the server's removal signal, Snapshot preserves the
+state for restoration. Both are additive — old clients ignore them.
 
 ### Database Schema
 
-New `detachedclients` collection:
+No new collection. Reuse the existing `clients` collection by adding a field to
+`ClientDocInfo`:
 
-| Field | Type | Description |
-|-------|------|-------------|
-| project_id | ID | Project identifier |
-| doc_id | ID | Document identifier |
-| actor_id | ActorID | Detached client's actor ID |
-| detached_lamport | int64 | Client's lamport at detach time |
-| created_at | Time | When the record was created |
+```go
+type ClientDocInfo struct {
+    Status          string
+    ServerSeq       int64
+    ClientSeq       uint32
+    Epoch           int64
+    DetachedLamport int64  // NEW: lamport at detach time, 0 when not applicable
+}
+```
 
-Unique index on `(project_id, doc_id, actor_id)`.
+When a client detaches, `DetachDocument()` stores the lamport value. The server
+queries detached clients by checking `DetachedLamport > 0` on the existing
+`clients` collection. After all clients have been notified, `DetachedLamport` is
+reset to 0.
+
+This avoids a new collection, new indexes, and migration — the `clients` collection
+already tracks per-document client state and has a `project_id` index.
+
+### Implementation Scope
+
+#### Go PR: Server + Go Client
+
+| Layer | Changes |
+|-------|---------|
+| Proto | Add `detached_actors` to `ChangePack` (field 8) and `Snapshot` (field 3) |
+| DB | Add `DetachedLamport` to `ClientDocInfo`, update `DetachDocument()` signature |
+| MongoDB | Update `UpdateClientInfoAfterPushPull()` to store lamport on detach |
+| Memory DB | Same changes for in-memory implementation |
+| Server | In `pullPack()`: query detached clients, check minVV condition, populate `detached_actors` |
+| Snapshot | Include `detached_actors` in snapshot creation |
+| Go Client | Add `detachedActors` map to Document, augment change VV + minVV |
+| Converter | Serialize/deserialize `detached_actors` in ChangePack and Snapshot |
+| Tests | Integration tests for full detach → signal → cleanup cycle |
+
+#### JS SDK PR: Client (after Go PR merges)
+
+| Layer | Changes |
+|-------|---------|
+| Converter | `fromChangePack`: parse `detached_actors`, `fromSnapshot`: parse `detached_actors` |
+| Document | Add `detachedActors: Map<string, bigint>` field |
+| applyChangePack | Store detached actors, unset from VV |
+| applyChange | Augment change VV with detachedActors before execution |
+| garbageCollect | Augment minVV with detachedActors before GC |
+| applySnapshot | Restore `detachedActors` from snapshot |
+| Tests | Unit tests for augmentation logic, integration with server |
 
 ### Risks and Mitigation
 
@@ -144,8 +188,9 @@ Unique index on `(project_id, doc_id, actor_id)`.
 |------|------------|
 | Augmenting Change VV in-place mutates the object | Change objects are consumed once during execution, not reused |
 | Snapshot format change | Proto field 3 is additive; old snapshots deserialize with empty map |
-| Server restart between record and cleanup | detached_clients table is persistent |
 | Client re-attaches with same ActorID | Not possible; each ActivateClient generates a new ID |
+| Long-offline client delays cleanup | Same limitation as existing minVV — unavoidable without timeout |
+| DB query cost on PushPull | Same collection as existing client queries; DetachedLamport > 0 filter is lightweight; records reset after notification so no accumulation |
 
 ### Design Decisions
 
@@ -155,16 +200,22 @@ Unique index on `(project_id, doc_id, actor_id)`.
 | Augment VV before Execute, not change ticketKnown signatures | Minimizes code changes; VV augmentation is a single point |
 | Store detachedActors on document, not in VV type | Keeps VV type simple (`map[ActorID]int64`); avoids proto/serialization changes to VV |
 | Wait for ALL clients before signaling removal | Prevents the offline-client bug where a change creator genuinely didn't know the actor |
+| Reuse `ClientDocInfo` instead of new collection | ClientDocInfo already tracks per-document client state; avoids new collection, index, and migration overhead |
+| Unified `detached_actors` name in proto | ChangePack and Snapshot carry same data shape; role difference explained by comments |
+| `DetachedLamport` field name (not just `Lamport`) | Explicit about when the value was captured; avoids ambiguity when client is in attached state |
 
 ## Alternatives Considered
 
 | Alternative | Why not |
 |-------------|---------|
+| New `detachedclients` collection | Duplicates data already in `clients` collection; unnecessary migration |
+| Keep detached VV records as tombstones in `versionvectors` | Requires changing deletion logic in `updateVersionVector` and query filters in `GetMinVersionVector`; high impact |
 | Remove from server-side minVV only, keep in client VV | Doesn't reduce VV size in changes (main bandwidth concern) |
 | DAG-based causality tracking | Correct but requires major architectural change |
 | Epoch-based floor (single int64 replacing all removed actors) | Cannot distinguish detached actors from truly unknown new actors with lower lamport |
 | Change VV type to struct with active + detached maps | Large structural change to VV type; affects proto, serialization, all consumers |
 | Remove immediately on detach without waiting | Breaks causality for offline clients who haven't received the detach yet |
+| Separate proto field names (`removable_actors` / `detached_actors`) | Same data shape; unified name is simpler, role difference handled by comments |
 
 ## Tasks
 

--- a/docs/tasks/active/20260422-vv-cleanup-go-todo.md
+++ b/docs/tasks/active/20260422-vv-cleanup-go-todo.md
@@ -1,0 +1,872 @@
+# VV Cleanup — Go Server + Go Client Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Created**: 2026-04-22
+
+**Goal:** Remove detached clients' lamport entries from Version Vectors to stop VV from growing indefinitely.
+
+**Architecture:** Server records DetachedLamport in existing ClientDocInfo on detach. On each PushPull, server checks if all attached clients have caught up (minVV >= detachedLamport), then signals removal via `detached_actors` in ChangePack. Clients augment change VV and minVV with detachedActors before execution and GC.
+
+**Design doc:** `docs/design/vv-cleanup.md`
+
+---
+
+### Task 1: Proto Changes
+
+**Files:**
+- Modify: `api/yorkie/v1/resources.proto`
+
+- [ ] **Step 1: Add detached_actors to ChangePack**
+
+In `api/yorkie/v1/resources.proto`, add field 8 to ChangePack:
+
+```protobuf
+message ChangePack {
+  string document_key = 1;
+  Checkpoint checkpoint = 2;
+  bytes snapshot = 3;
+  repeated Change changes = 4;
+  TimeTicket min_synced_ticket = 5; // deprecated
+  bool is_removed = 6;
+  VersionVector version_vector = 7;
+  // detached_actors contains actors safe to remove from VV.
+  // Server signals this when all clients have caught up.
+  map<string, int64> detached_actors = 8;
+}
+```
+
+- [ ] **Step 2: Add detached_actors to Snapshot**
+
+In the same file, add field 3 to Snapshot:
+
+```protobuf
+message Snapshot {
+  JSONElement root = 1;
+  map<string, Presence> presences = 2;
+  // detached_actors preserves removed actor lamports for VV
+  // augmentation when restoring from snapshot.
+  map<string, int64> detached_actors = 3;
+}
+```
+
+- [ ] **Step 3: Regenerate protobuf code**
+
+Run: `make proto`
+Expected: Generated Go files updated in `api/yorkie/v1/`
+
+- [ ] **Step 4: Verify build**
+
+Run: `make build`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/yorkie/v1/
+git commit -m "Add detached_actors field to ChangePack and Snapshot proto"
+```
+
+---
+
+### Task 2: DB Schema — Add DetachedLamport to ClientDocInfo
+
+**Files:**
+- Modify: `server/backend/database/client_info.go`
+
+- [ ] **Step 1: Add DetachedLamport field to ClientDocInfo**
+
+In `server/backend/database/client_info.go`, update the struct at line 54:
+
+```go
+type ClientDocInfo struct {
+	Status          string `bson:"status"`
+	ServerSeq       int64  `bson:"server_seq"`
+	ClientSeq       uint32 `bson:"client_seq"`
+	Epoch           int64  `bson:"epoch"`
+	DetachedLamport int64  `bson:"detached_lamport,omitempty"`
+}
+```
+
+- [ ] **Step 2: Update DetachDocument to accept and store lamport**
+
+Update the method at line 182:
+
+```go
+func (i *ClientInfo) DetachDocument(docID types.ID, detachedLamport int64) error {
+	if err := i.EnsureDocumentAttachedOrAttaching(docID); err != nil {
+		return err
+	}
+
+	i.Documents[docID].Status = DocumentDetached
+	i.Documents[docID].ClientSeq = 0
+	i.Documents[docID].ServerSeq = 0
+	i.Documents[docID].DetachedLamport = detachedLamport
+	i.UpdatedAt = gotime.Now()
+
+	return nil
+}
+```
+
+- [ ] **Step 3: Update DeepCopy to include DetachedLamport**
+
+In the DeepCopy method at line 318, update the ClientDocInfo copy:
+
+```go
+documents[docID] = &ClientDocInfo{
+	Status:          docInfo.Status,
+	ServerSeq:       docInfo.ServerSeq,
+	ClientSeq:       docInfo.ClientSeq,
+	Epoch:           docInfo.Epoch,
+	DetachedLamport: docInfo.DetachedLamport,
+}
+```
+
+- [ ] **Step 4: Fix all callers of DetachDocument**
+
+Search all call sites of `DetachDocument(` and update to pass the lamport value.
+The callers need to pass the client's lamport at detach time. Each call site
+should have access to the version vector or lamport from the change pack.
+
+Key call sites to update:
+- `server/rpc/yorkie_server.go` — DetachDocument RPC handler
+- `server/rpc/cluster_server.go` — Cluster DetachDocument handler
+- `server/packs/pushpull.go` — if detach is handled inline
+
+For each call site, extract the lamport from the client's version vector:
+```go
+// Example: get max lamport from the request's version vector
+clientInfo.DetachDocument(docID, reqPack.VersionVector.MaxLamport())
+```
+
+- [ ] **Step 5: Verify build compiles**
+
+Run: `make build`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 6: Run unit tests**
+
+Run: `make test`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/backend/database/client_info.go
+# Also add any files with updated DetachDocument call sites
+git commit -m "Add DetachedLamport field to ClientDocInfo"
+```
+
+---
+
+### Task 3: Database Interface — Add FindDetachedClients Method
+
+**Files:**
+- Modify: `server/backend/database/database.go`
+- Modify: `server/backend/database/mongo/client.go`
+- Modify: `server/backend/database/memory/database.go`
+
+- [ ] **Step 1: Define DetachedClientInfo struct**
+
+In `server/backend/database/client_info.go`, add:
+
+```go
+// DetachedClientInfo contains information about a detached client for VV cleanup.
+type DetachedClientInfo struct {
+	ActorID         time.ActorID
+	DetachedLamport int64
+}
+```
+
+- [ ] **Step 2: Add FindDetachedClients to Database interface**
+
+In `server/backend/database/database.go`, add to the interface:
+
+```go
+// FindDetachedClients returns detached clients with non-zero DetachedLamport
+// for the given document.
+FindDetachedClients(
+	ctx context.Context,
+	docRefKey types.DocRefKey,
+) ([]DetachedClientInfo, error)
+```
+
+- [ ] **Step 3: Add ResetDetachedLamport to Database interface**
+
+In the same interface, add:
+
+```go
+// ResetDetachedLamport resets the DetachedLamport of the given client
+// after all attached clients have been notified.
+ResetDetachedLamport(
+	ctx context.Context,
+	clientID types.ID,
+	docID types.ID,
+) error
+```
+
+- [ ] **Step 4: Implement FindDetachedClients in MongoDB**
+
+In `server/backend/database/mongo/client.go`:
+
+```go
+func (c *Client) FindDetachedClients(
+	ctx context.Context,
+	docRefKey types.DocRefKey,
+) ([]database.DetachedClientInfo, error) {
+	filter := bson.M{
+		"project_id": docRefKey.ProjectID,
+		fmt.Sprintf("documents.%s.status", docRefKey.DocID): database.DocumentDetached,
+		fmt.Sprintf("documents.%s.detached_lamport", docRefKey.DocID): bson.M{"$gt": int64(0)},
+	}
+
+	cursor, err := c.collection(ColClients).Find(ctx, filter)
+	if err != nil {
+		return nil, fmt.Errorf("find detached clients: %w", err)
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+
+	var results []database.DetachedClientInfo
+	for cursor.Next(ctx) {
+		var info database.ClientInfo
+		if err := cursor.Decode(&info); err != nil {
+			return nil, fmt.Errorf("decode client info: %w", err)
+		}
+		results = append(results, database.DetachedClientInfo{
+			ActorID:         info.Key,
+			DetachedLamport: info.Documents[docRefKey.DocID].DetachedLamport,
+		})
+	}
+
+	return results, nil
+}
+```
+
+NOTE: `ActorID` should be derived from the client's actor ID, not `Key`. Check how
+the codebase maps ClientInfo to ActorID — it may require looking up the client's
+actor from the version vector or storing it separately.
+
+- [ ] **Step 5: Implement FindDetachedClients in Memory DB**
+
+In `server/backend/database/memory/database.go`:
+
+```go
+func (d *DB) FindDetachedClients(
+	ctx context.Context,
+	docRefKey types.DocRefKey,
+) ([]database.DetachedClientInfo, error) {
+	txn := d.db.Txn(false)
+	defer txn.Abort()
+
+	iterator, err := txn.Get(tblClients, "project_id", docRefKey.ProjectID.String())
+	if err != nil {
+		return nil, fmt.Errorf("find detached clients: %w", err)
+	}
+
+	var results []database.DetachedClientInfo
+	for raw := iterator.Next(); raw != nil; raw = iterator.Next() {
+		info := raw.(*database.ClientInfo)
+		docInfo, ok := info.Documents[docRefKey.DocID]
+		if !ok {
+			continue
+		}
+		if docInfo.Status == database.DocumentDetached && docInfo.DetachedLamport > 0 {
+			results = append(results, database.DetachedClientInfo{
+				ActorID:         info.Key,
+				DetachedLamport: docInfo.DetachedLamport,
+			})
+		}
+	}
+
+	return results, nil
+}
+```
+
+- [ ] **Step 6: Implement ResetDetachedLamport in both DB backends**
+
+MongoDB:
+```go
+func (c *Client) ResetDetachedLamport(
+	ctx context.Context,
+	clientID types.ID,
+	docID types.ID,
+) error {
+	_, err := c.collection(ColClients).UpdateOne(ctx, bson.M{
+		"_id": clientID,
+	}, bson.M{
+		"$set": bson.M{
+			clientDocInfoKey(docID, "detached_lamport"): int64(0),
+		},
+	})
+	return err
+}
+```
+
+Memory DB: find the client by ID and set `DetachedLamport = 0`.
+
+- [ ] **Step 7: Verify build and tests**
+
+Run: `make build && make test`
+Expected: BUILD SUCCESS, tests PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add server/backend/database/
+git commit -m "Add FindDetachedClients and ResetDetachedLamport to database layer"
+```
+
+---
+
+### Task 4: Server Logic — Signal detached_actors in PushPull Response
+
+**Files:**
+- Modify: `server/packs/pushpull.go`
+- Modify: `server/packs/serverpack.go`
+
+- [ ] **Step 1: Add DetachedActors to ServerPack**
+
+In `server/packs/serverpack.go`, add field to the struct:
+
+```go
+type ServerPack struct {
+	DocumentKey   key.Key
+	Checkpoint    change.Checkpoint
+	ChangeInfos   []*database.ChangeInfo
+	Snapshot      []byte
+	VersionVector time.VersionVector
+	IsRemoved     bool
+	DetachedActors map[string]int64  // NEW: actorID → lamport
+}
+```
+
+- [ ] **Step 2: Update ToPBChangePack to include DetachedActors**
+
+In the `ToPBChangePack` method of ServerPack, add `DetachedActors` to the
+protobuf conversion:
+
+```go
+pbPack.DetachedActors = p.DetachedActors
+```
+
+- [ ] **Step 3: Add detached_actors logic in pullPack**
+
+In `server/packs/pushpull.go`, in the `pullPack` function, after computing
+`minVersionVector` (around line 303), add the detached actors check:
+
+```go
+// 04. Find detached clients whose lamport is covered by minVV.
+detachedClients, err := be.DB.FindDetachedClients(ctx, docInfo.RefKey())
+if err != nil {
+	return nil, err
+}
+
+detachedActors := make(map[string]int64)
+for _, dc := range detachedClients {
+	if l, ok := minVersionVector.Get(dc.ActorID); ok && l >= dc.DetachedLamport {
+		detachedActors[dc.ActorID.String()] = dc.DetachedLamport
+	}
+}
+
+if len(detachedActors) > 0 {
+	resPack.DetachedActors = detachedActors
+}
+```
+
+NOTE: After signaling, the server should eventually reset DetachedLamport.
+However, the reset should happen only after all clients receive the signal.
+A simpler approach: reset after the first signal, since the condition
+`minVV >= detachedLamport` already guarantees all clients have caught up.
+The server can reset immediately after including in the response:
+
+```go
+for _, dc := range detachedClients {
+	if l, ok := minVersionVector.Get(dc.ActorID); ok && l >= dc.DetachedLamport {
+		detachedActors[dc.ActorID.String()] = dc.DetachedLamport
+		// Reset since all clients are already caught up
+		if err := be.DB.ResetDetachedLamport(ctx, dc.ClientID, docInfo.ID); err != nil {
+			return nil, err
+		}
+	}
+}
+```
+
+IMPORTANT: The DetachedClientInfo struct may need a `ClientID` field for the
+reset. Adjust the struct and queries accordingly.
+
+- [ ] **Step 4: Verify build**
+
+Run: `make build`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/packs/
+git commit -m "Signal detached_actors in PushPull response when minVV covers detach lamport"
+```
+
+---
+
+### Task 5: Converter — Serialize/Deserialize detached_actors
+
+**Files:**
+- Modify: `api/converter/to_pb.go`
+- Modify: `api/converter/from_pb.go`
+- Modify: `api/converter/to_bytes.go`
+- Modify: `api/converter/from_bytes.go`
+- Modify: `pkg/document/change/pack.go`
+
+- [ ] **Step 1: Add DetachedActors to change.Pack**
+
+In `pkg/document/change/pack.go`, add to the Pack struct:
+
+```go
+type Pack struct {
+	DocumentKey   key.Key
+	Checkpoint    Checkpoint
+	Changes       []*Change
+	Snapshot      []byte
+	VersionVector time.VersionVector
+	IsRemoved     bool
+	DetachedActors map[time.ActorID]int64  // NEW
+}
+```
+
+- [ ] **Step 2: Update ToChangePack converter**
+
+In `api/converter/to_pb.go`, update `ToChangePack`:
+
+```go
+func ToChangePack(pack *change.Pack) (*api.ChangePack, error) {
+	pbChanges, err := ToChanges(pack.Changes)
+	if err != nil {
+		return nil, err
+	}
+
+	pbVersionVector, err := ToVersionVector(pack.VersionVector)
+	if err != nil {
+		return nil, err
+	}
+
+	pbDetachedActors := make(map[string]int64)
+	for actorID, lamport := range pack.DetachedActors {
+		pbDetachedActors[actorID.String()] = lamport
+	}
+
+	return &api.ChangePack{
+		DocumentKey:    pack.DocumentKey.String(),
+		Checkpoint:     ToCheckpoint(pack.Checkpoint),
+		Changes:        pbChanges,
+		Snapshot:       pack.Snapshot,
+		VersionVector:  pbVersionVector,
+		IsRemoved:      pack.IsRemoved,
+		DetachedActors: pbDetachedActors,
+	}, nil
+}
+```
+
+- [ ] **Step 3: Update FromChangePack converter**
+
+In `api/converter/from_pb.go`, update `FromChangePack`:
+
+```go
+// After existing parsing, add:
+detachedActors := make(map[time.ActorID]int64)
+for actorIDStr, lamport := range pbPack.DetachedActors {
+	actorID, err := time.ActorIDFromHex(actorIDStr)
+	if err != nil {
+		return nil, err
+	}
+	detachedActors[actorID] = lamport
+}
+
+pack := &change.Pack{
+	DocumentKey:    key.Key(pbPack.DocumentKey),
+	Checkpoint:     fromCheckpoint(pbPack.Checkpoint),
+	Changes:        changes,
+	Snapshot:       pbPack.Snapshot,
+	IsRemoved:      pbPack.IsRemoved,
+	VersionVector:  versionVector,
+	DetachedActors: detachedActors,
+}
+```
+
+- [ ] **Step 4: Update SnapshotToBytes to include detached_actors**
+
+In `api/converter/to_bytes.go`, update `SnapshotToBytes` signature and body:
+
+```go
+func SnapshotToBytes(
+	obj *crdt.Object,
+	presences map[string]presence.Data,
+	detachedActors map[time.ActorID]int64,
+) ([]byte, error) {
+	pbElem, err := toJSONElement(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	pbPresences := ToPresences(presences)
+
+	pbDetachedActors := make(map[string]int64)
+	for actorID, lamport := range detachedActors {
+		pbDetachedActors[actorID.String()] = lamport
+	}
+
+	bytes, err := proto.Marshal(&api.Snapshot{
+		Root:           pbElem,
+		Presences:      pbPresences,
+		DetachedActors: pbDetachedActors,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal Snapshot to bytes: %w", err)
+	}
+
+	return bytes, nil
+}
+```
+
+- [ ] **Step 5: Update BytesToSnapshot to return detached_actors**
+
+In `api/converter/from_bytes.go`, update `BytesToSnapshot`:
+
+```go
+func BytesToSnapshot(snapshot []byte) (*crdt.Object, *presence.Map, map[time.ActorID]int64, error) {
+	if len(snapshot) == 0 {
+		return crdt.NewObject(crdt.NewElementRHT(), time.InitialTicket), presence.NewMap(), nil, nil
+	}
+
+	pbSnapshot := &api.Snapshot{}
+	if err := proto.Unmarshal(snapshot, pbSnapshot); err != nil {
+		return nil, nil, nil, fmt.Errorf("unmarshal snapshot: %w", err)
+	}
+
+	obj, err := fromJSONElement(pbSnapshot.GetRoot())
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	presences := fromPresences(pbSnapshot.GetPresences())
+
+	detachedActors := make(map[time.ActorID]int64)
+	for actorIDStr, lamport := range pbSnapshot.GetDetachedActors() {
+		actorID, err := time.ActorIDFromHex(actorIDStr)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		detachedActors[actorID] = lamport
+	}
+
+	return obj.(*crdt.Object), presences, detachedActors, nil
+}
+```
+
+- [ ] **Step 6: Fix all callers of SnapshotToBytes and BytesToSnapshot**
+
+Search for all call sites and update signatures. Key locations:
+- `server/packs/snapshots.go` or wherever snapshots are created
+- `pkg/document/internal_document.go:applySnapshot`
+
+- [ ] **Step 7: Verify build and tests**
+
+Run: `make build && make test`
+Expected: BUILD SUCCESS, PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add api/converter/ pkg/document/change/pack.go
+git commit -m "Add detached_actors serialization to ChangePack and Snapshot converters"
+```
+
+---
+
+### Task 6: Go Client — Document-Level detachedActors
+
+**Files:**
+- Modify: `pkg/document/internal_document.go`
+- Modify: `pkg/document/document.go`
+
+- [ ] **Step 1: Add detachedActors map to InternalDocument**
+
+In `pkg/document/internal_document.go`, add field to the struct:
+
+```go
+type InternalDocument struct {
+	key            key.Key
+	status         StatusType
+	checkpoint     change.Checkpoint
+	changeID       change.ID
+	root           *crdt.Root
+	presences      *presence.Map
+	onlineClients  map[string]bool
+	localChanges   []*change.Change
+	detachedActors map[time.ActorID]int64  // NEW
+}
+```
+
+Initialize in the constructor (find `NewInternalDocument` or equivalent):
+
+```go
+detachedActors: make(map[time.ActorID]int64),
+```
+
+- [ ] **Step 2: Add methods to InternalDocument**
+
+```go
+// DetachedActors returns the detached actors map.
+func (d *InternalDocument) DetachedActors() map[time.ActorID]int64 {
+	return d.detachedActors
+}
+
+// AddDetachedActors adds the given detached actors and removes them from VV.
+func (d *InternalDocument) AddDetachedActors(actors map[time.ActorID]int64) {
+	for actorID, lamport := range actors {
+		d.detachedActors[actorID] = lamport
+		d.changeID.VersionVector().Unset(actorID)
+	}
+}
+
+// AugmentVV augments the given VV with detached actors' lamport values.
+func (d *InternalDocument) AugmentVV(vv time.VersionVector) time.VersionVector {
+	for actorID, lamport := range d.detachedActors {
+		if _, ok := vv.Get(actorID); !ok {
+			vv.Set(actorID, lamport)
+		}
+	}
+	return vv
+}
+```
+
+- [ ] **Step 3: Update applySnapshot to restore detachedActors**
+
+In `pkg/document/internal_document.go`, update `applySnapshot`:
+
+```go
+func (d *InternalDocument) applySnapshot(snapshot []byte, vector time.VersionVector) error {
+	rootObj, presences, detachedActors, err := converter.BytesToSnapshot(snapshot)
+	if err != nil {
+		return err
+	}
+
+	d.root = crdt.NewRoot(rootObj)
+	d.presences = presences
+	d.detachedActors = detachedActors
+	d.changeID = d.changeID.SetClocks(vector.MaxLamport(), vector)
+
+	return nil
+}
+```
+
+- [ ] **Step 4: Update ApplyChangePack to process detached_actors**
+
+In `pkg/document/document.go`, update `ApplyChangePack`:
+
+```go
+func (d *Document) ApplyChangePack(pack *change.Pack) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	// 01. Process detached actors from server signal.
+	if len(pack.DetachedActors) > 0 {
+		d.doc.AddDetachedActors(pack.DetachedActors)
+	}
+
+	// 02. Apply remote changes to both the cloneRoot and the document.
+	hasSnapshot := len(pack.Snapshot) > 0
+	// ... rest of existing logic
+```
+
+- [ ] **Step 5: Augment change VV before applying remote changes**
+
+Find where remote changes are applied (the `applyChanges` method or equivalent).
+Before each change is executed, augment its VV:
+
+```go
+// Before executing the change:
+d.doc.AugmentVV(c.ID().VersionVector())
+```
+
+- [ ] **Step 6: Augment minVV before GC**
+
+In `ApplyChangePack`, update the GC call:
+
+```go
+// 04. Do Garbage collection.
+if !d.options.DisableGC && !hasSnapshot {
+	augmentedVV := d.doc.AugmentVV(pack.VersionVector.DeepCopy())
+	d.GarbageCollect(augmentedVV)
+}
+```
+
+- [ ] **Step 7: Verify build and tests**
+
+Run: `make build && make test`
+Expected: BUILD SUCCESS, PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add pkg/document/
+git commit -m "Add detachedActors to Document for VV augmentation on change execution and GC"
+```
+
+---
+
+### Task 7: Snapshot Creation — Include detachedActors
+
+**Files:**
+- Modify: Server-side snapshot creation (find where `SnapshotToBytes` is called)
+
+- [ ] **Step 1: Update snapshot creation to pass detachedActors**
+
+Find the snapshot creation call site (likely in `server/packs/` or
+`server/backend/database/`). Update to pass `detachedActors`:
+
+The server creates snapshots from the document state. The document's
+`detachedActors` should be included. This requires the server to:
+1. Track which actors are detached but not yet fully cleaned up
+2. Pass that information when creating the snapshot
+
+Find the exact call site of `SnapshotToBytes` and update accordingly.
+
+- [ ] **Step 2: Verify build and tests**
+
+Run: `make build && make test`
+Expected: BUILD SUCCESS, PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/
+git commit -m "Include detachedActors in snapshot creation for state restoration"
+```
+
+---
+
+### Task 8: MongoDB — Update Detach Handling in UpdateClientInfoAfterPushPull
+
+**Files:**
+- Modify: `server/backend/database/mongo/client.go`
+- Modify: `server/backend/database/memory/database.go`
+
+- [ ] **Step 1: Update MongoDB detach BSON update**
+
+In `server/backend/database/mongo/client.go`, in the detach branch of
+`UpdateClientInfoAfterPushPull` (around line 1259), add `detached_lamport`:
+
+```go
+} else {
+	updater = bson.M{
+		"$set": bson.M{
+			clientDocInfoKey(docInfo.ID, "server_seq"):        0,
+			clientDocInfoKey(docInfo.ID, "client_seq"):        0,
+			clientDocInfoKey(docInfo.ID, StatusKey):            clientDocInfo.Status,
+			clientDocInfoKey(docInfo.ID, "detached_lamport"):   clientDocInfo.DetachedLamport,
+			"updated_at":                                       info.UpdatedAt,
+		},
+		"$pull": bson.M{
+			"attached_docs":  docInfo.ID,
+			"attaching_docs": docInfo.ID,
+		},
+	}
+}
+```
+
+- [ ] **Step 2: Update Memory DB equivalently**
+
+Ensure the memory DB implementation also persists DetachedLamport on detach.
+
+- [ ] **Step 3: Run integration tests**
+
+Run: `make test -tags integration` (if MongoDB is available)
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/backend/database/
+git commit -m "Persist DetachedLamport in MongoDB and Memory DB on detach"
+```
+
+---
+
+### Task 9: Integration Tests
+
+**Files:**
+- Create or modify: `test/integration/vv_cleanup_test.go` (or add to existing VV test file)
+
+- [ ] **Step 1: Write test for basic detach → cleanup cycle**
+
+```go
+func TestVVCleanupAfterDetach(t *testing.T) {
+	// 1. Client A and B attach to the same document
+	// 2. Both clients make edits (so both appear in each other's VV)
+	// 3. Client B detaches
+	// 4. Client A syncs — should eventually receive detached_actors with B's actorID
+	// 5. Verify Client A's VV no longer contains B's actorID
+	// 6. Verify Client A can still apply changes correctly (causality preserved)
+}
+```
+
+- [ ] **Step 2: Write test for GC after VV cleanup**
+
+```go
+func TestGCAfterVVCleanup(t *testing.T) {
+	// 1. Client A and B attach, both edit
+	// 2. Client A deletes an element
+	// 3. Client B syncs (receives the delete)
+	// 4. Client B detaches
+	// 5. Client A syncs — receives detached_actors
+	// 6. Client A triggers GC — verify the deleted element is collected
+	//    (minVV augmented with detachedActors should allow GC)
+}
+```
+
+- [ ] **Step 3: Write test for snapshot restore with detachedActors**
+
+```go
+func TestSnapshotRestoreWithDetachedActors(t *testing.T) {
+	// 1. Client A and B attach, both edit, B detaches
+	// 2. Client A syncs and receives detached_actors
+	// 3. Force snapshot creation
+	// 4. New Client C attaches — receives snapshot
+	// 5. Verify Client C has B in detachedActors
+	// 6. Verify Client C can process changes correctly
+}
+```
+
+- [ ] **Step 4: Run all tests**
+
+Run: `make test`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/
+git commit -m "Add integration tests for VV cleanup after client detach"
+```
+
+---
+
+### Task 10: Lint and Final Verification
+
+- [ ] **Step 1: Run linter**
+
+Run: `make lint`
+Expected: No errors
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `make test`
+Expected: ALL PASS
+
+- [ ] **Step 3: Fix any issues found**
+
+- [ ] **Step 4: Final commit if needed**
+
+```bash
+git commit -m "Fix lint issues in VV cleanup implementation"
+```

--- a/docs/tasks/active/20260422-vv-cleanup-js-todo.md
+++ b/docs/tasks/active/20260422-vv-cleanup-js-todo.md
@@ -1,0 +1,525 @@
+# VV Cleanup — JS SDK Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Created**: 2026-04-22
+
+**Goal:** Apply VV cleanup to JS SDK so clients can remove detached actors from VV and augment change VV / minVV for correct causality and GC.
+
+**Architecture:** When the server sends `detached_actors` in ChangePack, the JS client stores them in a `detachedActors` map on Document, removes them from the document's VV, and augments change VV before execution and minVV before GC. Snapshots also carry `detached_actors` for state restoration.
+
+**Prerequisite:** Go PR (server-side changes) must be merged first. Proto changes (`detached_actors` on ChangePack field 8 and Snapshot field 3) are already in place.
+
+**Design doc:** `docs/design/vv-cleanup.md` (in yorkie repo)
+
+---
+
+### Task 1: Proto Types Update
+
+After the Go PR merges and `make proto` regenerates the proto files, the JS SDK
+proto types need to be regenerated from the updated `.proto` files.
+
+**Files:**
+- Modify: `packages/sdk/src/api/yorkie/v1/resources_pb.ts` (auto-generated)
+
+- [ ] **Step 1: Regenerate proto types**
+
+Run the SDK's proto generation command (check package.json for the exact script).
+After regeneration, verify that `ChangePack` now has `detachedActors` field and
+`Snapshot` has `detachedActors` field in `resources_pb.ts`.
+
+- [ ] **Step 2: Verify the generated types**
+
+Check that `resources_pb.ts` contains:
+
+```typescript
+// In ChangePack type:
+detachedActors: { [key: string]: bigint };
+
+// In Snapshot type:
+detachedActors: { [key: string]: bigint };
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/sdk/src/api/yorkie/v1/
+git commit -m "Regenerate proto types with detached_actors fields"
+```
+
+---
+
+### Task 2: ChangePack Class — Add detachedActors
+
+**Files:**
+- Modify: `packages/sdk/src/document/change/change_pack.ts`
+
+- [ ] **Step 1: Add detachedActors field and update constructor**
+
+```typescript
+export class ChangePack<P extends Indexable> {
+  private documentKey: string;
+  private checkpoint: Checkpoint;
+  private isRemoved: boolean;
+  private changes: Array<Change<P>>;
+  private snapshot?: Uint8Array;
+  private versionVector?: VersionVector;
+  private detachedActors: Map<string, bigint>;  // NEW
+
+  constructor(
+    key: string,
+    checkpoint: Checkpoint,
+    isRemoved: boolean,
+    changes: Array<Change<P>>,
+    versionVector?: VersionVector,
+    snapshot?: Uint8Array,
+    detachedActors?: Map<string, bigint>,
+  ) {
+    this.documentKey = key;
+    this.checkpoint = checkpoint;
+    this.isRemoved = isRemoved;
+    this.changes = changes;
+    this.snapshot = snapshot;
+    this.versionVector = versionVector;
+    this.detachedActors = detachedActors ?? new Map();
+  }
+```
+
+- [ ] **Step 2: Update static create method**
+
+```typescript
+  public static create<P extends Indexable>(
+    key: string,
+    checkpoint: Checkpoint,
+    isRemoved: boolean,
+    changes: Array<Change<P>>,
+    versionVector?: VersionVector,
+    snapshot?: Uint8Array,
+    detachedActors?: Map<string, bigint>,
+  ): ChangePack<P> {
+    return new ChangePack<P>(
+      key,
+      checkpoint,
+      isRemoved,
+      changes,
+      versionVector,
+      snapshot,
+      detachedActors,
+    );
+  }
+```
+
+- [ ] **Step 3: Add getter**
+
+```typescript
+  /**
+   * `getDetachedActors` returns the detached actors map from the server signal.
+   */
+  public getDetachedActors(): Map<string, bigint> {
+    return this.detachedActors;
+  }
+```
+
+- [ ] **Step 4: Verify build**
+
+Run: `npm run build` (or the project's build command)
+Expected: BUILD SUCCESS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/sdk/src/document/change/change_pack.ts
+git commit -m "Add detachedActors field to ChangePack class"
+```
+
+---
+
+### Task 3: Converter — Parse detached_actors
+
+**Files:**
+- Modify: `packages/sdk/src/api/converter.ts`
+
+- [ ] **Step 1: Update fromChangePack to parse detached_actors**
+
+At line 1459, update `fromChangePack`:
+
+```typescript
+function fromChangePack<P extends Indexable>(
+  pbPack: PbChangePack,
+): ChangePack<P> {
+  const detachedActors = new Map<string, bigint>();
+  for (const [key, value] of Object.entries(pbPack.detachedActors)) {
+    const hexKey = bytesToHex(base64ToUint8Array(key));
+    detachedActors.set(hexKey, BigInt(value.toString()));
+  }
+
+  return ChangePack.create<P>(
+    pbPack.documentKey!,
+    fromCheckpoint(pbPack.checkpoint!),
+    pbPack.isRemoved,
+    fromChanges(pbPack.changes),
+    fromVersionVector(pbPack.versionVector),
+    pbPack.snapshot,
+    detachedActors,
+  );
+}
+```
+
+- [ ] **Step 2: Update toChangePack to serialize detached_actors**
+
+At line 871, update `toChangePack`:
+
+```typescript
+function toChangePack(pack: ChangePack<Indexable>): PbChangePack {
+  const pbDetachedActors: { [key: string]: bigint } = {};
+  for (const [actorID, lamport] of pack.getDetachedActors()) {
+    const base64ActorID = uint8ArrayToBase64(toUint8Array(actorID));
+    pbDetachedActors[base64ActorID] = lamport;
+  }
+
+  return create(PbChangePackSchema, {
+    documentKey: pack.getDocumentKey(),
+    checkpoint: toCheckpoint(pack.getCheckpoint()),
+    isRemoved: pack.getIsRemoved(),
+    changes: toChanges(pack.getChanges()),
+    snapshot: pack.getSnapshot(),
+    versionVector: toVersionVector(pack.getVersionVector()),
+    detachedActors: pbDetachedActors,
+  });
+}
+```
+
+- [ ] **Step 3: Update bytesToSnapshot to return detached_actors**
+
+At line 1642, update `bytesToSnapshot`:
+
+```typescript
+function bytesToSnapshot<P extends Indexable>(
+  bytes?: Uint8Array,
+): {
+  root: CRDTObject;
+  presences: Map<ActorID, P>;
+  detachedActors: Map<string, bigint>;
+} {
+  if (!bytes) {
+    return {
+      root: CRDTObject.create(InitialTimeTicket),
+      presences: new Map(),
+      detachedActors: new Map(),
+    };
+  }
+
+  const snapshot = fromBinary(PbSnapshotSchema, bytes);
+  const detachedActors = new Map<string, bigint>();
+  for (const [key, value] of Object.entries(snapshot.detachedActors)) {
+    const hexKey = bytesToHex(base64ToUint8Array(key));
+    detachedActors.set(hexKey, BigInt(value.toString()));
+  }
+
+  return {
+    root: fromElement(snapshot.root!) as CRDTObject,
+    presences: fromPresences<P>(snapshot.presences),
+    detachedActors,
+  };
+}
+```
+
+- [ ] **Step 4: Fix all callers of bytesToSnapshot**
+
+Search for `bytesToSnapshot` call sites and update to destructure `detachedActors`.
+Key location: `document.ts:applySnapshot`.
+
+- [ ] **Step 5: Verify build**
+
+Run: `npm run build`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/sdk/src/api/converter.ts
+git commit -m "Add detached_actors serialization to converter"
+```
+
+---
+
+### Task 4: Document — detachedActors Map and VV Augmentation
+
+**Files:**
+- Modify: `packages/sdk/src/document/document.ts`
+
+- [ ] **Step 1: Add detachedActors field to Document class**
+
+In the class field declarations (around line 532):
+
+```typescript
+  private detachedActors: Map<string, bigint>;
+```
+
+Initialize in the constructor:
+
+```typescript
+  this.detachedActors = new Map();
+```
+
+- [ ] **Step 2: Add augmentVV helper method**
+
+```typescript
+  /**
+   * `augmentVV` augments the given version vector with detached actors'
+   * lamport values for correct causality detection and GC.
+   */
+  private augmentVV(vv: VersionVector): VersionVector {
+    for (const [actorID, lamport] of this.detachedActors) {
+      if (!vv.has(actorID)) {
+        vv.set(actorID, lamport);
+      }
+    }
+    return vv;
+  }
+```
+
+- [ ] **Step 3: Add addDetachedActors helper method**
+
+```typescript
+  /**
+   * `addDetachedActors` stores detached actors and removes them from the
+   * document's version vector.
+   */
+  private addDetachedActors(actors: Map<string, bigint>): void {
+    for (const [actorID, lamport] of actors) {
+      this.detachedActors.set(actorID, lamport);
+      this.changeID.getVersionVector().unset(actorID);
+    }
+  }
+```
+
+- [ ] **Step 4: Update applyChangePack to process detached_actors**
+
+At line 1097, update `applyChangePack`:
+
+```typescript
+  public applyChangePack(pack: ChangePack<P>): void {
+    // 01. Process detached actors from server signal.
+    const detachedActors = pack.getDetachedActors();
+    if (detachedActors.size > 0) {
+      this.addDetachedActors(detachedActors);
+    }
+
+    // 02. Apply snapshot or changes to the root object.
+    if (pack.hasSnapshot()) {
+      this.applySnapshot(
+        pack.getCheckpoint().getServerSeq(),
+        pack.getVersionVector()!,
+        pack.getSnapshot()!,
+        pack.getCheckpoint().getClientSeq(),
+      );
+    } else {
+      this.applyChanges(pack.getChanges(), OpSource.Remote);
+      this.removePushedLocalChanges(pack.getCheckpoint().getClientSeq());
+    }
+
+    // 03. Update the checkpoint.
+    this.checkpoint = this.checkpoint.forward(pack.getCheckpoint());
+
+    // 04. Do Garbage collection.
+    if (!pack.hasSnapshot()) {
+      const augmentedVV = this.augmentVV(pack.getVersionVector()!.deepcopy());
+      this.garbageCollect(augmentedVV);
+    }
+
+    // 05. Update the status.
+    if (pack.getIsRemoved()) {
+      this.applyStatus(DocStatus.Removed);
+    }
+
+    if (logger.isEnabled(LogLevel.Trivial)) {
+      logger.trivial(`${this.root.toJSON()}`);
+    }
+  }
+```
+
+- [ ] **Step 5: Augment change VV before execution**
+
+In the `applyChange` method (around line 1441), augment the change's VV
+before executing:
+
+```typescript
+  private applyChange(change: Change<P>, source: OpSource): void {
+    // Augment change VV with detached actors for causality detection.
+    if (source === OpSource.Remote) {
+      const changeVV = change.getID().getVersionVector();
+      if (changeVV) {
+        this.augmentVV(changeVV);
+      }
+    }
+
+    // ... rest of existing applyChange logic
+  }
+```
+
+- [ ] **Step 6: Update applySnapshot to restore detachedActors**
+
+Update `applySnapshot` (line 1356):
+
+```typescript
+  public applySnapshot(
+    serverSeq: bigint,
+    snapshotVector: VersionVector,
+    snapshot?: Uint8Array,
+    clientSeq: number = -1,
+  ) {
+    const { root, presences, detachedActors } =
+      converter.bytesToSnapshot<P>(snapshot);
+    this.root = new CRDTRoot(root);
+    this.presences = presences;
+    this.detachedActors = detachedActors;
+    this.changeID = this.changeID.setClocks(
+      snapshotVector.maxLamport(),
+      snapshotVector,
+    );
+
+    // ... rest of existing logic unchanged
+  }
+```
+
+- [ ] **Step 7: Verify build**
+
+Run: `npm run build`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/sdk/src/document/document.ts
+git commit -m "Add detachedActors to Document for VV augmentation"
+```
+
+---
+
+### Task 5: Unit Tests
+
+**Files:**
+- Create: `packages/sdk/test/unit/document/vv_cleanup_test.ts` (or add to existing test file)
+
+- [ ] **Step 1: Write test for addDetachedActors**
+
+```typescript
+import { Document } from '@yorkie-js-sdk/src/document/document';
+import { vectorOf } from '../helper/helper';
+
+describe('VV Cleanup', () => {
+  it('should remove detached actors from VV', () => {
+    // Setup: create document with VV containing actors A, B
+    // Act: call addDetachedActors with actor B
+    // Assert: document VV no longer has actor B
+    // Assert: detachedActors map contains actor B
+  });
+});
+```
+
+- [ ] **Step 2: Write test for augmentVV**
+
+```typescript
+  it('should augment VV with detached actors', () => {
+    // Setup: document has detachedActors = { B: 5 }
+    // Act: augmentVV on a VV that lacks actor B
+    // Assert: augmented VV contains B with lamport 5
+  });
+
+  it('should not overwrite existing VV entry when augmenting', () => {
+    // Setup: document has detachedActors = { B: 5 }
+    // Act: augmentVV on a VV that already has B with lamport 10
+    // Assert: VV still has B with lamport 10 (not overwritten)
+  });
+```
+
+- [ ] **Step 3: Write test for ChangePack detached_actors round-trip**
+
+```typescript
+  it('should serialize and deserialize detached_actors in ChangePack', () => {
+    // Setup: create ChangePack with detachedActors
+    // Act: toChangePack → fromChangePack
+    // Assert: detachedActors preserved
+  });
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm test` (or the project's test command)
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/sdk/test/
+git commit -m "Add unit tests for VV cleanup"
+```
+
+---
+
+### Task 6: Integration Tests
+
+**Files:**
+- Modify: `packages/sdk/test/integration/gc_test.ts` or create new test file
+
+- [ ] **Step 1: Write integration test for detach → VV cleanup cycle**
+
+Using the existing `withTwoClientsAndDocuments` helper:
+
+```typescript
+it('should clean up VV after client detach', async () => {
+  // 1. Client A and B attach to document
+  // 2. Both make edits (both actors in each other's VV)
+  // 3. Client B detaches
+  // 4. Client A syncs multiple times until detached_actors received
+  // 5. Verify Client A's VV no longer contains B's actorID
+  // 6. Client A can still make edits and sync correctly
+});
+```
+
+- [ ] **Step 2: Write integration test for GC with detached actors**
+
+```typescript
+it('should garbage collect correctly after VV cleanup', async () => {
+  // 1. Client A and B attach, both edit
+  // 2. Client A deletes an element
+  // 3. Client B syncs (receives delete), then detaches
+  // 4. Client A syncs (receives detached_actors)
+  // 5. Verify GC count is correct (augmented minVV allows GC)
+});
+```
+
+- [ ] **Step 3: Run integration tests**
+
+Run: `npm run test:integration` (or equivalent)
+Expected: ALL PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/sdk/test/
+git commit -m "Add integration tests for VV cleanup with client detach"
+```
+
+---
+
+### Task 7: Lint and Final Verification
+
+- [ ] **Step 1: Run linter**
+
+Run: `npm run lint`
+Expected: No errors
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `npm test`
+Expected: ALL PASS
+
+- [ ] **Step 3: Fix any issues**
+
+- [ ] **Step 4: Final commit if needed**
+
+```bash
+git commit -m "Fix lint issues in VV cleanup implementation"
+```

--- a/docs/tasks/active/README.md
+++ b/docs/tasks/active/README.md
@@ -1,7 +1,8 @@
 ---
-updated: 2026-04-17
+updated: 2026-04-22
 ---
 
 # Active Tasks
 
-(none)
+- [VV Cleanup — Go Server + Client](20260422-vv-cleanup-go-todo.md)
+- [VV Cleanup — JS SDK](20260422-vv-cleanup-js-todo.md)

--- a/pkg/document/change/pack.go
+++ b/pkg/document/change/pack.go
@@ -42,6 +42,9 @@ type Pack struct {
 
 	// IsRemoved is a flag that indicates whether the document is removed.
 	IsRemoved bool
+
+	// DetachedActors is a map of detached actor IDs to their lamport values.
+	DetachedActors map[time.ActorID]int64
 }
 
 // NewPack creates a new instance of Pack.

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -215,7 +215,12 @@ func (d *Document) ApplyChangePack(pack *change.Pack) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	// 01. Apply remote changes to both the cloneRoot and the document.
+	// 01. Process detached actors from server signal.
+	if len(pack.DetachedActors) > 0 {
+		d.doc.AddDetachedActors(pack.DetachedActors)
+	}
+
+	// 02. Apply remote changes to both the cloneRoot and the document.
 	hasSnapshot := len(pack.Snapshot) > 0
 
 	if hasSnapshot {
@@ -230,7 +235,7 @@ func (d *Document) ApplyChangePack(pack *change.Pack) error {
 		}
 	}
 
-	// 02. Remove local changes applied to server.
+	// 03. Remove local changes applied to server.
 	for d.doc.HasLocalChanges() {
 		c := d.doc.localChanges[0]
 		if c.ClientSeq() > pack.Checkpoint.ClientSeq {
@@ -245,15 +250,17 @@ func (d *Document) ApplyChangePack(pack *change.Pack) error {
 		}
 	}
 
-	// 03. Update the checkpoint.
+	// 04. Update the checkpoint.
 	d.doc.checkpoint = d.doc.checkpoint.Forward(pack.Checkpoint)
 
-	// 04. Do Garbage collection.
+	// 05. Do Garbage collection.
 	if !d.options.DisableGC && !hasSnapshot {
-		d.GarbageCollect(pack.VersionVector)
+		gcVV := pack.VersionVector.DeepCopy()
+		d.doc.AugmentVV(gcVV)
+		d.GarbageCollect(gcVV)
 	}
 
-	// 05. Update the status.
+	// 06. Update the status.
 	if pack.IsRemoved {
 		d.SetStatus(StatusRemoved)
 	}

--- a/pkg/document/internal_document.go
+++ b/pkg/document/internal_document.go
@@ -266,7 +266,7 @@ func (d *InternalDocument) AddDetachedActors(actors map[time.ActorID]int64) {
 // This ensures correct causality detection and GC after VV cleanup.
 func (d *InternalDocument) AugmentVV(vv time.VersionVector) {
 	for actorID, lamport := range d.detachedActors {
-		if _, ok := vv.Get(actorID); !ok {
+		if existing, ok := vv.Get(actorID); !ok || existing < lamport {
 			vv.Set(actorID, lamport)
 		}
 	}

--- a/pkg/document/internal_document.go
+++ b/pkg/document/internal_document.go
@@ -76,6 +76,10 @@ type InternalDocument struct {
 	// localChanges is the list of the changes that are not yet sent to the
 	// server.
 	localChanges []*change.Change
+
+	// detachedActors is a map of detached actor IDs to their lamport at detach time.
+	// Used to augment VV for correct causality detection and GC after VV cleanup.
+	detachedActors map[time.ActorID]int64
 }
 
 // NewInternalDocument creates a new instance of InternalDocument.
@@ -84,13 +88,14 @@ func NewInternalDocument(k key.Key) *InternalDocument {
 
 	// TODO(hackerwins): We need to initialize the presence of the actor who edited the document.
 	return &InternalDocument{
-		key:           k,
-		status:        StatusDetached,
-		root:          crdt.NewRoot(root),
-		checkpoint:    change.InitialCheckpoint,
-		changeID:      change.InitialID(),
-		presences:     presence.NewMap(),
-		onlineClients: make(map[string]bool),
+		key:            k,
+		status:         StatusDetached,
+		root:           crdt.NewRoot(root),
+		checkpoint:     change.InitialCheckpoint,
+		changeID:       change.InitialID(),
+		presences:      presence.NewMap(),
+		onlineClients:  make(map[string]bool),
+		detachedActors: make(map[time.ActorID]int64),
 	}
 }
 
@@ -102,19 +107,24 @@ func NewInternalDocumentFromSnapshot(
 	vector time.VersionVector,
 	snapshot []byte,
 ) (*InternalDocument, error) {
-	obj, presences, _, err := converter.BytesToSnapshot(snapshot)
+	obj, presences, detachedActors, err := converter.BytesToSnapshot(snapshot)
 	if err != nil {
 		return nil, err
 	}
 
+	if detachedActors == nil {
+		detachedActors = make(map[time.ActorID]int64)
+	}
+
 	return &InternalDocument{
-		key:           k,
-		status:        StatusDetached,
-		root:          crdt.NewRoot(obj),
-		presences:     presences,
-		onlineClients: make(map[string]bool),
-		checkpoint:    change.InitialCheckpoint.NextServerSeq(serverSeq),
-		changeID:      change.InitialID().SetClocks(lamport, vector),
+		key:            k,
+		status:         StatusDetached,
+		root:           crdt.NewRoot(obj),
+		presences:      presences,
+		onlineClients:  make(map[string]bool),
+		checkpoint:     change.InitialCheckpoint.NextServerSeq(serverSeq),
+		changeID:       change.InitialID().SetClocks(lamport, vector),
+		detachedActors: detachedActors,
 	}, nil
 }
 
@@ -150,7 +160,12 @@ func (d *InternalDocument) HasLocalChanges() bool {
 func (d *InternalDocument) ApplyChangePack(pack *change.Pack, disableGC bool) error {
 	hasSnapshot := len(pack.Snapshot) > 0
 
-	// 01. Apply remote changes to both the cloneRoot and the document.
+	// 01. Process detached actors from server signal.
+	if len(pack.DetachedActors) > 0 {
+		d.AddDetachedActors(pack.DetachedActors)
+	}
+
+	// 02. Apply remote changes to both the cloneRoot and the document.
 	if hasSnapshot {
 		if err := d.applySnapshot(pack.Snapshot, pack.VersionVector); err != nil {
 			return err
@@ -161,7 +176,7 @@ func (d *InternalDocument) ApplyChangePack(pack *change.Pack, disableGC bool) er
 		}
 	}
 
-	// 02. Remove local changes applied to server.
+	// 03. Remove local changes applied to server.
 	for d.HasLocalChanges() {
 		c := d.localChanges[0]
 		if c.ClientSeq() > pack.Checkpoint.ClientSeq {
@@ -170,11 +185,14 @@ func (d *InternalDocument) ApplyChangePack(pack *change.Pack, disableGC bool) er
 		d.localChanges = d.localChanges[1:]
 	}
 
-	// 03. Update the checkpoint.
+	// 04. Update the checkpoint.
 	d.checkpoint = d.checkpoint.Forward(pack.Checkpoint)
 
+	// 05. Do Garbage collection.
 	if !disableGC && pack.VersionVector != nil && !hasSnapshot {
-		if _, err := d.GarbageCollect(pack.VersionVector); err != nil {
+		gcVV := pack.VersionVector.DeepCopy()
+		d.AugmentVV(gcVV)
+		if _, err := d.GarbageCollect(gcVV); err != nil {
 			return err
 		}
 	}
@@ -231,6 +249,29 @@ func (d *InternalDocument) VersionVector() time.VersionVector {
 	return d.changeID.VersionVector()
 }
 
+// DetachedActors returns the detached actors map.
+func (d *InternalDocument) DetachedActors() map[time.ActorID]int64 {
+	return d.detachedActors
+}
+
+// AddDetachedActors stores the given detached actors and removes them from the document's VV.
+func (d *InternalDocument) AddDetachedActors(actors map[time.ActorID]int64) {
+	for actorID, lamport := range actors {
+		d.detachedActors[actorID] = lamport
+		d.changeID.VersionVector().Unset(actorID)
+	}
+}
+
+// AugmentVV augments the given VV with detached actors' lamport values.
+// This ensures correct causality detection and GC after VV cleanup.
+func (d *InternalDocument) AugmentVV(vv time.VersionVector) {
+	for actorID, lamport := range d.detachedActors {
+		if _, ok := vv.Get(actorID); !ok {
+			vv.Set(actorID, lamport)
+		}
+	}
+}
+
 // SetStatus sets the status of this document.
 func (d *InternalDocument) SetStatus(status StatusType) {
 	d.status = status
@@ -257,13 +298,17 @@ func (d *InternalDocument) RootObject() *crdt.Object {
 }
 
 func (d *InternalDocument) applySnapshot(snapshot []byte, vector time.VersionVector) error {
-	rootObj, presences, _, err := converter.BytesToSnapshot(snapshot)
+	rootObj, presences, detachedActors, err := converter.BytesToSnapshot(snapshot)
 	if err != nil {
 		return err
 	}
 
 	d.root = crdt.NewRoot(rootObj)
 	d.presences = presences
+	d.detachedActors = detachedActors
+	if d.detachedActors == nil {
+		d.detachedActors = make(map[time.ActorID]int64)
+	}
 
 	// NOTE(chacha912): Documents created from snapshots were experiencing edit
 	// restrictions due to low lamport values.
@@ -290,6 +335,10 @@ func (d *InternalDocument) ApplyChanges(changes ...*change.Change) ([]DocEvent, 
 			_, wasOnline = d.onlineClients[clientID]
 			prevPresence = d.Presence(clientID)
 		}
+
+		// Augment change VV with detached actors' lamport values so that
+		// causality detection and GC work correctly after VV cleanup.
+		d.AugmentVV(c.ID().VersionVector())
 
 		if err := c.Execute(d.root, d.presences); err != nil {
 			return nil, err
@@ -439,6 +488,11 @@ func (d *InternalDocument) DeepCopy() (*InternalDocument, error) {
 		onlineClients[id] = true
 	}
 
+	detachedActors := make(map[time.ActorID]int64)
+	for id, lamport := range d.detachedActors {
+		detachedActors[id] = lamport
+	}
+
 	return &InternalDocument{
 		key:        d.key,
 		status:     d.status,
@@ -449,9 +503,10 @@ func (d *InternalDocument) DeepCopy() (*InternalDocument, error) {
 		// COnsider removing this in the future.
 		changeID: d.changeID.DeepCopy(),
 
-		root:          root,
-		presences:     d.presences.DeepCopy(),
-		onlineClients: onlineClients,
-		localChanges:  d.localChanges,
+		root:           root,
+		presences:      d.presences.DeepCopy(),
+		onlineClients:  onlineClients,
+		localChanges:   d.localChanges,
+		detachedActors: detachedActors,
 	}, nil
 }

--- a/pkg/document/internal_document.go
+++ b/pkg/document/internal_document.go
@@ -353,6 +353,11 @@ func (d *InternalDocument) ApplyChanges(changes ...*change.Change) ([]DocEvent, 
 			}
 		}
 
+		// Remove augmented detached actor entries before SyncClocks to
+		// prevent them from propagating back into the document's VV.
+		for actorID := range d.detachedActors {
+			c.ID().VersionVector().Unset(actorID)
+		}
 		d.changeID = d.changeID.SyncClocks(c.ID())
 	}
 

--- a/pkg/document/internal_document.go
+++ b/pkg/document/internal_document.go
@@ -102,7 +102,7 @@ func NewInternalDocumentFromSnapshot(
 	vector time.VersionVector,
 	snapshot []byte,
 ) (*InternalDocument, error) {
-	obj, presences, err := converter.BytesToSnapshot(snapshot)
+	obj, presences, _, err := converter.BytesToSnapshot(snapshot)
 	if err != nil {
 		return nil, err
 	}
@@ -257,7 +257,7 @@ func (d *InternalDocument) RootObject() *crdt.Object {
 }
 
 func (d *InternalDocument) applySnapshot(snapshot []byte, vector time.VersionVector) error {
-	rootObj, presences, err := converter.BytesToSnapshot(snapshot)
+	rootObj, presences, _, err := converter.BytesToSnapshot(snapshot)
 	if err != nil {
 		return err
 	}

--- a/server/backend/database/client_info.go
+++ b/server/backend/database/client_info.go
@@ -54,10 +54,11 @@ const (
 // ClientDocInfo is a structure representing information of the document
 // attached to the client.
 type ClientDocInfo struct {
-	Status    string `bson:"status"`
-	ServerSeq int64  `bson:"server_seq"`
-	ClientSeq uint32 `bson:"client_seq"`
-	Epoch     int64  `bson:"epoch"`
+	Status          string `bson:"status"`
+	ServerSeq       int64  `bson:"server_seq"`
+	ClientSeq       uint32 `bson:"client_seq"`
+	Epoch           int64  `bson:"epoch"`
+	DetachedLamport int64  `bson:"detached_lamport,omitempty"`
 }
 
 // ClientDocInfoMap is a map that associates DocRefKey with ClientDocInfo instances.
@@ -179,7 +180,7 @@ func (i *ClientInfo) IsAttaching(docID types.ID) bool {
 }
 
 // DetachDocument detaches the given document from this client.
-func (i *ClientInfo) DetachDocument(docID types.ID) error {
+func (i *ClientInfo) DetachDocument(docID types.ID, detachedLamport int64) error {
 	if err := i.EnsureDocumentAttachedOrAttaching(docID); err != nil {
 		return err
 	}
@@ -187,6 +188,7 @@ func (i *ClientInfo) DetachDocument(docID types.ID) error {
 	i.Documents[docID].Status = DocumentDetached
 	i.Documents[docID].ClientSeq = 0
 	i.Documents[docID].ServerSeq = 0
+	i.Documents[docID].DetachedLamport = detachedLamport
 	i.UpdatedAt = gotime.Now()
 
 	return nil
@@ -324,10 +326,11 @@ func (i *ClientInfo) DeepCopy() *ClientInfo {
 	documents := make(map[types.ID]*ClientDocInfo, len(i.Documents))
 	for docID, docInfo := range i.Documents {
 		documents[docID] = &ClientDocInfo{
-			Status:    docInfo.Status,
-			ServerSeq: docInfo.ServerSeq,
-			ClientSeq: docInfo.ClientSeq,
-			Epoch:     docInfo.Epoch,
+			Status:          docInfo.Status,
+			ServerSeq:       docInfo.ServerSeq,
+			ClientSeq:       docInfo.ClientSeq,
+			Epoch:           docInfo.Epoch,
+			DetachedLamport: docInfo.DetachedLamport,
 		}
 	}
 
@@ -370,12 +373,13 @@ func (i *ClientInfo) UpdateDocStatus(
 	docID types.ID,
 	status document.StatusType,
 	cp change.Checkpoint,
+	detachedLamport int64,
 ) error {
 	switch status {
 	case document.StatusRemoved:
 		return i.RemoveDocument(docID)
 	case document.StatusDetached:
-		return i.DetachDocument(docID)
+		return i.DetachDocument(docID, detachedLamport)
 	default:
 		return i.UpdateCheckpoint(docID, cp)
 	}

--- a/server/backend/database/client_info.go
+++ b/server/backend/database/client_info.go
@@ -51,6 +51,13 @@ const (
 	DocumentRemoved   = "removed"
 )
 
+// DetachedClientInfo contains information about a detached client for VV cleanup.
+type DetachedClientInfo struct {
+	ClientID        types.ID
+	ActorID         time.ActorID
+	DetachedLamport int64
+}
+
 // ClientDocInfo is a structure representing information of the document
 // attached to the client.
 type ClientDocInfo struct {

--- a/server/backend/database/client_info_test.go
+++ b/server/backend/database/client_info_test.go
@@ -48,7 +48,7 @@ func TestClientInfo(t *testing.T) {
 		err = clientInfo.EnsureDocumentAttached(dummyDocID)
 		assert.NoError(t, err)
 
-		err = clientInfo.DetachDocument(dummyDocID)
+		err = clientInfo.DetachDocument(dummyDocID, 0)
 		assert.NoError(t, err)
 		isAttached, err = clientInfo.IsAttached(dummyDocID)
 		assert.NoError(t, err)
@@ -108,7 +108,7 @@ func TestClientInfo(t *testing.T) {
 		err = clientInfo.EnsureDocumentAttached(dummyDocID)
 		assert.ErrorIs(t, err, database.ErrClientNotActivated)
 
-		err = clientInfo.DetachDocument(dummyDocID)
+		err = clientInfo.DetachDocument(dummyDocID, 0)
 		assert.ErrorIs(t, err, database.ErrClientNotActivated)
 	})
 
@@ -116,7 +116,7 @@ func TestClientInfo(t *testing.T) {
 		clientInfo := database.ClientInfo{
 			Status: database.ClientActivated,
 		}
-		err := clientInfo.DetachDocument(dummyDocID)
+		err := clientInfo.DetachDocument(dummyDocID, 0)
 		assert.ErrorIs(t, err, database.ErrDocumentNotAttached)
 	})
 

--- a/server/backend/database/database.go
+++ b/server/backend/database/database.go
@@ -246,6 +246,21 @@ type Database interface {
 	// FindAttachedClientCountsByDocIDs returns the number of attached clients of the given documents as a map.
 	FindAttachedClientCountsByDocIDs(ctx context.Context, projectID types.ID, docIDs []types.ID) (map[types.ID]int, error)
 
+	// FindDetachedClients returns detached clients with non-zero DetachedLamport
+	// for the given document.
+	FindDetachedClients(
+		ctx context.Context,
+		docRefKey types.DocRefKey,
+	) ([]DetachedClientInfo, error)
+
+	// ResetDetachedLamport resets the DetachedLamport of the given client's document
+	// after all attached clients have been notified.
+	ResetDetachedLamport(
+		ctx context.Context,
+		clientID types.ID,
+		docID types.ID,
+	) error
+
 	// FindActiveClients finds active clients for deactivation checking.
 	FindActiveClients(ctx context.Context, candidatesLimit int, lastClientID types.ID) ([]*ClientInfo, types.ID, error)
 

--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -1418,7 +1418,7 @@ func (d *DB) FindDetachedClients(
 		if docInfo.Status == database.DocumentDetached && docInfo.DetachedLamport > 0 {
 			actorID, err := info.ID.ToActorID()
 			if err != nil {
-				return nil, fmt.Errorf("convert client ID to actor ID %s: %w", info.ID, err)
+				continue
 			}
 			result = append(result, database.DetachedClientInfo{
 				ClientID:        info.ID,

--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -2038,7 +2038,7 @@ func (d *DB) CreateSnapshotInfo(
 	docRefKey types.DocRefKey,
 	doc *document.InternalDocument,
 ) error {
-	snapshot, err := converter.SnapshotToBytes(doc.RootObject(), doc.AllPresences())
+	snapshot, err := converter.SnapshotToBytes(doc.RootObject(), doc.AllPresences(), nil)
 	if err != nil {
 		return err
 	}

--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -1393,6 +1393,74 @@ func (d *DB) FindAttachedClientCountsByDocIDs(
 	return attachedClientMap, nil
 }
 
+// FindDetachedClients returns detached clients with non-zero DetachedLamport
+// for the given document.
+func (d *DB) FindDetachedClients(
+	_ context.Context,
+	docRefKey types.DocRefKey,
+) ([]database.DetachedClientInfo, error) {
+	txn := d.db.Txn(false)
+	defer txn.Abort()
+
+	iter, err := txn.Get(tblClients, "project_id", docRefKey.ProjectID.String())
+	if err != nil {
+		return nil, fmt.Errorf("find detached clients of %s: %w", docRefKey, err)
+	}
+
+	var result []database.DetachedClientInfo
+	for raw := iter.Next(); raw != nil; raw = iter.Next() {
+		info := raw.(*database.ClientInfo)
+		docInfo := info.Documents[docRefKey.DocID]
+		if docInfo == nil {
+			continue
+		}
+		if docInfo.Status == database.DocumentDetached && docInfo.DetachedLamport > 0 {
+			actorID, err := info.ID.ToActorID()
+			if err != nil {
+				return nil, fmt.Errorf("convert client ID to actor ID %s: %w", info.ID, err)
+			}
+			result = append(result, database.DetachedClientInfo{
+				ClientID:        info.ID,
+				ActorID:         actorID,
+				DetachedLamport: docInfo.DetachedLamport,
+			})
+		}
+	}
+
+	return result, nil
+}
+
+// ResetDetachedLamport resets the DetachedLamport of the given client's document
+// after all attached clients have been notified.
+func (d *DB) ResetDetachedLamport(
+	_ context.Context,
+	clientID types.ID,
+	docID types.ID,
+) error {
+	txn := d.db.Txn(true)
+	defer txn.Abort()
+
+	raw, err := txn.First(tblClients, "id", clientID.String())
+	if err != nil {
+		return fmt.Errorf("reset detached lamport of %s for %s: %w", clientID, docID, err)
+	}
+	if raw == nil {
+		return fmt.Errorf("reset detached lamport of %s for %s: %w", clientID, docID, database.ErrClientNotFound)
+	}
+
+	loaded := raw.(*database.ClientInfo).DeepCopy()
+	if docInfo, ok := loaded.Documents[docID]; ok {
+		docInfo.DetachedLamport = 0
+	}
+
+	if err := txn.Insert(tblClients, loaded); err != nil {
+		return fmt.Errorf("reset detached lamport of %s for %s: %w", clientID, docID, err)
+	}
+	txn.Commit()
+
+	return nil
+}
+
 // FindOrCreateDocInfo finds the document or creates it if it does not exist.
 func (d *DB) FindOrCreateDocInfo(
 	_ context.Context,

--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -1192,7 +1192,8 @@ func (d *DB) UpdateClientInfoAfterPushPull(
 
 	if !attached {
 		loaded.Documents[docRefKey.DocID] = &database.ClientDocInfo{
-			Status: clientDocInfo.Status,
+			Status:          clientDocInfo.Status,
+			DetachedLamport: clientDocInfo.DetachedLamport,
 		}
 		loaded.UpdatedAt = gotime.Now()
 	} else {

--- a/server/backend/database/memory/database_test.go
+++ b/server/backend/database/memory/database_test.go
@@ -148,6 +148,14 @@ func TestDB(t *testing.T) {
 		testcases.RunFindAttachedClientCountsByDocIDsTest(t, db, projectID)
 	})
 
+	t.Run("FindDetachedClients test", func(t *testing.T) {
+		testcases.RunFindDetachedClientsTest(t, db, projectID)
+	})
+
+	t.Run("ResetDetachedLamport test", func(t *testing.T) {
+		testcases.RunResetDetachedLamportTest(t, db, projectID)
+	})
+
 	t.Run("RunPurgeDocument test", func(t *testing.T) {
 		testcases.RunPurgeDocument(t, db, projectID)
 	})

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -1259,10 +1259,11 @@ func (c *Client) UpdateClientInfoAfterPushPull(
 	} else {
 		updater = bson.M{
 			"$set": bson.M{
-				clientDocInfoKey(docInfo.ID, "server_seq"): 0,
-				clientDocInfoKey(docInfo.ID, "client_seq"): 0,
-				clientDocInfoKey(docInfo.ID, StatusKey):    clientDocInfo.Status,
-				"updated_at":                               info.UpdatedAt,
+				clientDocInfoKey(docInfo.ID, "server_seq"):        0,
+				clientDocInfoKey(docInfo.ID, "client_seq"):        0,
+				clientDocInfoKey(docInfo.ID, StatusKey):           clientDocInfo.Status,
+				clientDocInfoKey(docInfo.ID, "detached_lamport"): clientDocInfo.DetachedLamport,
+				"updated_at": info.UpdatedAt,
 			},
 			"$pull": bson.M{
 				"attached_docs":  docInfo.ID,
@@ -2075,7 +2076,7 @@ func (c *Client) CreateSnapshotInfo(
 	docRefKey types.DocRefKey,
 	doc *document.InternalDocument,
 ) error {
-	snapshot, err := converter.SnapshotToBytes(doc.RootObject(), doc.AllPresences())
+	snapshot, err := converter.SnapshotToBytes(doc.RootObject(), doc.AllPresences(), nil)
 	if err != nil {
 		return err
 	}

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -1442,6 +1442,70 @@ func (c *Client) FindAttachedClientCountsByDocIDs(
 	return attachedClientMap, nil
 }
 
+// FindDetachedClients returns detached clients with non-zero DetachedLamport
+// for the given document.
+func (c *Client) FindDetachedClients(
+	ctx context.Context,
+	docRefKey types.DocRefKey,
+) ([]database.DetachedClientInfo, error) {
+	filter := bson.M{
+		"project_id": docRefKey.ProjectID,
+		clientDocInfoKey(docRefKey.DocID, StatusKey): database.DocumentDetached,
+		clientDocInfoKey(docRefKey.DocID, "detached_lamport"): bson.M{"$gt": int64(0)},
+	}
+
+	cursor, err := c.collection(ColClients).Find(ctx, filter)
+	if err != nil {
+		return nil, fmt.Errorf("find detached clients of %s: %w", docRefKey, err)
+	}
+
+	var infos []*database.ClientInfo
+	if err := cursor.All(ctx, &infos); err != nil {
+		return nil, fmt.Errorf("find detached clients of %s: %w", docRefKey, err)
+	}
+
+	var result []database.DetachedClientInfo
+	for _, info := range infos {
+		actorID, err := info.ID.ToActorID()
+		if err != nil {
+			return nil, fmt.Errorf("convert client ID to actor ID %s: %w", info.ID, err)
+		}
+
+		result = append(result, database.DetachedClientInfo{
+			ClientID:        info.ID,
+			ActorID:         actorID,
+			DetachedLamport: info.Documents[docRefKey.DocID].DetachedLamport,
+		})
+	}
+
+	return result, nil
+}
+
+// ResetDetachedLamport resets the DetachedLamport of the given client's document
+// after all attached clients have been notified.
+func (c *Client) ResetDetachedLamport(
+	ctx context.Context,
+	clientID types.ID,
+	docID types.ID,
+) error {
+	result, err := c.collection(ColClients).UpdateOne(ctx, bson.M{
+		"_id": clientID,
+	}, bson.M{
+		"$set": bson.M{
+			clientDocInfoKey(docID, "detached_lamport"): int64(0),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("reset detached lamport of %s for %s: %w", clientID, docID, err)
+	}
+
+	if result.MatchedCount == 0 {
+		return fmt.Errorf("reset detached lamport of %s for %s: %w", clientID, docID, database.ErrClientNotFound)
+	}
+
+	return nil
+}
+
 // FindOrCreateDocInfo finds the document or creates it if it does not exist.
 func (c *Client) FindOrCreateDocInfo(
 	ctx context.Context,

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -1259,9 +1259,9 @@ func (c *Client) UpdateClientInfoAfterPushPull(
 	} else {
 		updater = bson.M{
 			"$set": bson.M{
-				clientDocInfoKey(docInfo.ID, "server_seq"):        0,
-				clientDocInfoKey(docInfo.ID, "client_seq"):        0,
-				clientDocInfoKey(docInfo.ID, StatusKey):           clientDocInfo.Status,
+				clientDocInfoKey(docInfo.ID, "server_seq"):       0,
+				clientDocInfoKey(docInfo.ID, "client_seq"):       0,
+				clientDocInfoKey(docInfo.ID, StatusKey):          clientDocInfo.Status,
 				clientDocInfoKey(docInfo.ID, "detached_lamport"): clientDocInfo.DetachedLamport,
 				"updated_at": info.UpdatedAt,
 			},
@@ -1451,7 +1451,7 @@ func (c *Client) FindDetachedClients(
 ) ([]database.DetachedClientInfo, error) {
 	filter := bson.M{
 		"project_id": docRefKey.ProjectID,
-		clientDocInfoKey(docRefKey.DocID, StatusKey): database.DocumentDetached,
+		clientDocInfoKey(docRefKey.DocID, StatusKey):          database.DocumentDetached,
 		clientDocInfoKey(docRefKey.DocID, "detached_lamport"): bson.M{"$gt": int64(0)},
 	}
 
@@ -1469,7 +1469,7 @@ func (c *Client) FindDetachedClients(
 	for _, info := range infos {
 		actorID, err := info.ID.ToActorID()
 		if err != nil {
-			return nil, fmt.Errorf("convert client ID to actor ID %s: %w", info.ID, err)
+			continue
 		}
 
 		result = append(result, database.DetachedClientInfo{

--- a/server/backend/database/testcases/testcases.go
+++ b/server/backend/database/testcases/testcases.go
@@ -2266,6 +2266,85 @@ func RunFindAttachedClientCountsByDocIDsTest(t *testing.T, db database.Database,
 	})
 }
 
+// RunFindDetachedClientsTest runs the FindDetachedClients tests for the given db.
+func RunFindDetachedClientsTest(t *testing.T, db database.Database, projectID types.ID) {
+	t.Run("FindDetachedClients test", func(t *testing.T) {
+		ctx := context.Background()
+
+		// 01. Create a client and a document then attach the document to the client.
+		clientInfo, err := db.ActivateClient(ctx, projectID, t.Name(), nil)
+		assert.NoError(t, err)
+		docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
+		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+		assert.NoError(t, err)
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
+		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+
+		// 02. Detach the document with a non-zero DetachedLamport.
+		assert.NoError(t, clientInfo.DetachDocument(docInfo.ID, 42))
+		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+
+		// 03. FindDetachedClients should return exactly one result.
+		docRefKey := docInfo.RefKey()
+		detached, err := db.FindDetachedClients(ctx, docRefKey)
+		assert.NoError(t, err)
+		assert.Len(t, detached, 1)
+		expectedActorID, err := clientInfo.ID.ToActorID()
+		assert.NoError(t, err)
+		assert.Equal(t, clientInfo.ID, detached[0].ClientID)
+		assert.Equal(t, expectedActorID, detached[0].ActorID)
+		assert.Equal(t, int64(42), detached[0].DetachedLamport)
+
+		// 04. A client with DetachedLamport = 0 should not be returned.
+		clientInfo2, err := db.ActivateClient(ctx, projectID, t.Name()+"2", nil)
+		assert.NoError(t, err)
+		_, err = db.FindOrCreateDocInfo(ctx, clientInfo2.RefKey(), docKey)
+		assert.NoError(t, err)
+		assert.NoError(t, clientInfo2.AttachDocument(docInfo.ID, false, docInfo.Epoch))
+		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo2, docInfo))
+		assert.NoError(t, clientInfo2.DetachDocument(docInfo.ID, 0))
+		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo2, docInfo))
+
+		detached, err = db.FindDetachedClients(ctx, docRefKey)
+		assert.NoError(t, err)
+		assert.Len(t, detached, 1)
+		assert.Equal(t, clientInfo.ID, detached[0].ClientID)
+	})
+}
+
+// RunResetDetachedLamportTest runs the ResetDetachedLamport tests for the given db.
+func RunResetDetachedLamportTest(t *testing.T, db database.Database, projectID types.ID) {
+	t.Run("ResetDetachedLamport test", func(t *testing.T) {
+		ctx := context.Background()
+
+		// 01. Create a client and a document, attach and detach with non-zero lamport.
+		clientInfo, err := db.ActivateClient(ctx, projectID, t.Name(), nil)
+		assert.NoError(t, err)
+		docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
+		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+		assert.NoError(t, err)
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
+		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+		assert.NoError(t, clientInfo.DetachDocument(docInfo.ID, 100))
+		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+
+		// 02. Verify the detached client is found.
+		docRefKey := docInfo.RefKey()
+		detached, err := db.FindDetachedClients(ctx, docRefKey)
+		assert.NoError(t, err)
+		assert.Len(t, detached, 1)
+
+		// 03. Reset the DetachedLamport.
+		err = db.ResetDetachedLamport(ctx, clientInfo.ID, docInfo.ID)
+		assert.NoError(t, err)
+
+		// 04. FindDetachedClients should return empty after reset.
+		detached, err = db.FindDetachedClients(ctx, docRefKey)
+		assert.NoError(t, err)
+		assert.Len(t, detached, 0)
+	})
+}
+
 // RunPurgeDocument runs the RunPurgeDocument tests for the given db.
 func RunPurgeDocument(t *testing.T, db database.Database, projectID types.ID) {
 	t.Run("PurgeDocument test", func(t *testing.T) {

--- a/server/backend/database/testcases/testcases.go
+++ b/server/backend/database/testcases/testcases.go
@@ -1148,7 +1148,7 @@ func RunTryAttachingAndDeactivateClientTest(t *testing.T, db database.Database, 
 		assert.Error(t, err)
 
 		// 06. failure case: client is deactivated
-		assert.NoError(t, clientInfo.DetachDocument(docInfo.ID))
+		assert.NoError(t, clientInfo.DetachDocument(docInfo.ID, 0))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 		_, err = db.DeactivateClient(ctx, clientInfo.RefKey())
 		assert.NoError(t, err)
@@ -1183,7 +1183,7 @@ func RunTryAttachingAndDeactivateClientTest(t *testing.T, db database.Database, 
 		assert.Error(t, err)
 
 		// 04. failure case: client is already deactivated
-		assert.NoError(t, clientInfo.DetachDocument(docInfo.ID))
+		assert.NoError(t, clientInfo.DetachDocument(docInfo.ID, 0))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 		_, err = db.DeactivateClient(ctx, clientInfo.RefKey())
 		assert.NoError(t, err)
@@ -1857,7 +1857,7 @@ func RunUpdateClientInfoAfterPushPullTest(t *testing.T, db database.Database, pr
 		assert.Equal(t, result.Documents[docInfo.ID].ClientSeq, uint32(1))
 		assert.NoError(t, err)
 
-		assert.NoError(t, clientInfo.DetachDocument(docInfo.ID))
+		assert.NoError(t, clientInfo.DetachDocument(docInfo.ID, 0))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		result, err = db.FindClientInfoByRefKey(ctx, clientInfo.RefKey())
@@ -1972,7 +1972,7 @@ func RunIsDocumentAttachedOrAttachingTest(t *testing.T, db database.Database, pr
 		assert.True(t, attached)
 
 		// 03. Check if document is attached after detaching
-		assert.NoError(t, c1.DetachDocument(docRefKey1.DocID))
+		assert.NoError(t, c1.DetachDocument(docRefKey1.DocID, 0))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c1, d1))
 		attached, err = db.IsDocumentAttachedOrAttaching(ctx, docRefKey1, "")
 		assert.NoError(t, err)
@@ -1988,14 +1988,14 @@ func RunIsDocumentAttachedOrAttachingTest(t *testing.T, db database.Database, pr
 		assert.True(t, attached)
 
 		// 05. Check if document is attached after a client detaching
-		assert.NoError(t, c1.DetachDocument(docRefKey1.DocID))
+		assert.NoError(t, c1.DetachDocument(docRefKey1.DocID, 0))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c1, d1))
 		attached, err = db.IsDocumentAttachedOrAttaching(ctx, docRefKey1, "")
 		assert.NoError(t, err)
 		assert.True(t, attached)
 
 		// 06. Check if document is attached after another client detaching
-		assert.NoError(t, c2.DetachDocument(docRefKey1.DocID))
+		assert.NoError(t, c2.DetachDocument(docRefKey1.DocID, 0))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c2, d1))
 		attached, err = db.IsDocumentAttachedOrAttaching(ctx, docRefKey1, "")
 		assert.NoError(t, err)
@@ -2029,7 +2029,7 @@ func RunIsDocumentAttachedOrAttachingTest(t *testing.T, db database.Database, pr
 		assert.True(t, attached)
 
 		// 02. Check if a document is attached after detaching another document
-		assert.NoError(t, c1.DetachDocument(docRefKey2.DocID))
+		assert.NoError(t, c1.DetachDocument(docRefKey2.DocID, 0))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c1, d2))
 		attached, err = db.IsDocumentAttachedOrAttaching(ctx, docRefKey2, "")
 		assert.NoError(t, err)
@@ -2039,7 +2039,7 @@ func RunIsDocumentAttachedOrAttachingTest(t *testing.T, db database.Database, pr
 		assert.True(t, attached)
 
 		// 03. Check if a document is attached after detaching remaining document
-		assert.NoError(t, c1.DetachDocument(docRefKey1.DocID))
+		assert.NoError(t, c1.DetachDocument(docRefKey1.DocID, 0))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c1, d1))
 		attached, err = db.IsDocumentAttachedOrAttaching(ctx, docRefKey1, "")
 		assert.NoError(t, err)
@@ -2086,7 +2086,7 @@ func RunIsDocumentAttachedOrAttachingTest(t *testing.T, db database.Database, pr
 		// Cleanup
 		c1, err = db.FindClientInfoByRefKey(ctx, c1.RefKey())
 		assert.NoError(t, err)
-		assert.NoError(t, c1.DetachDocument(docRefKey1.DocID))
+		assert.NoError(t, c1.DetachDocument(docRefKey1.DocID, 0))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c1, d1))
 	})
 
@@ -2118,7 +2118,7 @@ func RunIsDocumentAttachedOrAttachingTest(t *testing.T, db database.Database, pr
 		assert.False(t, attached)
 
 		// 03. Check if document is attached after detaching
-		assert.NoError(t, c1.DetachDocument(docRefKey1.DocID))
+		assert.NoError(t, c1.DetachDocument(docRefKey1.DocID, 0))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c1, d1))
 		attached, err = db.IsDocumentAttachedOrAttaching(ctx, docRefKey1, "")
 		assert.NoError(t, err)
@@ -2143,7 +2143,7 @@ func RunIsDocumentAttachedOrAttachingTest(t *testing.T, db database.Database, pr
 		assert.True(t, attached)
 
 		// 05. Check if document is attached after a client detaching
-		assert.NoError(t, c1.DetachDocument(docRefKey1.DocID))
+		assert.NoError(t, c1.DetachDocument(docRefKey1.DocID, 0))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c1, d1))
 		attached, err = db.IsDocumentAttachedOrAttaching(ctx, docRefKey1, "")
 		assert.NoError(t, err)
@@ -2156,7 +2156,7 @@ func RunIsDocumentAttachedOrAttachingTest(t *testing.T, db database.Database, pr
 		assert.False(t, attached)
 
 		// 06. Check if document is attached after another client detaching
-		assert.NoError(t, c2.DetachDocument(docRefKey1.DocID))
+		assert.NoError(t, c2.DetachDocument(docRefKey1.DocID, 0))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c2, d1))
 		attached, err = db.IsDocumentAttachedOrAttaching(ctx, docRefKey1, "")
 		assert.NoError(t, err)
@@ -2197,14 +2197,14 @@ func RunFindClientInfosByAttachedDocRefKeyTest(t *testing.T, db database.Databas
 		assert.Equal(t, clientInfo1.ID, clientInfos[0].ID)
 		assert.Equal(t, clientInfo2.ID, clientInfos[1].ID)
 
-		assert.NoError(t, clientInfo1.DetachDocument(docRefKey.DocID))
+		assert.NoError(t, clientInfo1.DetachDocument(docRefKey.DocID, 0))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo1, docInfo))
 		clientInfos, err = db.FindAttachedClientInfosByRefKey(ctx, docRefKey)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(clientInfos))
 		assert.Equal(t, clientInfo2.ID, clientInfos[0].ID)
 
-		assert.NoError(t, clientInfo2.DetachDocument(docRefKey.DocID))
+		assert.NoError(t, clientInfo2.DetachDocument(docRefKey.DocID, 0))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo2, docInfo))
 		clientInfos, err = db.FindAttachedClientInfosByRefKey(ctx, docRefKey)
 		assert.NoError(t, err)
@@ -2234,7 +2234,7 @@ func RunFindAttachedClientCountsByDocIDsTest(t *testing.T, db database.Database,
 			assert.Equal(t, 2, attachedMap[docInfo1.ID])
 			assert.Equal(t, 1, attachedMap[docInfo2.ID])
 		}
-		assert.NoError(t, clientInfo1.DetachDocument(docInfo1.ID))
+		assert.NoError(t, clientInfo1.DetachDocument(docInfo1.ID, 0))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo1, docInfo1))
 		{
 			attachedMap, err := db.FindAttachedClientCountsByDocIDs(ctx, projectID, []types.ID{docInfo1.ID})
@@ -2242,7 +2242,7 @@ func RunFindAttachedClientCountsByDocIDsTest(t *testing.T, db database.Database,
 			assert.Len(t, attachedMap, 1)
 			assert.Equal(t, 1, attachedMap[docInfo1.ID])
 		}
-		assert.NoError(t, clientInfo2.DetachDocument(docInfo1.ID))
+		assert.NoError(t, clientInfo2.DetachDocument(docInfo1.ID, 0))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo2, docInfo1))
 		{
 			attachedMap, err := db.FindAttachedClientCountsByDocIDs(ctx, projectID, []types.ID{docInfo1.ID, docInfo2.ID})

--- a/server/packs/pushpull.go
+++ b/server/packs/pushpull.go
@@ -309,6 +309,11 @@ func pullPack(
 	}
 
 	// 04. Find detached clients whose lamport is covered by minVV.
+	// The condition minVV[actorID] >= detachedLamport is idempotent, so
+	// detached_actors is sent to every client on each sync until the
+	// detached client is deactivated. This avoids the race where resetting
+	// DetachedLamport after one client's sync would cause other clients
+	// to miss the cleanup signal.
 	detachedClients, err := be.DB.FindDetachedClients(ctx, docInfo.RefKey())
 	if err != nil {
 		return nil, err
@@ -318,9 +323,6 @@ func pullPack(
 	for _, dc := range detachedClients {
 		if l, ok := minVersionVector.Get(dc.ActorID); ok && l >= dc.DetachedLamport {
 			detachedActors[dc.ActorID.String()] = dc.DetachedLamport
-			if err := be.DB.ResetDetachedLamport(ctx, dc.ClientID, docInfo.ID); err != nil {
-				return nil, err
-			}
 		}
 	}
 
@@ -443,7 +445,21 @@ func pullSnapshot(
 		}
 	}
 
-	snapshot, err := converter.SnapshotToBytes(doc.RootObject(), doc.AllPresences(), nil)
+	// Include detached actors in the snapshot so that clients restoring
+	// from it can augment VVs for previously cleaned-up actors.
+	detachedClients, err := be.DB.FindDetachedClients(ctx, docInfo.RefKey())
+	if err != nil {
+		return nil, err
+	}
+	var detachedActors map[time.ActorID]int64
+	if len(detachedClients) > 0 {
+		detachedActors = make(map[time.ActorID]int64)
+		for _, dc := range detachedClients {
+			detachedActors[dc.ActorID] = dc.DetachedLamport
+		}
+	}
+
+	snapshot, err := converter.SnapshotToBytes(doc.RootObject(), doc.AllPresences(), detachedActors)
 	if err != nil {
 		return nil, err
 	}

--- a/server/packs/pushpull.go
+++ b/server/packs/pushpull.go
@@ -307,6 +307,27 @@ func pullPack(
 	if resPack.SnapshotLen() == 0 {
 		resPack.VersionVector = minVersionVector
 	}
+
+	// 04. Find detached clients whose lamport is covered by minVV.
+	detachedClients, err := be.DB.FindDetachedClients(ctx, docInfo.RefKey())
+	if err != nil {
+		return nil, err
+	}
+
+	detachedActors := make(map[string]int64)
+	for _, dc := range detachedClients {
+		if l, ok := minVersionVector.Get(dc.ActorID); ok && l >= dc.DetachedLamport {
+			detachedActors[dc.ActorID.String()] = dc.DetachedLamport
+			if err := be.DB.ResetDetachedLamport(ctx, dc.ClientID, docInfo.ID); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if len(detachedActors) > 0 {
+		resPack.DetachedActors = detachedActors
+	}
+
 	if !clientInfo.IsServerClient() {
 		if err := be.DB.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo); err != nil {
 			return nil, err
@@ -422,7 +443,7 @@ func pullSnapshot(
 		}
 	}
 
-	snapshot, err := converter.SnapshotToBytes(doc.RootObject(), doc.AllPresences())
+	snapshot, err := converter.SnapshotToBytes(doc.RootObject(), doc.AllPresences(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/server/packs/pushpull.go
+++ b/server/packs/pushpull.go
@@ -295,7 +295,10 @@ func pullPack(
 	resPack.ApplyDocInfo(docInfo)
 
 	// 02. update the document's status in the client.
-	if err := clientInfo.UpdateDocStatus(docInfo.ID, opts.Status, resPack.Checkpoint, reqPack.VersionVector.MaxLamport()); err != nil {
+	maxLamport := reqPack.VersionVector.MaxLamport()
+	if err := clientInfo.UpdateDocStatus(
+		docInfo.ID, opts.Status, resPack.Checkpoint, maxLamport,
+	); err != nil {
 		return nil, err
 	}
 

--- a/server/packs/pushpull.go
+++ b/server/packs/pushpull.go
@@ -295,7 +295,7 @@ func pullPack(
 	resPack.ApplyDocInfo(docInfo)
 
 	// 02. update the document's status in the client.
-	if err := clientInfo.UpdateDocStatus(docInfo.ID, opts.Status, resPack.Checkpoint); err != nil {
+	if err := clientInfo.UpdateDocStatus(docInfo.ID, opts.Status, resPack.Checkpoint, reqPack.VersionVector.MaxLamport()); err != nil {
 		return nil, err
 	}
 

--- a/server/packs/serverpack.go
+++ b/server/packs/serverpack.go
@@ -49,6 +49,10 @@ type ServerPack struct {
 
 	// IsRemoved is a flag that indicates whether the document is removed.
 	IsRemoved bool
+
+	// DetachedActors is a map of actor IDs to their lamport at detach time.
+	// Server signals this when all clients have caught up.
+	DetachedActors map[string]int64
 }
 
 // NewServerPack creates a new instance of ServerPack.
@@ -132,6 +136,7 @@ func (p *ServerPack) ToPBChangePack() (*api.ChangePack, error) {
 	}
 
 	pbPack.VersionVector = pbVersionVector
+	pbPack.DetachedActors = p.DetachedActors
 
 	return pbPack, nil
 }

--- a/server/rpc/admin_server.go
+++ b/server/rpc/admin_server.go
@@ -557,7 +557,7 @@ func (s *adminServer) GetSnapshotMeta(
 		return nil, err
 	}
 
-	snapshot, err := converter.SnapshotToBytes(doc.RootObject(), doc.AllPresences())
+	snapshot, err := converter.SnapshotToBytes(doc.RootObject(), doc.AllPresences(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/test/bench/vv_bench_test.go
+++ b/test/bench/vv_bench_test.go
@@ -79,7 +79,7 @@ func benchmarkVV(b *testing.B, svr *server.Yorkie, clientCnt int) {
 		changePackSize := proto.Size(pbPack)
 		b.ReportMetric(float64(changePackSize), "1_changepack(bytes)")
 
-		snapshot, err := converter.SnapshotToBytes(d1.RootObject(), d1.AllPresences())
+		snapshot, err := converter.SnapshotToBytes(d1.RootObject(), d1.AllPresences(), nil)
 		assert.NoError(b, err)
 		snapshotSize := len(snapshot)
 		b.ReportMetric(float64(snapshotSize), "2_snapshot(bytes)")
@@ -126,7 +126,7 @@ func benchmarkVV(b *testing.B, svr *server.Yorkie, clientCnt int) {
 		changePackSize = proto.Size(pbPack)
 		b.ReportMetric(float64(changePackSize), "5_changepack_after_detach(bytes)")
 
-		snapshot, err = converter.SnapshotToBytes(dN1.RootObject(), dN1.AllPresences())
+		snapshot, err = converter.SnapshotToBytes(dN1.RootObject(), dN1.AllPresences(), nil)
 		assert.NoError(b, err)
 		snapshotSize = len(snapshot)
 		b.ReportMetric(float64(snapshotSize), "6_snapshot_after_detach(bytes)")

--- a/test/integration/vv_cleanup_test.go
+++ b/test/integration/vv_cleanup_test.go
@@ -1,0 +1,235 @@
+//go:build integration
+
+/*
+ * Copyright 2024 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/pkg/document"
+	"github.com/yorkie-team/yorkie/pkg/document/json"
+	"github.com/yorkie-team/yorkie/pkg/document/presence"
+	"github.com/yorkie-team/yorkie/test/helper"
+)
+
+func TestVVCleanupAfterDetach(t *testing.T) {
+	clients := activeClients(t, 2)
+	c1, c2 := clients[0], clients[1]
+	defer deactivateAndCloseClients(t, clients)
+
+	t.Run("detached client actor is removed from VV after sync", func(t *testing.T) {
+		ctx := context.Background()
+		d1 := document.New(helper.TestKey(t))
+		assert.NoError(t, c1.Attach(ctx, d1))
+
+		d2 := document.New(helper.TestKey(t))
+		assert.NoError(t, c2.Attach(ctx, d2))
+
+		// Both clients make edits so both actors appear in VVs.
+		assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetInteger("a", 1)
+			return nil
+		}, "c1 sets a"))
+
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+
+		assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetInteger("b", 2)
+			return nil
+		}, "c2 sets b"))
+
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c1.Sync(ctx))
+
+		// Verify both actors are in d1's VV before detach.
+		_, hasC2Before := d1.VersionVector().Get(d2.ActorID())
+		assert.True(t, hasC2Before, "c2 should be in d1's VV before detach")
+
+		// c2 detaches.
+		assert.NoError(t, c2.Detach(ctx, d2))
+
+		// c1 syncs — should receive detached_actors and remove c2 from VV.
+		assert.NoError(t, c1.Sync(ctx))
+
+		_, hasC2After := d1.VersionVector().Get(d2.ActorID())
+		assert.False(t, hasC2After, "c2 should be removed from d1's VV after detach + sync")
+
+		// c1 can still make edits and sync correctly.
+		assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetInteger("c", 3)
+			return nil
+		}, "c1 sets c after cleanup"))
+		assert.NoError(t, c1.Sync(ctx))
+
+		assert.Equal(t, `{"a":1,"b":2,"c":3}`, d1.Marshal())
+
+		assert.NoError(t, c1.Detach(ctx, d1))
+	})
+
+	t.Run("VV cleanup with three clients and one detach", func(t *testing.T) {
+		clients3 := activeClients(t, 3)
+		c1, c2, c3 := clients3[0], clients3[1], clients3[2]
+		defer deactivateAndCloseClients(t, clients3)
+
+		ctx := context.Background()
+		d1 := document.New(helper.TestKey(t))
+		d2 := document.New(helper.TestKey(t))
+		d3 := document.New(helper.TestKey(t))
+
+		assert.NoError(t, c1.Attach(ctx, d1))
+		assert.NoError(t, c2.Attach(ctx, d2))
+		assert.NoError(t, c3.Attach(ctx, d3))
+
+		// All clients make edits and sync.
+		assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetInteger("x", 1)
+			return nil
+		}))
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c3.Sync(ctx))
+
+		assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetInteger("y", 2)
+			return nil
+		}))
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c3.Sync(ctx))
+
+		// c3 detaches.
+		assert.NoError(t, c3.Detach(ctx, d3))
+
+		// c1 and c2 sync — both should eventually remove c3 from their VVs.
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+
+		_, hasC3InD1 := d1.VersionVector().Get(d3.ActorID())
+		assert.False(t, hasC3InD1, "c3 should be removed from d1's VV")
+
+		_, hasC3InD2 := d2.VersionVector().Get(d3.ActorID())
+		assert.False(t, hasC3InD2, "c3 should be removed from d2's VV")
+
+		// Remaining clients can still collaborate.
+		assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetInteger("z", 3)
+			return nil
+		}))
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+		assert.Equal(t, d1.Marshal(), d2.Marshal())
+
+		assert.NoError(t, c1.Detach(ctx, d1))
+		assert.NoError(t, c2.Detach(ctx, d2))
+	})
+}
+
+func TestGCAfterVVCleanup(t *testing.T) {
+	clients := activeClients(t, 2)
+	c1, c2 := clients[0], clients[1]
+	defer deactivateAndCloseClients(t, clients)
+
+	t.Run("GC works correctly after VV cleanup with augmented minVV", func(t *testing.T) {
+		ctx := context.Background()
+		d1 := document.New(helper.TestKey(t))
+		assert.NoError(t, c1.Attach(ctx, d1))
+
+		d2 := document.New(helper.TestKey(t))
+		assert.NoError(t, c2.Attach(ctx, d2))
+
+		// c1 creates elements and syncs.
+		assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetInteger("1", 1)
+			root.SetNewArray("2").AddInteger(1, 2, 3)
+			root.SetInteger("3", 3)
+			return nil
+		}, "sets 1,2,3"))
+
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+
+		// c1 deletes an element to create garbage.
+		assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.Delete("2")
+			return nil
+		}, "deletes 2"))
+		assert.Equal(t, 4, d1.GarbageLen())
+
+		assert.NoError(t, c1.Sync(ctx))
+
+		// c2 syncs to get the delete, then detaches.
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c2.Detach(ctx, d2))
+
+		// c1 syncs — receives detached_actors, VV cleanup happens.
+		assert.NoError(t, c1.Sync(ctx))
+
+		_, hasC2 := d1.VersionVector().Get(d2.ActorID())
+		assert.False(t, hasC2, "c2 should be removed from d1's VV after detach")
+
+		// c1 syncs again — GC should work with augmented minVV.
+		assert.NoError(t, c1.Sync(ctx))
+		assert.Equal(t, 0, d1.GarbageLen(), "garbage should be collected after VV cleanup")
+
+		assert.NoError(t, c1.Detach(ctx, d1))
+	})
+
+	t.Run("GC with text type after VV cleanup", func(t *testing.T) {
+		ctx := context.Background()
+		d1 := document.New(helper.TestKey(t))
+		assert.NoError(t, c1.Attach(ctx, d1))
+
+		d2 := document.New(helper.TestKey(t))
+		assert.NoError(t, c2.Attach(ctx, d2))
+
+		// c1 creates text and both sync.
+		assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewText("text").Edit(0, 0, "abc")
+			return nil
+		}, "sets text"))
+
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+
+		// c1 deletes text content to create garbage.
+		assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("text").Edit(0, 3, "")
+			return nil
+		}, "deletes text content"))
+		assert.Equal(t, 3, d1.GarbageLen())
+
+		assert.NoError(t, c1.Sync(ctx))
+
+		// c2 syncs to get the delete, then detaches.
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c2.Detach(ctx, d2))
+
+		// c1 syncs — receives detached_actors.
+		assert.NoError(t, c1.Sync(ctx))
+
+		// c1 syncs again — GC should collect the garbage nodes.
+		assert.NoError(t, c1.Sync(ctx))
+		assert.Equal(t, 0, d1.GarbageLen(), "text garbage should be collected after VV cleanup")
+
+		assert.NoError(t, c1.Detach(ctx, d1))
+	})
+}

--- a/test/integration/vv_cleanup_test.go
+++ b/test/integration/vv_cleanup_test.go
@@ -215,7 +215,7 @@ func TestGCAfterVVCleanup(t *testing.T) {
 			root.GetText("text").Edit(0, 3, "")
 			return nil
 		}, "deletes text content"))
-		assert.Equal(t, 3, d1.GarbageLen())
+		assert.Equal(t, 1, d1.GarbageLen())
 
 		assert.NoError(t, c1.Sync(ctx))
 


### PR DESCRIPTION
## Summary

- Remove detached clients' lamport entries from Version Vectors to stop VV from growing indefinitely
- Server signals `detached_actors` in ChangePack when `minVV[actorID] >= detachedLamport` for all attached clients
- Client stores detached actors, augments change VV for causality detection and minVV for GC
- Reuse existing `ClientDocInfo` with new `DetachedLamport` field instead of adding a new DB collection

## Changes

- **Proto**: Add `detached_actors` to `ChangePack` (field 8) and `Snapshot` (field 3)
- **DB**: Add `DetachedLamport` to `ClientDocInfo`, `FindDetachedClients`, `ResetDetachedLamport`
- **Server**: Compute and signal `detached_actors` in `pullPack`, include in snapshot
- **Converter**: Serialize/deserialize `detached_actors` in ChangePack and Snapshot
- **Client**: `detachedActors` map on Document, VV augmentation before execution and GC
- **Tests**: Integration tests for detach→cleanup cycle and GC, DB unit tests

## Design doc

`docs/design/vv-cleanup.md`

## Test plan

- [x] `make build` passes
- [x] `make lint` passes
- [x] Unit tests pass (`pkg/document/`, `api/converter/`, `server/backend/database/memory/`)
- [x] Integration tests compile (`go vet -tags integration`)
- [x] JS SDK integration tests pass (2006/2006) against this server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Snapshots and change packs now carry detached-actor info so server and clients can coordinate VV cleanup.

* **Improvements**
  * Version-vector cleanup for detached clients to bound VV growth and improve garbage-collection accuracy.
  * GC now considers detached-actor data to enable timely element removal after detach.

* **Tests**
  * Added integration tests validating VV cleanup and GC behavior post-detach.

* **Documentation**
  * Design and task plans updated for VV-cleanup rollout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->