### PR TITLE
Skip leadership write when active leader exists

### DIFF
--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -228,13 +228,29 @@ func (c *Client) tryAcquireLeadership(
 	rpcAddr string,
 	leaseMS int64,
 ) (*database.ClusterNodeInfo, error) {
-	// Generate a new lease token
+	// Check if there is already an active leader with a valid lease.
+	// This avoids unnecessary write attempts that would cause duplicate key
+	// errors on the is_leader_true_unique index.
+	count, err := c.collection(ColClusterNodes).CountDocuments(
+		ctx,
+		bson.M{
+			"is_leader": true,
+			"$expr":     bson.M{"$gte": bson.A{"$expires_at", "$$NOW"}},
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("check active leader: %w", err)
+	}
+	if count > 0 {
+		return nil, nil
+	}
+
+	// No active leader found. Try to acquire leadership using atomic upsert.
 	token, err := database.GenerateLeaseToken()
 	if err != nil {
 		return nil, fmt.Errorf("generate lease token: %w", err)
 	}
 
-	// Try to acquire leadership using atomic upsert.
 	result := c.collection(ColClusterNodes).FindOneAndUpdate(
 		ctx,
 		bson.M{"rpc_addr": rpcAddr},
@@ -254,8 +270,8 @@ func (c *Client) tryAcquireLeadership(
 
 	info := &database.ClusterNodeInfo{}
 	if err := result.Decode(info); err != nil {
-		// If the error is due to a duplicate key, it means another node has
-		// already acquired leadership.
+		// If the error is due to a duplicate key, it means another node
+		// acquired leadership between the read check and this write.
 		if mongo.IsDuplicateKeyError(err) {
 			return nil, nil
 		}

--- a/server/backend/database/testcases/testcases.go
+++ b/server/backend/database/testcases/testcases.go
@@ -113,6 +113,37 @@ func RunLeadershipTest(
 		assert.True(t, renewedInfo.ExpiresAt.Compare(info.ExpiresAt) >= 0) // Expiry should extend
 	})
 
+	t.Run("TryLeadership should return nil for follower when active leader exists", func(t *testing.T) {
+		ctx := context.Background()
+		require.NoError(t, db.RemoveClusterNodes(ctx))
+
+		leaseDuration := 30 * gotime.Second
+
+		// First node acquires leadership
+		info, err := db.TryLeadership(ctx, nodeIDOne, "", leaseDuration)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+
+		// Second node tries to acquire — should get nil without error
+		info2, err := db.TryLeadership(ctx, nodeIDTwo, "", leaseDuration)
+		require.NoError(t, err)
+		assert.Nil(t, info2)
+
+		// Verify both nodes are registered and only one is leader
+		nodes, err := db.FindClusterNodes(ctx, leaseDuration)
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(nodes))
+
+		leaderCount := 0
+		for _, node := range nodes {
+			if node.IsLeader {
+				leaderCount++
+				assert.Equal(t, nodeIDOne, node.RPCAddr)
+			}
+		}
+		assert.Equal(t, 1, leaderCount)
+	})
+
 	t.Run("TryLeadership should fail with invalid token", func(t *testing.T) {
 		ctx := context.Background()
 		require.NoError(t, db.RemoveClusterNodes(ctx))

--- a/server/backend/database/testcases/testcases.go
+++ b/server/backend/database/testcases/testcases.go
@@ -144,6 +144,26 @@ func RunLeadershipTest(
 		assert.Equal(t, 1, leaderCount)
 	})
 
+	t.Run("TryLeadership should return nil when leader retries with empty token before lease expires", func(t *testing.T) {
+		ctx := context.Background()
+		require.NoError(t, db.RemoveClusterNodes(ctx))
+
+		leaseDuration := 30 * gotime.Second
+
+		// Initial acquisition succeeds.
+		info, err := db.TryLeadership(ctx, nodeIDOne, "", leaseDuration)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+
+		// Same node retries with empty token (e.g., a restart that lost the
+		// in-memory lease token). The active lease blocks re-acquire until it
+		// expires; recovery waits for expiry rather than racing to refresh
+		// the existing row.
+		info2, err := db.TryLeadership(ctx, nodeIDOne, "", leaseDuration)
+		require.NoError(t, err)
+		assert.Nil(t, info2)
+	})
+
 	t.Run("TryLeadership should fail with invalid token", func(t *testing.T) {
 		ctx := context.Background()
 		require.NoError(t, db.RemoveClusterNodes(ctx))


### PR DESCRIPTION
Title: Skip leadership write when active leader exists

Body:

**What this PR does / why we need it**:

Follower nodes unconditionally attempt `FindOneAndUpdate` with `is_leader=true` every renewal cycle
(default 5s). With N nodes, this produces N-1 duplicate key errors per cycle on the
`is_leader_true_unique` partial unique index. In production with 10 nodes, this generates ~155K MongoDB
errors/day, flooding DBA error logs.

This PR adds a read check (`CountDocuments`) before the write attempt to verify whether an active leader
with a valid lease exists. If so, the write is skipped entirely. The `DuplicateKeyError` handling is
retained as a race-condition safety net.

This aligns the MongoDB implementation with the in-memory implementation, which already checks for an
active leader before attempting acquisition (see `memory/database.go` lines 97-106).

**Impact**:
| Metric | Before | After |
|--------|--------|-------|
| Writes per cycle (10 nodes) | 10 (9 fail) | 1 (leader renewal only) |
| MongoDB errors/min | ~108 | ~0 (race only) |
| Read ops per cycle | 0 | 9 (lightweight CountDocuments) |

**Which issue(s) this PR fixes**:

Fixes MongoDB duplicate key error noise in `clusternodes` collection reported by DBA.

**Special notes for your reviewer**:

- The in-memory implementation (`memory/database.go`) already has this read-before-write pattern — this
PR aligns the MongoDB implementation.
- `DuplicateKeyError` handling is intentionally kept for the rare race between read check and write.
- The `$expr` + `$$NOW` pattern for checking lease expiry is consistent with the existing
`tryRenewLeadership` method.

**Does this PR introduce a user-facing change?**:

```release-note
Reduce unnecessary MongoDB write operations during leader election by checking for active leader before
attempting acquisition.
```

Checklist:
- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved leadership acquisition robustness by pre-checking for an existing active leader, preventing unnecessary takeover attempts and clarifying race-window behavior.
  * Current leader retrying while its lease is active now behaves gracefully without error.

* **Tests**
  * Added coverage to ensure followers do not acquire leadership when an active leader exists and that only one node is marked leader during concurrent attempts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yorkie-team/yorkie/pull/1804)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->