### PR TITLE
Release v0.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and Yorkie adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## [v0.7.7] - 2026-04-26
+
+### Added
+
+- Support IntegerDedupCnt in YSON serialization with HLL round-trip by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1774
+
+### Changed
+
+- Simplify Tree.Edit with typed options and extracted helper by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1777
+
+### Fixed
+
+- Fix splitLevel>=2 concurrent convergence (Fixes 13-18) by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1776
+- Fix SplitElement computing VisibleLength with removed children by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1772
+
 ## [v0.7.6] - 2026-04-23
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-YORKIE_VERSION := 0.7.6
+YORKIE_VERSION := 0.7.7
 
 GO_PROJECT = github.com/yorkie-team/yorkie
 

--- a/api/docs/yorkie.base.yaml
+++ b/api/docs/yorkie.base.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Yorkie
   description: "Yorkie is an open source document store for building collaborative editing applications."
-  version: v0.7.6
+  version: v0.7.7
 servers:
   - url: https://api.yorkie.dev
     description: Production server

--- a/api/docs/yorkie/v1/admin.openapi.yaml
+++ b/api/docs/yorkie/v1/admin.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.6
+  version: v0.7.7
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/api/docs/yorkie/v1/resources.openapi.yaml
+++ b/api/docs/yorkie/v1/resources.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.6
+  version: v0.7.7
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/api/docs/yorkie/v1/yorkie.openapi.yaml
+++ b/api/docs/yorkie/v1/yorkie.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.6
+  version: v0.7.7
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/build/charts/yorkie-cluster/Chart.yaml
+++ b/build/charts/yorkie-cluster/Chart.yaml
@@ -9,8 +9,8 @@ maintainers:
 
 sources:
   - https://github.com/yorkie-team/yorkie
-version: 0.7.6
-appVersion: "0.7.6"
+version: 0.7.7
+appVersion: "0.7.7"
 kubeVersion: ">=1.28.0-0"
 
 dependencies:

--- a/build/charts/yorkie-monitoring/Chart.yaml
+++ b/build/charts/yorkie-monitoring/Chart.yaml
@@ -11,8 +11,8 @@ maintainers:
 
 sources:
   - https://github.com/yorkie-team/yorkie
-version: 0.7.6
-appVersion: "0.7.6"
+version: 0.7.7
+appVersion: "0.7.7"
 kubeVersion: ">=1.24.0-0"
 
 keywords:


### PR DESCRIPTION
## Changes

### Added
- Support IntegerDedupCnt in YSON serialization with HLL round-trip #1774

### Changed
- Simplify Tree.Edit with typed options and extracted helper #1777

### Fixed
- Fix splitLevel>=2 concurrent convergence (Fixes 13-18) #1776
- Fix SplitElement computing VisibleLength with removed children #1772

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.7.7

* **New Features**
  * Added support for `IntegerDedupCnt` in YSON serialization with HLL round-trip capability.

* **Bug Fixes**
  * Fixed convergence issues in tree split operations at level 2 and above during concurrent operations.
  * Fixed visibility length calculation for split elements when child nodes are removed.

* **Chores**
  * Version updated to v0.7.7 across build and API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->