### PR TITLE
Link docs hierarchy from README and fix broken design references

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ Full, comprehensive [documentation](https://yorkie.dev/docs) is available on the
 - [with iOS SDK](https://yorkie.dev/docs/getting-started/with-ios-sdk)
 - [with Android SDK](https://yorkie.dev/docs/getting-started/with-android-sdk)
 
+## Project Documentation
+
+- [docs/design/](docs/design/README.md) — Architectural design documents
+- [docs/tasks/](docs/tasks/README.md) — Task tracking (active and archived)
+- [test/k6/](test/k6/README.md) — Load testing setup
+- [CHANGELOG.md](CHANGELOG.md) — Release notes
+- [ROADMAP.md](ROADMAP.md) — Roadmap
+- [MAINTAINING.md](MAINTAINING.md) — Release and maintenance procedures
+- [CLAUDE.md](CLAUDE.md) — Agent instructions for AI-assisted development
+
 ## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md) for details on submitting patches and the contribution workflow.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Full, comprehensive [documentation](https://yorkie.dev/docs) is available on the
 - [docs/design/](docs/design/README.md) — Architectural design documents
 - [docs/tasks/](docs/tasks/README.md) — Task tracking (active and archived)
 - [test/k6/](test/k6/README.md) — Load testing setup
+- [build/charts/](build/charts/README.md) — Helm charts (cluster, monitoring, analytics)
+- [build/docker/](build/docker/README.md) — Docker Compose files for local dev
 - [CHANGELOG.md](CHANGELOG.md) — Release notes
 - [ROADMAP.md](ROADMAP.md) — Roadmap
 - [MAINTAINING.md](MAINTAINING.md) — Release and maintenance procedures

--- a/build/charts/README.md
+++ b/build/charts/README.md
@@ -4,6 +4,6 @@ This directory contains the Helm charts for Yorkie.
 
 ## Charts
 
-- [yorkie-cluster](./yorkie-cluster): Helm chart for Yorkie cluster
-- [yorkie-monitoring](./yorkie-monitoring): Helm chart for Yorkie cluster monitoring system with Prometheus and Grafana
-- [yorkie-analytics](./yorkie-analytics): Helm chart for Yorkie cluster analytics system with Kafka and StarRocks
+- [yorkie-cluster](./yorkie-cluster/README.md): Helm chart for Yorkie cluster
+- [yorkie-monitoring](./yorkie-monitoring/README.md): Helm chart for Yorkie cluster monitoring system with Prometheus and Grafana
+- [yorkie-analytics](./yorkie-analytics/README.md): Helm chart for Yorkie cluster analytics system with Kafka and StarRocks

--- a/build/docker/README.md
+++ b/build/docker/README.md
@@ -20,3 +20,9 @@ The docker-compose files we use are as follows:
  runs MongoDB.
 - `docker-compose-full.yml`: This file builds Yorkie and launches it. It also runs
  MongoDB and monitoring tools such as Prometheus and Grafana.
+
+## Subdirectories
+
+- [analytics/](./analytics/README.md): Compose stack for analytics (Kafka, StarRocks)
+- [monitoring/](./monitoring/README.md): Compose stack for monitoring (Prometheus, Grafana)
+- [sharding/](./sharding/README.md): Compose stack for sharded MongoDB topology

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -13,6 +13,7 @@
 ### CRDT
 
 - [Undo/Redo](undo-redo.md): Per-client undo/redo with reverse operations and position reconciliation
+- [Tree Split Undo/Redo](tree-split-undo-redo.md): Boundary-deletion reverse ops for `Tree.Edit` with `splitLevel >= 1` plus pre-tombstoned descendant filtering
 - [VersionVector](version-vector.md): VersionVector for GC and Resolving conflicts in CRDT
 - [VV Cleanup](vv-cleanup.md): Remove detached client's lamport from version vectors
 - [Garbage Collection](garbage-collection.md): Removing tombstones in CRDT

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,5 +1,7 @@
 # Design Document
 
+New design documents should be based on [TEMPLATE.md](TEMPLATE.md).
+
 ## Contents
 
 ### Document & Presence
@@ -21,6 +23,8 @@
 - [GC Registration on Set Conflict](gc-registration-on-set-conflict.md): Fix missing GC registration when new element loses LWW conflict
 - [Tree](tree.md): Tree data structure for tree-based rich text editor
 - [Concurrent Merge and Split](concurrent-merge-split.md): Fix convergence bugs in concurrent tree merge/split operations
+- [Counter Dedup](counter-dedup.md): Counter dedup mode using HyperLogLog for high-volume idempotent counting
+- [Array Move Convergence](array-move-convergence.md): Fix convergence bugs in concurrent array move operations
 - [Range Deletion in SplayTree](range-deletion-in-splay-tree.md): Improving range deletion in SplayTree
 
 ### Schema
@@ -39,10 +43,8 @@
 - [Fine-grained Document Locking](fine-grained-document-locking.md): Fine-grained document locking for high concurrency
 - [OLAP Stack for MAU Tracking](olap-stack.md): OLAP stack for Monthly Active Users (MAU) tracking
 - [Cluster Service Authentication](cluster-service-auth.md): Shared secret authentication for inter-node cluster RPCs
-
-### Serialization
-
-- [YSON DedupCounter Serialization](yson-dedup-counter.md): YSON marshal/parse/grammar support for IntegerDedupCnt with HLL round-trip
+- [MCP Server](mcp.md): Model Context Protocol server integration for AI assistants
+- [Snapshot Overflow](snapshot-overflow.md): Handling Yorkie snapshots that exceed MongoDB's 16MB BSON limit
 
 ## Maintaining the Document
 

--- a/docs/design/tree-split-undo-redo.md
+++ b/docs/design/tree-split-undo-redo.md
@@ -1,0 +1,209 @@
+---
+title: tree-split-undo-redo
+target-version: 0.7.8
+---
+
+# Tree Split Undo/Redo
+
+## Summary
+
+Generating reverse operations for `Tree.Edit` with `splitLevel >= 1`
+unlocks Yorkie-native undo/redo for paragraph splitting (Enter key) in
+ProseMirror and Wafflebase. This document describes the boundary
+deletion approach used as the reverse operation for both `splitLevel=1`
+and `splitLevel=2`, the undo/redo cycle, and an additional fix for
+content accumulation when the deleted subtree contains
+already-tombstoned descendants.
+
+This document is canonical across Yorkie SDKs. See
+[undo-redo.md](undo-redo.md) for the broader undo/redo architecture and
+how this fits in.
+
+### Goals
+
+- Generate reverse operations for `splitLevel >= 1` split edits.
+- Support single-client undo/redo cycles: split → undo → redo → undo.
+- Support 2-client concurrent scenarios where remote edits do not
+  overlap with the split boundary (reconciliation Cases 1–2).
+- Avoid resurrecting independently-tombstoned descendants when undoing
+  a parent delete that includes those descendants.
+
+### Non-Goals
+
+- Overlapping range reconciliation Cases 3–6 — Phase 2 scope, unchanged
+  by this work.
+- New operation types or protocol changes.
+
+## Proposal Details
+
+### Reverse Operation: Boundary Deletion
+
+A split creates new element boundaries without removing any nodes. The
+boundary size is `2 * splitLevel` tokens (one close + one open tag per
+level):
+
+```
+splitLevel=1: <p>ab|cd</p>  →  <p>ab</p><p>cd</p>          (2 boundary tokens)
+splitLevel=2: <div><p>ab|cd</p></div>
+            → <div><p>ab</p></div><div><p>cd</p></div>      (4 boundary tokens)
+```
+
+The reverse is a **boundary deletion** — a `splitLevel=0` edit that
+removes the boundary tokens, merging the split elements back:
+
+```
+L1 reverse: edit(fromIdx, fromIdx + 2, undefined, 0)   // delete 2 boundary tokens
+L2 reverse: edit(fromIdx, fromIdx + 4, undefined, 0)   // delete 4 boundary tokens
+```
+
+The reverse op is a standard `TreeEditOperation` with `isUndoOp=true`,
+`splitLevel=0`, and integer indices for reconciliation. This means:
+
+1. **No new operation types.** The reverse reuses the existing
+   `TreeEditOperation` infrastructure.
+2. **Reconciliation unchanged.** The reverse op is `splitLevel=0`, so
+   the existing 6-case overlap logic in `reconcileOperation` applies
+   directly.
+3. **Redo works automatically.** When the boundary deletion (undo)
+   executes, it removes nodes and produces its own reverse via the
+   existing `toReverseOperation` path — a `splitLevel=0` re-insertion
+   of the boundary nodes.
+
+### Undo/Redo Cycle
+
+```
+split(L1)
+  → undo: boundary delete (splitLevel=0, removes 2 tokens)
+    → redo: re-insert boundary nodes (splitLevel=0, deep-copied nodes)
+      → undo again: boundary delete (same as first undo)
+```
+
+Each step produces a standard `splitLevel=0` reverse op, so the entire
+cycle uses existing infrastructure after the initial reverse op
+generation.
+
+### Pre-tombstoned Descendant Filtering
+
+Independent of split semantics, the `splitLevel=0` reverse op for a
+parent delete must not resurrect descendants the user had already
+deleted in earlier operations.
+
+Scenario (manual two-step split flow used by Wafflebase): insert a
+sibling block with an empty inline, type into the inline, undo each
+char (tombstoning the texts), then undo the block insert and later
+redo it.
+
+Without filtering, `clearRemovedAt` walks the whole deep-copied
+subtree and clears every descendant's `removedAt`, resurrecting
+content the user had independently deleted. Each undo→redo cycle
+revives those descendants and the next parent-undo re-tombstones
+them, growing `reverseContents` per cycle.
+
+Fix: `CRDTTree.edit()` collects a `preTombstoned` set of node IDs that
+were tombstoned **before** this edit ran. `editT`'s return tuple
+exposes this set, and `toReverseOperation` deep-copies the top-level
+removed node, drops descendants whose IDs are in `preTombstoned`,
+then clears `removedAt` on the survivors. The redo therefore restores
+only what this edit just transitioned from visible to tombstoned.
+
+This preserves CRDT identity (same node IDs revived on redo, no new
+nodes created), so multi-client semantics for non-overlapping
+concurrent edits are unchanged.
+
+### Edge Cases
+
+| Case | Behavior |
+|------|----------|
+| Front split (`<p>\|ab</p>` → `<p></p><p>ab</p>`) | Undo deletes 2 boundary tokens, merges empty element back |
+| Back split (`<p>ab\|</p>` → `<p>ab</p><p></p>`) | Same — boundary deletion merges trailing empty element |
+| L2 front split (`<div><p>\|ab</p></div>`) | Undo deletes 4 boundary tokens, merges both levels back |
+| L2 back split (`<div><p>ab\|</p></div>`) | Same — 4 boundary tokens removed |
+| Concurrent parent deletion | `fromIdx + boundarySize > tree.getSize()` guard → undo is no-op |
+| Concurrent insert into split result (non-overlapping) | Reconciliation Cases 1–2 shift indices correctly |
+| Concurrent insert into split boundary (overlapping) | Out of scope — Cases 3–6, Phase 2 |
+| Parent delete with already-tombstoned descendants | Pre-tombstoned filtering drops them from `reverseContents`; redo does not resurrect |
+
+### Risks and Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| Boundary size assumption (`2 * splitLevel`) wrong if concurrent edits insert nodes between split boundaries | L1 concurrent split converges. L2 forward convergence also passes. Reconciliation Cases 1–2 handle non-overlapping shifts. |
+| L2 boundary deletion removes 4 tokens — more structural change than L1 | Same merge path as L1, applied twice. Verified with L2-specific tests (front/middle/back). |
+| Merge semantics on undo may differ from original pre-split state (`mergedFrom`/`mergedAt` metadata) | Boundary deletion triggers the standard CRDTTree merge path, same as user-initiated merge. |
+| Redo re-inserts deep-copied boundary nodes — node IDs may conflict with GC | Existing `splitLevel=0` redo path already handles this. |
+| Without pre-tombstoned filtering, undo→redo of a parent delete with prior-deleted descendants accumulates content per cycle | `preTombstoned` set, populated during `CRDTTree.edit()`, is consumed by `toReverseOperation` to drop those descendants from `reverseContents`. |
+
+### Design Decisions
+
+| Decision | Reason |
+|----------|--------|
+| Boundary deletion as reverse | Reverse op is `splitLevel=0`, reuses all existing reconciliation and redo infrastructure. Simplest approach. |
+| L1 first, L2 after forward fix | L2 forward convergence was broken when L1 undo was implemented. After the forward fix, L2 undo proceeded. |
+| L2 single-client tests first | Validate the boundary-deletion mechanism for 4 tokens before adding multi-client complexity. |
+| Single guard relaxation for L2 | `toSplitReverseOperation` already supports any splitLevel via the `boundarySize` formula. |
+| `boundarySize = 2 * splitLevel` | Each split level creates one close tag + one open tag = 2 tree index tokens per level. |
+| Filter `reverseContents` by `preTombstoned`, not by tombstone ticket equality | LWW overwrites of `removedAt` on already-tombstoned nodes make ticket equality unreliable. Capturing the pre-edit tombstone state by ID is robust. |
+
+### Alternatives Considered
+
+| Alternative | Why not |
+|-------------|---------|
+| **Content-based reverse for splits** (deep-copy original node, delete split result, re-insert original) | Concurrent edits to the split result would be lost. Dangerous in collaborative environment. |
+| **Split-aware reverse** (store splitLevel in reverse, execute merge on undo) | Merge is just boundary deletion. Adds a new reverse op variant for no benefit. |
+| **OT-literal reverseOp payload** (Text-style content-only reverse) | Loses CRDT identity for tree elements; element attributes (RHT) require timestamp re-issuance, changing concurrent semantics; the surgical descendant filter solves the accumulation bug without these costs. |
+
+## Test Strategy
+
+The JS SDK uses the table-driven pattern from `history_tree_test.ts`,
+declaring a state space and iterating over combinations.
+
+### Test State Space
+
+```
+┌─────────────────┬─────────────────────────────────────────────────┐
+│ Variable        │ Domain                                          │
+├─────────────────┼─────────────────────────────────────────────────┤
+│ SplitPosition   │ {front, middle, back}                           │
+│ Action          │ {undo, undo-redo, undo-redo-undo}               │
+│ ClientCount     │ {1, 2}                                          │
+│ ChainOp         │ {split-only, split+insert-text, split+delete,   │
+│                 │  insert-text+split}                              │
+│ RemoteOp        │ {insert-text, delete-text, insert-element}      │
+│ RemotePosition  │ {before-split, after-split, different-element}  │
+└─────────────────┴─────────────────────────────────────────────────┘
+```
+
+### L1 Sections
+
+- **A**: Single-client split undo/redo (table-driven, 9 tests).
+- **B**: Single-client chained ops with snapshot verification (9 tests).
+- **C**: Multi-client convergence with `withTwoClientsAndDocuments` (9 tests).
+- **D**: Edge cases — empty paragraph undo, concurrent parent deletion.
+
+### L2 Sections
+
+L2 initial tree: `<doc><div><p>ABCD</p></div></doc>`. Splits use
+`splitLevel=2` and create 4 boundary tokens at three positions:
+
+```
+<doc>  <div>  <p>  A  B  C  D  </p>  </div>  </doc>
+  0      1     2   3  4  5  6    7      8
+```
+
+- **E**: Single-client L2 split undo/redo (9 tests).
+- **F**: Single-client L2 chained ops (8 pass, 1 skipped — consecutive
+  L2 splits produce tombstone structure that breaks boundary-deletion
+  reverse).
+- **G**: Multi-client L2 convergence using
+  `<doc><div><p>ABCD</p></div><div><p>EFGH</p></div></doc>` (18 tests:
+  9 undo + 9 redo).
+- **H**: Multi-client L2 edge cases — front/back L2 split undo with
+  concurrent remote insert (2 tests).
+
+### Pre-tombstoned Filtering Regression
+
+Single-it test in `history_tree_split_repro_test.ts` reproduces the
+4-cycle type-undo-undo-redo flow against an empty inline in a sibling
+block, then asserts the redoStack-top `contents` size is constant
+across cycles. Before the fix the size grows by 4 per cycle
+(`[6, 10, 14, 18]`); after the fix it stays at 2 (`[2, 2, 2, 2]`).

--- a/docs/design/tree-split-undo-redo.md
+++ b/docs/design/tree-split-undo-redo.md
@@ -202,7 +202,7 @@ L2 initial tree: `<doc><div><p>ABCD</p></div></doc>`. Splits use
 
 ### Pre-tombstoned Filtering Regression
 
-Single-it test in `history_tree_split_repro_test.ts` reproduces the
+A regression test in `history_tree_split_test.ts` reproduces the
 4-cycle type-undo-undo-redo flow against an empty inline in a sibling
 block, then asserts the redoStack-top `contents` size is constant
 across cycles. Before the fix the size grows by 4 per cycle

--- a/docs/design/tree.md
+++ b/docs/design/tree.md
@@ -119,23 +119,23 @@ The core process of the `Tree.Edit` operation is as follows:
 3. Delete nodes in the range of `fromTreePos` to `toTreePos`.
 4. Insert the given nodes at the appropriate positions (insert operation only).
 
-**[[STEP 1]](https://github.com/yorkie-team/yorkie/blob/fd3b15c7d2c482464b6c8470339bcc497204114e/pkg/document/json/tree.go#L121C1-L128)** Find `CRDTTree.TreePos` from the given `fromIdx` and `toIdx` (local editing only)
+**[STEP 1](https://github.com/yorkie-team/yorkie/blob/fd3b15c7d2c482464b6c8470339bcc497204114e/pkg/document/json/tree.go#L121C1-L128)** Find `CRDTTree.TreePos` from the given `fromIdx` and `toIdx` (local editing only)
 
 In the case of local editing, the given `index`es are converted to `CRDTTree.TreePos`. The detailed process is the same as described in the 'Tree Coordinate System' above.
 
-**[[STEP 2]](https://github.com/yorkie-team/yorkie/blob/fd3b15c7d2c482464b6c8470339bcc497204114e/pkg/document/crdt/tree.go#L572C1-L580C3)** Find the corresponding left sibling node and parent node within the `IndexTree` based on `CRDTTree.TreePos`
+**[STEP 2](https://github.com/yorkie-team/yorkie/blob/fd3b15c7d2c482464b6c8470339bcc497204114e/pkg/document/crdt/tree.go#L572C1-L580C3)** Find the corresponding left sibling node and parent node within the `IndexTree` based on `CRDTTree.TreePos`
 
 2-1. For text nodes, if necessary, split nodes at the appropriate positions to find the left sibling node.
 
 2-2. Determine the sequence of nodes and find the appropriate position. Since `Clone`s of each client might exist in different states, the `findFloorNode` function is used to find the closest node (lower bound).
 
-**[[STEP 3]](https://github.com/yorkie-team/yorkie/blob/fd3b15c7d2c482464b6c8470339bcc497204114e/pkg/document/crdt/tree.go#L582-L640)** Delete nodes in the range of `fromTreePos` to `toTreePos`
+**[STEP 3](https://github.com/yorkie-team/yorkie/blob/fd3b15c7d2c482464b6c8470339bcc497204114e/pkg/document/crdt/tree.go#L582-L640)** Delete nodes in the range of `fromTreePos` to `toTreePos`
 
 3-1. Traverse the range and identify nodes to be removed. If a node is an element node and doesn't include both opening and closing tags, it is excluded from removal.
 
 3-2. Check each node's visibility using the version vector and mark nodes with tombstones in the `IndexTree` to indicate removal.
 
-**[[STEP 4]](https://github.com/yorkie-team/yorkie/blob/fd3b15c7d2c482464b6c8470339bcc497204114e/pkg/document/crdt/tree.go#L642-L681)** Insert the given nodes at the appropriate positions (insert operation only)
+**[STEP 4](https://github.com/yorkie-team/yorkie/blob/fd3b15c7d2c482464b6c8470339bcc497204114e/pkg/document/crdt/tree.go#L642-L681)** Insert the given nodes at the appropriate positions (insert operation only)
 
 4-1. If the left sibling node at the insertion position is the same as the parent node, it means the node will be inserted as the leftmost child of the parent. Hence, the node is inserted at the leftmost position of the parent's children list.
 

--- a/docs/design/undo-redo.md
+++ b/docs/design/undo-redo.md
@@ -1,6 +1,6 @@
 ---
 title: undo-redo
-target-version: 0.7.5
+target-version: 0.7.8
 ---
 
 # Undo/Redo (History)
@@ -26,8 +26,6 @@ operations valid when remote edits arrive.
 ### Non-Goals
 
 - Server-side undo/redo or global history browsing.
-- Undo/redo for `Tree.Edit` with `splitLevel >= 2` at the CRDT layer (deferred
-  until L2 forward convergence is fixed; `splitLevel=1` is supported).
 - Overlapping range reconciliation for Tree (Cases 3–6, deferred to Phase 2).
 - Undo/redo for `TreeStyleOperation` with multi-client reconciliation (single-client undo/redo is now supported via PR #1221).
 
@@ -80,7 +78,7 @@ mapping, and each subsection below explains the details.
 | `EditOperation` (Text.edit) | `EditOperation` |
 | `StyleOperation` (Text.style) | `StyleOperation` |
 | `TreeEditOperation` (Tree.edit, splitLevel=0) | `TreeEditOperation` |
-| `TreeEditOperation` (Tree.edit, splitLevel=1) | `TreeEditOperation` (boundary deletion) |
+| `TreeEditOperation` (Tree.edit, splitLevel >= 1) | `TreeEditOperation` (boundary deletion) — see [tree-split-undo-redo.md](tree-split-undo-redo.md) |
 | `TreeStyleOperation` (Tree.style) | `TreeStyleOperation` |
 
 #### Object.set → SetOperation
@@ -264,10 +262,17 @@ a hierarchical structure with element nodes and text nodes.
 #### Reverse Operation
 
 When `Tree.edit([from, to], contents, splitLevel)` executes:
-1. `CRDTTree.edit()` returns the removed nodes and the pre-edit `fromIdx`.
+1. `CRDTTree.edit()` returns the removed nodes, the pre-edit `fromIdx`, and a
+   `preTombstoned` set of node IDs that were already tombstoned **before** this
+   edit ran.
 2. The reverse operation:
    - **For deletion (contents=undefined)**: deep-copies the removed nodes,
-     clears their tombstone markers, and stores them as `reverseContents`.
+     **filters out descendants whose IDs are in `preTombstoned`**, clears
+     tombstone markers on the surviving nodes, and stores them as
+     `reverseContents`. The filter is essential — without it, undoing a parent
+     delete would resurrect descendants that the user had independently
+     deleted in earlier operations, causing content accumulation across
+     undo/redo cycles in nested-edit scenarios (see Risks below).
    - **For insertion**: stores no content (the reverse is a deletion).
    - **For replacement**: combines both — deep-copies removed nodes and marks the
      inserted content range for deletion.
@@ -312,40 +317,18 @@ When a remote change is applied, `Document` scans the History stacks and calls
 `reconcileTreeEdit()` for each pending `TreeEditOperation` targeting the same
 tree.
 
-#### Split Undo/Redo (splitLevel=1)
+#### Split Undo/Redo
 
-A split creates new element boundaries without removing any nodes:
+A split creates element boundaries without removing nodes. The reverse is a
+`splitLevel=0` **boundary deletion** that removes those tokens
+(`2 * splitLevel` per level), merging the split elements back. The reverse is
+a standard `TreeEditOperation`, so reconciliation and redo reuse the
+existing `splitLevel=0` paths.
 
-```
-splitLevel=1: <p>ab|cd</p>  →  <p>ab</p><p>cd</p>   (2 boundary tokens)
-```
-
-The reverse is a **boundary deletion** — a `splitLevel=0` edit that removes the
-boundary tokens, merging the split elements back:
-
-```
-reverse: edit(fromIdx, fromIdx + 2, undefined, 0)   // delete 2 boundary tokens
-```
-
-This approach reuses all existing infrastructure:
-- The reverse op is a standard `TreeEditOperation` with `isUndoOp=true` and
-  `splitLevel=0`.
-- Reconciliation uses the existing 6-case overlap logic unchanged.
-- Redo works automatically: the boundary deletion produces its own reverse via
-  the existing `toReverseOperation` path.
-
-The `toSplitReverseOperation` method is guarded for pure L1 splits only
-(`splitLevel === 1`, no contents, no removed nodes). This prevents generating
-incorrect reverse ops for unsupported split shapes (L2+, split+delete combos).
-
-The undo/redo cycle:
-
-```
-split(L1)
-  → undo: boundary delete (splitLevel=0, removes 2 tokens)
-    → redo: re-insert boundary nodes (splitLevel=0, deep-copied nodes)
-      → undo again: boundary delete (same as first undo)
-```
+Both `splitLevel=1` and `splitLevel=2` are supported. See
+[tree-split-undo-redo.md](tree-split-undo-redo.md) for boundary-token
+mechanics, the undo/redo cycle, edge cases, pre-tombstoned descendant
+filtering, and the test matrix.
 
 **Implementation note:** `splitElement` recomputes `visibleSize` from children's
 `paddedSize()`. Since `IndexTreeNode.paddedSize()` does not return 0 for removed
@@ -425,6 +408,20 @@ by the undo operation might point to collected nodes. Mitigation: undo operation
 use `findPos()` (index-based lookup) at execution time rather than relying on
 stale CRDT positions.
 
+**Risk: Tree reverseOp resurrects already-deleted descendants (single-client).**
+Without descendant filtering, a parent-delete's reverseOp deep-copies the
+parent and traverses every descendant — including ones the user had already
+tombstoned in earlier operations. Clearing tombstones on the entire subtree
+makes the redo bring back content the user never intended to restore.
+Repeating the cycle (type → undo chars → undo parent → redo parent → type
+more → undo chars → undo parent) produces compounding `reverseContents`
+across cycles, since each cycle re-tombstones nodes that the previous redo
+revived. Mitigation: the reverseOp generator drops descendants whose IDs are
+in `preTombstoned` (collected during `CRDTTree.edit()`), so only the nodes
+this edit actually transitioned from visible to tombstoned are resurrected
+on redo. This preserves CRDT identity and concurrent-edit semantics — the
+fix is purely in `toReverseOperation`.
+
 **Risk: Asymmetric reconciliation for overlapping Tree edits.**
 As described in Phase 2, overlapping range reconciliation for Tree uses
 asymmetric integer indices. Mitigation: Cases 3–6 are skipped in Phase 1. The
@@ -445,11 +442,12 @@ Oldest entries are evicted when the cap is reached.
 | Text multi-client reconciliation | ✅ | Convergence passes for all 7 cases (but see content correctness below) |
 | Array undo | ✅ | add, remove, move, set |
 | Tree single-client (splitLevel=0) | ✅ | All op types + chained ops |
-| Tree split L1 undo/redo | ✅ | Boundary-deletion reverse ops (PR #1219) |
+| Tree split undo/redo (L1 + L2) | ✅ | Boundary-deletion reverse ops. See [tree-split-undo-redo.md](tree-split-undo-redo.md). |
 | Tree multi-client (non-overlapping) | ✅ | Cases 1, 2, 7 (left/right/adjacent) |
 | TreeStyleOperation single-client | ✅ | setStyle, removeStyle undo/redo (PR #1221) |
 | TreeStyleOperation multi-client | ✅ | style×style (18 tests), style×edit/split (24 tests) (PR #1221) |
 | Tree redo divergence | ✅ | Fixed via CRDTTreePos-based undo execution + reconciliation disabled (branch `tree-undo-pos-normalization`) |
+| Tree reverseOp descendant filtering | ✅ | `preTombstoned` set returned from `CRDTTree.edit()` and consumed by `toReverseOperation` — drops already-tombstoned descendants from `reverseContents` so nested edits (typing inside a later-deleted parent) don't accumulate across undo/redo cycles |
 
 #### Remaining Work
 
@@ -459,7 +457,6 @@ Oldest entries are evicted when the cap is reached.
 | HIGH | Tree reconciliation Cases 3-6 | Blocked by overlapping undo content duplication — same root cause. 4 tests skipped. |
 | HIGH | Array Set + Move undo | Set after Move restores value at dead position. Requires proto change. See analysis below. 4 tests skipped in JS SDK. |
 | MED | GC vs undo interaction | Issue #664. GC can purge elements still referenced by undo/redo stack. |
-| LOW | splitLevel≥2 undo/redo | Blocked by L2 forward convergence (68/320 concurrent tests fail). |
 | LOW | History reconciliation performance | O(n) stack scan → indexed lookup. |
 
 ### Analysis: Overlapping Undo Content Duplication

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -1,8 +1,8 @@
 ---
-updated: 2026-04-22
+updated: 2026-04-29
 ---
 
 # Tasks
 
-- `active/` — In-progress tasks
-- `archive/` — Completed tasks
+- [active/](active/README.md) — In-progress tasks
+- [archive/](archive/README.md) — Completed tasks

--- a/docs/tasks/archive/README.md
+++ b/docs/tasks/archive/README.md
@@ -6,16 +6,17 @@ updated: 2026-04-22
 
 ## 2026-03
 
-- [[20260327-document-epoch-todo]] — Document Epoch Implementation Plan
+- [20260327-document-epoch-todo](2026/03/20260327-document-epoch-todo.md) — Document Epoch Implementation Plan
 
 ## 2026-04
 
-- [[20260402-style-by-path-range-todo]] — **Created**: 2026-04-02
-- [[20260406-concurrent-merge-split-todo]] — **Created**: 2026-04-06
-- [[20260410-merged-fields-snapshot-todo]] — **Created**: 2026-04-10
-- [[20260410-tree-style-split-divergence-todo]] — ---
-- [[20260413-counter-dedup-todo]] — **Created**: 2026-04-13
-- [[20260417-epoch-aware-push-todo]] — **Created**: 2026-04-17
-- [[20260418-istio-gateway-only-todo]] — **Created**: 2026-04-18
-- [[20260421-array-move-convergence-todo]] — Array Move Convergence Implementation Plan
+- [20260402-style-by-path-range-todo](2026/04/20260402-style-by-path-range-todo.md) / [lessons](2026/04/20260402-style-by-path-range-lessons.md) — **Created**: 2026-04-02
+- [20260406-concurrent-merge-split-todo](2026/04/20260406-concurrent-merge-split-todo.md) — **Created**: 2026-04-06
+- [20260410-merged-fields-snapshot-todo](2026/04/20260410-merged-fields-snapshot-todo.md) / [lessons](2026/04/20260410-merged-fields-snapshot-lessons.md) — **Created**: 2026-04-10
+- [20260410-tree-style-split-divergence-todo](2026/04/20260410-tree-style-split-divergence-todo.md) / [lessons](2026/04/20260410-tree-style-split-divergence-lessons.md)
+- [20260413-counter-dedup-todo](2026/04/20260413-counter-dedup-todo.md) — **Created**: 2026-04-13
+- [20260417-epoch-aware-push-todo](2026/04/20260417-epoch-aware-push-todo.md) — **Created**: 2026-04-17
+- [20260418-istio-gateway-only-todo](2026/04/20260418-istio-gateway-only-todo.md) — **Created**: 2026-04-18
+- [20260421-array-move-convergence-todo](2026/04/20260421-array-move-convergence-todo.md) — Array Move Convergence Implementation Plan
+- [20260424-split-level-2-convergence-todo](2026/04/20260424-split-level-2-convergence-todo.md) — split-level-2 convergence (also tracked in active/04/)
 


### PR DESCRIPTION
## Summary

- Add a Project Documentation section to \`README.md\` linking \`docs/design/\`, \`docs/tasks/\`, \`test/k6/\`, \`CHANGELOG.md\`, \`ROADMAP.md\`, \`MAINTAINING.md\`, and \`CLAUDE.md\` so they are reachable from the project's entry point.
- Add the four design docs missing from \`docs/design/README.md\` (\`array-move-convergence\`, \`mcp\`, \`snapshot-overflow\`, \`counter-dedup\`) and link \`TEMPLATE.md\` from the header.
- Remove the broken \`yson-dedup-counter.md\` entry — that file does not exist. \`counter-dedup.md\` covers the related dedup-counter design and is now listed in the CRDT section.
- Fix four broken STEP markers in \`docs/design/tree.md\`. The original syntax \`**[[STEP 1]](URL)**\` parses as a wikilink to "STEP 1" followed by literal \`(URL)\` text — neither GitHub nor link checkers render it as a clickable link. Switch to \`**[STEP 1](URL)**\` so the links resolve.
- Convert the archive index from wikilinks to relative markdown links. Wikilinks resolve by basename only, and several task slugs are duplicated across sibling submodules (yorkie-js-sdk, yorkie-team.github.io/temp), which made some files appear unreachable from their own README.
- Pair three lessons files (\`style-by-path-range\`, \`merged-fields-snapshot\`, \`tree-style-split-divergence\`) with their todos in the archive index.
- Convert inline-code path references in \`docs/tasks/README.md\` to real markdown links.

Found via the link connectivity check script being added to second-brain ([yorkie-team/second-brain#34](https://github.com/yorkie-team/second-brain/pull/34)).

The \`binaries/\` directory still has stale \`CONTRIBUTING.md\` references in its release READMEs, but \`binaries/\` is gitignored and only exists locally after a release build — those don't appear in the repo.

## Test plan

- [x] Verified the corrected STEP 1-4 links resolve to the GitHub source URLs
- [x] Verified the new design entries point at existing files
- [x] Verified the archive index entries resolve to the actual archived todo/lessons files
- [ ] Reviewer to spot-check the new Project Documentation section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “Project Documentation” section linking architecture, testing, Helm charts, Docker Compose, and maintenance guides.
  * New design docs for Tree undo/redo and split-level behavior; expanded undo/redo guidance and risk/mitigation notes.
  * Improved markdown/link formatting across design and task docs; updated task timestamps and archive entries.
  * Updated Helm chart and Docker Compose README navigation to clearer, per-chart and per-stack destinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->