### PR TITLE
Cascade channel session detach on client deactivate

### DIFF
--- a/api/docs/yorkie/v1/cluster.openapi.yaml
+++ b/api/docs/yorkie/v1/cluster.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.5
+  version: v0.7.8
 servers:
 - description: Production server
   url: https://api.yorkie.dev
@@ -18,6 +18,18 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/yorkie.v1.ClusterService.CompactDocument.yorkie.v1.ClusterServiceCompactDocumentResponse'
+        default:
+          $ref: '#/components/responses/connect.error'
+      tags:
+      - yorkie.v1.ClusterService
+  /yorkie.v1.ClusterService/DetachActorFromChannels:
+    post:
+      description: ""
+      requestBody:
+        $ref: '#/components/requestBodies/yorkie.v1.ClusterService.DetachActorFromChannels.yorkie.v1.ClusterServiceDetachActorFromChannelsRequest'
+      responses:
+        "200":
+          $ref: '#/components/responses/yorkie.v1.ClusterService.DetachActorFromChannels.yorkie.v1.ClusterServiceDetachActorFromChannelsResponse'
         default:
           $ref: '#/components/responses/connect.error'
       tags:
@@ -117,6 +129,15 @@ components:
           schema:
             $ref: '#/components/schemas/yorkie.v1.ClusterServiceCompactDocumentRequest'
       required: true
+    yorkie.v1.ClusterService.DetachActorFromChannels.yorkie.v1.ClusterServiceDetachActorFromChannelsRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.ClusterServiceDetachActorFromChannelsRequest'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.ClusterServiceDetachActorFromChannelsRequest'
+      required: true
     yorkie.v1.ClusterService.DetachDocument.yorkie.v1.ClusterServiceDetachDocumentRequest:
       content:
         application/json:
@@ -198,6 +219,15 @@ components:
         application/proto:
           schema:
             $ref: '#/components/schemas/yorkie.v1.ClusterServiceCompactDocumentResponse'
+      description: ""
+    yorkie.v1.ClusterService.DetachActorFromChannels.yorkie.v1.ClusterServiceDetachActorFromChannelsResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.ClusterServiceDetachActorFromChannelsResponse'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.ClusterServiceDetachActorFromChannelsResponse'
       description: ""
     yorkie.v1.ClusterService.DetachDocument.yorkie.v1.ClusterServiceDetachDocumentResponse:
       content:
@@ -450,6 +480,33 @@ components:
           title: compacted
           type: boolean
       title: ClusterServiceCompactDocumentResponse
+      type: object
+    yorkie.v1.ClusterServiceDetachActorFromChannelsRequest:
+      additionalProperties: false
+      description: ""
+      properties:
+        actorId:
+          additionalProperties: false
+          description: ""
+          title: actor_id
+          type: string
+        projectId:
+          additionalProperties: false
+          description: ""
+          title: project_id
+          type: string
+      title: ClusterServiceDetachActorFromChannelsRequest
+      type: object
+    yorkie.v1.ClusterServiceDetachActorFromChannelsResponse:
+      additionalProperties: false
+      description: ""
+      properties:
+        detachedCount:
+          additionalProperties: false
+          description: ""
+          title: detached_count
+          type: integer
+      title: ClusterServiceDetachActorFromChannelsResponse
       type: object
     yorkie.v1.ClusterServiceDetachDocumentRequest:
       additionalProperties: false

--- a/api/yorkie/v1/cluster.pb.go
+++ b/api/yorkie/v1/cluster.pb.go
@@ -808,6 +808,102 @@ func (x *ClusterServiceGetChannelCountResponse) GetChannelCount() int32 {
 	return 0
 }
 
+type ClusterServiceDetachActorFromChannelsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ProjectId     string                 `protobuf:"bytes,1,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
+	ActorId       string                 `protobuf:"bytes,2,opt,name=actor_id,json=actorId,proto3" json:"actor_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ClusterServiceDetachActorFromChannelsRequest) Reset() {
+	*x = ClusterServiceDetachActorFromChannelsRequest{}
+	mi := &file_yorkie_v1_cluster_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ClusterServiceDetachActorFromChannelsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClusterServiceDetachActorFromChannelsRequest) ProtoMessage() {}
+
+func (x *ClusterServiceDetachActorFromChannelsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_yorkie_v1_cluster_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClusterServiceDetachActorFromChannelsRequest.ProtoReflect.Descriptor instead.
+func (*ClusterServiceDetachActorFromChannelsRequest) Descriptor() ([]byte, []int) {
+	return file_yorkie_v1_cluster_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *ClusterServiceDetachActorFromChannelsRequest) GetProjectId() string {
+	if x != nil {
+		return x.ProjectId
+	}
+	return ""
+}
+
+func (x *ClusterServiceDetachActorFromChannelsRequest) GetActorId() string {
+	if x != nil {
+		return x.ActorId
+	}
+	return ""
+}
+
+type ClusterServiceDetachActorFromChannelsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	DetachedCount int32                  `protobuf:"varint,1,opt,name=detached_count,json=detachedCount,proto3" json:"detached_count,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ClusterServiceDetachActorFromChannelsResponse) Reset() {
+	*x = ClusterServiceDetachActorFromChannelsResponse{}
+	mi := &file_yorkie_v1_cluster_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ClusterServiceDetachActorFromChannelsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClusterServiceDetachActorFromChannelsResponse) ProtoMessage() {}
+
+func (x *ClusterServiceDetachActorFromChannelsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_yorkie_v1_cluster_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClusterServiceDetachActorFromChannelsResponse.ProtoReflect.Descriptor instead.
+func (*ClusterServiceDetachActorFromChannelsResponse) Descriptor() ([]byte, []int) {
+	return file_yorkie_v1_cluster_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *ClusterServiceDetachActorFromChannelsResponse) GetDetachedCount() int32 {
+	if x != nil {
+		return x.DetachedCount
+	}
+	return 0
+}
+
 type InvalidateCacheRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	CacheType     CacheType              `protobuf:"varint,1,opt,name=cache_type,json=cacheType,proto3,enum=yorkie.v1.CacheType" json:"cache_type,omitempty"`
@@ -818,7 +914,7 @@ type InvalidateCacheRequest struct {
 
 func (x *InvalidateCacheRequest) Reset() {
 	*x = InvalidateCacheRequest{}
-	mi := &file_yorkie_v1_cluster_proto_msgTypes[14]
+	mi := &file_yorkie_v1_cluster_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -830,7 +926,7 @@ func (x *InvalidateCacheRequest) String() string {
 func (*InvalidateCacheRequest) ProtoMessage() {}
 
 func (x *InvalidateCacheRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_cluster_proto_msgTypes[14]
+	mi := &file_yorkie_v1_cluster_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -843,7 +939,7 @@ func (x *InvalidateCacheRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InvalidateCacheRequest.ProtoReflect.Descriptor instead.
 func (*InvalidateCacheRequest) Descriptor() ([]byte, []int) {
-	return file_yorkie_v1_cluster_proto_rawDescGZIP(), []int{14}
+	return file_yorkie_v1_cluster_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *InvalidateCacheRequest) GetCacheType() CacheType {
@@ -869,7 +965,7 @@ type InvalidateCacheResponse struct {
 
 func (x *InvalidateCacheResponse) Reset() {
 	*x = InvalidateCacheResponse{}
-	mi := &file_yorkie_v1_cluster_proto_msgTypes[15]
+	mi := &file_yorkie_v1_cluster_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -881,7 +977,7 @@ func (x *InvalidateCacheResponse) String() string {
 func (*InvalidateCacheResponse) ProtoMessage() {}
 
 func (x *InvalidateCacheResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_cluster_proto_msgTypes[15]
+	mi := &file_yorkie_v1_cluster_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -894,7 +990,7 @@ func (x *InvalidateCacheResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InvalidateCacheResponse.ProtoReflect.Descriptor instead.
 func (*InvalidateCacheResponse) Descriptor() ([]byte, []int) {
-	return file_yorkie_v1_cluster_proto_rawDescGZIP(), []int{15}
+	return file_yorkie_v1_cluster_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *InvalidateCacheResponse) GetSuccess() bool {
@@ -957,7 +1053,13 @@ const file_yorkie_v1_cluster_proto_rawDesc = "" +
 	"\n" +
 	"project_id\x18\x01 \x01(\tR\tprojectId\"L\n" +
 	"%ClusterServiceGetChannelCountResponse\x12#\n" +
-	"\rchannel_count\x18\x01 \x01(\x05R\fchannelCount\"_\n" +
+	"\rchannel_count\x18\x01 \x01(\x05R\fchannelCount\"h\n" +
+	",ClusterServiceDetachActorFromChannelsRequest\x12\x1d\n" +
+	"\n" +
+	"project_id\x18\x01 \x01(\tR\tprojectId\x12\x19\n" +
+	"\bactor_id\x18\x02 \x01(\tR\aactorId\"V\n" +
+	"-ClusterServiceDetachActorFromChannelsResponse\x12%\n" +
+	"\x0edetached_count\x18\x01 \x01(\x05R\rdetachedCount\"_\n" +
 	"\x16InvalidateCacheRequest\x123\n" +
 	"\n" +
 	"cache_type\x18\x01 \x01(\x0e2\x14.yorkie.v1.CacheTypeR\tcacheType\x12\x10\n" +
@@ -968,7 +1070,7 @@ const file_yorkie_v1_cluster_proto_rawDesc = "" +
 	"\x16CACHE_TYPE_UNSPECIFIED\x10\x00\x12\x16\n" +
 	"\x12CACHE_TYPE_PROJECT\x10\x01\x12\x15\n" +
 	"\x11CACHE_TYPE_CLIENT\x10\x02\x12\x17\n" +
-	"\x13CACHE_TYPE_DOCUMENT\x10\x032\x8a\a\n" +
+	"\x13CACHE_TYPE_DOCUMENT\x10\x032\x9b\b\n" +
 	"\x0eClusterService\x12s\n" +
 	"\x0eDetachDocument\x12..yorkie.v1.ClusterServiceDetachDocumentRequest\x1a/.yorkie.v1.ClusterServiceDetachDocumentResponse\"\x00\x12v\n" +
 	"\x0fCompactDocument\x12/.yorkie.v1.ClusterServiceCompactDocumentRequest\x1a0.yorkie.v1.ClusterServiceCompactDocumentResponse\"\x00\x12p\n" +
@@ -976,7 +1078,8 @@ const file_yorkie_v1_cluster_proto_rawDesc = "" +
 	"\vGetDocument\x12+.yorkie.v1.ClusterServiceGetDocumentRequest\x1a,.yorkie.v1.ClusterServiceGetDocumentResponse\"\x00\x12m\n" +
 	"\fListChannels\x12,.yorkie.v1.ClusterServiceListChannelsRequest\x1a-.yorkie.v1.ClusterServiceListChannelsResponse\"\x00\x12j\n" +
 	"\vGetChannels\x12+.yorkie.v1.ClusterServiceGetChannelsRequest\x1a,.yorkie.v1.ClusterServiceGetChannelsResponse\"\x00\x12v\n" +
-	"\x0fGetChannelCount\x12/.yorkie.v1.ClusterServiceGetChannelCountRequest\x1a0.yorkie.v1.ClusterServiceGetChannelCountResponse\"\x00\x12Z\n" +
+	"\x0fGetChannelCount\x12/.yorkie.v1.ClusterServiceGetChannelCountRequest\x1a0.yorkie.v1.ClusterServiceGetChannelCountResponse\"\x00\x12\x8e\x01\n" +
+	"\x17DetachActorFromChannels\x127.yorkie.v1.ClusterServiceDetachActorFromChannelsRequest\x1a8.yorkie.v1.ClusterServiceDetachActorFromChannelsResponse\"\x00\x12Z\n" +
 	"\x0fInvalidateCache\x12!.yorkie.v1.InvalidateCacheRequest\x1a\".yorkie.v1.InvalidateCacheResponse\"\x00BE\n" +
 	"\x11dev.yorkie.api.v1P\x01Z.github.com/yorkie-team/yorkie/api/yorkie/v1;v1b\x06proto3"
 
@@ -993,35 +1096,37 @@ func file_yorkie_v1_cluster_proto_rawDescGZIP() []byte {
 }
 
 var file_yorkie_v1_cluster_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_yorkie_v1_cluster_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
+var file_yorkie_v1_cluster_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_yorkie_v1_cluster_proto_goTypes = []any{
 	(CacheType)(0), // 0: yorkie.v1.CacheType
-	(*ClusterServiceDetachDocumentRequest)(nil),   // 1: yorkie.v1.ClusterServiceDetachDocumentRequest
-	(*ClusterServiceDetachDocumentResponse)(nil),  // 2: yorkie.v1.ClusterServiceDetachDocumentResponse
-	(*ClusterServiceCompactDocumentRequest)(nil),  // 3: yorkie.v1.ClusterServiceCompactDocumentRequest
-	(*ClusterServiceCompactDocumentResponse)(nil), // 4: yorkie.v1.ClusterServiceCompactDocumentResponse
-	(*ClusterServicePurgeDocumentRequest)(nil),    // 5: yorkie.v1.ClusterServicePurgeDocumentRequest
-	(*ClusterServicePurgeDocumentResponse)(nil),   // 6: yorkie.v1.ClusterServicePurgeDocumentResponse
-	(*ClusterServiceGetDocumentRequest)(nil),      // 7: yorkie.v1.ClusterServiceGetDocumentRequest
-	(*ClusterServiceGetDocumentResponse)(nil),     // 8: yorkie.v1.ClusterServiceGetDocumentResponse
-	(*ClusterServiceListChannelsRequest)(nil),     // 9: yorkie.v1.ClusterServiceListChannelsRequest
-	(*ClusterServiceListChannelsResponse)(nil),    // 10: yorkie.v1.ClusterServiceListChannelsResponse
-	(*ClusterServiceGetChannelsRequest)(nil),      // 11: yorkie.v1.ClusterServiceGetChannelsRequest
-	(*ClusterServiceGetChannelsResponse)(nil),     // 12: yorkie.v1.ClusterServiceGetChannelsResponse
-	(*ClusterServiceGetChannelCountRequest)(nil),  // 13: yorkie.v1.ClusterServiceGetChannelCountRequest
-	(*ClusterServiceGetChannelCountResponse)(nil), // 14: yorkie.v1.ClusterServiceGetChannelCountResponse
-	(*InvalidateCacheRequest)(nil),                // 15: yorkie.v1.InvalidateCacheRequest
-	(*InvalidateCacheResponse)(nil),               // 16: yorkie.v1.InvalidateCacheResponse
-	(*Project)(nil),                               // 17: yorkie.v1.Project
-	(*DocumentSummary)(nil),                       // 18: yorkie.v1.DocumentSummary
-	(*ChannelSummary)(nil),                        // 19: yorkie.v1.ChannelSummary
+	(*ClusterServiceDetachDocumentRequest)(nil),           // 1: yorkie.v1.ClusterServiceDetachDocumentRequest
+	(*ClusterServiceDetachDocumentResponse)(nil),          // 2: yorkie.v1.ClusterServiceDetachDocumentResponse
+	(*ClusterServiceCompactDocumentRequest)(nil),          // 3: yorkie.v1.ClusterServiceCompactDocumentRequest
+	(*ClusterServiceCompactDocumentResponse)(nil),         // 4: yorkie.v1.ClusterServiceCompactDocumentResponse
+	(*ClusterServicePurgeDocumentRequest)(nil),            // 5: yorkie.v1.ClusterServicePurgeDocumentRequest
+	(*ClusterServicePurgeDocumentResponse)(nil),           // 6: yorkie.v1.ClusterServicePurgeDocumentResponse
+	(*ClusterServiceGetDocumentRequest)(nil),              // 7: yorkie.v1.ClusterServiceGetDocumentRequest
+	(*ClusterServiceGetDocumentResponse)(nil),             // 8: yorkie.v1.ClusterServiceGetDocumentResponse
+	(*ClusterServiceListChannelsRequest)(nil),             // 9: yorkie.v1.ClusterServiceListChannelsRequest
+	(*ClusterServiceListChannelsResponse)(nil),            // 10: yorkie.v1.ClusterServiceListChannelsResponse
+	(*ClusterServiceGetChannelsRequest)(nil),              // 11: yorkie.v1.ClusterServiceGetChannelsRequest
+	(*ClusterServiceGetChannelsResponse)(nil),             // 12: yorkie.v1.ClusterServiceGetChannelsResponse
+	(*ClusterServiceGetChannelCountRequest)(nil),          // 13: yorkie.v1.ClusterServiceGetChannelCountRequest
+	(*ClusterServiceGetChannelCountResponse)(nil),         // 14: yorkie.v1.ClusterServiceGetChannelCountResponse
+	(*ClusterServiceDetachActorFromChannelsRequest)(nil),  // 15: yorkie.v1.ClusterServiceDetachActorFromChannelsRequest
+	(*ClusterServiceDetachActorFromChannelsResponse)(nil), // 16: yorkie.v1.ClusterServiceDetachActorFromChannelsResponse
+	(*InvalidateCacheRequest)(nil),                        // 17: yorkie.v1.InvalidateCacheRequest
+	(*InvalidateCacheResponse)(nil),                       // 18: yorkie.v1.InvalidateCacheResponse
+	(*Project)(nil),                                       // 19: yorkie.v1.Project
+	(*DocumentSummary)(nil),                               // 20: yorkie.v1.DocumentSummary
+	(*ChannelSummary)(nil),                                // 21: yorkie.v1.ChannelSummary
 }
 var file_yorkie_v1_cluster_proto_depIdxs = []int32{
-	17, // 0: yorkie.v1.ClusterServiceDetachDocumentRequest.project:type_name -> yorkie.v1.Project
-	17, // 1: yorkie.v1.ClusterServiceGetDocumentRequest.project:type_name -> yorkie.v1.Project
-	18, // 2: yorkie.v1.ClusterServiceGetDocumentResponse.document:type_name -> yorkie.v1.DocumentSummary
-	19, // 3: yorkie.v1.ClusterServiceListChannelsResponse.channels:type_name -> yorkie.v1.ChannelSummary
-	19, // 4: yorkie.v1.ClusterServiceGetChannelsResponse.channels:type_name -> yorkie.v1.ChannelSummary
+	19, // 0: yorkie.v1.ClusterServiceDetachDocumentRequest.project:type_name -> yorkie.v1.Project
+	19, // 1: yorkie.v1.ClusterServiceGetDocumentRequest.project:type_name -> yorkie.v1.Project
+	20, // 2: yorkie.v1.ClusterServiceGetDocumentResponse.document:type_name -> yorkie.v1.DocumentSummary
+	21, // 3: yorkie.v1.ClusterServiceListChannelsResponse.channels:type_name -> yorkie.v1.ChannelSummary
+	21, // 4: yorkie.v1.ClusterServiceGetChannelsResponse.channels:type_name -> yorkie.v1.ChannelSummary
 	0,  // 5: yorkie.v1.InvalidateCacheRequest.cache_type:type_name -> yorkie.v1.CacheType
 	1,  // 6: yorkie.v1.ClusterService.DetachDocument:input_type -> yorkie.v1.ClusterServiceDetachDocumentRequest
 	3,  // 7: yorkie.v1.ClusterService.CompactDocument:input_type -> yorkie.v1.ClusterServiceCompactDocumentRequest
@@ -1030,17 +1135,19 @@ var file_yorkie_v1_cluster_proto_depIdxs = []int32{
 	9,  // 10: yorkie.v1.ClusterService.ListChannels:input_type -> yorkie.v1.ClusterServiceListChannelsRequest
 	11, // 11: yorkie.v1.ClusterService.GetChannels:input_type -> yorkie.v1.ClusterServiceGetChannelsRequest
 	13, // 12: yorkie.v1.ClusterService.GetChannelCount:input_type -> yorkie.v1.ClusterServiceGetChannelCountRequest
-	15, // 13: yorkie.v1.ClusterService.InvalidateCache:input_type -> yorkie.v1.InvalidateCacheRequest
-	2,  // 14: yorkie.v1.ClusterService.DetachDocument:output_type -> yorkie.v1.ClusterServiceDetachDocumentResponse
-	4,  // 15: yorkie.v1.ClusterService.CompactDocument:output_type -> yorkie.v1.ClusterServiceCompactDocumentResponse
-	6,  // 16: yorkie.v1.ClusterService.PurgeDocument:output_type -> yorkie.v1.ClusterServicePurgeDocumentResponse
-	8,  // 17: yorkie.v1.ClusterService.GetDocument:output_type -> yorkie.v1.ClusterServiceGetDocumentResponse
-	10, // 18: yorkie.v1.ClusterService.ListChannels:output_type -> yorkie.v1.ClusterServiceListChannelsResponse
-	12, // 19: yorkie.v1.ClusterService.GetChannels:output_type -> yorkie.v1.ClusterServiceGetChannelsResponse
-	14, // 20: yorkie.v1.ClusterService.GetChannelCount:output_type -> yorkie.v1.ClusterServiceGetChannelCountResponse
-	16, // 21: yorkie.v1.ClusterService.InvalidateCache:output_type -> yorkie.v1.InvalidateCacheResponse
-	14, // [14:22] is the sub-list for method output_type
-	6,  // [6:14] is the sub-list for method input_type
+	15, // 13: yorkie.v1.ClusterService.DetachActorFromChannels:input_type -> yorkie.v1.ClusterServiceDetachActorFromChannelsRequest
+	17, // 14: yorkie.v1.ClusterService.InvalidateCache:input_type -> yorkie.v1.InvalidateCacheRequest
+	2,  // 15: yorkie.v1.ClusterService.DetachDocument:output_type -> yorkie.v1.ClusterServiceDetachDocumentResponse
+	4,  // 16: yorkie.v1.ClusterService.CompactDocument:output_type -> yorkie.v1.ClusterServiceCompactDocumentResponse
+	6,  // 17: yorkie.v1.ClusterService.PurgeDocument:output_type -> yorkie.v1.ClusterServicePurgeDocumentResponse
+	8,  // 18: yorkie.v1.ClusterService.GetDocument:output_type -> yorkie.v1.ClusterServiceGetDocumentResponse
+	10, // 19: yorkie.v1.ClusterService.ListChannels:output_type -> yorkie.v1.ClusterServiceListChannelsResponse
+	12, // 20: yorkie.v1.ClusterService.GetChannels:output_type -> yorkie.v1.ClusterServiceGetChannelsResponse
+	14, // 21: yorkie.v1.ClusterService.GetChannelCount:output_type -> yorkie.v1.ClusterServiceGetChannelCountResponse
+	16, // 22: yorkie.v1.ClusterService.DetachActorFromChannels:output_type -> yorkie.v1.ClusterServiceDetachActorFromChannelsResponse
+	18, // 23: yorkie.v1.ClusterService.InvalidateCache:output_type -> yorkie.v1.InvalidateCacheResponse
+	15, // [15:24] is the sub-list for method output_type
+	6,  // [6:15] is the sub-list for method input_type
 	6,  // [6:6] is the sub-list for extension type_name
 	6,  // [6:6] is the sub-list for extension extendee
 	0,  // [0:6] is the sub-list for field type_name
@@ -1058,7 +1165,7 @@ func file_yorkie_v1_cluster_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_yorkie_v1_cluster_proto_rawDesc), len(file_yorkie_v1_cluster_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   16,
+			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/yorkie/v1/cluster.proto
+++ b/api/yorkie/v1/cluster.proto
@@ -33,6 +33,7 @@ service ClusterService {
   rpc ListChannels (ClusterServiceListChannelsRequest) returns (ClusterServiceListChannelsResponse) {}
   rpc GetChannels (ClusterServiceGetChannelsRequest) returns (ClusterServiceGetChannelsResponse) {}
   rpc GetChannelCount (ClusterServiceGetChannelCountRequest) returns (ClusterServiceGetChannelCountResponse) {}
+  rpc DetachActorFromChannels (ClusterServiceDetachActorFromChannelsRequest) returns (ClusterServiceDetachActorFromChannelsResponse) {}
   rpc InvalidateCache (InvalidateCacheRequest) returns (InvalidateCacheResponse) {}
 }
 
@@ -101,6 +102,15 @@ message ClusterServiceGetChannelCountRequest {
 
 message ClusterServiceGetChannelCountResponse {
   int32 channel_count = 1;
+}
+
+message ClusterServiceDetachActorFromChannelsRequest {
+  string project_id = 1;
+  string actor_id = 2;
+}
+
+message ClusterServiceDetachActorFromChannelsResponse {
+  int32 detached_count = 1;
 }
 
 enum CacheType {

--- a/api/yorkie/v1/v1connect/cluster.connect.go
+++ b/api/yorkie/v1/v1connect/cluster.connect.go
@@ -69,6 +69,9 @@ const (
 	// ClusterServiceGetChannelCountProcedure is the fully-qualified name of the ClusterService's
 	// GetChannelCount RPC.
 	ClusterServiceGetChannelCountProcedure = "/yorkie.v1.ClusterService/GetChannelCount"
+	// ClusterServiceDetachActorFromChannelsProcedure is the fully-qualified name of the
+	// ClusterService's DetachActorFromChannels RPC.
+	ClusterServiceDetachActorFromChannelsProcedure = "/yorkie.v1.ClusterService/DetachActorFromChannels"
 	// ClusterServiceInvalidateCacheProcedure is the fully-qualified name of the ClusterService's
 	// InvalidateCache RPC.
 	ClusterServiceInvalidateCacheProcedure = "/yorkie.v1.ClusterService/InvalidateCache"
@@ -83,6 +86,7 @@ type ClusterServiceClient interface {
 	ListChannels(context.Context, *connect.Request[v1.ClusterServiceListChannelsRequest]) (*connect.Response[v1.ClusterServiceListChannelsResponse], error)
 	GetChannels(context.Context, *connect.Request[v1.ClusterServiceGetChannelsRequest]) (*connect.Response[v1.ClusterServiceGetChannelsResponse], error)
 	GetChannelCount(context.Context, *connect.Request[v1.ClusterServiceGetChannelCountRequest]) (*connect.Response[v1.ClusterServiceGetChannelCountResponse], error)
+	DetachActorFromChannels(context.Context, *connect.Request[v1.ClusterServiceDetachActorFromChannelsRequest]) (*connect.Response[v1.ClusterServiceDetachActorFromChannelsResponse], error)
 	InvalidateCache(context.Context, *connect.Request[v1.InvalidateCacheRequest]) (*connect.Response[v1.InvalidateCacheResponse], error)
 }
 
@@ -131,6 +135,11 @@ func NewClusterServiceClient(httpClient connect.HTTPClient, baseURL string, opts
 			baseURL+ClusterServiceGetChannelCountProcedure,
 			opts...,
 		),
+		detachActorFromChannels: connect.NewClient[v1.ClusterServiceDetachActorFromChannelsRequest, v1.ClusterServiceDetachActorFromChannelsResponse](
+			httpClient,
+			baseURL+ClusterServiceDetachActorFromChannelsProcedure,
+			opts...,
+		),
 		invalidateCache: connect.NewClient[v1.InvalidateCacheRequest, v1.InvalidateCacheResponse](
 			httpClient,
 			baseURL+ClusterServiceInvalidateCacheProcedure,
@@ -141,14 +150,15 @@ func NewClusterServiceClient(httpClient connect.HTTPClient, baseURL string, opts
 
 // clusterServiceClient implements ClusterServiceClient.
 type clusterServiceClient struct {
-	detachDocument  *connect.Client[v1.ClusterServiceDetachDocumentRequest, v1.ClusterServiceDetachDocumentResponse]
-	compactDocument *connect.Client[v1.ClusterServiceCompactDocumentRequest, v1.ClusterServiceCompactDocumentResponse]
-	purgeDocument   *connect.Client[v1.ClusterServicePurgeDocumentRequest, v1.ClusterServicePurgeDocumentResponse]
-	getDocument     *connect.Client[v1.ClusterServiceGetDocumentRequest, v1.ClusterServiceGetDocumentResponse]
-	listChannels    *connect.Client[v1.ClusterServiceListChannelsRequest, v1.ClusterServiceListChannelsResponse]
-	getChannels     *connect.Client[v1.ClusterServiceGetChannelsRequest, v1.ClusterServiceGetChannelsResponse]
-	getChannelCount *connect.Client[v1.ClusterServiceGetChannelCountRequest, v1.ClusterServiceGetChannelCountResponse]
-	invalidateCache *connect.Client[v1.InvalidateCacheRequest, v1.InvalidateCacheResponse]
+	detachDocument          *connect.Client[v1.ClusterServiceDetachDocumentRequest, v1.ClusterServiceDetachDocumentResponse]
+	compactDocument         *connect.Client[v1.ClusterServiceCompactDocumentRequest, v1.ClusterServiceCompactDocumentResponse]
+	purgeDocument           *connect.Client[v1.ClusterServicePurgeDocumentRequest, v1.ClusterServicePurgeDocumentResponse]
+	getDocument             *connect.Client[v1.ClusterServiceGetDocumentRequest, v1.ClusterServiceGetDocumentResponse]
+	listChannels            *connect.Client[v1.ClusterServiceListChannelsRequest, v1.ClusterServiceListChannelsResponse]
+	getChannels             *connect.Client[v1.ClusterServiceGetChannelsRequest, v1.ClusterServiceGetChannelsResponse]
+	getChannelCount         *connect.Client[v1.ClusterServiceGetChannelCountRequest, v1.ClusterServiceGetChannelCountResponse]
+	detachActorFromChannels *connect.Client[v1.ClusterServiceDetachActorFromChannelsRequest, v1.ClusterServiceDetachActorFromChannelsResponse]
+	invalidateCache         *connect.Client[v1.InvalidateCacheRequest, v1.InvalidateCacheResponse]
 }
 
 // DetachDocument calls yorkie.v1.ClusterService.DetachDocument.
@@ -186,6 +196,11 @@ func (c *clusterServiceClient) GetChannelCount(ctx context.Context, req *connect
 	return c.getChannelCount.CallUnary(ctx, req)
 }
 
+// DetachActorFromChannels calls yorkie.v1.ClusterService.DetachActorFromChannels.
+func (c *clusterServiceClient) DetachActorFromChannels(ctx context.Context, req *connect.Request[v1.ClusterServiceDetachActorFromChannelsRequest]) (*connect.Response[v1.ClusterServiceDetachActorFromChannelsResponse], error) {
+	return c.detachActorFromChannels.CallUnary(ctx, req)
+}
+
 // InvalidateCache calls yorkie.v1.ClusterService.InvalidateCache.
 func (c *clusterServiceClient) InvalidateCache(ctx context.Context, req *connect.Request[v1.InvalidateCacheRequest]) (*connect.Response[v1.InvalidateCacheResponse], error) {
 	return c.invalidateCache.CallUnary(ctx, req)
@@ -200,6 +215,7 @@ type ClusterServiceHandler interface {
 	ListChannels(context.Context, *connect.Request[v1.ClusterServiceListChannelsRequest]) (*connect.Response[v1.ClusterServiceListChannelsResponse], error)
 	GetChannels(context.Context, *connect.Request[v1.ClusterServiceGetChannelsRequest]) (*connect.Response[v1.ClusterServiceGetChannelsResponse], error)
 	GetChannelCount(context.Context, *connect.Request[v1.ClusterServiceGetChannelCountRequest]) (*connect.Response[v1.ClusterServiceGetChannelCountResponse], error)
+	DetachActorFromChannels(context.Context, *connect.Request[v1.ClusterServiceDetachActorFromChannelsRequest]) (*connect.Response[v1.ClusterServiceDetachActorFromChannelsResponse], error)
 	InvalidateCache(context.Context, *connect.Request[v1.InvalidateCacheRequest]) (*connect.Response[v1.InvalidateCacheResponse], error)
 }
 
@@ -244,6 +260,11 @@ func NewClusterServiceHandler(svc ClusterServiceHandler, opts ...connect.Handler
 		svc.GetChannelCount,
 		opts...,
 	)
+	clusterServiceDetachActorFromChannelsHandler := connect.NewUnaryHandler(
+		ClusterServiceDetachActorFromChannelsProcedure,
+		svc.DetachActorFromChannels,
+		opts...,
+	)
 	clusterServiceInvalidateCacheHandler := connect.NewUnaryHandler(
 		ClusterServiceInvalidateCacheProcedure,
 		svc.InvalidateCache,
@@ -265,6 +286,8 @@ func NewClusterServiceHandler(svc ClusterServiceHandler, opts ...connect.Handler
 			clusterServiceGetChannelsHandler.ServeHTTP(w, r)
 		case ClusterServiceGetChannelCountProcedure:
 			clusterServiceGetChannelCountHandler.ServeHTTP(w, r)
+		case ClusterServiceDetachActorFromChannelsProcedure:
+			clusterServiceDetachActorFromChannelsHandler.ServeHTTP(w, r)
 		case ClusterServiceInvalidateCacheProcedure:
 			clusterServiceInvalidateCacheHandler.ServeHTTP(w, r)
 		default:
@@ -302,6 +325,10 @@ func (UnimplementedClusterServiceHandler) GetChannels(context.Context, *connect.
 
 func (UnimplementedClusterServiceHandler) GetChannelCount(context.Context, *connect.Request[v1.ClusterServiceGetChannelCountRequest]) (*connect.Response[v1.ClusterServiceGetChannelCountResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("yorkie.v1.ClusterService.GetChannelCount is not implemented"))
+}
+
+func (UnimplementedClusterServiceHandler) DetachActorFromChannels(context.Context, *connect.Request[v1.ClusterServiceDetachActorFromChannelsRequest]) (*connect.Response[v1.ClusterServiceDetachActorFromChannelsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("yorkie.v1.ClusterService.DetachActorFromChannels is not implemented"))
 }
 
 func (UnimplementedClusterServiceHandler) InvalidateCache(context.Context, *connect.Request[v1.InvalidateCacheRequest]) (*connect.Response[v1.InvalidateCacheResponse], error) {

--- a/cluster/client.go
+++ b/cluster/client.go
@@ -373,6 +373,30 @@ func (c *Client) GetChannelCount(
 	return response.Msg.ChannelCount, nil
 }
 
+// DetachActorFromChannels requests the remote node to detach all channel
+// sessions held by the given actor on that node.
+func (c *Client) DetachActorFromChannels(
+	ctx context.Context,
+	projectID types.ID,
+	actorID time.ActorID,
+) (int32, error) {
+	ctx, cancel := context.WithTimeout(ctx, c.rpcTimeout)
+	defer cancel()
+
+	response, err := c.client.DetachActorFromChannels(
+		ctx,
+		connect.NewRequest(&api.ClusterServiceDetachActorFromChannelsRequest{
+			ProjectId: projectID.String(),
+			ActorId:   actorID.String(),
+		}),
+	)
+	if err != nil {
+		return 0, fromConnectError(err)
+	}
+
+	return response.Msg.DetachedCount, nil
+}
+
 // InvalidateCache invalidates the cache of the given type and key.
 func (c *Client) InvalidateCache(
 	ctx context.Context,

--- a/docs/tasks/active/05/20260511-deactivate-channel-cascade-lessons.md
+++ b/docs/tasks/active/05/20260511-deactivate-channel-cascade-lessons.md
@@ -1,0 +1,71 @@
+**Created**: 2026-05-11
+
+# Lessons: Deactivate channel cascade
+
+## The 30s "deactivate problem" wasn't deactivate's fault
+
+Initial framing was "deactivate doesn't clean up", suggesting a bug in
+`clients.Deactivate`. Reading the code showed the async path is sound:
+`be.Go` creates a fresh background context, so cancelled request
+contexts don't kill the work, and a `ClientDeactivatedEvent` is
+produced afterward.
+
+The real story showed up in the server logs: `PublishChannel` fired on
+every refresh (attach), but no `Detach` calls or `CHAN: ... expires[]`
+cleanup lines appeared until ~60s later. Two separate systems were at
+play — client lifecycle (DB `clientInfo`) and channel sessions
+(in-memory per-server map with a 60s TTL) — and the cascade between
+them simply did not exist. The user's "30s" estimate was actually
+~60s + cleanup tick.
+
+Rule: when reported symptoms include a specific number, find the
+matching constant in code before forming a hypothesis. The TTL
+defaults (`ChannelSessionTTL=60s`, `ChannelSessionCleanupInterval=10s`,
+`HousekeepingInterval=30s`) each have a distinct fingerprint in
+operator-visible latency.
+
+## SDK fix vs server fix is not really a choice
+
+We considered fixing this in the SDK (send `DetachChannel` on
+`pagehide` via `sendBeacon`) instead of cascading from the server.
+The SDK path has unfixable limits: every SDK language must implement
+it, every browser quirk reappears, and the request still has to leave
+the page alive. The server cascade is one place, all SDKs benefit,
+and the channel TTL becomes the true last-resort safety net rather
+than the primary cleanup mechanism.
+
+Rule: when an "SDK should call X on unload" fix is on the table, ask
+whether the server can derive the cleanup itself from an existing
+event it already receives. If yes, prefer it — best-effort
+cross-network calls during unload are inherently lossy.
+
+## Cluster broadcast was already a paved road
+
+Initial assumption was that adding an actor-keyed cluster RPC would
+require building a new "broadcast to all peers" primitive. In fact
+`BroadcastChannelList`/`BroadcastChannelCount` already enumerate
+cluster nodes via `prepareClusterClients` and fan out per-node RPCs
+with partial-failure handling. The new
+`BroadcastDetachActorFromChannels` is a near-clone of
+`BroadcastChannelCount`.
+
+Rule: before proposing infrastructure, grep for the verb you want
+("broadcast", "fanout") in the package. Yorkie has historically added
+a broadcast helper per use case rather than a generic one; the
+template lives next to the existing helper.
+
+## protoc-gen-go version drift produces fake diffs
+
+`make proto` regenerated `admin.pb.go`, `resources.pb.go`, and
+`yorkie.pb.go` with thousands of lines of unrelated changes purely
+because the locally-installed `protoc-gen-go` (v1.31.0) didn't match
+the version originally used (v1.36.10, recorded in each file's
+generated header). The cluster.proto edit was real; the rest was
+codegen-style drift that would have inflated the PR diff and confused
+reviewers.
+
+Rule: after `make proto`, diff a known-untouched `.pb.go` file. Any
+hunks there mean the local toolchain version disagrees with what
+generated the committed code — fix the toolchain (install the version
+recorded in the file's header comment) and regenerate, rather than
+committing the drift.

--- a/docs/tasks/active/05/20260511-deactivate-channel-cascade-todo.md
+++ b/docs/tasks/active/05/20260511-deactivate-channel-cascade-todo.md
@@ -57,7 +57,7 @@ Need to add one and use `prepareClusterClients` (same pattern as
 
   message ClusterServiceDetachActorFromChannelsRequest {
     string project_id = 1;
-    bytes actor_id = 2;
+    string actor_id = 2;
   }
   message ClusterServiceDetachActorFromChannelsResponse {
     int32 detached_count = 1;

--- a/docs/tasks/active/05/20260511-deactivate-channel-cascade-todo.md
+++ b/docs/tasks/active/05/20260511-deactivate-channel-cascade-todo.md
@@ -1,0 +1,120 @@
+**Created**: 2026-05-11
+
+# Cascade Channel Session Detach on Client Deactivate
+
+## Problem
+
+When a browser refreshes/closes without sending explicit detach RPCs, the
+channel session lingers until `ChannelSessionTTL` (default 60s) expires
+and the cleanup ticker (10s) sweeps it. Users observe ~60s of stale
+membership in channel polling.
+
+`clients.Deactivate` already handles document detach via cluster, but
+channel sessions are managed in a separate per-server in-memory map
+(`channel.Manager`) and are not cascaded.
+
+## Goal
+
+Move responsibility for channel session cleanup from the SDK to the
+server. When `clients.Deactivate` runs (via SDK-triggered RPC or via
+housekeeping), all channel sessions held by the actor — **across the
+entire cluster** — should be detached in the same call.
+
+Worst-case stale window improves:
+- RPC path (SDK reachable): immediate detach
+- Housekeeping path (SDK unreachable): ~30s (housekeeping interval)
+- Channel TTL remains as last-resort safety net (~60s)
+
+## Why cluster broadcast is needed
+
+Channels are sharded across cluster nodes by `channelKey.FirstPath()`
+(Istio consistent hashing). A single actor may hold sessions on
+multiple servers. Deactivate is keyed by clientID and routes to one
+server, which only knows about its own local channel sessions.
+
+Existing cluster RPCs (`DetachDocument`, `ListChannels`, etc.) all
+route by channel/document key, so no actor-keyed cluster RPC exists.
+Need to add one and use `prepareClusterClients` (same pattern as
+`BroadcastChannelList`) to fan out.
+
+## Plan
+
+### Step 1: Channel Manager — `DetachByActor`
+- [ ] **Add `DetachByActor(ctx, actor time.ActorID) (int, error)` to `channel.Manager`**
+  - Look up `m.clientToSession[actor]`, snapshot session IDs (avoid
+    iterator invalidation during deletion)
+  - Call existing `Detach` per session
+  - Return number of detached sessions
+  - Continue on per-session error; aggregate and log
+- [ ] **Unit test** — attach 2 channels for actor A, 1 channel for
+  actor B; DetachByActor(A) removes only A's sessions
+
+### Step 2: Cluster RPC — `DetachActorFromChannels`
+- [ ] **Add to `api/yorkie/v1/cluster.proto`**
+  ```proto
+  rpc DetachActorFromChannels (ClusterServiceDetachActorFromChannelsRequest)
+    returns (ClusterServiceDetachActorFromChannelsResponse) {}
+
+  message ClusterServiceDetachActorFromChannelsRequest {
+    string project_id = 1;
+    bytes actor_id = 2;
+  }
+  message ClusterServiceDetachActorFromChannelsResponse {
+    int32 detached_count = 1;
+  }
+  ```
+- [ ] **Run `make proto`**
+- [ ] **Implement RPC handler in `server/rpc/cluster_server.go`**
+  - Validates project, decodes actor ID, calls local
+    `s.backend.Channel.DetachByActor`
+
+### Step 3: Backend broadcast helper
+- [ ] **Add `BroadcastDetachActorFromChannels(ctx, projectID, actorID)`
+  to `server/backend/backend.go`**
+  - Mirror `BroadcastChannelCount` shape
+  - For each cluster node, call RPC; aggregate detached count
+  - Best-effort: log partial failures, do not fail overall
+
+### Step 4: Wire cascade into `clients.Deactivate`
+- [ ] **Call `be.BroadcastDetachActorFromChannels` after cluster
+  document detach loop, before `be.DB.DeactivateClient`**
+- [ ] Log error but do not fail deactivation (best-effort; channel
+  TTL is the final safety net)
+
+### Step 5: ClusterClient pool method
+- [ ] **Add `DetachActorFromChannels(ctx, projectID, actorID)` to
+  ClusterClient in `server/backend/pool_*.go`** (mirror existing
+  `ListChannels` shape)
+
+### Step 6: Integration tests
+- [ ] **`test/integration/channel_test.go`**: Activate → AttachChannel
+  → DeactivateClient → assert `SessionCount` drops to 0 immediately
+  (well before TTL)
+- [ ] Cover both `Synchronous=true` and async path
+- [ ] Verify housekeeping cascade: force inactive client (skip
+  RefreshChannel), confirm cleanup at housekeeping tick (not at TTL)
+
+## Out of Scope
+
+- SDK changes: leave `DetachChannel` RPC API intact for explicit
+  unsubscribe scenarios.
+- Optimizing housekeeping fan-out (N clients × M nodes RPCs). Same
+  amplification exists in `BroadcastChannelList`; revisit only if
+  operational data shows it's a problem.
+
+## Verification
+
+- `make lint && make test`
+- `make test -tags integration`
+- Manual: run server with debug log, refresh test page 10×, confirm
+  immediate detach (no `CHAN: ... expires[...]` from TTL cleanup)
+
+## Files
+
+- `api/yorkie/v1/cluster.proto`
+- `server/backend/channel/manager.go` — `DetachByActor`
+- `server/rpc/cluster_server.go` — RPC handler
+- `server/backend/backend.go` — `BroadcastDetachActorFromChannels`
+- `server/backend/pool_*.go` — ClusterClient method
+- `server/clients/clients.go` — cascade call in `Deactivate`
+- `test/integration/channel_test.go` — new test cases

--- a/server/backend/backend.go
+++ b/server/backend/backend.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/yorkie-team/yorkie/api/types"
 	"github.com/yorkie-team/yorkie/cluster"
+	"github.com/yorkie-team/yorkie/pkg/document/time"
 	pkgwebhook "github.com/yorkie-team/yorkie/pkg/webhook"
 	"github.com/yorkie-team/yorkie/server/backend/background"
 	"github.com/yorkie-team/yorkie/server/backend/cache"
@@ -454,6 +455,48 @@ func (b *Backend) BroadcastChannelCount(
 		channelCount += int(count)
 	}
 	return channelCount, nil
+}
+
+// BroadcastDetachActorFromChannels asks every cluster node to detach all
+// channel sessions held by the given actor. Used during client deactivation
+// to cascade cleanup across the cluster, since channels are sharded per node
+// and any of them may hold sessions for the actor.
+//
+// Best-effort: per-node failures are logged but do not abort the broadcast.
+// The channel session TTL still backstops any node we failed to reach.
+func (b *Backend) BroadcastDetachActorFromChannels(
+	ctx context.Context,
+	projectID types.ID,
+	actorID time.ActorID,
+) (int, error) {
+	nodes, err := b.prepareClusterClients(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("broadcast detach actor from channels: %w", err)
+	}
+
+	detached := 0
+	var errs []error
+	for _, node := range nodes {
+		nodeAddr := node.RPCAddr
+
+		cli, err := b.ClusterClientPool.Get(nodeAddr)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("get client for %s: %w", nodeAddr, err))
+			continue
+		}
+
+		count, err := cli.DetachActorFromChannels(ctx, projectID, actorID)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("detach actor on %s: %w", nodeAddr, err))
+			continue
+		}
+		detached += int(count)
+	}
+
+	if len(errs) > 0 {
+		logging.From(ctx).Warnf("partial failure in detach actor broadcast: %v", errors.Join(errs...))
+	}
+	return detached, nil
 }
 
 // prepareClusterClients returns cluster nodes and prunes inactive clients.

--- a/server/backend/channel/manager.go
+++ b/server/backend/channel/manager.go
@@ -396,25 +396,47 @@ func (m *Manager) Detach(
 	return newSessionCount, nil
 }
 
-// DetachByActor detaches all channel sessions held by the given actor on
-// this server. It is used during client deactivation to cascade cleanup
-// without waiting for the channel session TTL to expire.
+// DetachByActor detaches channel sessions held by the given actor under the
+// given project on this server. It is used during client deactivation to
+// cascade cleanup without waiting for the channel session TTL to expire.
 //
-// Errors on individual sessions are logged but do not abort the loop —
-// the goal is to evict as much as possible; remaining stale sessions
-// are caught by the cleanup ticker.
-func (m *Manager) DetachByActor(ctx context.Context, actor time.ActorID) (int, error) {
+// Sessions are scoped to the project — a sibling project that happens to
+// share the same actor ID is untouched. Errors on individual sessions are
+// logged but do not abort the loop; the goal is to evict as much as
+// possible, and the cleanup ticker catches anything missed.
+func (m *Manager) DetachByActor(
+	ctx context.Context,
+	projectID types.ID,
+	actor time.ActorID,
+) (int, error) {
 	clientSessionMap, ok := m.clientToSession.Get(actor)
 	if !ok {
 		return 0, nil
 	}
 
-	sessionIDs := clientSessionMap.Values()
+	// Snapshot (channelRefKey, sessionID) pairs so we can filter by project
+	// without keeping the inner cmap pinned for the duration of Detach calls.
+	channelKeys := clientSessionMap.Keys()
+	type sessionRef struct {
+		key types.ChannelRefKey
+		id  types.ID
+	}
+	targets := make([]sessionRef, 0, len(channelKeys))
+	for _, key := range channelKeys {
+		if key.ProjectID != projectID {
+			continue
+		}
+		sessionID, ok := clientSessionMap.Get(key)
+		if !ok {
+			continue
+		}
+		targets = append(targets, sessionRef{key: key, id: sessionID})
+	}
 
 	detached := 0
-	for _, sessionID := range sessionIDs {
-		if _, err := m.Detach(ctx, sessionID); err != nil {
-			logging.From(ctx).Warnf("detach session %s for actor %s: %v", sessionID, actor, err)
+	for _, t := range targets {
+		if _, err := m.Detach(ctx, t.id); err != nil {
+			logging.From(ctx).Warnf("detach session %s for actor %s: %v", t.id, actor, err)
 			continue
 		}
 		detached++

--- a/server/backend/channel/manager.go
+++ b/server/backend/channel/manager.go
@@ -396,6 +396,33 @@ func (m *Manager) Detach(
 	return newSessionCount, nil
 }
 
+// DetachByActor detaches all channel sessions held by the given actor on
+// this server. It is used during client deactivation to cascade cleanup
+// without waiting for the channel session TTL to expire.
+//
+// Errors on individual sessions are logged but do not abort the loop —
+// the goal is to evict as much as possible; remaining stale sessions
+// are caught by the cleanup ticker.
+func (m *Manager) DetachByActor(ctx context.Context, actor time.ActorID) (int, error) {
+	clientSessionMap, ok := m.clientToSession.Get(actor)
+	if !ok {
+		return 0, nil
+	}
+
+	sessionIDs := clientSessionMap.Values()
+
+	detached := 0
+	for _, sessionID := range sessionIDs {
+		if _, err := m.Detach(ctx, sessionID); err != nil {
+			logging.From(ctx).Warnf("detach session %s for actor %s: %v", sessionID, actor, err)
+			continue
+		}
+		detached++
+	}
+
+	return detached, nil
+}
+
 // Refresh extends the TTL of an existing session by updating its activity time.
 func (m *Manager) Refresh(
 	ctx context.Context,

--- a/server/backend/channel/manager_test.go
+++ b/server/backend/channel/manager_test.go
@@ -820,7 +820,7 @@ func TestChannelManager_AttachDetachErrors(t *testing.T) {
 }
 
 func TestChannelManager_DetachByActor(t *testing.T) {
-	t.Run("detaches all sessions held by the actor", func(t *testing.T) {
+	t.Run("detaches all sessions held by the actor in the project", func(t *testing.T) {
 		ctx := context.Background()
 		manager, _, _ := createManager(t, 60*time.Second, 10*time.Second)
 		projectID := types.NewID()
@@ -841,7 +841,7 @@ func TestChannelManager_DetachByActor(t *testing.T) {
 		_, _, err = manager.Attach(ctx, keyB1, actorB)
 		assert.NoError(t, err)
 
-		detached, err := manager.DetachByActor(ctx, actorA)
+		detached, err := manager.DetachByActor(ctx, projectID, actorA)
 		assert.NoError(t, err)
 		assert.Equal(t, 2, detached)
 
@@ -850,14 +850,41 @@ func TestChannelManager_DetachByActor(t *testing.T) {
 		assert.Equal(t, int64(1), manager.SessionCount(keyB1, false))
 	})
 
-	t.Run("returns zero when actor has no sessions", func(t *testing.T) {
+	t.Run("leaves sessions in sibling projects untouched", func(t *testing.T) {
 		ctx := context.Background()
 		manager, _, _ := createManager(t, 60*time.Second, 10*time.Second)
+		projectA := types.NewID()
+		projectB := types.NewID()
 
 		actor, err := pkgtime.ActorIDFromHex(fmt.Sprintf("a%023d", 0))
 		assert.NoError(t, err)
 
-		detached, err := manager.DetachByActor(ctx, actor)
+		keyInA := types.ChannelRefKey{ProjectID: projectA, ChannelKey: "room-1"}
+		keyInB := types.ChannelRefKey{ProjectID: projectB, ChannelKey: "room-1"}
+
+		_, _, err = manager.Attach(ctx, keyInA, actor)
+		assert.NoError(t, err)
+		_, _, err = manager.Attach(ctx, keyInB, actor)
+		assert.NoError(t, err)
+
+		detached, err := manager.DetachByActor(ctx, projectA, actor)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, detached)
+
+		assert.Equal(t, int64(0), manager.SessionCount(keyInA, false))
+		assert.Equal(t, int64(1), manager.SessionCount(keyInB, false),
+			"detach must be project-scoped: the sibling project's session must survive")
+	})
+
+	t.Run("returns zero when actor has no sessions", func(t *testing.T) {
+		ctx := context.Background()
+		manager, _, _ := createManager(t, 60*time.Second, 10*time.Second)
+		projectID := types.NewID()
+
+		actor, err := pkgtime.ActorIDFromHex(fmt.Sprintf("a%023d", 0))
+		assert.NoError(t, err)
+
+		detached, err := manager.DetachByActor(ctx, projectID, actor)
 		assert.NoError(t, err)
 		assert.Equal(t, 0, detached)
 	})

--- a/server/backend/channel/manager_test.go
+++ b/server/backend/channel/manager_test.go
@@ -819,6 +819,50 @@ func TestChannelManager_AttachDetachErrors(t *testing.T) {
 	})
 }
 
+func TestChannelManager_DetachByActor(t *testing.T) {
+	t.Run("detaches all sessions held by the actor", func(t *testing.T) {
+		ctx := context.Background()
+		manager, _, _ := createManager(t, 60*time.Second, 10*time.Second)
+		projectID := types.NewID()
+
+		actorA, err := pkgtime.ActorIDFromHex(fmt.Sprintf("a%023d", 0))
+		assert.NoError(t, err)
+		actorB, err := pkgtime.ActorIDFromHex(fmt.Sprintf("b%023d", 0))
+		assert.NoError(t, err)
+
+		keyA1 := types.ChannelRefKey{ProjectID: projectID, ChannelKey: "room-1"}
+		keyA2 := types.ChannelRefKey{ProjectID: projectID, ChannelKey: "room-2"}
+		keyB1 := types.ChannelRefKey{ProjectID: projectID, ChannelKey: "room-3"}
+
+		_, _, err = manager.Attach(ctx, keyA1, actorA)
+		assert.NoError(t, err)
+		_, _, err = manager.Attach(ctx, keyA2, actorA)
+		assert.NoError(t, err)
+		_, _, err = manager.Attach(ctx, keyB1, actorB)
+		assert.NoError(t, err)
+
+		detached, err := manager.DetachByActor(ctx, actorA)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, detached)
+
+		assert.Equal(t, int64(0), manager.SessionCount(keyA1, false))
+		assert.Equal(t, int64(0), manager.SessionCount(keyA2, false))
+		assert.Equal(t, int64(1), manager.SessionCount(keyB1, false))
+	})
+
+	t.Run("returns zero when actor has no sessions", func(t *testing.T) {
+		ctx := context.Background()
+		manager, _, _ := createManager(t, 60*time.Second, 10*time.Second)
+
+		actor, err := pkgtime.ActorIDFromHex(fmt.Sprintf("a%023d", 0))
+		assert.NoError(t, err)
+
+		detached, err := manager.DetachByActor(ctx, actor)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, detached)
+	})
+}
+
 func TestChannelManager_Stats(t *testing.T) {
 	t.Run("stats returns correct counts", func(t *testing.T) {
 		ctx := context.Background()

--- a/server/clients/clients.go
+++ b/server/clients/clients.go
@@ -109,6 +109,13 @@ func Deactivate(
 		}
 	}
 
+	// Cascade channel session cleanup across the cluster. Best-effort: per-node
+	// failures are logged inside the broadcast helper; channel TTL backstops
+	// anything we miss here.
+	if _, err := be.BroadcastDetachActorFromChannels(ctx, project.ID, actorID); err != nil {
+		logging.From(ctx).Warnf("cascade detach channel sessions: %v", err)
+	}
+
 	return be.DB.DeactivateClient(ctx, refKey)
 }
 

--- a/server/rpc/cluster_server.go
+++ b/server/rpc/cluster_server.go
@@ -325,18 +325,24 @@ func (s *clusterServer) GetChannelCount(
 }
 
 // DetachActorFromChannels detaches all channel sessions held by the given
-// actor on this server. Used by the deactivate cascade to evict per-server
-// sessions across the cluster without waiting for the session TTL.
+// actor (scoped to the given project) on this server. Used by the deactivate
+// cascade to evict per-server sessions across the cluster without waiting
+// for the session TTL.
 func (s *clusterServer) DetachActorFromChannels(
 	ctx context.Context,
 	req *connect.Request[api.ClusterServiceDetachActorFromChannelsRequest],
 ) (*connect.Response[api.ClusterServiceDetachActorFromChannelsResponse], error) {
+	projectID := types.ID(req.Msg.ProjectId)
+	if err := projectID.Validate(); err != nil {
+		return nil, err
+	}
+
 	actorID, err := time.ActorIDFromHex(req.Msg.ActorId)
 	if err != nil {
 		return nil, err
 	}
 
-	detached, err := s.backend.Channel.DetachByActor(ctx, actorID)
+	detached, err := s.backend.Channel.DetachByActor(ctx, projectID, actorID)
 	if err != nil {
 		return nil, err
 	}

--- a/server/rpc/cluster_server.go
+++ b/server/rpc/cluster_server.go
@@ -324,6 +324,28 @@ func (s *clusterServer) GetChannelCount(
 	}), nil
 }
 
+// DetachActorFromChannels detaches all channel sessions held by the given
+// actor on this server. Used by the deactivate cascade to evict per-server
+// sessions across the cluster without waiting for the session TTL.
+func (s *clusterServer) DetachActorFromChannels(
+	ctx context.Context,
+	req *connect.Request[api.ClusterServiceDetachActorFromChannelsRequest],
+) (*connect.Response[api.ClusterServiceDetachActorFromChannelsResponse], error) {
+	actorID, err := time.ActorIDFromHex(req.Msg.ActorId)
+	if err != nil {
+		return nil, err
+	}
+
+	detached, err := s.backend.Channel.DetachByActor(ctx, actorID)
+	if err != nil {
+		return nil, err
+	}
+
+	return connect.NewResponse(&api.ClusterServiceDetachActorFromChannelsResponse{
+		DetachedCount: int32(detached),
+	}), nil
+}
+
 // InvalidateCache invalidates the cache of the given type and key.
 func (s *clusterServer) InvalidateCache(
 	ctx context.Context,

--- a/test/integration/channel_test.go
+++ b/test/integration/channel_test.go
@@ -1077,17 +1077,29 @@ func TestChannelIntegration(t *testing.T) {
 		require.NoError(t, err)
 		defer close2()
 
-		// latestCount keeps the most recent value seen on a count channel,
-		// since the watch stream may push multiple updates while we wait.
+		// Track the most recent value seen on each count channel; the watch
+		// stream may push multiple updates while we wait. Once a stream is
+		// closed we stop draining it: receive-from-closed yields the zero
+		// value forever, which would otherwise spin the predicate and stall
+		// assert.Eventually instead of letting it time out cleanly.
 		var latest1, latest2 int64 = -1, -1
+		c1, c2 := count1Chan, count2Chan
 		drainAndCheck := func(target1, target2 int64) func() bool {
 			return func() bool {
 				for {
 					select {
-					case c := <-count1Chan:
-						latest1 = c
-					case c := <-count2Chan:
-						latest2 = c
+					case v, ok := <-c1:
+						if !ok {
+							c1 = nil
+							continue
+						}
+						latest1 = v
+					case v, ok := <-c2:
+						if !ok {
+							c2 = nil
+							continue
+						}
+						latest2 = v
 					default:
 						return latest1 == target1 && latest2 == target2
 					}

--- a/test/integration/channel_test.go
+++ b/test/integration/channel_test.go
@@ -1048,4 +1048,71 @@ func TestChannelIntegration(t *testing.T) {
 			assert.Equal(t, int64(0), channel.SessionCount())
 		}
 	})
+
+	t.Run("deactivate cascades channel session detach", func(t *testing.T) {
+		// Channel session TTL is many seconds; assertion timeouts here are much
+		// shorter, so passing means cascade ran rather than TTL cleanup.
+		clients := activeClients(t, 2)
+		target, watcher := clients[0], clients[1]
+		defer func() {
+			assert.NoError(t, watcher.Deactivate(ctx))
+			assert.NoError(t, watcher.Close())
+			assert.NoError(t, target.Close())
+		}()
+
+		chanKey1 := helper.TestKey(t) + "-r1"
+		chanKey2 := helper.TestKey(t) + "-r2"
+
+		watcherCh1, err := channel.New(key.Key(chanKey1))
+		require.NoError(t, err)
+		watcherCh2, err := channel.New(key.Key(chanKey2))
+		require.NoError(t, err)
+		require.NoError(t, watcher.Attach(ctx, watcherCh1))
+		require.NoError(t, watcher.Attach(ctx, watcherCh2))
+
+		count1Chan, close1, err := watcher.WatchChannel(ctx, watcherCh1)
+		require.NoError(t, err)
+		defer close1()
+		count2Chan, close2, err := watcher.WatchChannel(ctx, watcherCh2)
+		require.NoError(t, err)
+		defer close2()
+
+		// latestCount keeps the most recent value seen on a count channel,
+		// since the watch stream may push multiple updates while we wait.
+		var latest1, latest2 int64 = -1, -1
+		drainAndCheck := func(target1, target2 int64) func() bool {
+			return func() bool {
+				for {
+					select {
+					case c := <-count1Chan:
+						latest1 = c
+					case c := <-count2Chan:
+						latest2 = c
+					default:
+						return latest1 == target1 && latest2 == target2
+					}
+				}
+			}
+		}
+
+		// After attach, watcher receives initial count = 1 on each channel.
+		assert.Eventually(t, drainAndCheck(1, 1), 10*time.Second, 100*time.Millisecond,
+			"initial counts should be 1 on both channels")
+
+		targetCh1, err := channel.New(key.Key(chanKey1))
+		require.NoError(t, err)
+		targetCh2, err := channel.New(key.Key(chanKey2))
+		require.NoError(t, err)
+		require.NoError(t, target.Attach(ctx, targetCh1))
+		require.NoError(t, target.Attach(ctx, targetCh2))
+
+		assert.Eventually(t, drainAndCheck(2, 2), 10*time.Second, 100*time.Millisecond,
+			"both channels should show 2 sessions after target attaches")
+
+		require.NoError(t, target.Deactivate(ctx))
+
+		// Cascade should detach target's sessions far faster than channel TTL.
+		assert.Eventually(t, drainAndCheck(1, 1), 10*time.Second, 100*time.Millisecond,
+			"cascade should detach target's sessions on Deactivate, well before channel TTL")
+	})
 }


### PR DESCRIPTION
## Summary

- Clients that lose their browser without sending an explicit `DetachChannel` (refresh, tab close, network drop) stay in channel polling for up to ~60s, until `ChannelSessionTTL` expires and the cleanup ticker sweeps them. `clients.Deactivate` already cleans up documents via cluster RPC but leaves channel sessions untouched, and channels are sharded per node so no single server knows where a given actor's sessions live.
- Adds an actor-keyed cluster RPC `DetachActorFromChannels` and a backend helper `BroadcastDetachActorFromChannels` (mirrors `BroadcastChannelCount`) that fans the detach out to every cluster node and runs the existing `Detach` path locally for that actor's sessions.
- Calls the broadcast from `clients.Deactivate` as best-effort: per-node failures are logged but do not fail deactivation. `ChannelSessionTTL` remains the final safety net for nodes we couldn't reach.

## Why server-side cascade vs SDK fix

Cleaning up on `pagehide`/`beforeunload` in each SDK has structural limits: every SDK language needs the same fix, browsers cancel pending fetches on unload (sendBeacon partially mitigates), and any missed cleanup still falls through to the same TTL window. The server already produces a deactivation event for every client lifecycle; cascading from that one event covers all SDKs and unload paths in one place, with the TTL as a true last-resort backstop.

## Test plan

- [x] `go test ./server/backend/channel/` — new `DetachByActor` unit tests + existing channel suite pass
- [x] `go test -tags integration ./test/integration/ -run TestChannelIntegration` — full channel integration suite passes, including new `deactivate cascades channel session detach` test that asserts `SessionCount` drops within 10s (well below 60s TTL)
- [x] Manual verification with `./bin/yorkie server -l debug`: 10 page refreshes + 1 new tab produce immediate `Detach` events with no `CHAN: ... expires[]` cleanup lines (prior behavior had ~9 expires per cycle)

## Out of scope

- SDK changes: `DetachChannel` RPC API stays as-is for explicit per-channel unsubscribe.
- Optimizing fan-out under high housekeeping volume (N inactive clients × M cluster nodes RPCs per tick). Same amplification pattern exists in `BroadcastChannelList`; revisit only if operational data shows it's a problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cluster-wide cascade to immediately detach channel sessions for an actor when a client deactivates.
  * New cluster RPC to request actor-detach across nodes.

* **Documentation**
  * Added task design and lessons learned documenting the cascade approach and rollout guidance.

* **Tests**
  * Added integration and unit tests verifying immediate detach behavior and manager-level detach logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yorkie-team/yorkie/pull/1794)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->