### PR TITLE
Replace single LRU with sharded LRU to reduce lock conte…

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -17,6 +17,8 @@
 package cache_test
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -68,6 +70,74 @@ func TestLRUWithStats(t *testing.T) {
 		assert.Equal(t, int64(2), c.Stats().Misses())
 		assert.Equal(t, int64(5), c.Stats().Total())
 		assert.Equal(t, 60.0, c.Stats().HitRate())
+	})
+}
+
+func TestLRUConcurrency(t *testing.T) {
+	t.Run("concurrent Get and Add", func(t *testing.T) {
+		c, err := cache.NewLRU[string, int](1024, "concurrent-cache")
+		assert.NoError(t, err)
+
+		const numGoroutines = 100
+		const numOps = 1000
+
+		// Pre-populate half the keys so Gets have a mix of hits and misses.
+		for i := 0; i < numOps/2; i++ {
+			c.Add(fmt.Sprintf("key-%d", i), i)
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+		for g := 0; g < numGoroutines; g++ {
+			go func(id int) {
+				defer wg.Done()
+				for i := 0; i < numOps; i++ {
+					key := fmt.Sprintf("key-%d", i)
+					if i%2 == 0 {
+						c.Add(key, id*numOps+i)
+					} else {
+						c.Get(key)
+					}
+				}
+			}(g)
+		}
+		wg.Wait()
+
+		// Stats should be consistent: total = hits + misses.
+		stats := c.Stats()
+		assert.Equal(t, stats.Total(), stats.Hits()+stats.Misses())
+		assert.Greater(t, stats.Total(), int64(0))
+	})
+
+	t.Run("concurrent operations on same keys", func(t *testing.T) {
+		c, err := cache.NewLRU[string, int](64, "contention-cache")
+		assert.NoError(t, err)
+
+		const numGoroutines = 50
+		const numOps = 500
+
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+		for g := 0; g < numGoroutines; g++ {
+			go func() {
+				defer wg.Done()
+				for i := 0; i < numOps; i++ {
+					key := fmt.Sprintf("hot-key-%d", i%10)
+					c.Add(key, i)
+					c.Get(key)
+					c.Contains(key)
+					c.Peek(key)
+					c.Remove(key)
+				}
+			}()
+		}
+		wg.Wait()
+
+		// Verify the cache is still functional after heavy contention.
+		c.Add("final", 42)
+		val, ok := c.Get("final")
+		assert.True(t, ok)
+		assert.Equal(t, 42, val)
 	})
 }
 

--- a/pkg/cache/lru_with_stats.go
+++ b/pkg/cache/lru_with_stats.go
@@ -18,14 +18,15 @@
 package cache
 
 import (
-	"fmt"
-	"hash/fnv"
+	"hash/maphash"
 	"sync/atomic"
 
 	lru "github.com/hashicorp/golang-lru/v2"
 )
 
 const numShards = 16
+
+var hashSeed = maphash.MakeSeed()
 
 // LRU is a sharded LRU cache wrapper that tracks hit/miss statistics.
 // Keys are distributed across multiple shards to reduce lock contention.
@@ -60,9 +61,7 @@ func NewLRU[K comparable, V any](size int, name string) (*LRU[K, V], error) {
 
 // shard returns the shard index for the given key.
 func (c *LRU[K, V]) shard(key K) int {
-	h := fnv.New32a()
-	_, _ = fmt.Fprintf(h, "%v", key)
-	return int(h.Sum32() & (numShards - 1))
+	return int(maphash.Comparable(hashSeed, key) & (numShards - 1))
 }
 
 // Get retrieves a value from the cache and updates statistics.

--- a/pkg/cache/lru_with_stats.go
+++ b/pkg/cache/lru_with_stats.go
@@ -18,35 +18,56 @@
 package cache
 
 import (
+	"fmt"
+	"hash/fnv"
 	"sync/atomic"
 
 	lru "github.com/hashicorp/golang-lru/v2"
 )
 
-// LRU is an LRU cache wrapper that tracks hit/miss statistics.
+const numShards = 16
+
+// LRU is a sharded LRU cache wrapper that tracks hit/miss statistics.
+// Keys are distributed across multiple shards to reduce lock contention.
 type LRU[K comparable, V any] struct {
-	cache *lru.Cache[K, V]
-	stats *Stats
-	name  string
+	shards [numShards]*lru.Cache[K, V]
+	stats  *Stats
+	name   string
 }
 
-// NewLRU creates a new LRU cache with statistics tracking.
+// NewLRU creates a new sharded LRU cache with statistics tracking.
 func NewLRU[K comparable, V any](size int, name string) (*LRU[K, V], error) {
-	cache, err := lru.New[K, V](size)
-	if err != nil {
-		return nil, err
+	perShard := size / numShards
+	if perShard < 1 {
+		perShard = 1
 	}
 
-	return &LRU[K, V]{
-		cache: cache,
+	c := &LRU[K, V]{
 		stats: &Stats{},
 		name:  name,
-	}, nil
+	}
+
+	for i := 0; i < numShards; i++ {
+		shard, err := lru.New[K, V](perShard)
+		if err != nil {
+			return nil, err
+		}
+		c.shards[i] = shard
+	}
+
+	return c, nil
+}
+
+// shard returns the shard index for the given key.
+func (c *LRU[K, V]) shard(key K) int {
+	h := fnv.New32a()
+	_, _ = fmt.Fprintf(h, "%v", key)
+	return int(h.Sum32() & (numShards - 1))
 }
 
 // Get retrieves a value from the cache and updates statistics.
 func (c *LRU[K, V]) Get(key K) (V, bool) {
-	value, ok := c.cache.Get(key)
+	value, ok := c.shards[c.shard(key)].Get(key)
 	if ok {
 		atomic.AddInt64(&c.stats.hits, 1)
 	} else {
@@ -57,32 +78,38 @@ func (c *LRU[K, V]) Get(key K) (V, bool) {
 
 // Add adds a value to the cache.
 func (c *LRU[K, V]) Add(key K, value V) bool {
-	return c.cache.Add(key, value)
+	return c.shards[c.shard(key)].Add(key, value)
 }
 
 // Contains checks if a key exists in the cache without updating statistics.
 func (c *LRU[K, V]) Contains(key K) bool {
-	return c.cache.Contains(key)
+	return c.shards[c.shard(key)].Contains(key)
 }
 
 // Peek retrieves a value from the cache without updating LRU or statistics.
 func (c *LRU[K, V]) Peek(key K) (V, bool) {
-	return c.cache.Peek(key)
+	return c.shards[c.shard(key)].Peek(key)
 }
 
 // Remove removes a key from the cache.
 func (c *LRU[K, V]) Remove(key K) bool {
-	return c.cache.Remove(key)
+	return c.shards[c.shard(key)].Remove(key)
 }
 
 // Purge clears all entries from the cache.
 func (c *LRU[K, V]) Purge() {
-	c.cache.Purge()
+	for i := 0; i < numShards; i++ {
+		c.shards[i].Purge()
+	}
 }
 
 // Len returns the number of items in the cache.
 func (c *LRU[K, V]) Len() int {
-	return c.cache.Len()
+	n := 0
+	for i := 0; i < numShards; i++ {
+		n += c.shards[i].Len()
+	}
+	return n
 }
 
 // Stats returns the cache statistics.


### PR DESCRIPTION
**What this PR does / why we need it**:

Replace single `hashicorp/golang-lru/v2.Cache` (global `sync.Mutex`) with 16-shard LRU in `pkg/cache/lru_with_stats.go`. Keys are distributed via FNV hash, reducing lock contention by ~16x under high concurrency.

Channel Presence skew mode benchmark (20K concurrent connections) revealed severe lock contention on a single Yorkie pod:

| Goroutines blocked | Call site |
|---|---|
| 3,013 | `golang-lru/v2.Cache.Get()` → `Mutex.Lock` |
| 1,136 | `golang-lru/v2.Cache.Add()` → `Mutex.Lock` |

Hottest path: `mongo/client.go:1173` — `FindClientInfoByRefKey` → `clientCache.Get()`

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

All existing interfaces (`Get`, `Add`, `Contains`, `Peek`, `Remove`, `Purge`, `Len`, `Stats`, `Name`) are preserved. `LRUWithExpires` is out of scope (separate implementation, low contention).

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation**:

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive concurrency coverage for cache operations, validating behavior and statistics under mixed concurrent workloads.

* **Performance**
  * Cache internals reworked for stronger concurrent access; improves throughput and maintains hit/miss accounting and overall correctness under contention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->