### PR TITLE
Add shared secret authentication for ClusterService

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ output.txt
 
 # log files
 *.log
+
+# worktrees
+.worktrees

--- a/build/charts/yorkie-cluster/templates/yorkie/deployment.yaml
+++ b/build/charts/yorkie-cluster/templates/yorkie/deployment.yaml
@@ -88,6 +88,10 @@ spec:
           "--backend-rpc-addr",
           "$(POD_IP):{{ .Values.yorkie.ports.rpcPort }}",
           "--backend-use-default-project={{ .Values.yorkie.args.useDefaultProject }}",
+          {{- if .Values.yorkie.args.clusterSecret }}
+          "--cluster-secret",
+          "{{ .Values.yorkie.args.clusterSecret }}",
+          {{- end }}
           {{- if .Values.yorkie.logLevel }}
           "--log-level",
           "{{ .Values.yorkie.logLevel }}",

--- a/build/charts/yorkie-cluster/values.yaml
+++ b/build/charts/yorkie-cluster/values.yaml
@@ -17,6 +17,10 @@ yorkie:
     # Connection URI will be generated from mongodb.credentials.databaseAdmin values
     dbConnectionUri: ""
     dbName: yorkie-meta
+    # Shared secret for authenticating inter-node cluster RPCs.
+    # If empty, all requests are allowed.
+    # Generate with: openssl rand -base64 24
+    clusterSecret: ""
 
   ports:
     rpcPort: 8080

--- a/cluster/client.go
+++ b/cluster/client.go
@@ -411,7 +411,9 @@ func (a clusterAuthInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryF
 
 func (a clusterAuthInterceptor) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
 	return func(ctx context.Context, spec connect.Spec) connect.StreamingClientConn {
-		return next(ctx, spec)
+		conn := next(ctx, spec)
+		conn.RequestHeader().Set(clusterSecretHeader, a.secret)
+		return conn
 	}
 }
 

--- a/cluster/client.go
+++ b/cluster/client.go
@@ -64,6 +64,11 @@ func WithPoolSize(size int) Option {
 	return func(o *Options) { o.PoolSize = size }
 }
 
+// WithClusterSecret configures the shared secret for cluster authentication.
+func WithClusterSecret(secret string) Option {
+	return func(o *Options) { o.ClusterSecret = secret }
+}
+
 // Options configures how we set up the client.
 type Options struct {
 	// IsSecure is whether to enable the TLS connection of the client.
@@ -80,14 +85,20 @@ type Options struct {
 	// PoolSize is the number of connections per host in the pool.
 	// If zero, defaults to 1.
 	PoolSize int
+
+	// ClusterSecret is the shared secret for authenticating cluster RPCs.
+	ClusterSecret string
 }
+
+const clusterSecretHeader = "x-cluster-secret"
 
 // Client is a client for admin service.
 type Client struct {
-	conn       *http.Client
-	client     v1connect.ClusterServiceClient
-	isSecure   bool
-	rpcTimeout gotime.Duration
+	conn        *http.Client
+	client      v1connect.ClusterServiceClient
+	connectOpts []connect.ClientOption
+	isSecure    bool
+	rpcTimeout  gotime.Duration
 }
 
 // New creates an instance of Client.
@@ -121,10 +132,19 @@ func New(opts ...Option) (*Client, error) {
 		}
 	}
 
+	var connectOpts []connect.ClientOption
+	if options.ClusterSecret != "" {
+		secret := options.ClusterSecret
+		connectOpts = append(connectOpts, connect.WithInterceptors(
+			clusterAuthInterceptor{secret: secret},
+		))
+	}
+
 	return &Client{
-		conn:       conn,
-		isSecure:   options.IsSecure,
-		rpcTimeout: options.RPCTimeout,
+		conn:        conn,
+		connectOpts: connectOpts,
+		isSecure:    options.IsSecure,
+		rpcTimeout:  options.RPCTimeout,
 	}, nil
 }
 
