### PR TITLE
fix(yson): support IntegerDedupCnt in Counter marshal/parse/grammar

### DIFF
--- a/pkg/document/yson/yson.go
+++ b/pkg/document/yson/yson.go
@@ -190,6 +190,8 @@ func (y Counter) Marshal() (string, error) {
 		return fmt.Sprintf("Counter(Int(%v))", y.Value), nil
 	case crdt.LongCnt:
 		return fmt.Sprintf("Counter(Long(%v))", y.Value), nil
+	case crdt.IntegerDedupCnt:
+		return fmt.Sprintf("DedupCounter(Int(%v))", y.Value), nil
 	default:
 		return "", fmt.Errorf("marshal counter: %w", ErrUnsupported)
 	}
@@ -305,7 +307,9 @@ func Unmarshal(data string, elem Element) error {
 		}
 
 	case *Counter:
-		counter, err := parseCounter(raw.(map[string]interface{}))
+		rawMap := raw.(map[string]interface{})
+		outerType, _ := rawMap["type"].(string)
+		counter, err := parseCounter(rawMap, outerType)
 		if err != nil {
 			return err
 		}
@@ -343,7 +347,9 @@ func parseTypedValue(raw map[string]interface{}) (interface{}, error) {
 
 		return val, nil
 	case "Counter":
-		return parseCounter(raw)
+		return parseCounter(raw, "Counter")
+	case "DedupCounter":
+		return parseCounter(raw, "DedupCounter")
 	case "Tree":
 		if value, ok := raw["value"].(map[string]interface{}); ok {
 			return parseTree(value)
@@ -426,15 +432,23 @@ func parseArray(raw []interface{}) (Array, error) {
 	return arr, nil
 }
 
-func parseCounter(raw map[string]interface{}) (Counter, error) {
+func parseCounter(raw map[string]interface{}, outerType string) (Counter, error) {
+	dedup := outerType == "DedupCounter"
 	counter := Counter{}
 	if value, ok := raw["value"].(map[string]interface{}); ok {
 		if t, ok := value["type"].(string); ok {
 			switch t {
 			case "Int":
-				counter.Type = crdt.IntegerCnt
+				if dedup {
+					counter.Type = crdt.IntegerDedupCnt
+				} else {
+					counter.Type = crdt.IntegerCnt
+				}
 				counter.Value = int32(value["value"].(float64))
 			case "Long":
+				// NOTE: LongDedupCnt not yet defined in crdt package;
+				// fall back to LongCnt for now. A follow-up change should
+				// add LongDedupCnt if dedup support is extended to int64.
 				counter.Type = crdt.LongCnt
 				counter.Value = int64(value["value"].(float64))
 			default:
@@ -531,6 +545,10 @@ func preprocessTypeValues(data string) string {
 		{`Tree()`, `{"type":"Tree","value":{}}`},
 
 		// Process constructors with values
+		// NOTE: DedupCounter must come before Counter since "DedupCounter"
+		// contains "Counter" as a substring — otherwise ReplaceAll would
+		// rewrite the inner occurrence first and corrupt the grammar.
+		{`DedupCounter(`, `{"type":"DedupCounter","value":`},
 		{`Counter(`, `{"type":"Counter","value":`},
 		{`Text(`, `{"type":"Text","value":`},
 		{`Tree(`, `{"type":"Tree","value":`},

--- a/pkg/document/yson/yson_test.go
+++ b/pkg/document/yson/yson_test.go
@@ -244,6 +244,7 @@ func TestYSONMarshal(t *testing.T) {
 			"key6": []byte{1, 2, 3},
 			"key7": gotime.Date(2025, 1, 2, 15, 4, 5, 58000000, gotime.UTC),
 			"key8": yson.Counter{Type: crdt.IntegerCnt, Value: int32(10)},
+			"keyd": yson.Counter{Type: crdt.IntegerDedupCnt, Value: int32(3)},
 			"key9": yson.Tree{
 				Root: yson.TreeNode{
 					Type:     "p",
@@ -266,6 +267,7 @@ func TestYSONMarshal(t *testing.T) {
 			"key6": BinData("AQID"),
 			"key7": Date("2025-01-02T15:04:05.058Z"),
 			"key8": Counter(Int(10)),
+			"keyd": DedupCounter(Int(3)),
 			"key9": Tree({"type":"p","children":[{"type":"text","value":"Tree in object"}]})
 		}`, &expected))
 		assert.Equal(t, expected, actual)
@@ -283,6 +285,7 @@ func TestYSONMarshal(t *testing.T) {
 			gotime.Date(2025, 1, 2, 15, 4, 5, 58000000, gotime.UTC),
 			yson.Counter{Type: crdt.IntegerCnt, Value: int32(32)},
 			yson.Counter{Type: crdt.LongCnt, Value: int64(64)},
+			yson.Counter{Type: crdt.IntegerDedupCnt, Value: int32(7)},
 			yson.Array{"nested", int64(1)},
 			yson.Object{"nested": "nest-obj"},
 			yson.Tree{
@@ -315,6 +318,7 @@ func TestYSONMarshal(t *testing.T) {
             Date("2025-01-02T15:04:05.058Z"),
             Counter(Int(32)),
             Counter(Long(64)),
+            DedupCounter(Int(7)),
             ["nested",Long(1)],
             {"nested":"nest-obj"},
             Tree({"type":"p","children":[{"type":"text","value":"Tree in array"}]}),
@@ -333,6 +337,22 @@ func TestYSONMarshal(t *testing.T) {
 		expected := yson.Counter{}
 		assert.NoError(t, yson.Unmarshal(`Counter(Long(100))`, &expected))
 		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("dedup counter marshal/unmarshal test", func(t *testing.T) {
+		// Regression guard for #1773: Counter.Marshal() and parseCounter()
+		// must round-trip IntegerDedupCnt values via DedupCounter(Int(N)).
+		counter := yson.Counter{Type: crdt.IntegerDedupCnt, Value: int32(42)}
+		actual := yson.Counter{}
+		marshalled, err := counter.Marshal()
+		assert.NoError(t, err)
+		assert.Equal(t, `DedupCounter(Int(42))`, marshalled)
+		assert.NoError(t, yson.Unmarshal(marshalled, &actual))
+
+		expected := yson.Counter{}
+		assert.NoError(t, yson.Unmarshal(`DedupCounter(Int(42))`, &expected))
+		assert.Equal(t, expected, actual)
+		assert.Equal(t, crdt.IntegerDedupCnt, actual.Type)
 	})
 
 	t.Run("text marshal/unmarshal test", func(t *testing.T) {

--- a/test/integration/counter_dedup_snapshot_test.go
+++ b/test/integration/counter_dedup_snapshot_test.go
@@ -1,0 +1,125 @@
+//go:build integration
+
+/*
+ * Repro test: dedup counter + snapshot interaction.
+ *
+ * Exercises the background storeSnapshot / storeRevision paths that
+ * process Documents containing IntegerDedupCnt. Two failure modes:
+ *   1. storeRevision → yson.go Counter.Marshal lacks dedup case
+ *      → "marshal counter: unsupported element"
+ *   2. storeSnapshot → doc.ApplyChangePack replays ops on loaded snapshot
+ *      → if the HLL state in the snapshot isn't restored correctly, the
+ *        next Increase op fails → "not applicable datatype"
+ *
+ * Both variants produce a silent server-side error (background goroutine)
+ * while client API returns success.
+ */
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/pkg/document"
+	"github.com/yorkie-team/yorkie/pkg/document/json"
+	"github.com/yorkie-team/yorkie/pkg/document/presence"
+	"github.com/yorkie-team/yorkie/test/helper"
+)
+
+// Variant 1: single client, many changes → triggers storeRevision path.
+func TestCounterDedupSnapshotReproSingleClient(t *testing.T) {
+	clients := activeClients(t, 2)
+	c1, c2 := clients[0], clients[1]
+	defer deactivateAndCloseClients(t, clients)
+
+	ctx := context.Background()
+	d1 := document.New(helper.TestKey(t))
+	assert.NoError(t, c1.Attach(ctx, d1))
+
+	const actors = 15
+	for i := 0; i < actors; i++ {
+		actor := fmt.Sprintf("user-%d", i)
+		err := d1.Update(func(root *json.Object, p *presence.Presence) error {
+			if i == 0 {
+				root.SetNewDedupCounter("uv").Add(actor)
+			} else {
+				root.GetCounter("uv").Add(actor)
+			}
+			return nil
+		}, fmt.Sprintf("add %s", actor))
+		assert.NoError(t, err)
+	}
+	assert.NoError(t, c1.Sync(ctx))
+
+	time.Sleep(2 * time.Second)
+
+	d2 := document.New(helper.TestKey(t))
+	assert.NoError(t, c2.Attach(ctx, d2))
+	assert.Equal(t, fmt.Sprintf(`{"uv":%d}`, actors), d2.Marshal())
+}
+
+// Variant 2: concurrent clients, each adding a distinct actor → triggers
+// the storeSnapshot replay path that references HLL state.
+func TestCounterDedupSnapshotReproConcurrent(t *testing.T) {
+	const N = 4     // concurrent clients
+	const perVu = 8 // each client adds 8 distinct actors
+	clients := activeClients(t, N+1)
+	verifier := clients[N]
+	defer deactivateAndCloseClients(t, clients)
+
+	ctx := context.Background()
+	docKey := helper.TestKey(t)
+
+	// Stage 1: one writer creates the dedup counter, syncs.
+	seed := document.New(docKey)
+	assert.NoError(t, clients[0].Attach(ctx, seed))
+	assert.NoError(t, seed.Update(func(root *json.Object, p *presence.Presence) error {
+		root.SetNewDedupCounter("uv").Add("seed")
+		return nil
+	}, "seed"))
+	assert.NoError(t, clients[0].Sync(ctx))
+
+	// Stage 2: N-1 more clients attach and concurrently add distinct actors.
+	docs := make([]*document.Document, N)
+	docs[0] = seed
+	for i := 1; i < N; i++ {
+		d := document.New(docKey)
+		assert.NoError(t, clients[i].Attach(ctx, d))
+		docs[i] = d
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(vu int) {
+			defer wg.Done()
+			for j := 0; j < perVu; j++ {
+				actor := fmt.Sprintf("user-%d-%d", vu, j)
+				err := docs[vu].Update(func(root *json.Object, p *presence.Presence) error {
+					root.GetCounter("uv").Add(actor)
+					return nil
+				}, actor)
+				assert.NoError(t, err)
+				assert.NoError(t, clients[vu].Sync(ctx))
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Stage 3: wait for background snapshot/revision goroutines to run.
+	time.Sleep(3 * time.Second)
+
+	// Stage 4: fresh client attaches — exercises server snapshot load/replay.
+	vDoc := document.New(docKey)
+	assert.NoError(t, verifier.Attach(ctx, vDoc))
+
+	// Expected = 1 (seed) + N*perVu distinct actors = 1 + 4*8 = 33
+	expected := 1 + N*perVu
+	assert.Equal(t, fmt.Sprintf(`{"uv":%d}`, expected), vDoc.Marshal())
+}


### PR DESCRIPTION
## What this PR does

Adds `crdt.IntegerDedupCnt` handling to `pkg/document/yson`. Before this
patch, any background code path that marshaled the document root via
YSON would fail silently for documents containing a dedup counter,
flooding server logs with `marshal counter: unsupported element`.

This addresses **Part 1** of #1773. See the issue for full
context, production impact, and the scope of Part 2 (not addressed
here — requires design discussion around HLL register preservation).

## Changes

Three YSON sites previously covered only `IntegerCnt` / `LongCnt`. All
three now also handle `IntegerDedupCnt`:

- **`Counter.Marshal()`** — emits `DedupCounter(Int(N))` for dedup.
- **`parseTypedValue()`** — dispatches `"DedupCounter"` type.
- **`parseCounter()`** — accepts `outerType string` to construct
  `IntegerDedupCnt` when the outer token is `DedupCounter`.
- **`preprocessTypeValues()`** — adds `DedupCounter(` to the YSON-text
  grammar table. It is placed **before** the existing `Counter(` entry
  because `DedupCounter` has `Counter` as a substring; reversing the
  order would cause `ReplaceAll` to rewrite the inner occurrence first
  and corrupt the grammar.

`LongDedupCnt` is not yet defined in the crdt package; this patch
covers only `Int`. Extending to `Long` is a single additional `switch`
case when `LongDedupCnt` lands.

## Tests

**Unit** — `pkg/document/yson/yson_test.go`:

- `TestYSONMarshal` object subtest: added `IntegerDedupCnt` entry and
  its YSON-text counterpart.
- `TestYSONMarshal` array subtest: added `IntegerDedupCnt` entry and
  its YSON-text counterpart.
- New `TestYSONMarshal` "dedup counter marshal/unmarshal test" subtest
  asserting the explicit round-trip form `DedupCounter(Int(42))` and
  that the decoded `Counter.Type` equals `crdt.IntegerDedupCnt`.

These fail without the fix with `ErrUnsupported` and pass after.

**Integration** — `test/integration/counter_dedup_snapshot_test.go`
(new file, build tag `integration`):

- `TestCounterDedupSnapshotReproSingleClient` — 15 adds against a
  dedup counter (> `helper.SnapshotThreshold = 10`) to force the
  background snapshot / revision goroutine. Asserts client-visible
  state is correct and a fresh client attaches successfully.
- `TestCounterDedupSnapshotReproConcurrent` — N concurrent clients each
  adding 8 distinct actors to the same doc. Exercises the background
  path under contention and verifies convergence for a verifier client.

Before this patch these tests still PASS at the client level but the
server logs `store revision of Document ... : marshal counter: unsupported element`
on every run. After this patch the log contains only the expected
`SNAP:` and `REV:` INFO lines.

(The concurrent test additionally surfaces `CompactDocument` warnings
— `content mismatch after rebuild` — which are caused by a separate
issue outside this PR's scope. See "Out of scope" below.)

## How to verify locally

```bash
# Unit
go test ./pkg/document/yson/...

# Integration (requires a MongoDB reachable at the test default URI)
go test -tags integration ./test/integration/ \
    -run "TestCounterDedup|TestYSONMarshal" -v -count=1
```

Expected: all tests PASS, no `ERROR` lines in the server log for the
new tests.

## Out of scope (tracked by Part 2 of #1773)

This patch preserves only the counter's derived `Value` across YSON
round-trip. The HLL register bitmap is not represented in YSON, which
means:

- **`CompactDocument` rebuild-compare fails for dedup docs.** The
  invariant check at `server/packs/compaction.go:105` fails because
  `crdt.NewCounter(IntegerDedupCnt, N, …)` ignores the passed value
  and initializes the counter with empty HLL state. Housekeeping
  auto-compaction silently skips these docs — safe, but changes keep
  accumulating.
- **Revision restore cannot recover dedup history.** The counter's
  count value is restored, but previously-deduplicated actors would be
  counted again on subsequent `Add`.

These require a YSON format change (add `Registers []byte` to
`yson.Counter`) or a strategy change (bypass YSON for dedup in the
compaction invariant). Rather than bundle them into this PR, the
discussion is kept in the linked issue under Part 2.

## Backward compatibility

Existing YSON outputs never contained `DedupCounter(...)` — under the
pre-patch code, any attempt to marshal a dedup counter returned
`ErrUnsupported` before producing output, so no stored revision in the
wild uses the new token. Introducing it is therefore non-breaking for
existing data.

The `parseCounter` signature changes from
`parseCounter(raw) → Counter` to
`parseCounter(raw, outerType string) → Counter`. This function is
unexported, so no external callers are affected.

## Closes

Issue #1773 — Part 1 only. Part 2 remains open for design
discussion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for serializing and deserializing deduplicated integer counters with proper type handling and round-trip conversion.

* **Tests**
  * Extended test coverage with regression and integration tests validating deduplicated counter behavior during snapshots and concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->