### PR TITLE
Fix splitLevel>=2 concurrent convergence (Fixes 13-18)

### DIFF
--- a/api/converter/converter_test.go
+++ b/api/converter/converter_test.go
@@ -399,7 +399,7 @@ func TestConverter(t *testing.T) {
 	})
 
 	// Sibling regression test covering the merge-merge overlap path
-	// (Fix 4 — mergedInto forwarding) across a snapshot roundtrip.
+	// (§1.1 mergedInto forwarding) across a snapshot roundtrip.
 	t.Run("tree merge-and-merge convergence across snapshot", func(t *testing.T) {
 		actorA, err := time.ActorIDFromHex("000000000000000000000011")
 		assert.NoError(t, err)

--- a/docs/design/concurrent-merge-split.md
+++ b/docs/design/concurrent-merge-split.md
@@ -169,22 +169,23 @@ partition. Without this, tombstoned children before the split point
 cause the visible-only offset to be smaller than the all-children
 offset, misplacing the partition boundary.
 
-### Fix 15: Advance left past split sibling in recursive split loop
+### Fix 15: skipActorID in recursive split loop
 
-**`split` function** — After `parent.Split()` creates a split sibling
-(linked via `InsNextID`), `left` is set to this sibling instead of
-`parent` for the next iteration. This ensures the next-level
-`FindOffset` places the split boundary AFTER all current-level split
-products, keeping them on the left side of the ancestor split.
+**`advancePastUnknownSplitSiblings`** — New `skipActorID` option stops
+advancement at siblings created by the current change's actor. In the
+split loop, `issueTimeTicket` creates siblings with lamports beyond the
+change's VV, making them appear "unknown". Without `skipActorID`, the
+function advances past the current operation's own split products,
+diverging from the clone path (VV=nil) where no advancement occurs.
 
-Without this, `advancePastUnknownSplitSiblings` in the next iteration
-cannot distinguish the just-created sibling from pre-existing ones
-(they share the same actor+lamport context), so it stops too early and
-the split product ends up on the wrong side.
+Since a single actor's changes are always sequential, an "unknown"
+sibling from the same actor is always our own creation, not a concurrent
+one. This preserves clone/root consistency while still advancing past
+genuine concurrent siblings from other actors.
 
-Only applies during concurrent replay (`versionVector` non-nil). In
-the non-concurrent case, `left = parent` is correct because no
-concurrent siblings exist.
+Previous approach (advancing `left` to the just-created sibling after
+`Split()`) achieved d1==d2 convergence but caused root tree structure to
+diverge from clone in 308 cases — the convergence was artificial.
 
 ### Fix 16: Move concurrent inserts at split boundary to the left
 
@@ -215,13 +216,21 @@ left-partition child) means it should stay in the left partition.
 | EditEdit | 901 | 0 |
 | StyleStyle | 145 | 0 |
 | EditStyle | 85 | 0 |
-| SplitSplit | 321 | 0 |
-| SplitEdit | 145 | 0 |
-| **Total** | **1597** | **0** |
+| SplitSplit | 299 | 22 |
+| SplitEdit | 140 | 5 |
+| **Total** | **1570** | **27** |
 
-Fixes 13-16 resolved all 53 previously-skipped `splitLevel >= 2`
-divergences. The property-based suite is now fully clean across all
-operation types and split levels.
+Fixes 13-16 resolved 26 of the original 53 skipped `splitLevel >= 2`
+divergences. The remaining 27 involve concurrent recursive splits where
+children redistribution at the parent level produces order-dependent
+results (see "Remaining Issue" below).
+
+### Clone/root consistency
+
+`syncClientsThenAssertEqual` and `syncClientsThenCheckEqual` now verify
+that each document's clone tree XML matches its root tree XML after
+sync. This catches bugs where `change.Execute(root, versionVector)`
+produces a different tree structure from `change.Execute(clone, nil)`.
 
 ### Text vs Element ID asymmetry
 
@@ -244,5 +253,28 @@ occur in sequence.
 | End-token guard over range clamping (Fix 11) | Clamping fails for element-level ranges; guard handles both text and element uniformly |
 | Relaxed parent check at ancestor splits (Fix 13) | Follows Fix 11 rationale: `InsNextID` is only set by `SplitElement`, so its existence is sufficient evidence |
 | `includeRemoved` in split loop offset (Fix 14) | Must match `SplitElement`'s `Children(true)` partition to avoid boundary mismatch |
-| Concurrent-only sibling advancement (Fix 15) | Local path must use `left = parent` for correct split semantics; remote path needs advancement to avoid boundary disagreement |
+| `skipActorID` in split loop advancement (Fix 15) | Same-actor siblings are own split products, not concurrent; advancing past them diverges root from clone |
 | Boundary insert migration in SplitElement (Fix 16) | CRDT position of concurrent insert is relative to pre-split child order; physical position after split is misleading |
+
+## Remaining Issue: Recursive Split Children Redistribution
+
+All 27 remaining divergences involve concurrent `splitLevel >= 2`
+operations on the same node. The root cause:
+
+When two clients both split node N at offset 0:
+- Each locally takes all children into the split sibling (sibling is
+  non-empty)
+- On replay, N is already empty, so the replayed split creates an empty
+  sibling
+
+The level-1 (parent) split boundary is then placed differently:
+- Client A: replays B's level-2, splits parent at offset 1 — A's
+  non-empty sibling goes to the right
+- Client B: parent was already split locally — A's empty replay sibling
+  stays in the left
+
+This produces different tree structures despite identical content.
+The fix requires a mechanism in `SplitElement` to deterministically
+redistribute children during concurrent splits, independent of
+application order. This is architecturally different from the offset-
+based fixes (13-16) and needs separate design.

--- a/docs/design/concurrent-merge-split.md
+++ b/docs/design/concurrent-merge-split.md
@@ -21,227 +21,336 @@ tree region, replicas diverge after synchronization.
 - Undo/redo for merge/split (deferred per `undo-redo.md` Phase 2).
 - General-purpose `Tree.Move` operation (Phase 2).
 
+## Text vs Element ID Asymmetry
+
+Understanding this asymmetry is essential for the rest of the document.
+
+- **Text split nodes** have deterministic IDs: same `CreatedAt` + offset.
+  Any client that knows the original node can resolve the split via
+  `findFloorNode`. No discovery problem.
+- **Element split nodes** have non-deterministic IDs: each split creates a
+  new ticket via `issueTimeTicket`. A client that didn't witness the split
+  cannot find the product by ID alone.
+- **`InsNextID`/`InsPrevID` chain** is the sole discovery mechanism for
+  concurrent element split products. `SplitElement` links the new (right)
+  node into this doubly-linked list. Every phase that must account for
+  concurrent element splits walks this chain.
+
+This asymmetry is why Phase 6 (Split) needs per-iteration sibling
+advancement in the recursive loop — each ancestor-level element split
+produces a new undiscoverable ID.
+
 ## Edit Execution Flow
 
 ```text
 Edit(from, to, contents, splitLevel)
-  ├── 01:   FindTreeNodesWithSplitText(from/to) — resolve CRDTTreePos
-  ├── 01-1: advancePastUnknownSplitSiblings (Fix 7)
-  ├── 02:   collectBetween — walk range, detect merge/delete targets
-  ├── 03:   Delete — tombstone nodes
-  ├── 04:   Merge — move children to fromParent, set mergedInto
-  ├── 04-1: Propagate deletes to merge-moved children (Fix 5)
-  ├── 05:   Split — SplitElement for splitLevel > 0
-  └── 06:   Insert — with parent-deletion guard + merge redirect
+  ├── Phase 1: Position Resolution (FindTreeNodesWithSplitText)
+  ├── Phase 2: Split Sibling Advance (advancePastUnknownSplitSiblings)
+  ├── Phase 3: Range Narrowing (cross-parent boundary)
+  ├── Phase 4: Range Collection (collectBetween)
+  ├──          Delete — tombstone nodes
+  ├── Phase 5: Merge — move children to fromParent, set mergedInto
+  ├──          Delete Propagation to merge-moved children
+  ├── Phase 6: Split — SplitElement for splitLevel > 0
+  └──          Insert — with parent-deletion guard + merge redirect
 ```
 
-## Fixes
+## Phase 1: Position Resolution
 
-### Fix 1: Split sibling cascade delete
+**Function**: `FindTreeNodesWithSplitText`
 
-**`collectBetween`** — When deleting an element, follow its `InsNextID`
-chain to include split siblings unknown to the editor's VV. Element-only;
-text splits use same-CreatedAt offset IDs that `findFloorNode` resolves.
+Resolves `CRDTTreePos` (parent ID + left sibling ID) into concrete tree
+node pointers. Two concurrent issues can corrupt resolution results.
 
-### Fix 2: Moved children guard
+### §1.1 Merge-Tombstone Redirect
 
-**`collectBetween`** — Exclude children whose parent is in
-`toBeMergedNodes` from the parent-cascade delete. These children are
-being moved by merge, not deleted.
+When the resolved parent has been tombstoned by a concurrent merge,
+its children have already been moved to the merge destination. The
+`mergedInto` forwarding pointer redirects resolution to that
+destination.
 
-### Fix 3: Merge-tombstone insert redirect
+`mergedInto` is a runtime cache on `TreeNode`, set during merge
+execution and rebuilt from the persisted `MergedFrom` field on
+snapshot load via `rebuildMergeState`. This enables a fast nil-check
+on the hot path without persisting a separate field.
 
-**`FindTreeNodesWithSplitText`** — When the resolved parent is
-tombstoned by a merge, redirect to the merge destination via `mergedInto`.
+### §1.2 Inverted Range Guard
 
-### Fix 4: mergedInto forwarding pointer
+**Function**: `traverseInPosRange`
 
-**`Edit` Step 04, `TreeNode`** — Runtime cache `mergedInto *TreeNodeID`
-on merge-source nodes. Set during merge; rebuilt from `MergedFrom` on
-snapshot load via `rebuildMergeState`. Enables fast nil-check in
-`FindTreeNodesWithSplitText`.
+When a merge redirect places the `to` position before `from` in tree
+order, the range is inverted. This is treated as a no-op
+(`if fromIdx > toIdx { return nil }`).
 
-### Fix 5: Delete propagation to merge-moved children
+## Phase 2: Split Sibling Advance
 
-**`Edit` Step 04-1** — When a merge-source is deleted (not merged),
-tombstone its former children in the merge target. Identified via
-`child.MergedFrom == source.id`. Skip when `mergedInto == fromParent`
-(concurrent merge, not delete).
+**Function**: `advancePastUnknownSplitSiblings`
 
-### Fix 6: Inverted range no-op
+After position resolution, `fromLeft`/`toLeft` may point to an element
+that has been split by a concurrent operation. The split product
+(right sibling) is unknown to the editor — its `CreatedAt` is not in
+the editor's version vector.
 
-**`traverseInPosRange`** — When a merge redirects `to` before `from`,
-treat the empty range as a no-op.
+This phase walks the `InsNextID` chain from the resolved left node,
+advancing past element split siblings that are unknown to the editor.
+Skip when `leftNode == parent` (leftmost position — no left sibling
+to advance from).
 
-### Fix 7: Split sibling forwarding
+This prevents multi-level split mispositioning and side-by-side
+insert/delete errors. Without it, operations target the original
+element instead of landing after all its split products.
 
-**`Edit` Step 01-1, `Style`, `RemoveStyle`** — After resolving positions,
-advance `fromLeft`/`toLeft` past element split siblings whose `CreatedAt`
-is not in the editor's VV. Skip when `leftNode == parent` (leftmost).
-Prevents multi-level split mispositioning, side-by-side insert/delete
-errors.
+The same advance logic is applied in `Style` and `RemoveStyle` entry
+points (see Phase 7).
 
-### Fix 8: SplitElement skips merge-moved children
+**Options** (used in Phase 6's recursive split loop):
+- `relaxParentCheck`: skip parent equality check at ancestor
+  iterations, where a concurrent ancestor split may move siblings to
+  different parents.
+- `skipActorID`: stop at siblings created by the current change's
+  actor, since same-actor siblings are own split products, not
+  concurrent ones.
 
-**`SplitElement`, `mergeNodes`** — Persist `MergedFrom` (source parent ID)
-and `MergedAt` (immutable merge ticket) on moved children. In
-`SplitElement`, keep right-partition children with `MergedFrom` in the
-original node when the merge source was a child of the split node and
-the editor's VV doesn't cover `MergedAt`. `MergedAt` is captured
-explicitly because `source.removedAt` can be overwritten by LWW.
+## Phase 3: Range Narrowing
 
-### Fix 9: Skip merge for concurrent elements
+**Location**: `Edit`, after position resolution
 
-**`collectBetween`** — When a delete range crosses into an element whose
-`CreatedAt` is not in the editor's VV, skip merge detection. The boundary
-crossing is an artifact of a concurrent split.
+When `fromParent` and `toParent` are different nodes — the from
+position is in the original parent while the to position landed in a
+split sibling — the `collectBetween` traversal range crosses parent
+boundaries and may include content from concurrent split products that
+wasn't in the editor's original range.
 
-### Fix 10: JS splitElement preserves tombstoned children
-
-**`index_tree.ts`** — Use `_children` (raw) instead of `children`
-(filtered) in `splitElement` to preserve tombstoned children across
-splits.
-
-### Fix 11: End-token split sibling guard for Style/RemoveStyle
-
-**`Style`, `RemoveStyle` callbacks** — When processing an End token,
-skip styling if the node has an `InsNextID` split sibling not in the
-editor's VV. The End token is in the range only because a concurrent
-split extended the traversal past the original element boundary.
-
-Helper: `hasUnknownSplitSibling(node, vv)` — follows `InsNextID`, checks
-the sibling is an element whose `CreatedAt` is not covered by VV.
-
-**Why End-token guard over range clamping**: Clamping works for text-level
-ranges but fails for element-level ranges where the editor selected
-children that moved to the split sibling. The guard handles both
-uniformly:
-
-- **Text-level** (range within element content): P's End token skipped →
-  P' Start rejected by `canStyle` → no elements styled. Matches the
-  unsplit behavior (no element tokens in range).
-- **Element-level** (range across children): parent End token skipped →
-  child Start token still styled via `canStyle`. Matches the unsplit
-  behavior (child was in the original range).
-
-### Fix 12: Copy attributes on split and propagate style to split siblings
-
-**`SplitElement`** — Deep-copy the original node's attributes (`Attrs`)
-to the split (right) node. Previously the right node was created with
-nil attributes, losing any styling.
-
-**`Style`, `RemoveStyle` callbacks** — After styling a node via its Start
-token, follow the `InsNextID` chain and apply the same style/remove-style
-to unknown split siblings (those whose `CreatedAt` is not covered by the
-editor's VV). This ensures that a style operation whose range was
-determined before a concurrent split also covers the right part.
-
-Without this propagation, the client that splits first misses the style
-on the right node, while the client that styles first copies it via the
-attribute deep-copy in split — causing divergence.
-
-Helper: `ticketKnown(vv, ticket)` — reused for the unknown-sibling check.
-
-### Fix 13: Fix 7 propagation into recursive split loop
-
-**`split` function** — The recursive split loop executes Fix 7
-(`advancePastUnknownSplitSiblings`) at each iteration, not just before
-the loop entry. Element splits produce non-deterministic IDs (new
-tickets, unlike text splits which reuse `CreatedAt` + offset), so the
-`InsNextID` chain is the only discovery path for concurrent element
-split siblings.
-
-The parent equality check in `advancePastUnknownSplitSiblings` is
-relaxed (skipped) at ancestor iterations via `relaxParentCheck` flag.
-A concurrent ancestor split may move siblings to different parents,
-causing the strict check to break the chain prematurely. Same rationale
-as Fix 11 (`hasUnknownSplitSibling`).
-
-If the advance moves `left` to a node under a different parent, `parent`
-is updated to match so `FindOffset` and `Split` operate on the correct
-subtree.
-
-### Fix 14: Include removed children in split loop offset
-
-**`split` function** — `FindOffset` in the split loop now passes
-`includeRemoved: true` to match `SplitElement`'s `Children(true)`
-partition. Without this, tombstoned children before the split point
-cause the visible-only offset to be smaller than the all-children
-offset, misplacing the partition boundary.
-
-### Fix 15: skipActorID in recursive split loop
-
-**`advancePastUnknownSplitSiblings`** — New `skipActorID` option stops
-advancement at siblings created by the current change's actor. In the
-split loop, `issueTimeTicket` creates siblings with lamports beyond the
-change's VV, making them appear "unknown". Without `skipActorID`, the
-function advances past the current operation's own split products,
-diverging from the clone path (VV=nil) where no advancement occurs.
-
-Since a single actor's changes are always sequential, an "unknown"
-sibling from the same actor is always our own creation, not a concurrent
-one. This preserves clone/root consistency while still advancing past
-genuine concurrent siblings from other actors.
-
-Previous approach (advancing `left` to the just-created sibling after
-`Split()`) achieved d1==d2 convergence but caused root tree structure to
-diverge from clone in 308 cases — the convergence was artificial.
-
-### Fix 16: Move concurrent inserts at split boundary to the left
-
-**`SplitElement`** — After partitioning children into left/right, any
-consecutive run of concurrent inserts (children whose `CreatedAt` is
-unknown to the splitter's `VersionVector`) at the start of the right
-partition is moved to the left partition. A concurrent insert placed
-between the split boundary and the next original child was positioned
-relative to the pre-split child order; its CRDT position (after a
-left-partition child) means it should stay in the left partition.
-
-Element split siblings (nodes with `InsPrevID`, non-text) are skipped
-during the boundary scan. Without this, a split sibling at the start
-of the right partition sets `boundaryReached=true`, hiding concurrent
-inserts that follow it. Text split siblings retain their boundary
-role because their deterministic IDs make them safe markers.
-
-### Fix 17: Move empty split sibling to existing InsNext sibling's parent
-
-**`Split`** — After creating a split sibling and linking it into the
-`InsNextID` chain, check whether the existing `InsNext` sibling is in
-a different parent (due to a prior parent-level split by another
-operation). If so, and the new split sibling has no children (empty),
-detach it from the original parent and insert it before `InsNext` in
-`InsNext`'s parent.
-
-This fixes the 22 `SplitSplit` divergences where concurrent
-`splitLevel >= 2` operations on the same node produce empty replay
-split siblings that land in different parents depending on application
-order. The fix is VV-independent (purely structural), so clone/root
-consistency is preserved automatically.
-
-The empty-children guard prevents false activation on splits at
-different positions, where the new sibling legitimately carries
-children and belongs in the original parent.
-
-### Fix 18: Narrow collectBetween range across split parent boundaries
-
-**`Edit` Step 01-2** — After position resolution, when `fromParent`
-and `toParent` are different nodes (the from position is in the
-original parent while the to position is in a split sibling), the
-traversal range crosses parent boundaries and may include content
-from concurrent split products that wasn't in the editor's original
-range. Follow `fromLeft`'s `InsNextID` chain to find a split sibling
-in `toParent`, and use that sibling as the `collectBetween` from
-position.
+Follow `fromLeft`'s `InsNextID` chain to find a split sibling whose
+parent is `toParent`, and use that sibling as the `collectBetween`
+from-position.
 
 Only the `collectBetween` range is narrowed. The original
 `fromParent`/`fromLeft` are preserved for merge, split, and insert
-steps so that content is inserted at the editor's intended position
-(matching the order-of-operations on the other replica, where
-Fix 16's boundary insert migration handles placement).
+steps so that content is inserted at the editor's intended position.
+On the other replica, §6.3 (Boundary Insert Migration) handles the
+symmetric placement.
 
 VV-independent: relies only on `InsNextID` chain and parent pointer
-comparison. Both clone (VV=nil) and root (VV=set) follow the same
-code path, preserving clone/root consistency.
+comparison, preserving clone/root consistency.
+
+## Phase 4: Range Collection
+
+**Function**: `collectBetween`
+
+Walks the resolved range to build lists of nodes to delete and merge.
+Three concurrent issues require special handling.
+
+### §4.1 Split Sibling Cascade
+
+When collecting an element for deletion, follow its `InsNextID` chain
+to include split siblings unknown to the editor's version vector.
+These siblings are part of the same logical element and must be
+deleted together. Element-only: text splits use deterministic
+offset-based IDs that `findFloorNode` already resolves.
+
+### §4.2 Moved Children Guard
+
+Exclude children whose parent is in `toBeMergedNodes` from the
+parent-cascade delete. These children are being moved by the merge
+operation, not deleted. Without this guard, merge-target children
+would be incorrectly tombstoned.
+
+### §4.3 Skip Concurrent Element Merge
+
+When a delete range crosses into an element whose `CreatedAt` is not
+in the editor's version vector, skip merge detection for that element.
+The boundary crossing is an artifact of a concurrent split — the
+editor's original range did not include this element, so detecting it
+as a merge target would be incorrect.
+
+## Phase 5: Merge
+
+**Functions**: `mergeNodes`, `propagateMergeDeletes`
+
+### §5.1 Child Migration and Forwarding Pointers
+
+During merge, children are moved from the merge-source to the
+merge-target (`fromParent`). Each moved child receives:
+
+- **`MergedFrom`** (persisted): the source parent's ID. Used to
+  identify which children were moved by this merge.
+- **`MergedAt`** (persisted): the immutable merge ticket. Needed
+  because `source.removedAt` can be overwritten by LWW, but the
+  merge timestamp must be stable for version-vector checks.
+- **`mergedInto`** (runtime cache): set on the source node, pointing
+  to the target. Rebuilt from `MergedFrom` on snapshot load.
+
+### §5.2 Delete Propagation to Merge-Moved Children
+
+When a merge-source is deleted (not merged), its former children —
+now in the merge target — must also be tombstoned. Children are
+identified via `child.MergedFrom == source.id`.
+
+Skip propagation when `mergedInto == fromParent`: this indicates a
+concurrent merge (both sides merged into each other), not a delete.
+
+## Phase 6: Split
+
+Three levels: `SplitElement` (child partitioning), `Split`
+(node-level linking), and the recursive split loop (ancestor
+traversal).
+
+### §6.1 SplitElement: Merge-Moved Children
+
+During child partitioning into left/right, children that were moved
+by a concurrent merge must stay in the original (left) node. A child
+is kept in the left partition when:
+
+1. Its `MergedFrom` identifies a source that was a child of the
+   split node, AND
+2. The editor's version vector does not cover the child's `MergedAt`.
+
+`MergedAt` (not `source.removedAt`) is used for the VV check because
+`removedAt` can be overwritten by LWW.
+
+### §6.2 SplitElement: Attribute Copy
+
+Deep-copy the original node's attributes (`Attrs`) to the split
+(right) node. Without this, the right node is created with nil
+attributes, losing any styling applied before the split.
+
+### §6.3 SplitElement: Boundary Insert Migration
+
+After partitioning children into left/right, any consecutive run of
+concurrent inserts (children whose `CreatedAt` is unknown to the
+splitter's version vector) at the start of the right partition is
+moved to the left partition.
+
+A concurrent insert placed between the split boundary and the next
+original child was positioned relative to the pre-split child order.
+Its CRDT position (after a left-partition child) means it belongs in
+the left partition.
+
+Element split siblings (nodes with `InsPrevID`, non-text) are skipped
+during the boundary scan — without this, a split sibling at the start
+of the right partition would prematurely stop the scan. Text split
+siblings retain their boundary role because their deterministic IDs
+make them safe markers.
+
+### §6.4 Split: Empty Sibling Re-Parenting
+
+After creating a split sibling and linking it into the `InsNextID`
+chain, check whether the existing `InsNext` sibling is in a different
+parent (due to a prior parent-level split by another operation). If
+so, and the new split sibling has no children (empty), detach it from
+the original parent and insert it before `InsNext` in `InsNext`'s
+parent.
+
+This fixes divergences where concurrent `splitLevel >= 2` operations
+produce empty replay split siblings that land in different parents
+depending on application order. The empty-children guard prevents
+false activation on splits at different positions, where the new
+sibling legitimately carries children.
+
+VV-independent (purely structural), preserving clone/root consistency.
+
+### §6.5 Recursive Split Loop: Per-Iteration Advance
+
+The recursive `split` function executes
+`advancePastUnknownSplitSiblings` at each iteration, not just before
+loop entry. Element splits produce non-deterministic IDs, so the
+`InsNextID` chain is the only discovery path for concurrent element
+split siblings at each ancestor level.
+
+The parent equality check is relaxed (`relaxParentCheck`) at ancestor
+iterations. A concurrent ancestor split may move siblings to different
+parents, causing the strict check to break the chain prematurely.
+
+If the advance moves `left` to a node under a different parent,
+`parent` is updated to match so `FindOffset` and `Split` operate on
+the correct subtree.
+
+### §6.6 Recursive Split Loop: Removed-Inclusive Offset
+
+`FindOffset` in the split loop passes `includeRemoved: true` to match
+`SplitElement`'s `Children(true)` partition. Without this, tombstoned
+children before the split point cause the visible-only offset to be
+smaller than the all-children offset, misplacing the partition
+boundary.
+
+### §6.7 Recursive Split Loop: skipActorID
+
+`advancePastUnknownSplitSiblings` accepts a `skipActorID` option that
+stops advancement at siblings created by the current change's actor.
+
+In the split loop, `issueTimeTicket` creates siblings with lamport
+timestamps beyond the change's version vector, making them appear
+"unknown". Without `skipActorID`, the function advances past the
+current operation's own split products, diverging from the clone path
+(`VV=nil`) where no advancement occurs.
+
+Since a single actor's changes are always sequential, an "unknown"
+sibling from the same actor is always our own creation, not a
+concurrent one. This preserves clone/root consistency while still
+advancing past genuine concurrent siblings from other actors.
+
+## Phase 7: Style Operations
+
+**Functions**: `Style`, `RemoveStyle`
+
+Style operations use the same split sibling advance as Edit (Phase 2)
+but require two additional mechanisms for concurrent split handling.
+
+### §7.1 End-Token Split Sibling Guard
+
+When processing an End token, skip styling if the node has an
+`InsNextID` split sibling not in the editor's version vector. The End
+token is in the range only because a concurrent split extended the
+traversal past the original element boundary.
+
+Helper: `hasUnknownSplitSibling(node, vv)` — follows `InsNextID`,
+checks the sibling is an element whose `CreatedAt` is not covered
+by VV. Omits parent-equality check (same rationale as §6.5).
+
+**Why End-token guard over range clamping**: Clamping works for
+text-level ranges but fails for element-level ranges where the
+editor selected children that moved to the split sibling. The guard
+handles both uniformly:
+
+- **Text-level** (range within element content): P's End token
+  skipped → P' Start rejected by `canStyle` → no elements styled.
+  Matches the unsplit behavior (no element tokens in range).
+- **Element-level** (range across children): parent End token
+  skipped → child Start token still styled via `canStyle`. Matches
+  the unsplit behavior (child was in the original range).
+
+### §7.2 Style Propagation to Split Siblings
+
+After styling a node via its Start token, follow the `InsNextID`
+chain and apply the same style/remove-style to unknown split siblings
+(those whose `CreatedAt` is not covered by the editor's VV).
+
+This ensures that a style operation whose range was determined before
+a concurrent split also covers the right part. Without this
+propagation, the client that splits first misses the style on the
+right node, while the client that styles first copies it via the
+attribute deep-copy in §6.2 — causing divergence.
+
+Helper: `ticketKnown(vv, ticket)` — reused for the unknown-sibling
+check.
+
+## Key Design Decisions
+
+| Decision | Reason |
+|----------|--------|
+| Implicit move over explicit `TreeMove` op | Same fixes needed; Move adds protocol complexity |
+| Persist `MergedFrom` + `MergedAt` in proto | Durable merge witness; `MergedAt` is immutable (unlike `removedAt` which LWW overwrites) |
+| `mergedInto` as runtime cache only | Fast nil-check on hot path; rebuilt from `MergedFrom` on load |
+| Derive moved-children on demand | `target.Children(true) | where MergedFrom == source.id`; call sites already have the target |
+| Position-level advance for splits (§2) | `collectBetween`-level fix can't distinguish contained vs side-by-side delete |
+| End-token guard over range clamping (§7.1) | Clamping fails for element-level ranges; guard handles both text and element uniformly |
+| Relaxed parent check at ancestor splits (§6.5) | `InsNextID` is only set by `SplitElement`, so its existence is sufficient evidence |
+| `includeRemoved` in split loop offset (§6.6) | Must match `SplitElement`'s `Children(true)` partition to avoid boundary mismatch |
+| `skipActorID` in split loop advancement (§6.7) | Same-actor siblings are own split products, not concurrent; advancing past them diverges root from clone |
+| Boundary insert migration in SplitElement (§6.3) | CRDT position of concurrent insert is relative to pre-split child order; physical position after split is misleading |
+| Empty sibling re-parenting in Split (§6.4) | When a concurrent parent split already separated siblings into different parents, a replay split's empty product must follow the existing chain to be deterministic; VV-independent to preserve clone/root consistency |
+| Narrow collectBetween only, preserve insert point (§3) | Adjusting fromLeft/fromParent for both delete and insert changes the insertion position, diverging from the other replica where §6.3's boundary migration handles placement |
 
 ## Convergence Coverage
 
@@ -266,9 +375,6 @@ code path, preserving clone/root consistency.
 | SplitEdit | 145 | 0 |
 | **Total** | **1597** | **0** |
 
-Fixes 13-18 resolved all 53 original skipped `splitLevel >= 2`
-divergences.
-
 ### Clone/root consistency
 
 `syncClientsThenAssertEqual` and `syncClientsThenCheckEqual` now verify
@@ -276,28 +382,27 @@ that each document's clone tree XML matches its root tree XML after
 sync. This catches bugs where `change.Execute(root, versionVector)`
 produces a different tree structure from `change.Execute(clone, nil)`.
 
-### Text vs Element ID asymmetry
+## Appendix: Fix Number Cross-Reference
 
-Text split nodes have deterministic IDs (same `CreatedAt` + offset),
-resolved by `findFloorNode`. Element split nodes have non-deterministic
-IDs (new ticket from `issueTimeTicket`), discoverable only via the
-`InsNextID` chain. This asymmetry is why Fixes 13-15 are needed
-specifically for the recursive split path where multiple element splits
-occur in sequence.
+For traceability from git history (commit messages reference Fix N).
 
-## Key Design Decisions
-
-| Decision | Reason |
-|----------|--------|
-| Implicit move over explicit `TreeMove` op | Same fixes needed; Move adds protocol complexity |
-| Persist `MergedFrom` + `MergedAt` in proto | Durable merge witness; `MergedAt` is immutable (unlike `removedAt` which LWW overwrites) |
-| `mergedInto` as runtime cache only | Fast nil-check on hot path; rebuilt from `MergedFrom` on load |
-| Derive moved-children on demand | `target.Children(true) | where MergedFrom == source.id`; call sites already have the target |
-| Position-level fix for splits (Fix 7) | `collectBetween`-level fix can't distinguish contained vs side-by-side delete |
-| End-token guard over range clamping (Fix 11) | Clamping fails for element-level ranges; guard handles both text and element uniformly |
-| Relaxed parent check at ancestor splits (Fix 13) | Follows Fix 11 rationale: `InsNextID` is only set by `SplitElement`, so its existence is sufficient evidence |
-| `includeRemoved` in split loop offset (Fix 14) | Must match `SplitElement`'s `Children(true)` partition to avoid boundary mismatch |
-| `skipActorID` in split loop advancement (Fix 15) | Same-actor siblings are own split products, not concurrent; advancing past them diverges root from clone |
-| Boundary insert migration in SplitElement (Fix 16) | CRDT position of concurrent insert is relative to pre-split child order; physical position after split is misleading |
-| Empty sibling re-parenting in Split (Fix 17) | When a concurrent parent split already separated siblings into different parents, a replay split's empty product must follow the existing chain to be deterministic; VV-independent to preserve clone/root consistency |
-| Narrow collectBetween only, preserve insert point (Fix 18) | Adjusting fromLeft/fromParent for both delete and insert changes the insertion position, diverging from the other replica where Fix 16's boundary migration handles placement |
+| Fix | Section | Short Description |
+|-----|---------|-------------------|
+| Fix 1 | §4.1 | Split sibling cascade delete in collectBetween |
+| Fix 2 | §4.2 | Moved children guard in collectBetween |
+| Fix 3 | §1.1 | Merge-tombstone insert redirect |
+| Fix 4 | §1.1 + §5.1 | mergedInto forwarding pointer + merge data model |
+| Fix 5 | §5.2 | Delete propagation to merge-moved children |
+| Fix 6 | §1.2 | Inverted range no-op |
+| Fix 7 | §2 | Split sibling advance |
+| Fix 8 | §6.1 | SplitElement skips merge-moved children |
+| Fix 9 | §4.3 | Skip concurrent element merge |
+| Fix 10 | N/A | JS-only: splitElement uses raw children |
+| Fix 11 | §7.1 | End-token split sibling guard |
+| Fix 12 | §6.2 + §7.2 | Attribute copy + style propagation |
+| Fix 13 | §6.5 | Per-iteration advance in recursive split loop |
+| Fix 14 | §6.6 | Removed-inclusive offset in split loop |
+| Fix 15 | §6.7 | skipActorID in split loop |
+| Fix 16 | §6.3 | Boundary insert migration in SplitElement |
+| Fix 17 | §6.4 | Empty sibling re-parenting in Split |
+| Fix 18 | §3 | Cross-parent range narrowing |

--- a/docs/design/concurrent-merge-split.md
+++ b/docs/design/concurrent-merge-split.md
@@ -197,6 +197,25 @@ between the split boundary and the next original child was positioned
 relative to the pre-split child order; its CRDT position (after a
 left-partition child) means it should stay in the left partition.
 
+### Fix 17: Move empty split sibling to existing InsNext sibling's parent
+
+**`Split`** — After creating a split sibling and linking it into the
+`InsNextID` chain, check whether the existing `InsNext` sibling is in
+a different parent (due to a prior parent-level split by another
+operation). If so, and the new split sibling has no children (empty),
+detach it from the original parent and insert it before `InsNext` in
+`InsNext`'s parent.
+
+This fixes the 22 `SplitSplit` divergences where concurrent
+`splitLevel >= 2` operations on the same node produce empty replay
+split siblings that land in different parents depending on application
+order. The fix is VV-independent (purely structural), so clone/root
+consistency is preserved automatically.
+
+The empty-children guard prevents false activation on splits at
+different positions, where the new sibling legitimately carries
+children and belongs in the original parent.
+
 ## Convergence Coverage
 
 ### Hand-crafted integration suite (`test/integration/tree_test.go`)
@@ -216,14 +235,15 @@ left-partition child) means it should stay in the left partition.
 | EditEdit | 901 | 0 |
 | StyleStyle | 145 | 0 |
 | EditStyle | 85 | 0 |
-| SplitSplit | 299 | 22 |
+| SplitSplit | 321 | 0 |
 | SplitEdit | 140 | 5 |
-| **Total** | **1570** | **27** |
+| **Total** | **1592** | **5** |
 
 Fixes 13-16 resolved 26 of the original 53 skipped `splitLevel >= 2`
-divergences. The remaining 27 involve concurrent recursive splits where
-children redistribution at the parent level produces order-dependent
-results (see "Remaining Issue" below).
+divergences. Fix 17 resolved all 22 remaining `SplitSplit` divergences.
+The remaining 5 involve concurrent `splitLevel >= 2` split with
+insert/replace/delete where a non-split child (e.g., `<i></i>`) lands
+in different parent partitions (see "Remaining Issue" below).
 
 ### Clone/root consistency
 
@@ -255,26 +275,18 @@ occur in sequence.
 | `includeRemoved` in split loop offset (Fix 14) | Must match `SplitElement`'s `Children(true)` partition to avoid boundary mismatch |
 | `skipActorID` in split loop advancement (Fix 15) | Same-actor siblings are own split products, not concurrent; advancing past them diverges root from clone |
 | Boundary insert migration in SplitElement (Fix 16) | CRDT position of concurrent insert is relative to pre-split child order; physical position after split is misleading |
+| Empty sibling re-parenting in Split (Fix 17) | When a concurrent parent split already separated siblings into different parents, a replay split's empty product must follow the existing chain to be deterministic; VV-independent to preserve clone/root consistency |
 
-## Remaining Issue: Recursive Split Children Redistribution
+## Remaining Issue: Concurrent Split + Insert Parent Placement
 
-All 27 remaining divergences involve concurrent `splitLevel >= 2`
-operations on the same node. The root cause:
+5 remaining divergences involve concurrent `splitLevel >= 2` split
+with insert/replace/delete operations. The root cause:
 
-When two clients both split node N at offset 0:
-- Each locally takes all children into the split sibling (sibling is
-  non-empty)
-- On replay, N is already empty, so the replayed split creates an empty
-  sibling
-
-The level-1 (parent) split boundary is then placed differently:
-- Client A: replays B's level-2, splits parent at offset 1 — A's
-  non-empty sibling goes to the right
-- Client B: parent was already split locally — A's empty replay sibling
-  stays in the left
-
-This produces different tree structures despite identical content.
-The fix requires a mechanism in `SplitElement` to deterministically
-redistribute children during concurrent splits, independent of
-application order. This is architecturally different from the offset-
-based fixes (13-16) and needs separate design.
+When one client splits at `splitLevel >= 2` and another inserts a
+child element (e.g., `<i></i>`) in the same region, the inserted node
+lands in different parent partitions depending on application order.
+Unlike the empty split sibling case (Fix 17), the inserted node is not
+a split sibling (no `InsPrevID`) and has no structural chain to follow.
+This requires a separate mechanism to deterministically assign
+non-split children to the correct partition during concurrent
+parent-level splits.

--- a/docs/design/concurrent-merge-split.md
+++ b/docs/design/concurrent-merge-split.md
@@ -222,6 +222,27 @@ The empty-children guard prevents false activation on splits at
 different positions, where the new sibling legitimately carries
 children and belongs in the original parent.
 
+### Fix 18: Narrow collectBetween range across split parent boundaries
+
+**`Edit` Step 01-2** — After position resolution, when `fromParent`
+and `toParent` are different nodes (the from position is in the
+original parent while the to position is in a split sibling), the
+traversal range crosses parent boundaries and may include content
+from concurrent split products that wasn't in the editor's original
+range. Follow `fromLeft`'s `InsNextID` chain to find a split sibling
+in `toParent`, and use that sibling as the `collectBetween` from
+position.
+
+Only the `collectBetween` range is narrowed. The original
+`fromParent`/`fromLeft` are preserved for merge, split, and insert
+steps so that content is inserted at the editor's intended position
+(matching the order-of-operations on the other replica, where
+Fix 16's boundary insert migration handles placement).
+
+VV-independent: relies only on `InsNextID` chain and parent pointer
+comparison. Both clone (VV=nil) and root (VV=set) follow the same
+code path, preserving clone/root consistency.
+
 ## Convergence Coverage
 
 ### Hand-crafted integration suite (`test/integration/tree_test.go`)
@@ -242,13 +263,11 @@ children and belongs in the original parent.
 | StyleStyle | 145 | 0 |
 | EditStyle | 85 | 0 |
 | SplitSplit | 321 | 0 |
-| SplitEdit | 143 | 2 |
-| **Total** | **1595** | **2** |
+| SplitEdit | 145 | 0 |
+| **Total** | **1597** | **0** |
 
-Fixes 13-17 resolved 51 of the original 53 skipped `splitLevel >= 2`
-divergences. The remaining 2 involve concurrent `splitLevel >= 2`
-split with replace/delete where the delete range resolves differently
-after split (see "Remaining Issue" below).
+Fixes 13-18 resolved all 53 original skipped `splitLevel >= 2`
+divergences.
 
 ### Clone/root consistency
 
@@ -281,14 +300,4 @@ occur in sequence.
 | `skipActorID` in split loop advancement (Fix 15) | Same-actor siblings are own split products, not concurrent; advancing past them diverges root from clone |
 | Boundary insert migration in SplitElement (Fix 16) | CRDT position of concurrent insert is relative to pre-split child order; physical position after split is misleading |
 | Empty sibling re-parenting in Split (Fix 17) | When a concurrent parent split already separated siblings into different parents, a replay split's empty product must follow the existing chain to be deterministic; VV-independent to preserve clone/root consistency |
-
-## Remaining Issue: Concurrent Split + Delete/Replace Range
-
-2 remaining divergences involve concurrent `splitLevel >= 2` split
-with replace or delete operations on an adjacent range. The root cause:
-
-When one client splits "abcd" into "ab"/"cd" at `splitLevel >= 2`
-and another deletes/replaces the adjacent `<p>efgh</p>`, the delete
-range resolves differently after the split is applied. On one replica
-"cd" is deleted along with "efgh", on the other it survives. This is
-a range-resolution divergence, not a children-placement issue.
+| Narrow collectBetween only, preserve insert point (Fix 18) | Adjusting fromLeft/fromParent for both delete and insert changes the insertion position, diverging from the other replica where Fix 16's boundary migration handles placement |

--- a/docs/design/concurrent-merge-split.md
+++ b/docs/design/concurrent-merge-split.md
@@ -197,6 +197,12 @@ between the split boundary and the next original child was positioned
 relative to the pre-split child order; its CRDT position (after a
 left-partition child) means it should stay in the left partition.
 
+Element split siblings (nodes with `InsPrevID`, non-text) are skipped
+during the boundary scan. Without this, a split sibling at the start
+of the right partition sets `boundaryReached=true`, hiding concurrent
+inserts that follow it. Text split siblings retain their boundary
+role because their deterministic IDs make them safe markers.
+
 ### Fix 17: Move empty split sibling to existing InsNext sibling's parent
 
 **`Split`** — After creating a split sibling and linking it into the
@@ -236,14 +242,13 @@ children and belongs in the original parent.
 | StyleStyle | 145 | 0 |
 | EditStyle | 85 | 0 |
 | SplitSplit | 321 | 0 |
-| SplitEdit | 140 | 5 |
-| **Total** | **1592** | **5** |
+| SplitEdit | 143 | 2 |
+| **Total** | **1595** | **2** |
 
-Fixes 13-16 resolved 26 of the original 53 skipped `splitLevel >= 2`
-divergences. Fix 17 resolved all 22 remaining `SplitSplit` divergences.
-The remaining 5 involve concurrent `splitLevel >= 2` split with
-insert/replace/delete where a non-split child (e.g., `<i></i>`) lands
-in different parent partitions (see "Remaining Issue" below).
+Fixes 13-17 resolved 51 of the original 53 skipped `splitLevel >= 2`
+divergences. The remaining 2 involve concurrent `splitLevel >= 2`
+split with replace/delete where the delete range resolves differently
+after split (see "Remaining Issue" below).
 
 ### Clone/root consistency
 
@@ -277,16 +282,13 @@ occur in sequence.
 | Boundary insert migration in SplitElement (Fix 16) | CRDT position of concurrent insert is relative to pre-split child order; physical position after split is misleading |
 | Empty sibling re-parenting in Split (Fix 17) | When a concurrent parent split already separated siblings into different parents, a replay split's empty product must follow the existing chain to be deterministic; VV-independent to preserve clone/root consistency |
 
-## Remaining Issue: Concurrent Split + Insert Parent Placement
+## Remaining Issue: Concurrent Split + Delete/Replace Range
 
-5 remaining divergences involve concurrent `splitLevel >= 2` split
-with insert/replace/delete operations. The root cause:
+2 remaining divergences involve concurrent `splitLevel >= 2` split
+with replace or delete operations on an adjacent range. The root cause:
 
-When one client splits at `splitLevel >= 2` and another inserts a
-child element (e.g., `<i></i>`) in the same region, the inserted node
-lands in different parent partitions depending on application order.
-Unlike the empty split sibling case (Fix 17), the inserted node is not
-a split sibling (no `InsPrevID`) and has no structural chain to follow.
-This requires a separate mechanism to deterministically assign
-non-split children to the correct partition during concurrent
-parent-level splits.
+When one client splits "abcd" into "ab"/"cd" at `splitLevel >= 2`
+and another deletes/replaces the adjacent `<p>efgh</p>`, the delete
+range resolves differently after the split is applied. On one replica
+"cd" is deleted along with "efgh", on the other it survives. This is
+a range-resolution divergence, not a children-placement issue.

--- a/docs/design/concurrent-merge-split.md
+++ b/docs/design/concurrent-merge-split.md
@@ -36,7 +36,7 @@ Understanding this asymmetry is essential for the rest of the document.
   node into this doubly-linked list. Every phase that must account for
   concurrent element splits walks this chain.
 
-This asymmetry is why Phase 6 (Split) needs per-iteration sibling
+This asymmetry is why Phase 7 (Split) needs per-iteration sibling
 advancement in the recursive loop — each ancestor-level element split
 produces a new undiscoverable ID.
 
@@ -48,11 +48,11 @@ Edit(from, to, contents, splitLevel)
   ├── Phase 2: Split Sibling Advance (advancePastUnknownSplitSiblings)
   ├── Phase 3: Range Narrowing (cross-parent boundary)
   ├── Phase 4: Range Collection (collectBetween)
-  ├──          Delete — tombstone nodes
-  ├── Phase 5: Merge — move children to fromParent, set mergedInto
-  ├──          Delete Propagation to merge-moved children
-  ├── Phase 6: Split — SplitElement for splitLevel > 0
-  └──          Insert — with parent-deletion guard + merge redirect
+  ├── Phase 5: Delete — tombstone collected nodes
+  ├── Phase 6: Merge — move children to fromParent, set mergedInto
+  │     └── Delete Propagation to merge-moved children
+  ├── Phase 7: Split — SplitElement for splitLevel > 0
+  └── Phase 8: Insert — with parent-deletion guard + merge redirect
 ```
 
 ## Phase 1: Position Resolution
@@ -101,9 +101,9 @@ insert/delete errors. Without it, operations target the original
 element instead of landing after all its split products.
 
 The same advance logic is applied in `Style` and `RemoveStyle` entry
-points (see Phase 7).
+points (see Phase 9).
 
-**Options** (used in Phase 6's recursive split loop):
+**Options** (used in Phase 7's recursive split loop):
 - `relaxParentCheck`: skip parent equality check at ancestor
   iterations, where a concurrent ancestor split may move siblings to
   different parents.
@@ -128,7 +128,7 @@ from-position.
 Only the `collectBetween` range is narrowed. The original
 `fromParent`/`fromLeft` are preserved for merge, split, and insert
 steps so that content is inserted at the editor's intended position.
-On the other replica, §6.3 (Boundary Insert Migration) handles the
+On the other replica, §7.3 (Boundary Insert Migration) handles the
 symmetric placement.
 
 VV-independent: relies only on `InsNextID` chain and parent pointer
@@ -164,11 +164,17 @@ The boundary crossing is an artifact of a concurrent split — the
 editor's original range did not include this element, so detecting it
 as a merge target would be incorrect.
 
-## Phase 5: Merge
+## Phase 5: Delete
+
+Tombstone the nodes collected in Phase 4. No concurrent merge/split-
+specific logic in this phase — it applies the deletion marks produced
+by `collectBetween`.
+
+## Phase 6: Merge
 
 **Functions**: `mergeNodes`, `propagateMergeDeletes`
 
-### §5.1 Child Migration and Forwarding Pointers
+### §6.1 Child Migration and Forwarding Pointers
 
 During merge, children are moved from the merge-source to the
 merge-target (`fromParent`). Each moved child receives:
@@ -181,7 +187,7 @@ merge-target (`fromParent`). Each moved child receives:
 - **`mergedInto`** (runtime cache): set on the source node, pointing
   to the target. Rebuilt from `MergedFrom` on snapshot load.
 
-### §5.2 Delete Propagation to Merge-Moved Children
+### §6.2 Delete Propagation to Merge-Moved Children
 
 When a merge-source is deleted (not merged), its former children —
 now in the merge target — must also be tombstoned. Children are
@@ -190,13 +196,13 @@ identified via `child.MergedFrom == source.id`.
 Skip propagation when `mergedInto == fromParent`: this indicates a
 concurrent merge (both sides merged into each other), not a delete.
 
-## Phase 6: Split
+## Phase 7: Split
 
 Three levels: `SplitElement` (child partitioning), `Split`
 (node-level linking), and the recursive split loop (ancestor
 traversal).
 
-### §6.1 SplitElement: Merge-Moved Children
+### §7.1 SplitElement: Merge-Moved Children
 
 During child partitioning into left/right, children that were moved
 by a concurrent merge must stay in the original (left) node. A child
@@ -209,13 +215,13 @@ is kept in the left partition when:
 `MergedAt` (not `source.removedAt`) is used for the VV check because
 `removedAt` can be overwritten by LWW.
 
-### §6.2 SplitElement: Attribute Copy
+### §7.2 SplitElement: Attribute Copy
 
 Deep-copy the original node's attributes (`Attrs`) to the split
 (right) node. Without this, the right node is created with nil
 attributes, losing any styling applied before the split.
 
-### §6.3 SplitElement: Boundary Insert Migration
+### §7.3 SplitElement: Boundary Insert Migration
 
 After partitioning children into left/right, any consecutive run of
 concurrent inserts (children whose `CreatedAt` is unknown to the
@@ -233,7 +239,7 @@ of the right partition would prematurely stop the scan. Text split
 siblings retain their boundary role because their deterministic IDs
 make them safe markers.
 
-### §6.4 Split: Empty Sibling Re-Parenting
+### §7.4 Split: Empty Sibling Re-Parenting
 
 After creating a split sibling and linking it into the `InsNextID`
 chain, check whether the existing `InsNext` sibling is in a different
@@ -250,7 +256,7 @@ sibling legitimately carries children.
 
 VV-independent (purely structural), preserving clone/root consistency.
 
-### §6.5 Recursive Split Loop: Per-Iteration Advance
+### §7.5 Recursive Split Loop: Per-Iteration Advance
 
 The recursive `split` function executes
 `advancePastUnknownSplitSiblings` at each iteration, not just before
@@ -266,7 +272,7 @@ If the advance moves `left` to a node under a different parent,
 `parent` is updated to match so `FindOffset` and `Split` operate on
 the correct subtree.
 
-### §6.6 Recursive Split Loop: Removed-Inclusive Offset
+### §7.6 Recursive Split Loop: Removed-Inclusive Offset
 
 `FindOffset` in the split loop passes `includeRemoved: true` to match
 `SplitElement`'s `Children(true)` partition. Without this, tombstoned
@@ -274,7 +280,7 @@ children before the split point cause the visible-only offset to be
 smaller than the all-children offset, misplacing the partition
 boundary.
 
-### §6.7 Recursive Split Loop: skipActorID
+### §7.7 Recursive Split Loop: skipActorID
 
 `advancePastUnknownSplitSiblings` accepts a `skipActorID` option that
 stops advancement at siblings created by the current change's actor.
@@ -290,14 +296,20 @@ sibling from the same actor is always our own creation, not a
 concurrent one. This preserves clone/root consistency while still
 advancing past genuine concurrent siblings from other actors.
 
-## Phase 7: Style Operations
+## Phase 8: Insert
+
+Insert content at the editor's intended position with parent-deletion
+guard and merge redirect. No concurrent merge/split-specific logic in
+this phase — the preceding phases ensure the insertion point is correct.
+
+## Phase 9: Style Operations
 
 **Functions**: `Style`, `RemoveStyle`
 
 Style operations use the same split sibling advance as Edit (Phase 2)
 but require two additional mechanisms for concurrent split handling.
 
-### §7.1 End-Token Split Sibling Guard
+### §9.1 End-Token Split Sibling Guard
 
 When processing an End token, skip styling if the node has an
 `InsNextID` split sibling not in the editor's version vector. The End
@@ -306,7 +318,7 @@ traversal past the original element boundary.
 
 Helper: `hasUnknownSplitSibling(node, vv)` — follows `InsNextID`,
 checks the sibling is an element whose `CreatedAt` is not covered
-by VV. Omits parent-equality check (same rationale as §6.5).
+by VV. Omits parent-equality check (same rationale as §7.5).
 
 **Why End-token guard over range clamping**: Clamping works for
 text-level ranges but fails for element-level ranges where the
@@ -320,7 +332,7 @@ handles both uniformly:
   skipped → child Start token still styled via `canStyle`. Matches
   the unsplit behavior (child was in the original range).
 
-### §7.2 Style Propagation to Split Siblings
+### §9.2 Style Propagation to Split Siblings
 
 After styling a node via its Start token, follow the `InsNextID`
 chain and apply the same style/remove-style to unknown split siblings
@@ -330,7 +342,7 @@ This ensures that a style operation whose range was determined before
 a concurrent split also covers the right part. Without this
 propagation, the client that splits first misses the style on the
 right node, while the client that styles first copies it via the
-attribute deep-copy in §6.2 — causing divergence.
+attribute deep-copy in §7.2 — causing divergence.
 
 Helper: `ticketKnown(vv, ticket)` — reused for the unknown-sibling
 check.
@@ -344,13 +356,13 @@ check.
 | `mergedInto` as runtime cache only | Fast nil-check on hot path; rebuilt from `MergedFrom` on load |
 | Derive moved-children on demand | `target.Children(true) | where MergedFrom == source.id`; call sites already have the target |
 | Position-level advance for splits (§2) | `collectBetween`-level fix can't distinguish contained vs side-by-side delete |
-| End-token guard over range clamping (§7.1) | Clamping fails for element-level ranges; guard handles both text and element uniformly |
-| Relaxed parent check at ancestor splits (§6.5) | `InsNextID` is only set by `SplitElement`, so its existence is sufficient evidence |
-| `includeRemoved` in split loop offset (§6.6) | Must match `SplitElement`'s `Children(true)` partition to avoid boundary mismatch |
-| `skipActorID` in split loop advancement (§6.7) | Same-actor siblings are own split products, not concurrent; advancing past them diverges root from clone |
-| Boundary insert migration in SplitElement (§6.3) | CRDT position of concurrent insert is relative to pre-split child order; physical position after split is misleading |
-| Empty sibling re-parenting in Split (§6.4) | When a concurrent parent split already separated siblings into different parents, a replay split's empty product must follow the existing chain to be deterministic; VV-independent to preserve clone/root consistency |
-| Narrow collectBetween only, preserve insert point (§3) | Adjusting fromLeft/fromParent for both delete and insert changes the insertion position, diverging from the other replica where §6.3's boundary migration handles placement |
+| End-token guard over range clamping (§9.1) | Clamping fails for element-level ranges; guard handles both text and element uniformly |
+| Relaxed parent check at ancestor splits (§7.5) | `InsNextID` is only set by `SplitElement`, so its existence is sufficient evidence |
+| `includeRemoved` in split loop offset (§7.6) | Must match `SplitElement`'s `Children(true)` partition to avoid boundary mismatch |
+| `skipActorID` in split loop advancement (§7.7) | Same-actor siblings are own split products, not concurrent; advancing past them diverges root from clone |
+| Boundary insert migration in SplitElement (§7.3) | CRDT position of concurrent insert is relative to pre-split child order; physical position after split is misleading |
+| Empty sibling re-parenting in Split (§7.4) | When a concurrent parent split already separated siblings into different parents, a replay split's empty product must follow the existing chain to be deterministic; VV-independent to preserve clone/root consistency |
+| Narrow collectBetween only, preserve insert point (§3) | Adjusting fromLeft/fromParent for both delete and insert changes the insertion position, diverging from the other replica where §7.3's boundary migration handles placement |
 
 ## Convergence Coverage
 
@@ -391,18 +403,18 @@ For traceability from git history (commit messages reference Fix N).
 | Fix 1 | §4.1 | Split sibling cascade delete in collectBetween |
 | Fix 2 | §4.2 | Moved children guard in collectBetween |
 | Fix 3 | §1.1 | Merge-tombstone insert redirect |
-| Fix 4 | §1.1 + §5.1 | mergedInto forwarding pointer + merge data model |
-| Fix 5 | §5.2 | Delete propagation to merge-moved children |
+| Fix 4 | §1.1 + §6.1 | mergedInto forwarding pointer + merge data model |
+| Fix 5 | §6.2 | Delete propagation to merge-moved children |
 | Fix 6 | §1.2 | Inverted range no-op |
 | Fix 7 | §2 | Split sibling advance |
-| Fix 8 | §6.1 | SplitElement skips merge-moved children |
+| Fix 8 | §7.1 | SplitElement skips merge-moved children |
 | Fix 9 | §4.3 | Skip concurrent element merge |
 | Fix 10 | N/A | JS-only: splitElement uses raw children |
-| Fix 11 | §7.1 | End-token split sibling guard |
-| Fix 12 | §6.2 + §7.2 | Attribute copy + style propagation |
-| Fix 13 | §6.5 | Per-iteration advance in recursive split loop |
-| Fix 14 | §6.6 | Removed-inclusive offset in split loop |
-| Fix 15 | §6.7 | skipActorID in split loop |
-| Fix 16 | §6.3 | Boundary insert migration in SplitElement |
-| Fix 17 | §6.4 | Empty sibling re-parenting in Split |
+| Fix 11 | §9.1 | End-token split sibling guard |
+| Fix 12 | §7.2 + §9.2 | Attribute copy + style propagation |
+| Fix 13 | §7.5 | Per-iteration advance in recursive split loop |
+| Fix 14 | §7.6 | Removed-inclusive offset in split loop |
+| Fix 15 | §7.7 | skipActorID in split loop |
+| Fix 16 | §7.3 | Boundary insert migration in SplitElement |
+| Fix 17 | §7.4 | Empty sibling re-parenting in Split |
 | Fix 18 | §3 | Cross-parent range narrowing |

--- a/docs/design/concurrent-merge-split.md
+++ b/docs/design/concurrent-merge-split.md
@@ -142,6 +142,60 @@ attribute deep-copy in split — causing divergence.
 
 Helper: `ticketKnown(vv, ticket)` — reused for the unknown-sibling check.
 
+### Fix 13: Fix 7 propagation into recursive split loop
+
+**`split` function** — The recursive split loop executes Fix 7
+(`advancePastUnknownSplitSiblings`) at each iteration, not just before
+the loop entry. Element splits produce non-deterministic IDs (new
+tickets, unlike text splits which reuse `CreatedAt` + offset), so the
+`InsNextID` chain is the only discovery path for concurrent element
+split siblings.
+
+The parent equality check in `advancePastUnknownSplitSiblings` is
+relaxed (skipped) at ancestor iterations via `relaxParentCheck` flag.
+A concurrent ancestor split may move siblings to different parents,
+causing the strict check to break the chain prematurely. Same rationale
+as Fix 11 (`hasUnknownSplitSibling`).
+
+If the advance moves `left` to a node under a different parent, `parent`
+is updated to match so `FindOffset` and `Split` operate on the correct
+subtree.
+
+### Fix 14: Include removed children in split loop offset
+
+**`split` function** — `FindOffset` in the split loop now passes
+`includeRemoved: true` to match `SplitElement`'s `Children(true)`
+partition. Without this, tombstoned children before the split point
+cause the visible-only offset to be smaller than the all-children
+offset, misplacing the partition boundary.
+
+### Fix 15: Advance left past split sibling in recursive split loop
+
+**`split` function** — After `parent.Split()` creates a split sibling
+(linked via `InsNextID`), `left` is set to this sibling instead of
+`parent` for the next iteration. This ensures the next-level
+`FindOffset` places the split boundary AFTER all current-level split
+products, keeping them on the left side of the ancestor split.
+
+Without this, `advancePastUnknownSplitSiblings` in the next iteration
+cannot distinguish the just-created sibling from pre-existing ones
+(they share the same actor+lamport context), so it stops too early and
+the split product ends up on the wrong side.
+
+Only applies during concurrent replay (`versionVector` non-nil). In
+the non-concurrent case, `left = parent` is correct because no
+concurrent siblings exist.
+
+### Fix 16: Move concurrent inserts at split boundary to the left
+
+**`SplitElement`** — After partitioning children into left/right, any
+consecutive run of concurrent inserts (children whose `CreatedAt` is
+unknown to the splitter's `VersionVector`) at the start of the right
+partition is moved to the left partition. A concurrent insert placed
+between the split boundary and the next original child was positioned
+relative to the pre-split child order; its CRDT position (after a
+left-partition child) means it should stay in the left partition.
+
 ## Convergence Coverage
 
 ### Hand-crafted integration suite (`test/integration/tree_test.go`)
@@ -158,16 +212,25 @@ Helper: `ticketKnown(vv, ticket)` — reused for the unknown-sibling check.
 
 | Suite | Pass | Skip (divergence) |
 |---|---:|---:|
-| EditEdit | 900 | 0 |
-| StyleStyle | 144 | 0 |
-| EditStyle | 84 | 0 |
-| SplitSplit | 274 | 46 |
-| SplitEdit | 137 | 7 |
-| **Total** | **1539** | **53** |
+| EditEdit | 901 | 0 |
+| StyleStyle | 145 | 0 |
+| EditStyle | 85 | 0 |
+| SplitSplit | 321 | 0 |
+| SplitEdit | 145 | 0 |
+| **Total** | **1597** | **0** |
 
-All 53 remaining divergences are `splitLevel >= 2` only.
-Fix 12 resolved 4 previously-skipped SplitEdit cases (`split-1` ×
-`style`/`remove-style` for `equal` and `B contains A` ranges).
+Fixes 13-16 resolved all 53 previously-skipped `splitLevel >= 2`
+divergences. The property-based suite is now fully clean across all
+operation types and split levels.
+
+### Text vs Element ID asymmetry
+
+Text split nodes have deterministic IDs (same `CreatedAt` + offset),
+resolved by `findFloorNode`. Element split nodes have non-deterministic
+IDs (new ticket from `issueTimeTicket`), discoverable only via the
+`InsNextID` chain. This asymmetry is why Fixes 13-15 are needed
+specifically for the recursive split path where multiple element splits
+occur in sequence.
 
 ## Key Design Decisions
 
@@ -179,12 +242,7 @@ Fix 12 resolved 4 previously-skipped SplitEdit cases (`split-1` ×
 | Derive moved-children on demand | `target.Children(true) | where MergedFrom == source.id`; call sites already have the target |
 | Position-level fix for splits (Fix 7) | `collectBetween`-level fix can't distinguish contained vs side-by-side delete |
 | End-token guard over range clamping (Fix 11) | Clamping fails for element-level ranges; guard handles both text and element uniformly |
-
-## Remaining Issue: `splitLevel >= 2`
-
-All remaining divergences (53 in the property-based suite) involve at
-least one `splitLevel = 2` operation. `splitLevel = 1` is fully clean
-across all operation types (edit, merge, split, style, remove-style).
-
-The recursive split path does not propagate Fix 7 (split sibling
-forwarding) or Fix 8 (`MergedFrom` filter) to ancestor split nodes.
+| Relaxed parent check at ancestor splits (Fix 13) | Follows Fix 11 rationale: `InsNextID` is only set by `SplitElement`, so its existence is sufficient evidence |
+| `includeRemoved` in split loop offset (Fix 14) | Must match `SplitElement`'s `Children(true)` partition to avoid boundary mismatch |
+| Concurrent-only sibling advancement (Fix 15) | Local path must use `left = parent` for correct split semantics; remote path needs advancement to avoid boundary disagreement |
+| Boundary insert migration in SplitElement (Fix 16) | CRDT position of concurrent insert is relative to pre-split child order; physical position after split is misleading |

--- a/docs/tasks/active/04/20260424-split-level-2-convergence-lessons.md
+++ b/docs/tasks/active/04/20260424-split-level-2-convergence-lessons.md
@@ -1,0 +1,39 @@
+**Created**: 2026-04-24
+
+# splitLevel>=2 Convergence — Lessons
+
+## Clone/root consistency is a mandatory check
+
+`syncClientsThenAssertEqual` only compared Marshal() (JSON) across
+documents (d1 vs d2). It did not compare clone vs root within the same
+document. This allowed Fix 15 to achieve d1==d2 convergence by making
+both roots diverge from their clones in the same way — 308 hidden
+mismatches.
+
+**Rule**: Always verify `doc.Root().GetTree(key).ToXML()` matches
+`doc.RootObject().Get(key).(*crdt.Tree).ToXML()` after sync.
+
+## VV-gated code must not change tree structure vs clone
+
+Any code that runs only when `versionVector != nil` changes the root
+path but not the clone path. If this code modifies tree structure
+(not just position resolution), root and clone will diverge.
+
+Fix 15's original approach (`left = splitSibling` only when VV is
+non-nil) violated this. The replacement (`skipActorID`) filters
+correctly without introducing root-only structural changes.
+
+## Same-actor siblings are not concurrent
+
+`advancePastUnknownSplitSiblings` uses VV to detect concurrent
+siblings. But `issueTimeTicket` creates tickets with lamports beyond
+the change's VV, making the current operation's own split products
+appear "unknown". The `skipActorID` parameter prevents this false
+positive. A single actor's changes are sequential, so an "unknown"
+sibling from the same actor is always our own creation.
+
+## Convergence tests can pass with wrong state
+
+d1==d2 convergence does not guarantee correctness. Both documents
+can converge to the same wrong state (root diverged from clone).
+The clone/root check catches this class of bug.

--- a/docs/tasks/active/04/20260424-split-level-2-convergence-lessons.md
+++ b/docs/tasks/active/04/20260424-split-level-2-convergence-lessons.md
@@ -6,9 +6,9 @@
 
 `syncClientsThenAssertEqual` only compared Marshal() (JSON) across
 documents (d1 vs d2). It did not compare clone vs root within the same
-document. This allowed Fix 15 to achieve d1==d2 convergence by making
-both roots diverge from their clones in the same way — 308 hidden
-mismatches.
+document. This allowed §7.7 (skipActorID) to achieve d1==d2
+convergence by making both roots diverge from their clones in the same
+way — 308 hidden mismatches.
 
 **Rule**: Always verify `doc.Root().GetTree(key).ToXML()` matches
 `doc.RootObject().Get(key).(*crdt.Tree).ToXML()` after sync.
@@ -19,7 +19,7 @@ Any code that runs only when `versionVector != nil` changes the root
 path but not the clone path. If this code modifies tree structure
 (not just position resolution), root and clone will diverge.
 
-Fix 15's original approach (`left = splitSibling` only when VV is
+§7.7's original approach (`left = splitSibling` only when VV is
 non-nil) violated this. The replacement (`skipActorID`) filters
 correctly without introducing root-only structural changes.
 
@@ -46,7 +46,7 @@ node, the `splitLevel-1` client never executes a parent-level
 only runs on the `splitLevel-2` side. The other client has no
 opportunity to apply the same redistribution.
 
-Fix 17 solved this by operating at the `Split()` level — the insertion
+§7.4 solved this by operating at the `Split()` level — the insertion
 point — which runs on BOTH clients regardless of `splitLevel`. When
 a replay split creates an empty sibling and the original node's
 existing InsNext sibling is in a different parent, the empty sibling
@@ -54,18 +54,18 @@ is moved to that parent.
 
 ## Structural fixes over VV-gated fixes
 
-Fix 17 uses no VV checks. It relies purely on tree structure
+§7.4 uses no VV checks. It relies purely on tree structure
 (`InsNext` parent comparison + empty children check). This avoids
 clone/root divergence by construction. Prefer structural invariants
 over VV-gated logic when the fix can be expressed structurally.
 
 ## Separate delete range from insertion point
 
-Fix 18 initially modified `fromParent`/`fromLeft` for both
-`collectBetween` (delete range) and the insert step. This fixed the
-delete divergence but moved the insertion point to the wrong parent
-(split sibling instead of original). On the other replica, the
-insert happened before the split and Fix 16's boundary migration
+§3 (Range Narrowing) initially modified `fromParent`/`fromLeft` for
+both `collectBetween` (delete range) and the insert step. This fixed
+the delete divergence but moved the insertion point to the wrong
+parent (split sibling instead of original). On the other replica,
+the insert happened before the split and §7.3's boundary migration
 handled placement.
 
 **Rule**: When narrowing a cross-parent traversal range, use

--- a/docs/tasks/active/04/20260424-split-level-2-convergence-lessons.md
+++ b/docs/tasks/active/04/20260424-split-level-2-convergence-lessons.md
@@ -37,3 +37,24 @@ sibling from the same actor is always our own creation.
 d1==d2 convergence does not guarantee correctness. Both documents
 can converge to the same wrong state (root diverged from clone).
 The clone/root check catches this class of bug.
+
+## SplitElement cannot fix cross-level divergences alone
+
+When `splitLevel-1` and `splitLevel-2` run concurrently on the same
+node, the `splitLevel-1` client never executes a parent-level
+`SplitElement`. Any fix inside `SplitElement` (partitioning logic)
+only runs on the `splitLevel-2` side. The other client has no
+opportunity to apply the same redistribution.
+
+Fix 17 solved this by operating at the `Split()` level — the insertion
+point — which runs on BOTH clients regardless of `splitLevel`. When
+a replay split creates an empty sibling and the original node's
+existing InsNext sibling is in a different parent, the empty sibling
+is moved to that parent.
+
+## Structural fixes over VV-gated fixes
+
+Fix 17 uses no VV checks. It relies purely on tree structure
+(`InsNext` parent comparison + empty children check). This avoids
+clone/root divergence by construction. Prefer structural invariants
+over VV-gated logic when the fix can be expressed structurally.

--- a/docs/tasks/active/04/20260424-split-level-2-convergence-lessons.md
+++ b/docs/tasks/active/04/20260424-split-level-2-convergence-lessons.md
@@ -58,3 +58,28 @@ Fix 17 uses no VV checks. It relies purely on tree structure
 (`InsNext` parent comparison + empty children check). This avoids
 clone/root divergence by construction. Prefer structural invariants
 over VV-gated logic when the fix can be expressed structurally.
+
+## Separate delete range from insertion point
+
+Fix 18 initially modified `fromParent`/`fromLeft` for both
+`collectBetween` (delete range) and the insert step. This fixed the
+delete divergence but moved the insertion point to the wrong parent
+(split sibling instead of original). On the other replica, the
+insert happened before the split and Fix 16's boundary migration
+handled placement.
+
+**Rule**: When narrowing a cross-parent traversal range, use
+separate variables for `collectBetween`. Preserve the original
+`fromParent`/`fromLeft` for merge, split, and insert steps so the
+content lands where the editor intended.
+
+## Text split IDs cross canDelete boundaries
+
+Text split nodes share `CreatedAt` with the original text, making
+them "known" to any client that knew the original. A concurrent
+element split places text("cd") — split from "abcd" — inside a new
+element split sibling. The delete traversal picks up this text via
+the cross-parent range and `canDelete` returns true because the
+`CreatedAt` is known. The fix must narrow the traversal range (not
+weaken `canDelete`), and must be VV-independent because clone also
+sees the same `CreatedAt`.

--- a/docs/tasks/active/04/20260424-split-level-2-convergence-todo.md
+++ b/docs/tasks/active/04/20260424-split-level-2-convergence-todo.md
@@ -1,0 +1,55 @@
+**Created**: 2026-04-24
+
+# splitLevel>=2 Convergence
+
+PR: https://github.com/yorkie-team/yorkie/pull/1776
+Branch: `fix-split-level-2-convergence`
+Design: `docs/design/concurrent-merge-split.md`
+
+## Goal
+
+Fix convergence divergences in concurrent `splitLevel >= 2` tree
+operations. Ensure clone/root consistency (root tree structure matches
+clone after change replay).
+
+## Done
+
+- [x] Fix 13: Propagate Fix 7 into recursive split loop with relaxed
+  parent check
+- [x] Fix 14: Include removed children in split loop offset
+  (`FindOffset` with `includeRemoved: true`)
+- [x] Fix 15: skipActorID — prevent advancing past own split products
+  in recursive split loop
+- [x] Fix 16: Move concurrent inserts at split boundary to the left
+  in SplitElement
+- [x] Add clone/root consistency check to `syncClientsThenAssertEqual`
+  and `syncClientsThenCheckEqual` (integration + complex)
+- [x] Add divergent-state XML logging to tree concurrency tests
+- [x] Verify 0 clone/root mismatches across all test suites
+
+## Remaining
+
+- [ ] Fix children redistribution in concurrent recursive splits
+  (27 divergences, see design doc "Remaining Issue" section)
+
+## Test Results
+
+### Integration (`test/integration/tree_test.go`)
+
+| Category | Total | Pass |
+|----------|------:|-----:|
+| All tree tests | 100+ | 100+ |
+
+### Complex (`test/complex/tree_concurrency_test.go`)
+
+| Suite | Pass | Skip |
+|-------|-----:|-----:|
+| EditEdit | 901 | 0 |
+| StyleStyle | 145 | 0 |
+| EditStyle | 85 | 0 |
+| SplitSplit | 299 | 22 |
+| SplitEdit | 140 | 5 |
+| **Total** | **1570** | **27** |
+
+All 27 skipped cases involve concurrent `splitLevel >= 2` and require
+children redistribution redesign (not offset-based fixes).

--- a/docs/tasks/active/04/20260424-split-level-2-convergence-todo.md
+++ b/docs/tasks/active/04/20260424-split-level-2-convergence-todo.md
@@ -14,28 +14,33 @@ clone after change replay).
 
 ## Done
 
-- [x] Fix 13: Propagate Fix 7 into recursive split loop with relaxed
-  parent check
-- [x] Fix 14: Include removed children in split loop offset
+- [x] §7.5: Propagate split sibling advance into recursive split loop
+  with relaxed parent check
+- [x] §7.6: Include removed children in split loop offset
   (`FindOffset` with `includeRemoved: true`)
-- [x] Fix 15: skipActorID — prevent advancing past own split products
+- [x] §7.7: skipActorID — prevent advancing past own split products
   in recursive split loop
-- [x] Fix 16: Move concurrent inserts at split boundary to the left
+- [x] §7.3: Move concurrent inserts at split boundary to the left
   in SplitElement; skip element split siblings during boundary scan
-- [x] Fix 17: Move empty split sibling to existing InsNext sibling's
+- [x] §7.4: Move empty split sibling to existing InsNext sibling's
   parent in Split — resolves all 22 SplitSplit divergences
-- [x] Fix 18: Narrow collectBetween range across split parent
+- [x] §3: Narrow collectBetween range across split parent
   boundaries; preserve original fromParent/fromLeft for insert —
   resolves last 2 SplitEdit divergences
+- [x] Add nil-guard for findFloorNode in Split (§7.4)
 
 - [x] Add clone/root consistency check to `syncClientsThenAssertEqual`
   and `syncClientsThenCheckEqual` (integration + complex)
 - [x] Add divergent-state XML logging to tree concurrency tests
 - [x] Verify 0 clone/root mismatches across all test suites
 
+- [x] Restructure design doc from Fix 1-18 chronological to algorithm
+  phase structure (Phase 1-9)
+- [x] Update code comments to reference design doc §sections
+
 ## Remaining
 
-All divergences resolved.
+All divergences resolved. JS SDK port pending (follow-up PR).
 
 ## Test Results
 
@@ -56,4 +61,4 @@ All divergences resolved.
 | SplitEdit | 145 | 0 |
 | **Total** | **1597** | **0** |
 
-All 53 original splitLevel >= 2 divergences resolved (Fixes 13-18).
+All 53 original splitLevel >= 2 divergences resolved.

--- a/docs/tasks/active/04/20260424-split-level-2-convergence-todo.md
+++ b/docs/tasks/active/04/20260424-split-level-2-convergence-todo.md
@@ -22,6 +22,8 @@ clone after change replay).
   in recursive split loop
 - [x] Fix 16: Move concurrent inserts at split boundary to the left
   in SplitElement
+- [x] Fix 17: Move empty split sibling to existing InsNext sibling's
+  parent in Split — resolves all 22 SplitSplit divergences
 - [x] Add clone/root consistency check to `syncClientsThenAssertEqual`
   and `syncClientsThenCheckEqual` (integration + complex)
 - [x] Add divergent-state XML logging to tree concurrency tests
@@ -29,8 +31,8 @@ clone after change replay).
 
 ## Remaining
 
-- [ ] Fix children redistribution in concurrent recursive splits
-  (27 divergences, see design doc "Remaining Issue" section)
+- [ ] Fix concurrent split + insert parent placement
+  (5 divergences in SplitEdit, see design doc "Remaining Issue")
 
 ## Test Results
 
@@ -47,9 +49,10 @@ clone after change replay).
 | EditEdit | 901 | 0 |
 | StyleStyle | 145 | 0 |
 | EditStyle | 85 | 0 |
-| SplitSplit | 299 | 22 |
+| SplitSplit | 321 | 0 |
 | SplitEdit | 140 | 5 |
-| **Total** | **1570** | **27** |
+| **Total** | **1592** | **5** |
 
-All 27 skipped cases involve concurrent `splitLevel >= 2` and require
-children redistribution redesign (not offset-based fixes).
+All 5 skipped cases involve concurrent `splitLevel >= 2` split with
+insert/replace/delete where a non-split child lands in different
+parent partitions.

--- a/docs/tasks/active/04/20260424-split-level-2-convergence-todo.md
+++ b/docs/tasks/active/04/20260424-split-level-2-convergence-todo.md
@@ -24,6 +24,9 @@ clone after change replay).
   in SplitElement; skip element split siblings during boundary scan
 - [x] Fix 17: Move empty split sibling to existing InsNext sibling's
   parent in Split — resolves all 22 SplitSplit divergences
+- [x] Fix 18: Narrow collectBetween range across split parent
+  boundaries; preserve original fromParent/fromLeft for insert —
+  resolves last 2 SplitEdit divergences
 
 - [x] Add clone/root consistency check to `syncClientsThenAssertEqual`
   and `syncClientsThenCheckEqual` (integration + complex)
@@ -32,8 +35,7 @@ clone after change replay).
 
 ## Remaining
 
-- [ ] Fix concurrent split + delete/replace range resolution
-  (2 divergences in SplitEdit, see design doc "Remaining Issue")
+All divergences resolved.
 
 ## Test Results
 
@@ -51,8 +53,7 @@ clone after change replay).
 | StyleStyle | 145 | 0 |
 | EditStyle | 85 | 0 |
 | SplitSplit | 321 | 0 |
-| SplitEdit | 143 | 2 |
-| **Total** | **1595** | **2** |
+| SplitEdit | 145 | 0 |
+| **Total** | **1597** | **0** |
 
-Remaining 2 skipped cases involve concurrent `splitLevel >= 2` split
-with replace/delete where the delete range resolves differently.
+All 53 original splitLevel >= 2 divergences resolved (Fixes 13-18).

--- a/docs/tasks/active/04/20260424-split-level-2-convergence-todo.md
+++ b/docs/tasks/active/04/20260424-split-level-2-convergence-todo.md
@@ -21,9 +21,10 @@ clone after change replay).
 - [x] Fix 15: skipActorID — prevent advancing past own split products
   in recursive split loop
 - [x] Fix 16: Move concurrent inserts at split boundary to the left
-  in SplitElement
+  in SplitElement; skip element split siblings during boundary scan
 - [x] Fix 17: Move empty split sibling to existing InsNext sibling's
   parent in Split — resolves all 22 SplitSplit divergences
+
 - [x] Add clone/root consistency check to `syncClientsThenAssertEqual`
   and `syncClientsThenCheckEqual` (integration + complex)
 - [x] Add divergent-state XML logging to tree concurrency tests
@@ -31,8 +32,8 @@ clone after change replay).
 
 ## Remaining
 
-- [ ] Fix concurrent split + insert parent placement
-  (5 divergences in SplitEdit, see design doc "Remaining Issue")
+- [ ] Fix concurrent split + delete/replace range resolution
+  (2 divergences in SplitEdit, see design doc "Remaining Issue")
 
 ## Test Results
 
@@ -50,9 +51,8 @@ clone after change replay).
 | StyleStyle | 145 | 0 |
 | EditStyle | 85 | 0 |
 | SplitSplit | 321 | 0 |
-| SplitEdit | 140 | 5 |
-| **Total** | **1592** | **5** |
+| SplitEdit | 143 | 2 |
+| **Total** | **1595** | **2** |
 
-All 5 skipped cases involve concurrent `splitLevel >= 2` split with
-insert/replace/delete where a non-split child lands in different
-parent partitions.
+Remaining 2 skipped cases involve concurrent `splitLevel >= 2` split
+with replace/delete where the delete range resolves differently.

--- a/docs/tasks/active/README.md
+++ b/docs/tasks/active/README.md
@@ -1,5 +1,5 @@
 ---
-updated: 2026-04-22
+updated: 2026-04-24
 ---
 
 # Active Tasks

--- a/docs/tasks/active/README.md
+++ b/docs/tasks/active/README.md
@@ -6,4 +6,4 @@ updated: 2026-04-24
 
 | Date | Task | Status |
 |------|------|--------|
-| 2026-04-24 | [splitLevel>=2 convergence](04/20260424-split-level-2-convergence-todo.md) ([lessons](04/20260424-split-level-2-convergence-lessons.md)) | 2 skip remaining |
+| 2026-04-24 | [splitLevel>=2 convergence](04/20260424-split-level-2-convergence-todo.md) ([lessons](04/20260424-split-level-2-convergence-lessons.md)) | 0 skip — all resolved |

--- a/docs/tasks/active/README.md
+++ b/docs/tasks/active/README.md
@@ -6,4 +6,4 @@ updated: 2026-04-24
 
 | Date | Task | Status |
 |------|------|--------|
-| 2026-04-24 | [splitLevel>=2 convergence](04/20260424-split-level-2-convergence-todo.md) ([lessons](04/20260424-split-level-2-convergence-lessons.md)) | 5 skip remaining |
+| 2026-04-24 | [splitLevel>=2 convergence](04/20260424-split-level-2-convergence-todo.md) ([lessons](04/20260424-split-level-2-convergence-lessons.md)) | 2 skip remaining |

--- a/docs/tasks/active/README.md
+++ b/docs/tasks/active/README.md
@@ -1,9 +1,9 @@
 ---
-updated: 2026-04-24
+updated: 2026-04-25
 ---
 
 # Active Tasks
 
 | Date | Task | Status |
 |------|------|--------|
-| 2026-04-24 | [splitLevel>=2 convergence](04/20260424-split-level-2-convergence-todo.md) ([lessons](04/20260424-split-level-2-convergence-lessons.md)) | 0 skip — all resolved |
+| 2026-04-24 | [splitLevel>=2 convergence](04/20260424-split-level-2-convergence-todo.md) ([lessons](04/20260424-split-level-2-convergence-lessons.md)) | 0 skip — all resolved, doc restructured |

--- a/docs/tasks/active/README.md
+++ b/docs/tasks/active/README.md
@@ -6,4 +6,4 @@ updated: 2026-04-24
 
 | Date | Task | Status |
 |------|------|--------|
-| 2026-04-24 | [splitLevel>=2 convergence](04/20260424-split-level-2-convergence-todo.md) ([lessons](04/20260424-split-level-2-convergence-lessons.md)) | 27 skip remaining |
+| 2026-04-24 | [splitLevel>=2 convergence](04/20260424-split-level-2-convergence-todo.md) ([lessons](04/20260424-split-level-2-convergence-lessons.md)) | 5 skip remaining |

--- a/docs/tasks/active/README.md
+++ b/docs/tasks/active/README.md
@@ -4,4 +4,6 @@ updated: 2026-04-24
 
 # Active Tasks
 
-(none)
+| Date | Task | Status |
+|------|------|--------|
+| 2026-04-24 | [splitLevel>=2 convergence](04/20260424-split-level-2-convergence-todo.md) ([lessons](04/20260424-split-level-2-convergence-lessons.md)) | 27 skip remaining |

--- a/docs/tasks/archive/2026/04/20260424-split-level-2-convergence-todo.md
+++ b/docs/tasks/archive/2026/04/20260424-split-level-2-convergence-todo.md
@@ -1,0 +1,573 @@
+# splitLevel >= 2 Convergence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the 53 remaining concurrent divergences for `splitLevel >= 2` operations in the Yorkie Tree CRDT.
+
+**Architecture:** Experiment-driven approach — classify failures first (Phase 1), then apply Fix 7 propagation in the recursive split loop (Phase 2), with parent-check relaxation and Fix 8 as follow-up phases. Each experiment records results and learnings.
+
+**Tech Stack:** Go (server), TypeScript (JS SDK). Property-based concurrent tests in `test/complex/tree_concurrency_test.go` (Go, `//go:build complex`).
+
+**Design doc:** `docs/design/split-level-2-convergence.md`
+
+---
+
+### Task 1: Establish Baseline — Run Skipped L2 Tests and Count
+
+**Files:**
+- Read: `test/complex/tree_concurrency_test.go`
+- Read: `pkg/document/crdt/tree.go`
+
+This task does not change any code. It establishes the exact failure count and collects divergent states for classification.
+
+- [ ] **Step 1: Run SplitSplit tests and capture skip count**
+
+Run from the yorkie repo root:
+
+```bash
+cd /Users/hackerwins/Development/yorkie-team/second-brain/03_projects/yorkie
+go test -tags complex -run TestTreeConcurrencySplitSplit -v -count=1 ./test/complex/ 2>&1 | tail -100
+```
+
+Expected: ~46 tests show `--- SKIP` with `different result`. Record the exact count.
+
+- [ ] **Step 2: Run SplitEdit tests and capture skip count**
+
+```bash
+go test -tags complex -run TestTreeConcurrencySplitEdit -v -count=1 ./test/complex/ 2>&1 | tail -100
+```
+
+Expected: ~7 tests show `--- SKIP`. Record the exact count.
+
+- [ ] **Step 3: Run full suite to confirm baseline**
+
+```bash
+go test -tags complex -run 'TestTreeConcurrency' -v -count=1 ./test/complex/ 2>&1 | grep -E 'SKIP|PASS|FAIL' | sort | uniq -c
+```
+
+Record: total pass, total skip, total fail. This is the baseline for all experiments.
+
+- [ ] **Step 4: Record baseline in the Experiment Log**
+
+Update `docs/design/split-level-2-convergence.md`, Experiment 1 section:
+
+```markdown
+### Experiment 1: Failure Classification
+
+- **Date:** 2026-04-24
+- **Hypothesis:** Most of the 53 failures are F7-pos (position mismatch at ancestor level).
+- **Method:** Run skipped tests, count and classify.
+- **Result:** SplitSplit: _/_ skip, SplitEdit: _/_ skip. Total: _/_ skip.
+- **Learnings:** (fill after classification)
+```
+
+- [ ] **Step 5: Commit baseline**
+
+```bash
+git add docs/design/split-level-2-convergence.md
+git commit -m "Record baseline skip counts for splitLevel>=2 convergence experiments"
+```
+
+---
+
+### Task 2: Classify Failures — Add Logging to Identify Root Causes
+
+**Files:**
+- Modify: `test/complex/tree_concurrency_test.go:232-248`
+
+Add verbose logging to the test harness so that when convergence fails, we can see the divergent XML states and identify what went wrong.
+
+- [ ] **Step 1: Add divergent-state logging to RunTestTreeConcurrency**
+
+In `test/complex/tree_concurrency_test.go`, modify the `runTest` function to log both replicas' XML when they diverge:
+
+```go
+flag := syncClientsThenCheckEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
+if flag {
+    return testResult{flag, `pass`}
+}
+xml1 := d1.Root().GetTree("t").ToXML()
+xml2 := d2.Root().GetTree("t").ToXML()
+return testResult{flag, fmt.Sprintf("different result\n  d1: %s\n  d2: %s", xml1, xml2)}
+```
+
+Also add `"fmt"` to the import block if not already present.
+
+- [ ] **Step 2: Run SplitSplit with verbose output and save to file**
+
+```bash
+go test -tags complex -run TestTreeConcurrencySplitSplit -v -count=1 ./test/complex/ 2>&1 | grep -A2 'SKIP' > /tmp/splitsplit-divergences.txt
+```
+
+- [ ] **Step 3: Run SplitEdit with verbose output and save to file**
+
+```bash
+go test -tags complex -run TestTreeConcurrencySplitEdit -v -count=1 ./test/complex/ 2>&1 | grep -A2 'SKIP' > /tmp/splitedit-divergences.txt
+```
+
+- [ ] **Step 4: Classify failures by examining divergent states**
+
+Examine `/tmp/splitsplit-divergences.txt` and `/tmp/splitedit-divergences.txt`. For each failed test, classify by comparing the two XMLs:
+
+- **F7-pos:** Nodes appear in wrong position (split sibling not advanced past)
+- **F7-parent:** Split sibling in different parent than expected (parent check broke chain)
+- **F8-ancestor:** Children partitioned to wrong side of split
+- **NEW:** Pattern doesn't match Fix 7 or Fix 8 gap
+
+Record classification counts in the design doc.
+
+- [ ] **Step 5: Update Experiment Log with classification results**
+
+Update `docs/design/split-level-2-convergence.md`, Experiment 1:
+
+```markdown
+- **Learnings:**
+  - F7-pos: _ tests
+  - F7-parent: _ tests
+  - F8-ancestor: _ tests
+  - NEW: _ tests
+  - Common divergence pattern: (describe)
+```
+
+- [ ] **Step 6: Commit classification results**
+
+```bash
+git add docs/design/split-level-2-convergence.md test/complex/tree_concurrency_test.go
+git commit -m "Add divergence logging and classify splitLevel>=2 test failures"
+```
+
+---
+
+### Task 3: Fix 7 Propagation — Add advancePast to Split Loop (Go)
+
+**Files:**
+- Modify: `pkg/document/crdt/tree.go:1325-1359` (split loop)
+
+This is the core fix: apply `advancePastUnknownSplitSiblings` at each iteration of the recursive split loop.
+
+- [ ] **Step 1: Modify the split loop to apply Fix 7 at each iteration**
+
+In `pkg/document/crdt/tree.go`, modify the `split` method (line 1325):
+
+```go
+func (t *Tree) split(
+	fromParent *TreeNode,
+	fromLeft *TreeNode,
+	splitLevel int,
+	issueTimeTicket func() *time.Ticket,
+	versionVector time.VersionVector,
+) error {
+	if splitLevel == 0 {
+		return nil
+	}
+
+	splitCount := 0
+	parent := fromParent
+	left := fromLeft
+	for splitCount < splitLevel {
+		// Fix 7 propagation: advance past unknown element split siblings
+		// at the current ancestor level. Without this, the position marker
+		// at ancestor levels does not account for concurrent splits that
+		// created unknown siblings (with non-deterministic element IDs
+		// discoverable only via InsNextID chain).
+		if left != parent {
+			left = t.advancePastUnknownSplitSiblings(left, versionVector)
+		}
+
+		var err error
+		offset := 0
+		if left != parent {
+			offset, err = parent.Index.FindOffset(left.Index)
+			if err != nil {
+				return err
+			}
+
+			offset++
+		}
+		if _, err := parent.Split(t, offset, issueTimeTicket, versionVector); err != nil {
+			return err
+		}
+		left = parent
+		parent = parent.Index.Parent.Value
+		splitCount++
+	}
+
+	return nil
+}
+```
+
+- [ ] **Step 2: Run SplitSplit tests to measure improvement**
+
+```bash
+go test -tags complex -run TestTreeConcurrencySplitSplit -v -count=1 ./test/complex/ 2>&1 | grep -E 'SKIP|PASS|FAIL' | sort | uniq -c
+```
+
+Record: how many skips reduced from baseline.
+
+- [ ] **Step 3: Run SplitEdit tests to measure improvement**
+
+```bash
+go test -tags complex -run TestTreeConcurrencySplitEdit -v -count=1 ./test/complex/ 2>&1 | grep -E 'SKIP|PASS|FAIL' | sort | uniq -c
+```
+
+- [ ] **Step 4: Run full suite to check for regressions**
+
+```bash
+go test -tags complex -run 'TestTreeConcurrency' -v -count=1 ./test/complex/ 2>&1 | grep -E 'SKIP|PASS|FAIL' | sort | uniq -c
+```
+
+Confirm: no previously-passing tests now fail. Total pass count must be >= 1539.
+
+- [ ] **Step 5: Run unit tests for regressions**
+
+```bash
+make test
+```
+
+All existing tests must pass.
+
+- [ ] **Step 6: Update Experiment Log**
+
+Update `docs/design/split-level-2-convergence.md`, Experiment 2:
+
+```markdown
+### Experiment 2: Fix 7 Propagation
+
+- **Date:** 2026-04-2X
+- **Hypothesis:** Adding advancePastUnknownSplitSiblings in the split loop resolves F7-pos failures.
+- **Change:** Added Fix 7 call at each iteration of the split loop in tree.go:split()
+- **Result:** _/53 tests fixed. New totals: _ pass, _ skip.
+- **Regressions:** _/1539 existing tests.
+- **Learnings:** (observations about which tests were fixed, which remain)
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pkg/document/crdt/tree.go docs/design/split-level-2-convergence.md
+git commit -m "Propagate Fix 7 (split sibling forwarding) into recursive split loop
+
+advancePastUnknownSplitSiblings was only applied before the split loop
+entry (Edit Step 01-1). For splitLevel >= 2, the position marker at
+ancestor levels was not advanced past concurrent unknown element split
+siblings. Element splits produce non-deterministic IDs (new tickets),
+so InsNextID chain traversal is the only discovery path.
+
+This change applies Fix 7 at each iteration of the recursive split
+loop, matching the approach already used for Fix 11 in Style/RemoveStyle."
+```
+
+---
+
+### Task 4: Parent Check Relaxation — Handle Moved Siblings (Go)
+
+**Files:**
+- Modify: `pkg/document/crdt/tree.go:1288-1323` (advancePastUnknownSplitSiblings)
+
+If Task 3 does not resolve all failures (particularly F7-parent cases), relax the parent equality check following the Fix 11 rationale.
+
+**Skip this task if Task 3 resolves all 53 failures.**
+
+- [ ] **Step 1: Add a relaxParentCheck parameter to advancePastUnknownSplitSiblings**
+
+In `pkg/document/crdt/tree.go`, modify the function signature and logic:
+
+```go
+// advancePastUnknownSplitSiblings follows the InsNextID chain of the given
+// node, advancing past element-type split siblings that the editing client
+// did not know about (not in versionVector).
+//
+// When relaxParentCheck is true, the parent-equality guard is skipped.
+// This is needed at ancestor levels of recursive splits (splitLevel >= 2)
+// where a concurrent ancestor split may have moved the sibling to a
+// different parent — same rationale as hasUnknownSplitSibling (Fix 11).
+func (t *Tree) advancePastUnknownSplitSiblings(
+	node *TreeNode,
+	versionVector time.VersionVector,
+	relaxParentCheck ...bool,
+) *TreeNode {
+	if len(versionVector) == 0 || node == nil {
+		return node
+	}
+
+	relaxParent := len(relaxParentCheck) > 0 && relaxParentCheck[0]
+
+	current := node
+	for current.InsNextID != nil {
+		next := t.findFloorNode(current.InsNextID)
+		if next == nil || next.IsText() {
+			break
+		}
+
+		// Stop if the sibling has been moved to a different parent
+		// (e.g., by a higher-level concurrent split).
+		// Skip this check when relaxParentCheck is true (ancestor split level).
+		if !relaxParent && next.Index.Parent != current.Index.Parent {
+			break
+		}
+
+		actorID := next.id.CreatedAt.ActorID()
+		if l, ok := versionVector.Get(actorID); ok && l >= next.id.CreatedAt.Lamport() {
+			break
+		}
+
+		current = next
+	}
+
+	return current
+}
+```
+
+- [ ] **Step 2: Update the split loop to pass relaxParentCheck=true**
+
+In the `split` method, update the Fix 7 call:
+
+```go
+		if left != parent {
+			left = t.advancePastUnknownSplitSiblings(left, versionVector, true)
+		}
+```
+
+The existing callers in Edit Step 01-1 (lines 995-999) remain unchanged — they pass no third argument, so `relaxParent` defaults to `false`.
+
+- [ ] **Step 3: Run SplitSplit and SplitEdit tests**
+
+```bash
+go test -tags complex -run 'TestTreeConcurrencySplitSplit|TestTreeConcurrencySplitEdit' -v -count=1 ./test/complex/ 2>&1 | grep -E 'SKIP|PASS|FAIL' | sort | uniq -c
+```
+
+- [ ] **Step 4: Run full suite for regressions**
+
+```bash
+go test -tags complex -run 'TestTreeConcurrency' -v -count=1 ./test/complex/ 2>&1 | grep -E 'SKIP|PASS|FAIL' | sort | uniq -c
+```
+
+No previously-passing tests may fail. Also run `make test`.
+
+- [ ] **Step 5: Update Experiment Log**
+
+Update `docs/design/split-level-2-convergence.md`, Experiment 3:
+
+```markdown
+### Experiment 3: Parent Check Relaxation
+
+- **Date:** 2026-04-2X
+- **Hypothesis:** Relaxing parent equality check (Fix 11 style) resolves F7-parent failures.
+- **Change:** Added relaxParentCheck parameter, used in split loop only.
+- **Result:** _/53 tests fixed (cumulative with Experiment 2). New totals: _ pass, _ skip.
+- **Regressions:** _/1539 existing tests.
+- **Learnings:**
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pkg/document/crdt/tree.go docs/design/split-level-2-convergence.md
+git commit -m "Relax parent equality check in split loop Fix 7 propagation
+
+In multi-level splits (splitLevel>=2), a concurrent ancestor split may
+move the split sibling to a different parent. The parent equality guard
+in advancePastUnknownSplitSiblings breaks the chain prematurely.
+
+Follow Fix 11 (hasUnknownSplitSibling) rationale: InsNextID is only set
+by SplitElement, so its existence is sufficient evidence of a split
+sibling. Parent check is relaxed only at ancestor iterations of the
+split loop; initial-level callers retain the strict check."
+```
+
+---
+
+### Task 5: Port Fixes to JS SDK
+
+**Files:**
+- Modify: `packages/sdk/src/document/crdt/tree.ts:1661-1676` (split loop)
+- Modify: `packages/sdk/src/document/crdt/tree.ts:968-1002` (advancePastUnknownSplitSiblings)
+
+Port whichever fixes succeeded in Tasks 3-4 to the JS SDK.
+
+- [ ] **Step 1: Add Fix 7 propagation to JS split loop**
+
+In `packages/sdk/src/document/crdt/tree.ts`, modify the split loop (line 1661):
+
+```typescript
+    // 04. Split: split the element nodes for the given split level.
+    if (splitLevel > 0) {
+      let splitCount = 0;
+      let parent = fromParent;
+      let left = fromLeft;
+      while (splitCount < splitLevel) {
+        // Fix 7 propagation: advance past unknown element split siblings
+        // at the current ancestor level.
+        if (left !== parent) {
+          left = this.advancePastUnknownSplitSiblings(left, versionVector, true);
+        }
+
+        parent.split(
+          this,
+          parent.findOffset(left, true) + 1,
+          issueTimeTicket,
+          versionVector,
+        );
+        left = parent;
+        parent = parent.parent!;
+        splitCount++;
+      }
+```
+
+- [ ] **Step 2: Add relaxParentCheck parameter to JS advancePastUnknownSplitSiblings**
+
+Modify the method (line 968):
+
+```typescript
+  private advancePastUnknownSplitSiblings(
+    node: CRDTTreeNode,
+    versionVector?: VersionVector,
+    relaxParentCheck = false,
+  ): CRDTTreeNode {
+    if (!versionVector || !node) {
+      return node;
+    }
+
+    let current = node;
+    while (current.insNextID) {
+      const next = this.findFloorNode(current.insNextID);
+      if (!next || next.isText) {
+        break;
+      }
+
+      // Stop if the sibling has been moved to a different parent
+      // (e.g., by a higher-level concurrent split).
+      // Skip this check when relaxParentCheck is true (ancestor split level).
+      if (!relaxParentCheck && next.parent !== current.parent) {
+        break;
+      }
+
+      const actorID = next.id.getCreatedAt().getActorID();
+      const knownLamport = versionVector.get(actorID);
+      if (
+        knownLamport !== undefined &&
+        knownLamport >= next.id.getCreatedAt().getLamport()
+      ) {
+        break;
+      }
+
+      current = next;
+    }
+
+    return current;
+  }
+```
+
+- [ ] **Step 3: Build and lint**
+
+```bash
+cd /Users/hackerwins/Development/yorkie-team/second-brain/03_projects/yorkie-js-sdk
+pnpm lint && pnpm sdk build
+```
+
+- [ ] **Step 4: Run tree tests**
+
+```bash
+pnpm sdk test test/integration/tree_test.ts
+```
+
+All existing tests must pass. No new test failures.
+
+- [ ] **Step 5: Run history tree tests**
+
+```bash
+pnpm sdk test test/integration/history_tree_test.ts
+```
+
+Verify no regressions in undo/redo tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/sdk/src/document/crdt/tree.ts
+git commit -m "Port Fix 7 propagation for splitLevel>=2 to JS SDK
+
+Mirror the Go server change: apply advancePastUnknownSplitSiblings at
+each iteration of the recursive split loop with relaxed parent check.
+Element split siblings have non-deterministic IDs (new tickets) and
+are only discoverable via InsNextID chain traversal."
+```
+
+---
+
+### Task 6: Record Final Results and Update Design Docs
+
+**Files:**
+- Modify: `docs/design/split-level-2-convergence.md`
+- Modify: `docs/design/concurrent-merge-split.md:183-191`
+
+- [ ] **Step 1: Run final full test suite (Go)**
+
+```bash
+cd /Users/hackerwins/Development/yorkie-team/second-brain/03_projects/yorkie
+go test -tags complex -run 'TestTreeConcurrency' -v -count=1 ./test/complex/ 2>&1 | grep -E 'SKIP|PASS|FAIL' | sort | uniq -c
+```
+
+Record final pass/skip/fail counts.
+
+- [ ] **Step 2: Update convergence coverage table in concurrent-merge-split.md**
+
+Update the "Convergence Coverage" section (line 146) and the "Remaining Issue" section (line 183) with the new test results:
+
+```markdown
+## Remaining Issue: `splitLevel >= 2`
+
+[Update with current status — how many of the 53 divergences are resolved,
+how many remain, and what the remaining root causes are.]
+```
+
+- [ ] **Step 3: Write final Experiment Log entries**
+
+Complete all experiment entries in `docs/design/split-level-2-convergence.md` with actual results and learnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/design/split-level-2-convergence.md docs/design/concurrent-merge-split.md
+git commit -m "Update convergence docs with splitLevel>=2 experiment results"
+```
+
+---
+
+### Task 7: Write Lessons Learned
+
+**Files:**
+- Create: `docs/tasks/active/20260424-split-level-2-convergence-lessons.md`
+
+- [ ] **Step 1: Write lessons file**
+
+Create `docs/tasks/active/20260424-split-level-2-convergence-lessons.md` with learnings from all experiments, including:
+
+- Which failures were Fix 7 vs Fix 8 vs NEW
+- Whether parent check relaxation was needed
+- Text vs Element ID asymmetry implications
+- Any unexpected findings
+- What remains for undo/redo enablement
+
+- [ ] **Step 2: Update active tasks README**
+
+Update `docs/tasks/active/README.md`:
+
+```markdown
+---
+updated: 2026-04-24
+---
+
+# Active Tasks
+
+| Task | Status |
+|------|--------|
+| [splitLevel>=2 Convergence](20260424-split-level-2-convergence-todo.md) | in progress |
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/tasks/active/
+git commit -m "Add splitLevel>=2 convergence task docs and lessons"
+```

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -1293,10 +1293,13 @@ func (t *Tree) collectBetween(
 func (t *Tree) advancePastUnknownSplitSiblings(
 	node *TreeNode,
 	versionVector time.VersionVector,
+	relaxParentCheck ...bool,
 ) *TreeNode {
 	if len(versionVector) == 0 || node == nil {
 		return node
 	}
+
+	relaxParent := len(relaxParentCheck) > 0 && relaxParentCheck[0]
 
 	current := node
 	for current.InsNextID != nil {
@@ -1307,7 +1310,12 @@ func (t *Tree) advancePastUnknownSplitSiblings(
 
 		// Stop if the sibling has been moved to a different parent
 		// (e.g., by a higher-level concurrent split).
-		if next.Index.Parent != current.Index.Parent {
+		// Skip this check when relaxParentCheck is true — at ancestor
+		// iterations of the split loop, a concurrent recursive split may
+		// have moved the sibling to a different parent. InsNextID is only
+		// set by SplitElement, so its existence is sufficient evidence
+		// of a split sibling (same rationale as hasUnknownSplitSibling).
+		if !relaxParent && next.Index.Parent != current.Index.Parent {
 			break
 		}
 
@@ -1337,6 +1345,22 @@ func (t *Tree) split(
 	parent := fromParent
 	left := fromLeft
 	for splitCount < splitLevel {
+		// Fix 7 propagation: advance past unknown element split siblings
+		// at the current ancestor level. Element splits produce non-
+		// deterministic IDs (new tickets) discoverable only via InsNextID
+		// chain. Use relaxed parent check because a concurrent ancestor
+		// split may have moved siblings to different parents.
+		if left != parent {
+			left = t.advancePastUnknownSplitSiblings(left, versionVector, true)
+			// If the advance moved left to a node under a different
+			// parent (due to a concurrent ancestor split), update parent
+			// to match so FindOffset and Split operate on the correct
+			// subtree.
+			if left.Index.Parent != nil && left.Index.Parent.Value != parent {
+				parent = left.Index.Parent.Value
+			}
+		}
+
 		var err error
 		offset := 0
 		if left != parent {

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -1058,8 +1058,39 @@ func (t *Tree) Edit(
 		toLeft = t.advancePastUnknownSplitSiblings(toLeft, versionVector)
 	}
 
+	// 01-2. Fix 18: When a concurrent element split placed fromLeft and
+	// toLeft in different parents, the traversal range crosses parent
+	// boundaries and may include split products (e.g., text created by
+	// a concurrent text split inside a split sibling element) that were
+	// not in the editor's original range. Advance fromLeft through its
+	// InsNextID chain to find a split sibling in toParent, narrowing the
+	// range to only the intended content. VV-independent to preserve
+	// clone/root consistency.
+	//
+	// Only the collectBetween range is narrowed. The original
+	// fromParent/fromLeft are preserved for merge, split, and insert
+	// steps so that content is inserted at the editor's intended
+	// position (matching the order-of-operations on the other replica).
+	collectFromParent, collectFromLeft := fromParent, fromLeft
+	if fromLeft != fromParent && fromParent != toParent {
+		current := fromLeft
+		for current.InsNextID != nil {
+			next := t.findFloorNode(current.InsNextID)
+			if next == nil || next.IsText() {
+				break
+			}
+			if next.Index.Parent != nil &&
+				next.Index.Parent.Value == toParent {
+				collectFromLeft = next
+				collectFromParent = toParent
+				break
+			}
+			current = next
+		}
+	}
+
 	toBeRemoveds, toBeMovedToFromParents, toBeMergedNodes, err := t.collectBetween(
-		fromParent, fromLeft, toParent, toLeft,
+		collectFromParent, collectFromLeft, toParent, toLeft,
 		editedAt, versionVector,
 	)
 	if err != nil {

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -471,12 +471,26 @@ func (n *TreeNode) SplitElement(
 	// original child was positioned relative to the pre-split child order.
 	// Its CRDT position (after a left-partition child) means it should
 	// stay in the left partition.
+	//
+	// Split siblings (nodes with InsPrevID) are skipped during the scan
+	// because they are not concurrent inserts — they are split products
+	// handled separately by Fix 17. Without skipping, a split sibling
+	// at the start of the right partition would set boundaryReached=true,
+	// hiding concurrent inserts that follow it.
 	if len(versionVector) > 0 {
 		var movedToLeft []*index.Node[*TreeNode]
 		var remaining []*index.Node[*TreeNode]
 		boundaryReached := false
 		for _, child := range actualRight {
 			if !boundaryReached {
+				// Skip element split siblings — they are not concurrent
+				// inserts but split products (handled by Fix 17). Text
+				// split siblings have deterministic IDs and should act
+				// as normal boundary markers.
+				if child.Value.InsPrevID != nil && !child.Value.IsText() {
+					remaining = append(remaining, child)
+					continue
+				}
 				actorID := child.Value.id.CreatedAt.ActorID()
 				if l, ok := versionVector.Get(actorID); !ok || l < child.Value.id.CreatedAt.Lamport() {
 					movedToLeft = append(movedToLeft, child)

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -158,7 +158,7 @@ type TreeNode struct {
 	// Persisted alongside MergedFrom because the source parent's
 	// removedAt may be overwritten by later LWW tombstones and thus
 	// cannot serve as the merge-time causal boundary for SplitElement's
-	// §6.1 version-vector check. See docs/design/concurrent-merge-split.md.
+	// §7.1 version-vector check. See docs/design/concurrent-merge-split.md.
 	MergedAt *time.Ticket
 
 	// mergedInto is a runtime cache pointing at the merge target (the
@@ -328,7 +328,7 @@ func (n *TreeNode) Split(
 			if insNext != nil {
 				insNext.InsPrevID = split.id
 
-				// §6.4 Empty Sibling Re-Parenting: When the existing
+				// §7.4 Empty Sibling Re-Parenting: When the existing
 				// InsNext sibling is in a different parent (due to a prior
 				// parent-level split), move the new split sibling to that
 				// parent. This ensures that split siblings land in the same
@@ -437,7 +437,7 @@ func (n *TreeNode) SplitElement(
 	leftChildren := allChildren[0:offset]
 	rightChildren := allChildren[offset:]
 
-	// §6.1 Merge-Moved Children: Keep children merge-moved from a
+	// §7.1 Merge-Moved Children: Keep children merge-moved from a
 	// source that is itself a child of the node being split in the
 	// original (left) partition. When the source is external (e.g., a
 	// sibling element that was merged), the content flows naturally to
@@ -467,14 +467,14 @@ func (n *TreeNode) SplitElement(
 		actualRight = append(actualRight, child)
 	}
 
-	// §6.3 Boundary Insert Migration: Move concurrent inserts at the
+	// §7.3 Boundary Insert Migration: Move concurrent inserts at the
 	// split boundary to the left. A concurrent insert placed between the
 	// split boundary and the next original child was positioned relative
 	// to the pre-split child order. Its CRDT position (after a
 	// left-partition child) means it should stay in the left partition.
 	//
 	// Element split siblings (nodes with InsPrevID) are skipped during
-	// the scan — they are split products handled by §6.4. Without
+	// the scan — they are split products handled by §7.4. Without
 	// skipping, a split sibling at the start of the right partition
 	// would set boundaryReached=true, hiding concurrent inserts that
 	// follow it.
@@ -485,7 +485,7 @@ func (n *TreeNode) SplitElement(
 		for _, child := range actualRight {
 			if !boundaryReached {
 				// Skip element split siblings — they are split products
-				// (handled by §6.4), not concurrent inserts. Text split
+				// (handled by §7.4), not concurrent inserts. Text split
 				// siblings have deterministic IDs and act as normal
 				// boundary markers.
 				if child.Value.InsPrevID != nil && !child.Value.IsText() {
@@ -741,8 +741,8 @@ func NewTree(root *TreeNode, createdAt *time.Ticket) *Tree {
 	// MergedFrom is the only merge-related field written to the snapshot;
 	// mergedInto, mergedChildIDs, and mergedAt are derived here so that a
 	// replica loaded from a snapshot can still handle concurrent ops that
-	// target merged-away parents (§1.1 redirect, §5.2 propagation,
-	// §6.1 split skip).
+	// target merged-away parents (§1.1 redirect, §6.2 propagation,
+	// §7.1 split skip).
 	tree.rebuildMergeState()
 
 	return tree
@@ -1086,7 +1086,7 @@ func (t *Tree) Edit(
 		return nil, resource.DataSize{}, err
 	}
 
-	// Delete: tombstone the collected nodes.
+	// Phase 5: Delete — tombstone the collected nodes.
 	var pairs []GCPair
 	for _, node := range toBeRemoveds {
 		if node.remove(editedAt) {
@@ -1097,25 +1097,25 @@ func (t *Tree) Edit(
 		}
 	}
 
-	// Phase 5: Merge — move children to fromParent, set forwarding pointers.
+	// Phase 6: Merge — move children to fromParent, set forwarding pointers.
 	if err := t.mergeNodes(
 		fromParent, toBeMovedToFromParents, toBeMergedNodes, editedAt,
 	); err != nil {
 		return nil, resource.DataSize{}, err
 	}
 
-	// §5.2: Propagate deletes to children moved by prior merges.
+	// §6.2: Propagate deletes to children moved by prior merges.
 	mergePairs := t.propagateMergeDeletes(
 		fromParent, toBeRemoveds, toBeMergedNodes, editedAt,
 	)
 	pairs = append(pairs, mergePairs...)
 
-	// Phase 6: Split — split element nodes for the given splitLevel.
+	// Phase 7: Split — split element nodes for the given splitLevel.
 	if err := t.split(fromParent, fromLeft, splitLevel, editedAt, issueTimeTicket, versionVector); err != nil {
 		return nil, resource.DataSize{}, err
 	}
 
-	// Insert: insert the given node at the given position.
+	// Phase 8: Insert — insert the given node at the given position.
 	if len(contents) != 0 {
 		leftInChildren := fromLeft
 
@@ -1450,12 +1450,12 @@ func (t *Tree) split(
 	parent := fromParent
 	left := fromLeft
 	for splitCount < splitLevel {
-		// §6.5 Per-Iteration Advance: advance past unknown element
+		// §7.5 Per-Iteration Advance: advance past unknown element
 		// split siblings at the current ancestor level. Element splits
 		// produce non-deterministic IDs discoverable only via InsNextID.
-		// Use relaxed parent check (§6.5) because a concurrent ancestor
+		// Use relaxed parent check (§7.5) because a concurrent ancestor
 		// split may have moved siblings to different parents.
-		// skipActorID (§6.7) prevents advancing past siblings created
+		// skipActorID (§7.7) prevents advancing past siblings created
 		// by the current operation's own issueTimeTicket — same-actor
 		// siblings are own split products, not concurrent.
 		if left != parent {

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -325,6 +325,25 @@ func (n *TreeNode) Split(
 			insNext := tree.findFloorNode(n.InsNextID)
 			insNext.InsPrevID = split.id
 			split.InsNextID = n.InsNextID
+
+			// Fix 17: When the existing InsNext sibling is in a different
+			// parent (due to a prior parent-level split), move the new
+			// split sibling to that parent. This ensures that split
+			// siblings land in the same parent regardless of operation
+			// application order, fixing concurrent splitLevel>=2
+			// divergences.
+			if !n.IsText() && insNext.Index.Parent != nil &&
+				insNext.Index.Parent != split.Index.Parent &&
+				len(split.Index.Children(true)) == 0 {
+				if err := split.Index.Parent.DetachChild(split.Index); err != nil {
+					return diff, err
+				}
+				if err := insNext.Index.Parent.InsertBefore(
+					split.Index, insNext.Index,
+				); err != nil {
+					return diff, err
+				}
+			}
 		}
 		n.InsNextID = split.id
 		tree.NodeMapByID.Put(split.id, split)
@@ -447,7 +466,7 @@ func (n *TreeNode) SplitElement(
 		actualRight = append(actualRight, child)
 	}
 
-	// Fix 13: Move concurrent inserts at the split boundary to the left.
+	// Fix 16: Move concurrent inserts at the split boundary to the left.
 	// A concurrent insert placed between the split boundary and the next
 	// original child was positioned relative to the pre-split child order.
 	// Its CRDT position (after a left-partition child) means it should

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -1058,7 +1058,7 @@ func (t *Tree) Edit(
 	pairs = append(pairs, mergePairs...)
 
 	// 04. Split: split the element nodes for the given splitLevel.
-	if err := t.split(fromParent, fromLeft, splitLevel, issueTimeTicket, versionVector); err != nil {
+	if err := t.split(fromParent, fromLeft, splitLevel, editedAt, issueTimeTicket, versionVector); err != nil {
 		return nil, resource.DataSize{}, err
 	}
 
@@ -1316,16 +1316,35 @@ func (t *Tree) collectBetween(
 // did not know about (not in versionVector). This ensures that concurrent
 // operations resolve positions after all split products the editor could
 // not have seen.
+//
+// Options (variadic):
+//   - relaxParentCheck (bool): skip parent equality check at ancestor
+//     iterations where concurrent splits may have reparented siblings.
+//   - skipActorID (*time.ActorID): stop at siblings created by this actor.
+//     Used in the split loop to avoid advancing past siblings created by
+//     the current operation's own issueTimeTicket (same actor, lamport
+//     beyond VV). Since a single actor's changes are sequential, an
+//     "unknown" sibling from the same actor must be our own creation,
+//     not a concurrent one.
 func (t *Tree) advancePastUnknownSplitSiblings(
 	node *TreeNode,
 	versionVector time.VersionVector,
-	relaxParentCheck ...bool,
+	opts ...any,
 ) *TreeNode {
 	if len(versionVector) == 0 || node == nil {
 		return node
 	}
 
-	relaxParent := len(relaxParentCheck) > 0 && relaxParentCheck[0]
+	var relaxParent bool
+	var skipActorID *time.ActorID
+	for _, opt := range opts {
+		switch v := opt.(type) {
+		case bool:
+			relaxParent = v
+		case *time.ActorID:
+			skipActorID = v
+		}
+	}
 
 	current := node
 	for current.InsNextID != nil {
@@ -1346,6 +1365,13 @@ func (t *Tree) advancePastUnknownSplitSiblings(
 		}
 
 		actorID := next.id.CreatedAt.ActorID()
+
+		// Stop at siblings from the same actor as the current operation.
+		// They are our own split products, not concurrent ones.
+		if skipActorID != nil && actorID == *skipActorID {
+			break
+		}
+
 		if l, ok := versionVector.Get(actorID); ok && l >= next.id.CreatedAt.Lamport() {
 			break
 		}
@@ -1360,6 +1386,7 @@ func (t *Tree) split(
 	fromParent *TreeNode,
 	fromLeft *TreeNode,
 	splitLevel int,
+	editedAt *time.Ticket,
 	issueTimeTicket func() *time.Ticket,
 	versionVector time.VersionVector,
 ) error {
@@ -1371,13 +1398,21 @@ func (t *Tree) split(
 	parent := fromParent
 	left := fromLeft
 	for splitCount < splitLevel {
-		// Fix 7 propagation: advance past unknown element split siblings
-		// at the current ancestor level. Element splits produce non-
-		// deterministic IDs (new tickets) discoverable only via InsNextID
-		// chain. Use relaxed parent check because a concurrent ancestor
-		// split may have moved siblings to different parents.
+		// Fix 13: advance past unknown element split siblings at the
+		// current ancestor level. Element splits produce non-deterministic
+		// IDs (new tickets) discoverable only via InsNextID chain.
+		// Use relaxed parent check because a concurrent ancestor split
+		// may have moved siblings to different parents.
+		//
+		// skipActorID prevents advancing past siblings created by the
+		// current operation's own issueTimeTicket. Their lamports exceed
+		// the change's VV (they are new tickets), making them look
+		// "unknown", but they are our own split products — not concurrent.
+		// Since a single actor's changes are always sequential, an
+		// "unknown" sibling from the same actor is always our own.
 		if left != parent {
-			left = t.advancePastUnknownSplitSiblings(left, versionVector, true)
+			changeActorID := editedAt.ActorID()
+			left = t.advancePastUnknownSplitSiblings(left, versionVector, true, &changeActorID)
 			// If the advance moved left to a node under a different
 			// parent (due to a concurrent ancestor split), update parent
 			// to match so FindOffset and Split operate on the correct
@@ -1399,31 +1434,6 @@ func (t *Tree) split(
 		}
 		if _, err := parent.Split(t, offset, issueTimeTicket, versionVector); err != nil {
 			return err
-		}
-
-		// After Split(), parent.InsNextID points to the sibling just
-		// created in this iteration. Set left to this sibling so that
-		// the next iteration's FindOffset at the grandparent level
-		// places the split boundary AFTER both the original node and
-		// its split product (keeping them on the left side).
-		//
-		// Without this, advancePastUnknownSplitSiblings in the next
-		// iteration cannot distinguish the just-created sibling from
-		// pre-existing siblings (they share the same actor+lamport),
-		// so it stops too early and the split product ends up on the
-		// wrong side.
-		//
-		// Only do this when versionVector is non-nil (concurrent
-		// replay). In the non-concurrent case (versionVector is nil),
-		// left = parent is correct because no concurrent siblings
-		// exist that could cause mis-placement.
-		if len(versionVector) > 0 && parent.InsNextID != nil {
-			if splitSibling := t.findFloorNode(parent.InsNextID); splitSibling != nil && !splitSibling.IsText() {
-				left = splitSibling
-				parent = left.Index.Parent.Value
-				splitCount++
-				continue
-			}
 		}
 
 		left = parent

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -158,7 +158,7 @@ type TreeNode struct {
 	// Persisted alongside MergedFrom because the source parent's
 	// removedAt may be overwritten by later LWW tombstones and thus
 	// cannot serve as the merge-time causal boundary for SplitElement's
-	// Fix 8 version-vector check. See docs/design/concurrent-merge-split.md.
+	// §6.1 version-vector check. See docs/design/concurrent-merge-split.md.
 	MergedAt *time.Ticket
 
 	// mergedInto is a runtime cache pointing at the merge target (the
@@ -328,12 +328,12 @@ func (n *TreeNode) Split(
 			if insNext != nil {
 				insNext.InsPrevID = split.id
 
-				// Fix 17: When the existing InsNext sibling is in a different
-				// parent (due to a prior parent-level split), move the new
-				// split sibling to that parent. This ensures that split
-				// siblings land in the same parent regardless of operation
-				// application order, fixing concurrent splitLevel>=2
-				// divergences.
+				// §6.4 Empty Sibling Re-Parenting: When the existing
+				// InsNext sibling is in a different parent (due to a prior
+				// parent-level split), move the new split sibling to that
+				// parent. This ensures that split siblings land in the same
+				// parent regardless of operation application order.
+				// VV-independent for clone/root consistency.
 				if !n.IsText() && insNext.Index.Parent != nil &&
 					insNext.Index.Parent != split.Index.Parent &&
 					len(split.Index.Children(true)) == 0 {
@@ -437,15 +437,13 @@ func (n *TreeNode) SplitElement(
 	leftChildren := allChildren[0:offset]
 	rightChildren := allChildren[offset:]
 
-	// Fix 8: Handle concurrent merge-moved children during split.
-	// When a child was merge-moved from a source that is itself a child
-	// of the node being split, the content was local to this level and
-	// should stay in the original (left) node. When the source is
-	// external (e.g., a sibling element that was merged), the content
-	// should flow naturally to the split (right) node. The merge ticket
-	// is read from the child's immutable MergedAt field — NOT from the
-	// source's removedAt, which may have been overwritten by a later
-	// LWW tombstone and would give a wrong concurrency answer.
+	// §6.1 Merge-Moved Children: Keep children merge-moved from a
+	// source that is itself a child of the node being split in the
+	// original (left) partition. When the source is external (e.g., a
+	// sibling element that was merged), the content flows naturally to
+	// the split (right) node. The merge ticket is read from the child's
+	// immutable MergedAt field — NOT from the source's removedAt, which
+	// may have been overwritten by a later LWW tombstone.
 	var actualRight []*index.Node[*TreeNode]
 	for _, child := range rightChildren {
 		if child.Value.MergedFrom != nil && child.Value.MergedAt != nil &&
@@ -469,27 +467,27 @@ func (n *TreeNode) SplitElement(
 		actualRight = append(actualRight, child)
 	}
 
-	// Fix 16: Move concurrent inserts at the split boundary to the left.
-	// A concurrent insert placed between the split boundary and the next
-	// original child was positioned relative to the pre-split child order.
-	// Its CRDT position (after a left-partition child) means it should
-	// stay in the left partition.
+	// §6.3 Boundary Insert Migration: Move concurrent inserts at the
+	// split boundary to the left. A concurrent insert placed between the
+	// split boundary and the next original child was positioned relative
+	// to the pre-split child order. Its CRDT position (after a
+	// left-partition child) means it should stay in the left partition.
 	//
-	// Split siblings (nodes with InsPrevID) are skipped during the scan
-	// because they are not concurrent inserts — they are split products
-	// handled separately by Fix 17. Without skipping, a split sibling
-	// at the start of the right partition would set boundaryReached=true,
-	// hiding concurrent inserts that follow it.
+	// Element split siblings (nodes with InsPrevID) are skipped during
+	// the scan — they are split products handled by §6.4. Without
+	// skipping, a split sibling at the start of the right partition
+	// would set boundaryReached=true, hiding concurrent inserts that
+	// follow it.
 	if len(versionVector) > 0 {
 		var movedToLeft []*index.Node[*TreeNode]
 		var remaining []*index.Node[*TreeNode]
 		boundaryReached := false
 		for _, child := range actualRight {
 			if !boundaryReached {
-				// Skip element split siblings — they are not concurrent
-				// inserts but split products (handled by Fix 17). Text
-				// split siblings have deterministic IDs and should act
-				// as normal boundary markers.
+				// Skip element split siblings — they are split products
+				// (handled by §6.4), not concurrent inserts. Text split
+				// siblings have deterministic IDs and act as normal
+				// boundary markers.
 				if child.Value.InsPrevID != nil && !child.Value.IsText() {
 					remaining = append(remaining, child)
 					continue
@@ -743,8 +741,8 @@ func NewTree(root *TreeNode, createdAt *time.Ticket) *Tree {
 	// MergedFrom is the only merge-related field written to the snapshot;
 	// mergedInto, mergedChildIDs, and mergedAt are derived here so that a
 	// replica loaded from a snapshot can still handle concurrent ops that
-	// target merged-away parents (Fix 3 redirect, Fix 5 propagation,
-	// Fix 8 split skip).
+	// target merged-away parents (§1.1 redirect, §5.2 propagation,
+	// §6.1 split skip).
 	tree.rebuildMergeState()
 
 	return tree
@@ -1034,7 +1032,7 @@ func (t *Tree) Edit(
 ) ([]GCPair, resource.DataSize, error) {
 	var diff resource.DataSize
 
-	// 01. find nodes from the given range and split nodes.
+	// Phase 1: Position Resolution — resolve CRDTTreePos to tree nodes.
 	fromParent, fromLeft, diffFrom, err := t.FindTreeNodesWithSplitText(from, editedAt)
 	if err != nil {
 		return nil, diff, err
@@ -1046,14 +1044,9 @@ func (t *Tree) Edit(
 
 	diff.Add(diffFrom, diffTo)
 
-	// 01-1. Advance past split siblings unknown to the editing client.
-	// When a concurrent SplitElement created siblings linked via InsNextID,
-	// the editor's position was computed against the unsplit tree. Advance
-	// past siblings the editor could not have seen so that the range
-	// starts/ends after all concurrent split products.
-	// Skip when leftNode == parent (leftmost child position) — advancing
-	// would change the semantics from "insert at front" to "insert after
-	// split sibling".
+	// Phase 2: Split Sibling Advance — advance past concurrent split
+	// products linked via InsNextID that the editor could not have seen.
+	// Skip when leftNode == parent (leftmost child position).
 	if fromLeft != fromParent {
 		fromLeft = t.advancePastUnknownSplitSiblings(fromLeft, versionVector)
 	}
@@ -1061,19 +1054,12 @@ func (t *Tree) Edit(
 		toLeft = t.advancePastUnknownSplitSiblings(toLeft, versionVector)
 	}
 
-	// 01-2. Fix 18: When a concurrent element split placed fromLeft and
-	// toLeft in different parents, the traversal range crosses parent
-	// boundaries and may include split products (e.g., text created by
-	// a concurrent text split inside a split sibling element) that were
-	// not in the editor's original range. Advance fromLeft through its
-	// InsNextID chain to find a split sibling in toParent, narrowing the
-	// range to only the intended content. VV-independent to preserve
-	// clone/root consistency.
-	//
-	// Only the collectBetween range is narrowed. The original
-	// fromParent/fromLeft are preserved for merge, split, and insert
-	// steps so that content is inserted at the editor's intended
-	// position (matching the order-of-operations on the other replica).
+	// Phase 3: Range Narrowing — when fromLeft and toLeft are in
+	// different parents (due to a concurrent element split), follow
+	// fromLeft's InsNextID chain to find a split sibling in toParent
+	// and narrow the collectBetween range. The original fromParent/
+	// fromLeft are preserved for merge, split, and insert steps.
+	// VV-independent for clone/root consistency.
 	collectFromParent, collectFromLeft := fromParent, fromLeft
 	if fromLeft != fromParent && fromParent != toParent {
 		current := fromLeft
@@ -1100,7 +1086,7 @@ func (t *Tree) Edit(
 		return nil, resource.DataSize{}, err
 	}
 
-	// 02. Delete: delete the nodes that are marked as removed.
+	// Delete: tombstone the collected nodes.
 	var pairs []GCPair
 	for _, node := range toBeRemoveds {
 		if node.remove(editedAt) {
@@ -1111,25 +1097,25 @@ func (t *Tree) Edit(
 		}
 	}
 
-	// 03. Merge: move children to fromParent and set forwarding pointers.
+	// Phase 5: Merge — move children to fromParent, set forwarding pointers.
 	if err := t.mergeNodes(
 		fromParent, toBeMovedToFromParents, toBeMergedNodes, editedAt,
 	); err != nil {
 		return nil, resource.DataSize{}, err
 	}
 
-	// 03-1. Propagate deletes to children moved by prior merges.
+	// §5.2: Propagate deletes to children moved by prior merges.
 	mergePairs := t.propagateMergeDeletes(
 		fromParent, toBeRemoveds, toBeMergedNodes, editedAt,
 	)
 	pairs = append(pairs, mergePairs...)
 
-	// 04. Split: split the element nodes for the given splitLevel.
+	// Phase 6: Split — split element nodes for the given splitLevel.
 	if err := t.split(fromParent, fromLeft, splitLevel, editedAt, issueTimeTicket, versionVector); err != nil {
 		return nil, resource.DataSize{}, err
 	}
 
-	// 05. Insert: insert the given node at the given position.
+	// Insert: insert the given node at the given position.
 	if len(contents) != 0 {
 		leftInChildren := fromLeft
 
@@ -1310,10 +1296,9 @@ func (t *Tree) collectBetween(
 				// 	return
 				// }
 
-				// Fix 9: Skip merge for elements created by concurrent
-				// operations. The editor didn't know about this element,
-				// so crossing into it is an artifact of a concurrent split,
-				// not an intentional merge.
+				// §4.3 Skip Concurrent Element Merge: the editor didn't
+				// know about this element, so crossing into it is an
+				// artifact of a concurrent split, not an intentional merge.
 				if ticketKnown(versionVector, node.id.CreatedAt) {
 					toBeMergedNodes = append(toBeMergedNodes, node)
 					for _, child := range node.Index.Children() {
@@ -1465,18 +1450,14 @@ func (t *Tree) split(
 	parent := fromParent
 	left := fromLeft
 	for splitCount < splitLevel {
-		// Fix 13: advance past unknown element split siblings at the
-		// current ancestor level. Element splits produce non-deterministic
-		// IDs (new tickets) discoverable only via InsNextID chain.
-		// Use relaxed parent check because a concurrent ancestor split
-		// may have moved siblings to different parents.
-		//
-		// skipActorID prevents advancing past siblings created by the
-		// current operation's own issueTimeTicket. Their lamports exceed
-		// the change's VV (they are new tickets), making them look
-		// "unknown", but they are our own split products — not concurrent.
-		// Since a single actor's changes are always sequential, an
-		// "unknown" sibling from the same actor is always our own.
+		// §6.5 Per-Iteration Advance: advance past unknown element
+		// split siblings at the current ancestor level. Element splits
+		// produce non-deterministic IDs discoverable only via InsNextID.
+		// Use relaxed parent check (§6.5) because a concurrent ancestor
+		// split may have moved siblings to different parents.
+		// skipActorID (§6.7) prevents advancing past siblings created
+		// by the current operation's own issueTimeTicket — same-actor
+		// siblings are own split products, not concurrent.
 		if left != parent {
 			changeActorID := editedAt.ActorID()
 			left = t.advancePastUnknownSplitSiblings(left, versionVector, true, &changeActorID)

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -323,25 +323,28 @@ func (n *TreeNode) Split(
 		split.InsPrevID = n.id
 		if n.InsNextID != nil {
 			insNext := tree.findFloorNode(n.InsNextID)
-			insNext.InsPrevID = split.id
 			split.InsNextID = n.InsNextID
 
-			// Fix 17: When the existing InsNext sibling is in a different
-			// parent (due to a prior parent-level split), move the new
-			// split sibling to that parent. This ensures that split
-			// siblings land in the same parent regardless of operation
-			// application order, fixing concurrent splitLevel>=2
-			// divergences.
-			if !n.IsText() && insNext.Index.Parent != nil &&
-				insNext.Index.Parent != split.Index.Parent &&
-				len(split.Index.Children(true)) == 0 {
-				if err := split.Index.Parent.DetachChild(split.Index); err != nil {
-					return diff, err
-				}
-				if err := insNext.Index.Parent.InsertBefore(
-					split.Index, insNext.Index,
-				); err != nil {
-					return diff, err
+			if insNext != nil {
+				insNext.InsPrevID = split.id
+
+				// Fix 17: When the existing InsNext sibling is in a different
+				// parent (due to a prior parent-level split), move the new
+				// split sibling to that parent. This ensures that split
+				// siblings land in the same parent regardless of operation
+				// application order, fixing concurrent splitLevel>=2
+				// divergences.
+				if !n.IsText() && insNext.Index.Parent != nil &&
+					insNext.Index.Parent != split.Index.Parent &&
+					len(split.Index.Children(true)) == 0 {
+					if err := split.Index.Parent.DetachChild(split.Index); err != nil {
+						return diff, err
+					}
+					if err := insNext.Index.Parent.InsertBefore(
+						split.Index, insNext.Index,
+					); err != nil {
+						return diff, err
+					}
 				}
 			}
 		}

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -447,6 +447,32 @@ func (n *TreeNode) SplitElement(
 		actualRight = append(actualRight, child)
 	}
 
+	// Fix 13: Move concurrent inserts at the split boundary to the left.
+	// A concurrent insert placed between the split boundary and the next
+	// original child was positioned relative to the pre-split child order.
+	// Its CRDT position (after a left-partition child) means it should
+	// stay in the left partition.
+	if len(versionVector) > 0 {
+		var movedToLeft []*index.Node[*TreeNode]
+		var remaining []*index.Node[*TreeNode]
+		boundaryReached := false
+		for _, child := range actualRight {
+			if !boundaryReached {
+				actorID := child.Value.id.CreatedAt.ActorID()
+				if l, ok := versionVector.Get(actorID); !ok || l < child.Value.id.CreatedAt.Lamport() {
+					movedToLeft = append(movedToLeft, child)
+					continue
+				}
+			}
+			boundaryReached = true
+			remaining = append(remaining, child)
+		}
+		if len(movedToLeft) > 0 {
+			leftChildren = append(leftChildren, movedToLeft...)
+			actualRight = remaining
+		}
+	}
+
 	if err := n.Index.SetChildren(leftChildren); err != nil {
 		return nil, diff, err
 	}
@@ -1364,7 +1390,7 @@ func (t *Tree) split(
 		var err error
 		offset := 0
 		if left != parent {
-			offset, err = parent.Index.FindOffset(left.Index)
+			offset, err = parent.Index.FindOffset(left.Index, true)
 			if err != nil {
 				return err
 			}
@@ -1374,6 +1400,32 @@ func (t *Tree) split(
 		if _, err := parent.Split(t, offset, issueTimeTicket, versionVector); err != nil {
 			return err
 		}
+
+		// After Split(), parent.InsNextID points to the sibling just
+		// created in this iteration. Set left to this sibling so that
+		// the next iteration's FindOffset at the grandparent level
+		// places the split boundary AFTER both the original node and
+		// its split product (keeping them on the left side).
+		//
+		// Without this, advancePastUnknownSplitSiblings in the next
+		// iteration cannot distinguish the just-created sibling from
+		// pre-existing siblings (they share the same actor+lamport),
+		// so it stops too early and the split product ends up on the
+		// wrong side.
+		//
+		// Only do this when versionVector is non-nil (concurrent
+		// replay). In the non-concurrent case (versionVector is nil),
+		// left = parent is correct because no concurrent siblings
+		// exist that could cause mis-placement.
+		if len(versionVector) > 0 && parent.InsNextID != nil {
+			if splitSibling := t.findFloorNode(parent.InsNextID); splitSibling != nil && !splitSibling.IsText() {
+				left = splitSibling
+				parent = left.Index.Parent.Value
+				splitCount++
+				continue
+			}
+		}
+
 		left = parent
 		parent = parent.Index.Parent.Value
 		splitCount++

--- a/test/complex/main_test.go
+++ b/test/complex/main_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/yorkie-team/yorkie/api/yorkie/v1/v1connect"
 	"github.com/yorkie-team/yorkie/client"
 	"github.com/yorkie-team/yorkie/pkg/document"
+	"github.com/yorkie-team/yorkie/pkg/document/crdt"
 	"github.com/yorkie-team/yorkie/server/backend"
 	"github.com/yorkie-team/yorkie/server/backend/database"
 	"github.com/yorkie-team/yorkie/server/profiling/prometheus"
@@ -172,6 +173,32 @@ func syncClientsThenCheckEqual(t *testing.T, pairs []clientAndDocPair) bool {
 		}
 	}
 
+	// Check clone and root tree consistency within each document.
+	for i, pair := range pairs {
+		if !checkCloneAndRootTreeEqual(i+1, pair.doc) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// checkCloneAndRootTreeEqual checks that each tree element in the document
+// has consistent XML between the clone and the root.
+func checkCloneAndRootTreeEqual(docIdx int, doc *document.Document) bool {
+	for key, elem := range doc.RootObject().Members() {
+		tree, ok := elem.(*crdt.Tree)
+		if !ok {
+			continue
+		}
+		rootXML := tree.ToXML()
+		cloneXML := doc.Root().GetTree(key).ToXML()
+		if cloneXML != rootXML {
+			fmt.Printf("d%d: clone/root mismatch for tree %q\n  clone: %s\n  root:  %s\n",
+				docIdx, key, cloneXML, rootXML)
+			return false
+		}
+	}
 	return true
 }
 

--- a/test/complex/tree_concurrency_test.go
+++ b/test/complex/tree_concurrency_test.go
@@ -246,7 +246,9 @@ func RunTestTreeConcurrency(testDesc string, t *testing.T, initialState json.Tre
 				desc += "(" + op1.getDesc() + "," + op2.getDesc() + ")"
 				t.Run(desc, func(t *testing.T) {
 					result := runTest(interval, op1, op2)
-					assert.True(t, result.flag, result.resultDesc)
+					if !result.flag {
+						t.Skip(result.resultDesc)
+					}
 				})
 			}
 		}

--- a/test/complex/tree_concurrency_test.go
+++ b/test/complex/tree_concurrency_test.go
@@ -246,9 +246,7 @@ func RunTestTreeConcurrency(testDesc string, t *testing.T, initialState json.Tre
 				desc += "(" + op1.getDesc() + "," + op2.getDesc() + ")"
 				t.Run(desc, func(t *testing.T) {
 					result := runTest(interval, op1, op2)
-					if !result.flag {
-						t.Skip(result.resultDesc)
-					}
+					assert.True(t, result.flag, result.resultDesc)
 				})
 			}
 		}

--- a/test/complex/tree_concurrency_test.go
+++ b/test/complex/tree_concurrency_test.go
@@ -20,6 +20,7 @@ package complex
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -233,7 +234,9 @@ func RunTestTreeConcurrency(testDesc string, t *testing.T, initialState json.Tre
 		if flag {
 			return testResult{flag, `pass`}
 		}
-		return testResult{flag, `different result`}
+		xml1 := d1.Root().GetTree("t").ToXML()
+		xml2 := d2.Root().GetTree("t").ToXML()
+		return testResult{flag, fmt.Sprintf("different result\n  d1: %s\n  d2: %s", xml1, xml2)}
 	}
 
 	for _, interval := range rangesArr {

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/yorkie-team/yorkie/client"
 	"github.com/yorkie-team/yorkie/pkg/document"
+	"github.com/yorkie-team/yorkie/pkg/document/crdt"
 	"github.com/yorkie-team/yorkie/pkg/document/presence"
 	"github.com/yorkie-team/yorkie/server"
 	"github.com/yorkie-team/yorkie/server/logging"
@@ -88,6 +89,11 @@ func syncClientsThenAssertEqual(t *testing.T, pairs []clientAndDocPair) {
 		fmt.Printf("after d%d: %s\n", i+2, v)
 		assert.Equal(t, expected, v)
 	}
+
+	// Assert clone and root tree consistency within each document.
+	for i, pair := range pairs {
+		assertCloneAndRootTreeEqual(t, i+1, pair.doc)
+	}
 }
 
 func syncClientsThenCheckEqual(t *testing.T, pairs []clientAndDocPair) bool {
@@ -118,6 +124,47 @@ func syncClientsThenCheckEqual(t *testing.T, pairs []clientAndDocPair) bool {
 		}
 	}
 
+	// Check clone and root tree consistency within each document.
+	for i, pair := range pairs {
+		if !checkCloneAndRootTreeEqual(i+1, pair.doc) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// assertCloneAndRootTreeEqual asserts that each tree element in the document
+// has consistent XML between the clone and the root.
+func assertCloneAndRootTreeEqual(t *testing.T, docIdx int, doc *document.Document) {
+	for key, elem := range doc.RootObject().Members() {
+		tree, ok := elem.(*crdt.Tree)
+		if !ok {
+			continue
+		}
+		rootXML := tree.ToXML()
+		cloneXML := doc.Root().GetTree(key).ToXML()
+		assert.Equal(t, cloneXML, rootXML,
+			"d%d: clone and root tree %q should match", docIdx, key)
+	}
+}
+
+// checkCloneAndRootTreeEqual checks that each tree element in the document
+// has consistent XML between the clone and the root.
+func checkCloneAndRootTreeEqual(docIdx int, doc *document.Document) bool {
+	for key, elem := range doc.RootObject().Members() {
+		tree, ok := elem.(*crdt.Tree)
+		if !ok {
+			continue
+		}
+		rootXML := tree.ToXML()
+		cloneXML := doc.Root().GetTree(key).ToXML()
+		if cloneXML != rootXML {
+			fmt.Printf("d%d: clone/root mismatch for tree %q\n  clone: %s\n  root:  %s\n",
+				docIdx, key, cloneXML, rootXML)
+			return false
+		}
+	}
 	return true
 }
 

--- a/test/integration/tree_test.go
+++ b/test/integration/tree_test.go
@@ -3028,7 +3028,7 @@ func TestTree(t *testing.T) {
 	// This structural difference could cause issues with GC and subsequent
 	// operations that reference tombstoned nodes by ID.
 	t.Run("split-with-concurrent-delete-overlapping-content", func(t *testing.T) {
-		// Fixed by Fix 9: skip merge for concurrent elements in collectBetween.
+		// Fixed by §4.3: skip merge for concurrent elements in collectBetween.
 		ctx := context.Background()
 		d1 := document.New(helper.TestKey(t))
 		assert.NoError(t, c1.Attach(ctx, d1))


### PR DESCRIPTION
## Summary

- Fix all 53 remaining `splitLevel >= 2` concurrent divergences in the property-based test suite
- Add Fixes 13-18 to the recursive split loop, `SplitElement`, and `Edit`, resolving position, partition, and range errors that occur when element splits (with non-deterministic IDs) interact at ancestor levels
- Replace Fix 15 with `skipActorID` approach to preserve clone/root consistency
- Restructure design doc from chronological fix-by-fix format to algorithm phase structure (Phase 1-9)
- Property-based suite: 1597/1597 pass, 0 skip (was 1544 pass, 53 skip)

### Fixes

| Fix | Section | Description |
|-----|---------|-------------|
| Fix 13 | §7.5 | Propagate `advancePastUnknownSplitSiblings` at each recursive split iteration with relaxed parent check |
| Fix 14 | §7.6 | Use `FindOffset` with `includeRemoved=true` to match `SplitElement`'s `Children(true)` |
| Fix 15 | §7.7 | `skipActorID` stops advancement at siblings created by the current actor, preserving clone/root consistency |
| Fix 16 | §7.3 | Move consecutive concurrent inserts at split boundary to left partition; skip element split siblings during boundary scan |
| Fix 17 | §7.4 | Move empty split sibling to existing InsNext sibling's parent when parents differ due to concurrent split |
| Fix 18 | §3 | Narrow `collectBetween` range when from/to positions span split parent boundaries; preserve original insert point |

### Root Cause

The recursive split loop creates element split siblings with non-deterministic IDs (new tickets, unlike text splits which reuse `CreatedAt` + offset). These siblings are only discoverable via the `InsNextID` chain. Six issues prevented correct convergence:

1. Fix 7 was applied only before the loop, not at each ancestor iteration (Fix 13)
2. The offset calculation used visible-only children while `SplitElement` partitions using all children including removed (Fix 14)
3. Same-actor siblings appeared "unknown" due to lamport clock advancement, causing false advancement past own split products (Fix 15)
4. Concurrent inserts at the split boundary were placed in the wrong partition (Fix 16)
5. Concurrent parent-level splits left empty replay siblings in the wrong parent (Fix 17)
6. Cross-parent-boundary ranges included content from concurrent split products not in the editor's original range (Fix 18)

### Design doc restructure

Reorganized `docs/design/concurrent-merge-split.md` from Fix 1-18 chronological order to algorithm phase structure:

| Phase | Name |
|-------|------|
| 1 | Position Resolution |
| 2 | Split Sibling Advance |
| 3 | Range Narrowing |
| 4 | Range Collection |
| 5 | Delete |
| 6 | Merge |
| 7 | Split |
| 8 | Insert |
| 9 | Style Operations |

Code comments updated to reference `§X.Y` section names instead of `Fix N`. Cross-reference appendix added for git history traceability.

### Clone/root consistency

`syncClientsThenAssertEqual` now verifies that each document's clone tree XML matches its root tree XML after sync. Fixes 15, 17, 18 are VV-independent (purely structural) to preserve this consistency.

## Test plan

- [x] Property-based concurrent suite: `go test -tags complex -run TestTreeConcurrency ./test/complex/` — 1597 pass, 0 skip, 0 fail
- [x] Unit tests: `make test` — all pass
- [x] Clone/root consistency verified across all tests
- [x] JS SDK port (yorkie-team/yorkie-js-sdk#1233)

## Squash merge message

```
Fix splitLevel>=2 concurrent convergence (Fixes 13-18)

Add six fixes to the recursive split loop, SplitElement, and Edit to
resolve all 53 remaining splitLevel>=2 concurrent divergences. Element
split siblings have non-deterministic IDs discoverable only via
InsNextID chain, requiring per-iteration advancement (§7.5), removed-
inclusive offset (§7.6), skipActorID (§7.7), boundary insert migration
(§7.3), empty sibling re-parenting (§7.4), and cross-parent range
narrowing (§3). Restructure design doc from Fix 1-18 chronological
order to algorithm phase structure (Phase 1-9) and update code comments
to reference §sections.

Property-based suite: 1597 pass, 0 skip (was 1544/53).
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)