@@ -152,7 +172,7 @@ func (c *Client) Dial(rpcAddr string) error {
 		}
 	}
 
-	c.client = v1connect.NewClusterServiceClient(c.conn, rpcAddr)
+	c.client = v1connect.NewClusterServiceClient(c.conn, rpcAddr, c.connectOpts...)
 
 	return nil
 }
@@ -374,6 +394,29 @@ func (c *Client) InvalidateCache(
 	}
 
 	return nil
+}
+
+// clusterAuthInterceptor is a connect client interceptor that attaches
+// the cluster secret header to every outgoing request.
+type clusterAuthInterceptor struct {
+	secret string
+}
+
+func (a clusterAuthInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		req.Header().Set(clusterSecretHeader, a.secret)
+		return next(ctx, req)
+	}
+}
+
+func (a clusterAuthInterceptor) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+	return func(ctx context.Context, spec connect.Spec) connect.StreamingClientConn {
+		return next(ctx, spec)
+	}
+}
+
+func (a clusterAuthInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+	return next
 }
 
 /**

--- a/cluster/client_test.go
+++ b/cluster/client_test.go
@@ -52,6 +52,12 @@ func TestOptions(t *testing.T) {
 		WithPoolSize(10)(&opts)
 		assert.Equal(t, 10, opts.PoolSize)
 	})
+
+	t.Run("WithClusterSecret sets cluster secret", func(t *testing.T) {
+		var opts Options
+		WithClusterSecret("my-secret")(&opts)
+		assert.Equal(t, "my-secret", opts.ClusterSecret)
+	})
 }
 
 func TestNew(t *testing.T) {

--- a/cmd/yorkie/server.go
+++ b/cmd/yorkie/server.go
@@ -602,5 +602,11 @@ func init() {
 		server.DefaultMaxConcurrentClusterRPCs,
 		"The maximum number of concurrent cluster RPC calls across the server.",
 	)
+	cmd.Flags().StringVar(
+		&conf.Backend.ClusterSecret,
+		"cluster-secret",
+		"",
+		"The shared secret for authenticating cluster RPC calls. If empty, all requests are allowed.",
+	)
 	rootCmd.AddCommand(cmd)
 }

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -37,6 +37,7 @@
 - [Document Epoch](document-epoch.md): Epoch-based detection and recovery for clients stale after compaction
 - [Fine-grained Document Locking](fine-grained-document-locking.md): Fine-grained document locking for high concurrency
 - [OLAP Stack for MAU Tracking](olap-stack.md): OLAP stack for Monthly Active Users (MAU) tracking
+- [Cluster Service Authentication](cluster-service-auth.md): Shared secret authentication for inter-node cluster RPCs
 
 ## Maintaining the Document
 

--- a/docs/design/cluster-service-auth.md
+++ b/docs/design/cluster-service-auth.md
@@ -1,0 +1,202 @@
+---
+title: cluster-service-auth
+target-version: 0.7.6
+---
+
+# Cluster Service Authentication
+
+## Problem
+
+ClusterService (`/yorkie.v1.ClusterService/*`) is designed for inter-node communication within the Yorkie cluster. However, it is registered on the same HTTP mux and port as YorkieService and AdminService (`server/rpc/server.go:82-85`), with no authentication in the interceptor (`server/rpc/interceptors/cluster.go`).
+
+In the current gateway-only Istio setup (no sidecar), both external and internal traffic flow through the same Istio Gateway:
+
+```
+External: Client → ALB → Istio Gateway (Envoy) → Yorkie Pod
+Internal: Yorkie Pod → Istio Gateway Service → Istio Gateway (Envoy) → Yorkie Pod
+```
+
+The VirtualService routes all `/yorkie.v1` prefixed paths, which includes ClusterService. Since external and internal requests share the same gateway, there is no infrastructure-level mechanism to distinguish them.
+
+This means anyone on the internet can call ClusterService RPCs such as `DetachDocument`, `PurgeDocument`, and `InvalidateCache` through `api.yorkie.dev`.
+
+Related: https://github.com/yorkie-team/yorkie/issues/1038
+
+### Goals
+
+- Block external access to ClusterService RPCs
+- Keep internal cluster communication working (both unicast via gateway and broadcast via Pod IP)
+- Minimal change scope: no gateway/Istio reconfiguration, no proto changes
+
+### Non-Goals
+
+- mTLS between cluster nodes (h2c is sufficient within VPC)
+- Secret rotation mechanism (can be added later)
+- Separating ClusterService to a different port
+
+## Design
+
+### Shared Secret Authentication
+
+All Yorkie nodes in the cluster share the same secret. The cluster client sends the secret in a request header, and the cluster interceptor validates it. Requests without a valid secret are rejected.
+
+### Configuration
+
+Add `ClusterSecret` to `backend.Config`:
+
+```go
+// ClusterSecret is the shared secret for authenticating inter-node
+// cluster RPCs. If empty, all requests are allowed.
+ClusterSecret string `yaml:"ClusterSecret"`
+```
+
+Add CLI flag `--cluster-secret` (follows existing `--cluster-*` naming):
+
+```go
+cmd.Flags().StringVar(
+    &conf.Backend.ClusterSecret,
+    "cluster-secret",
+    "",
+    "The shared secret for authenticating cluster RPC calls.",
+)
+```
+
+### Client Side (cluster/client.go)
+
+Store the secret in `Client` and attach it to every request via header:
+
+```go
+const clusterSecretHeader = "x-cluster-secret"
+
+type Client struct {
+    conn          *http.Client
+    client        v1connect.ClusterServiceClient
+    isSecure      bool
+    rpcTimeout    gotime.Duration
+    clusterSecret string
+}
+
+func WithClusterSecret(secret string) Option {
+    return func(o *Options) { o.ClusterSecret = secret }
+}
+```
+
+Each RPC method already builds a `connect.Request`. Add the header before calling:
+
+```go
+func (c *Client) withClusterSecret(req connect.AnyRequest) {
+    if c.clusterSecret != "" {
+        req.Header().Set(clusterSecretHeader, c.clusterSecret)
+    }
+}
+```
+
+### Server Side (server/rpc/interceptors/cluster.go)
+
+Add secret validation to `ClusterServiceInterceptor`:
+
+```go
+type ClusterServiceInterceptor struct {
+    backend       *backend.Backend
+    requestID     *requestID
+    clusterSecret string
+}
+
+func (i *ClusterServiceInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+    return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+        if !isClusterService(req.Spec().Procedure) {
+            return next(ctx, req)
+        }
+
+        if err := i.authenticate(req.Header()); err != nil {
+            return nil, err
+        }
+
+        // ... existing metrics logic
+    }
+}
+
+func (i *ClusterServiceInterceptor) authenticate(header http.Header) error {
+    if i.clusterSecret == "" {
+        return connect.NewError(connect.CodeUnauthenticated,
+            errors.New("invalid cluster secret"))
+    }
+
+    secret := header.Get(clusterSecretHeader)
+    if subtle.ConstantTimeCompare([]byte(secret), []byte(i.clusterSecret)) != 1 {
+        return connect.NewError(connect.CodeUnauthenticated,
+            errors.New("invalid cluster secret"))
+    }
+
+    return nil
+}
+```
+
+Key details:
+- Use `crypto/subtle.ConstantTimeCompare` to prevent timing attacks
+- If `ClusterSecret` is empty, allow all requests (backward compatible)
+- Apply to both `WrapUnary` and `WrapStreamingHandler`
+
+### Helm Chart (build/charts/yorkie-cluster)
+
+Pass `clusterSecret` in `values.yaml`. If set, the value is passed as `--cluster-secret` in the Deployment args. If empty, the flag is omitted and all ClusterService requests are allowed.
+
+```yaml
+yorkie:
+  args:
+    # Generate with: openssl rand -base64 24
+    clusterSecret: "<value>"
+```
+
+### Wiring
+
+`ClusterServiceInterceptor` receives the secret from `backend.Config`:
+
+```go
+// server/rpc/server.go
+clusterInterceptor := interceptors.NewClusterServiceInterceptor(be)
+```
+
+`ClusterClientPool` passes the secret when creating clients:
+
+```go
+// server/backend/backend.go
+cluster.WithClusterSecret(b.Config.ClusterSecret)
+```
+
+### Single-Node Mode
+
+When running a single Yorkie server (no cluster), `ClusterSecret` is empty by default. The interceptor allows all requests when the secret is empty, maintaining backward compatibility with existing deployments.
+
+### Risks and Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| Secret transmitted in plaintext over h2c | Acceptable within VPC. If cross-VPC communication is needed, enable TLS with `--cluster-secure` (already exists) |
+| Secret leaked in logs or error messages | Never log the secret value. Error messages say "invalid cluster secret", not the actual value |
+| All nodes must share the same secret | Single config value in Helm values.yaml, deployed uniformly via ArgoCD |
+| Empty secret allows all requests | Backward compatible. Operators must set a secret in production to enable authentication |
+
+### Design Decisions
+
+| Decision | Reason |
+|----------|--------|
+| Shared secret over mTLS | mTLS requires certificate management infrastructure. Shared secret is simple and sufficient for same-VPC communication |
+| Header-based over metadata-based | Connect RPC uses HTTP headers. Consistent with existing `x-shard-key` pattern |
+| Allow when secret is empty | Backward compatible with existing deployments. Operators opt in to authentication by setting a secret |
+| Constant-time comparison | Prevents timing side-channel attacks on the secret |
+| No VirtualService changes needed | Authentication at server level works regardless of gateway topology. No coupling to Istio configuration |
+
+## Alternatives Considered
+
+| Alternative | Why not |
+|-------------|---------|
+| VirtualService path blocking | Internal unicast also goes through the gateway, so it would block cluster communication too |
+| Istio AuthorizationPolicy with source IP | Pod CIDR is dynamic. Fragile and breaks on node scaling |
+| Separate port for ClusterService | Requires Helm chart, Service, and Istio changes. Much larger scope for the same result |
+| mTLS between nodes | Certificate provisioning and rotation adds operational complexity. Overkill for same-VPC |
+| API key per node | Unnecessary complexity. Nodes are homogeneous and trusted equally |
+
+## Tasks
+
+Track execution plans in `docs/tasks/active/` as separate task documents.

--- a/docs/design/cluster-service-auth.md
+++ b/docs/design/cluster-service-auth.md
@@ -11,7 +11,7 @@ ClusterService (`/yorkie.v1.ClusterService/*`) is designed for inter-node commun
 
 In the current gateway-only Istio setup (no sidecar), both external and internal traffic flow through the same Istio Gateway:
 
-```
+```text
 External: Client → ALB → Istio Gateway (Envoy) → Yorkie Pod
 Internal: Yorkie Pod → Istio Gateway Service → Istio Gateway (Envoy) → Yorkie Pod
 ```
@@ -118,8 +118,7 @@ func (i *ClusterServiceInterceptor) WrapUnary(next connect.UnaryFunc) connect.Un
 
 func (i *ClusterServiceInterceptor) authenticate(header http.Header) error {
     if i.clusterSecret == "" {
-        return connect.NewError(connect.CodeUnauthenticated,
-            errors.New("invalid cluster secret"))
+        return nil
     }
 
     secret := header.Get(clusterSecretHeader)
@@ -154,7 +153,7 @@ yorkie:
 
 ```go
 // server/rpc/server.go
-clusterInterceptor := interceptors.NewClusterServiceInterceptor(be)
+clusterInterceptor := interceptors.NewClusterServiceInterceptor(be, be.Config.ClusterSecret)
 ```
 
 `ClusterClientPool` passes the secret when creating clients:

--- a/server/backend/backend.go
+++ b/server/backend/backend.go
@@ -134,6 +134,7 @@ func New(
 		cluster.WithRPCTimeout(conf.ParseClusterRPCTimeout()),
 		cluster.WithClientTimeout(conf.ParseClusterClientTimeout()),
 		cluster.WithPoolSize(conf.ClusterClientPoolSize),
+		cluster.WithClusterSecret(conf.ClusterSecret),
 	)
 
 	// 04. Create the database instance. If the MongoDB configuration is given,

--- a/server/backend/config.go
+++ b/server/backend/config.go
@@ -104,6 +104,10 @@ type Config struct {
 	// RPC calls across the entire server. This prevents goroutine explosion
 	// when a cluster peer is slow or unresponsive. Default is 5000.
 	MaxConcurrentClusterRPCs int `yaml:"MaxConcurrentClusterRPCs"`
+
+	// ClusterSecret is the shared secret for authenticating inter-node
+	// cluster RPCs. If empty, all requests are allowed.
+	ClusterSecret string `yaml:"ClusterSecret"`
 }
 
 // Validate validates this config.

--- a/server/config.sample.yml
+++ b/server/config.sample.yml
@@ -107,6 +107,10 @@ Backend:
   # GatewayAddr is the address of the gateway server.
   GatewayAddr: "localhost:8080"
 
+  # ClusterSecret is the shared secret for authenticating inter-node
+  # cluster RPCs. If empty, all requests are allowed.
+  ClusterSecret: ""
+
 # Mongo is the MongoDB configuration (Optional).
 Mongo:
   # ConnectionTimeout is the timeout for connecting to MongoDB.

--- a/server/rpc/interceptors/cluster.go
+++ b/server/rpc/interceptors/cluster.go
@@ -18,6 +18,9 @@ package interceptors
 
 import (
 	"context"
+	"crypto/subtle"
+	"errors"
+	"net/http"
 	"strings"
 	gotime "time"
 
@@ -28,6 +31,8 @@ import (
 	"github.com/yorkie-team/yorkie/server/rpc/connecthelper"
 )
 
+const clusterSecretHeader = "x-cluster-secret"
+
 func isClusterService(method string) bool {
 	return strings.HasPrefix(method, "/yorkie.v1.ClusterService/")
 }
@@ -35,16 +40,34 @@ func isClusterService(method string) bool {
 // ClusterServiceInterceptor is an interceptor for building additional context
 // and handling metrics for server-to-server communication via ClusterService.
 type ClusterServiceInterceptor struct {
-	backend   *backend.Backend
-	requestID *requestID
+	backend       *backend.Backend
+	requestID     *requestID
+	clusterSecret string
 }
 
 // NewClusterServiceInterceptor creates a new instance of ClusterServiceInterceptor.
-func NewClusterServiceInterceptor(be *backend.Backend) *ClusterServiceInterceptor {
+func NewClusterServiceInterceptor(be *backend.Backend, clusterSecret string) *ClusterServiceInterceptor {
 	return &ClusterServiceInterceptor{
-		backend:   be,
-		requestID: newRequestID("c"),
+		backend:       be,
+		requestID:     newRequestID("c"),
+		clusterSecret: clusterSecret,
 	}
+}
+
+// authenticate validates the cluster secret from the request header.
+// If no secret is configured, all requests are allowed for backward compatibility.
+func (i *ClusterServiceInterceptor) authenticate(header http.Header) error {
+	if i.clusterSecret == "" {
+		return nil
+	}
+
+	secret := header.Get(clusterSecretHeader)
+	if subtle.ConstantTimeCompare([]byte(secret), []byte(i.clusterSecret)) != 1 {
+		return connect.NewError(connect.CodeUnauthenticated,
+			errors.New("invalid cluster secret"))
+	}
+
+	return nil
 }
 
 // WrapUnary creates a unary server interceptor for building additional context
@@ -56,6 +79,10 @@ func (i *ClusterServiceInterceptor) WrapUnary(next connect.UnaryFunc) connect.Un
 	) (connect.AnyResponse, error) {
 		if !isClusterService(req.Spec().Procedure) {
 			return next(ctx, req)
+		}
+
+		if err := i.authenticate(req.Header()); err != nil {
+			return nil, err
 		}
 
 		start := gotime.Now()
@@ -102,6 +129,10 @@ func (i *ClusterServiceInterceptor) WrapStreamingHandler(
 	) error {
 		if !isClusterService(conn.Spec().Procedure) {
 			return next(ctx, conn)
+		}
+
+		if err := i.authenticate(conn.RequestHeader()); err != nil {
+			return err
 		}
 
 		ctx = i.buildContext(ctx)

--- a/server/rpc/interceptors/cluster_test.go
+++ b/server/rpc/interceptors/cluster_test.go
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interceptors
+
+import (
+	"net/http"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClusterServiceAuthenticate(t *testing.T) {
+	t.Run("valid secret passes", func(t *testing.T) {
+		interceptor := &ClusterServiceInterceptor{
+			clusterSecret: "test-secret",
+		}
+
+		header := http.Header{}
+		header.Set(clusterSecretHeader, "test-secret")
+
+		err := interceptor.authenticate(header)
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid secret is rejected", func(t *testing.T) {
+		interceptor := &ClusterServiceInterceptor{
+			clusterSecret: "test-secret",
+		}
+
+		header := http.Header{}
+		header.Set(clusterSecretHeader, "wrong-secret")
+
+		err := interceptor.authenticate(header)
+		assert.Error(t, err)
+
+		var connectErr *connect.Error
+		assert.ErrorAs(t, err, &connectErr)
+		assert.Equal(t, connect.CodeUnauthenticated, connectErr.Code())
+		assert.Contains(t, connectErr.Message(), "invalid cluster secret")
+	})
+
+	t.Run("missing secret header is rejected", func(t *testing.T) {
+		interceptor := &ClusterServiceInterceptor{
+			clusterSecret: "test-secret",
+		}
+
+		header := http.Header{}
+
+		err := interceptor.authenticate(header)
+		assert.Error(t, err)
+
+		var connectErr *connect.Error
+		assert.ErrorAs(t, err, &connectErr)
+		assert.Equal(t, connect.CodeUnauthenticated, connectErr.Code())
+	})
+
+	t.Run("empty cluster secret allows all requests", func(t *testing.T) {
+		interceptor := &ClusterServiceInterceptor{
+			clusterSecret: "",
+		}
+
+		header := http.Header{}
+		header.Set(clusterSecretHeader, "any-secret")
+
+		err := interceptor.authenticate(header)
+		assert.NoError(t, err)
+	})
+
+	t.Run("empty cluster secret allows requests without header", func(t *testing.T) {
+		interceptor := &ClusterServiceInterceptor{
+			clusterSecret: "",
+		}
+
+		header := http.Header{}
+
+		err := interceptor.authenticate(header)
+		assert.NoError(t, err)
+	})
+}

--- a/server/rpc/interceptors/cluster_test.go
+++ b/server/rpc/interceptors/cluster_test.go
@@ -22,6 +22,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestClusterServiceAuthenticate(t *testing.T) {
@@ -49,7 +50,7 @@ func TestClusterServiceAuthenticate(t *testing.T) {
 		assert.Error(t, err)
 
 		var connectErr *connect.Error
-		assert.ErrorAs(t, err, &connectErr)
+		require.ErrorAs(t, err, &connectErr)
 		assert.Equal(t, connect.CodeUnauthenticated, connectErr.Code())
 		assert.Contains(t, connectErr.Message(), "invalid cluster secret")
 	})
@@ -65,7 +66,7 @@ func TestClusterServiceAuthenticate(t *testing.T) {
 		assert.Error(t, err)
 
 		var connectErr *connect.Error
-		assert.ErrorAs(t, err, &connectErr)
+		require.ErrorAs(t, err, &connectErr)
 		assert.Equal(t, connect.CodeUnauthenticated, connectErr.Code())
 	})
 

--- a/server/rpc/server.go
+++ b/server/rpc/server.go
@@ -57,7 +57,7 @@ func NewServer(conf *Config, be *backend.Backend) (*Server, error) {
 
 	yorkieInterceptor := interceptors.NewYorkieServiceInterceptor(be)
 	adminInterceptor := interceptors.NewAdminServiceInterceptor(be, tokenManager)
-	clusterInterceptor := interceptors.NewClusterServiceInterceptor(be)
+	clusterInterceptor := interceptors.NewClusterServiceInterceptor(be, be.Config.ClusterSecret)
 	defaultInterceptor := interceptors.NewDefaultInterceptor()
 
 	opts := []connect.HandlerOption{
@@ -77,8 +77,6 @@ func NewServer(conf *Config, be *backend.Backend) (*Server, error) {
 
 	yorkieServiceCtx, yorkieServiceCancel := context.WithCancel(context.Background())
 
-	// TODO(hackerwins): We need to block incoming requests to the cluster service,
-	// because the cluster service is for internal communication between Yorkie nodes.
 	mux := http.NewServeMux()
 	mux.Handle(v1connect.NewYorkieServiceHandler(newYorkieServer(yorkieServiceCtx, be), opts...))
 	mux.Handle(v1connect.NewAdminServiceHandler(newAdminServer(be, tokenManager, yorkieInterceptor), opts...))


### PR DESCRIPTION
## Summary

- Add optional shared secret authentication for ClusterService RPCs via `--cluster-secret` flag and `x-cluster-secret` header
- When set, the interceptor validates the header using constant-time comparison; when empty, all requests are allowed for backward compatibility
- Includes Helm chart support (`yorkie.args.clusterSecret` in values.yaml) and design document

## Motivation

ClusterService (`/yorkie.v1.ClusterService/*`) is for inter-node communication but is exposed on the same port as YorkieService and AdminService. In the gateway-only Istio setup, external and internal traffic share the same gateway, so there's no infra-level way to distinguish them. This allows external callers to invoke sensitive RPCs like `DetachDocument` and `PurgeDocument`.

Related: #1038

## Changes

- `server/backend/config.go`: Add `ClusterSecret` field
- `cmd/yorkie/server.go`: Add `--cluster-secret` CLI flag
- `server/rpc/interceptors/cluster.go`: Add `authenticate()` with `subtle.ConstantTimeCompare`
- `cluster/client.go`: Add connect client interceptor for automatic header injection
- `server/backend/backend.go`: Wire secret to cluster client pool
- `build/charts/yorkie-cluster/`: Add `clusterSecret` to values and deployment template
- `docs/design/cluster-service-auth.md`: Design document
- `server/rpc/interceptors/cluster_test.go`: Unit tests

## Test plan

- [x] Unit tests: valid/invalid/missing secret, empty secret allows all
- [x] Build passes
- [x] Minikube validation:
  - Without secret → `unauthenticated`
  - With wrong secret → `unauthenticated`
  - With correct secret → `success`
  - YorkieService unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional shared-secret authentication for inter-node cluster RPCs; clients attach the secret and servers validate it.
  * New CLI flag and configuration option to set the cluster secret; Helm chart and deployment args support passing the secret.

* **Documentation**
  * Added design doc and index entry describing cluster service authentication.

* **Tests**
  * Added unit tests covering secret handling and enforcement.

* **Chores**
  * Updated ignore rules to exclude local worktree directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->