### PR TITLE
Reduce channel session TTL from 60s to 15s

### DIFF
--- a/server/backend/channel/manager.go
+++ b/server/backend/channel/manager.go
@@ -146,7 +146,7 @@ func NewManager(
 	db database.Database,
 ) *Manager {
 	if ttl == 0 {
-		ttl = 60 * gotime.Second
+		ttl = 15 * gotime.Second
 	}
 
 	if cleanupInterval == 0 {

--- a/server/backend/channel/manager_test.go
+++ b/server/backend/channel/manager_test.go
@@ -253,7 +253,7 @@ func TestChannelManager_RefreshAndCleanup(t *testing.T) {
 	t.Run("default TTL is applied when zero", func(t *testing.T) {
 		manager, _, _ := createManager(t, 0, 0)
 
-		// Manager should have default TTL (60s)
+		// Manager should have default TTL (15s)
 		// We can't directly check the internal field, but we can verify it works
 		stats := manager.Stats()
 		assert.NotNil(t, stats)

--- a/server/config.go
+++ b/server/config.go
@@ -64,7 +64,7 @@ const (
 	DefaultKafkaSessionEventsTopic  = "session-events"
 	DefaultKafkaWriteTimeout        = 5 * time.Second
 
-	DefaultChannelSessionTTL             = 60 * time.Second
+	DefaultChannelSessionTTL             = 15 * time.Second
 	DefaultChannelSessionCleanupInterval = 10 * time.Second
 	DefaultChannelSessionCountCacheTTL   = 30 * time.Second
 	DefaultChannelSessionCountCacheSize  = 10000


### PR DESCRIPTION
## Summary

- `DefaultChannelSessionTTL`: 60s → 15s
- Stale-membership window after silent disconnect: **60–70s → 15–25s**
- Cleanup ticker interval (10s) is unchanged; combined with the new TTL the worst-case window is bounded by TTL + cleanup interval.
- Companion benchmark client already runs `RefreshChannel` at 5s, leaving a 3× safety margin (heartbeat × 3 ≤ TTL).

## Context

PR #1794 (`Cascade channel session detach on client deactivate`) tried to eliminate the 60s stale window via a cluster-wide broadcast on `DeactivateClient`, but benchmark (oss.navercorp.com/media-tool-dev/devops PR #354) showed it regresses Channel API latency by 4.5×–14.6× across normal / spike / F5 patterns.

This change explores a simpler path: keep TTL-only cleanup and just reduce TTL. No cross-node RPC, no new lock-acquisition paths.

## SDK compatibility note

The Go client default `ChannelHeartbeatInterval` is still 30s. Any deployment running both **server with 15s TTL** and **SDK with 30s heartbeat default** will see live clients flapping. Production rollout should either:
1. Override `channel-session-ttl` on the server to a value ≥ 3× the SDK heartbeat in use, or
2. Bump SDK defaults in lockstep.

## Test plan

- [x] `make build`, `make test` pass
- [x] `go vet ./...` clean
- [ ] Re-run benchmark suite (oss.navercorp.com PR #347) on this branch and compare against baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Default channel session timeout reduced from 60 seconds to 15 seconds. Sessions will now expire more quickly by default, improving resource efficiency and responsiveness for inactive connections.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yorkie-team/yorkie/pull/1798)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->