### PR TITLE
Channel RPC consolidation + PeekChannel

### DIFF
--- a/api/docs/yorkie/v1/cluster.openapi.yaml
+++ b/api/docs/yorkie/v1/cluster.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.5
+  version: v0.7.8
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/api/docs/yorkie/v1/yorkie.openapi.yaml
+++ b/api/docs/yorkie/v1/yorkie.openapi.yaml
@@ -2034,6 +2034,20 @@ components:
           description: ""
           title: client_id
           type: string
+        clientKey:
+          additionalProperties: false
+          description: |-
+            client_key and metadata are used only on the first call (when session_id
+             is empty). The server activates the client and attaches it to the channel
+             before refreshing, collapsing ActivateClient + AttachChannel + RefreshChannel
+             into a single round trip.
+          title: client_key
+          type: string
+        metadata:
+          additionalProperties: false
+          description: ""
+          title: metadata
+          type: object
         sessionId:
           additionalProperties: false
           description: ""
@@ -2041,10 +2055,34 @@ components:
           type: string
       title: RefreshChannelRequest
       type: object
+    yorkie.v1.RefreshChannelRequest.MetadataEntry:
+      additionalProperties: false
+      description: ""
+      properties:
+        key:
+          additionalProperties: false
+          description: ""
+          title: key
+          type: string
+        value:
+          additionalProperties: false
+          description: ""
+          title: value
+          type: string
+      title: MetadataEntry
+      type: object
     yorkie.v1.RefreshChannelResponse:
       additionalProperties: false
       description: ""
       properties:
+        clientId:
+          additionalProperties: false
+          description: |-
+            client_id and session_id are populated only when the request was a
+             first-call (i.e. session_id was empty). Subsequent heartbeats leave
+             these empty.
+          title: client_id
+          type: string
         sessionCount:
           additionalProperties: false
           description: ""
@@ -2052,6 +2090,11 @@ components:
           - type: string
           - type: number
           title: session_count
+        sessionId:
+          additionalProperties: false
+          description: ""
+          title: session_id
+          type: string
       title: RefreshChannelResponse
       type: object
     yorkie.v1.RemoveDocumentRequest:

--- a/api/types/auth_webhook.go
+++ b/api/types/auth_webhook.go
@@ -69,6 +69,7 @@ const (
 	AttachChannel  Method = "AttachChannel"
 	DetachChannel  Method = "DetachChannel"
 	RefreshChannel Method = "RefreshChannel"
+	PeekChannel    Method = "PeekChannel"
 	Broadcast      Method = "Broadcast"
 )
 
@@ -104,6 +105,7 @@ func AuthMethods() []Method {
 		AttachChannel,
 		DetachChannel,
 		RefreshChannel,
+		PeekChannel,
 		Broadcast,
 	}
 }

--- a/api/yorkie/v1/v1connect/yorkie.connect.go
+++ b/api/yorkie/v1/v1connect/yorkie.connect.go
@@ -33,7 +33,7 @@ import (
 // generated with a version of connect newer than the one compiled into your binary. You can fix the
 // problem by either regenerating this code with an older version of connect or updating the connect
 // version compiled into your binary.
-const _ = connect.IsAtLeastVersion0_1_0
+const _ = connect.IsAtLeastVersion1_13_0
 
 const (
 	// YorkieServiceName is the fully-qualified name of the YorkieService service.
@@ -95,6 +95,9 @@ const (
 	// YorkieServiceRefreshChannelProcedure is the fully-qualified name of the YorkieService's
 	// RefreshChannel RPC.
 	YorkieServiceRefreshChannelProcedure = "/yorkie.v1.YorkieService/RefreshChannel"
+	// YorkieServicePeekChannelProcedure is the fully-qualified name of the YorkieService's PeekChannel
+	// RPC.
+	YorkieServicePeekChannelProcedure = "/yorkie.v1.YorkieService/PeekChannel"
 	// YorkieServiceBroadcastProcedure is the fully-qualified name of the YorkieService's Broadcast RPC.
 	YorkieServiceBroadcastProcedure = "/yorkie.v1.YorkieService/Broadcast"
 )
@@ -119,6 +122,7 @@ type YorkieServiceClient interface {
 	AttachChannel(context.Context, *connect.Request[v1.AttachChannelRequest]) (*connect.Response[v1.AttachChannelResponse], error)
 	DetachChannel(context.Context, *connect.Request[v1.DetachChannelRequest]) (*connect.Response[v1.DetachChannelResponse], error)
 	RefreshChannel(context.Context, *connect.Request[v1.RefreshChannelRequest]) (*connect.Response[v1.RefreshChannelResponse], error)
+	PeekChannel(context.Context, *connect.Request[v1.PeekChannelRequest]) (*connect.Response[v1.PeekChannelResponse], error)
 	Broadcast(context.Context, *connect.Request[v1.BroadcastRequest]) (*connect.Response[v1.BroadcastResponse], error)
 }
 
@@ -131,91 +135,115 @@ type YorkieServiceClient interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewYorkieServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) YorkieServiceClient {
 	baseURL = strings.TrimRight(baseURL, "/")
+	yorkieServiceMethods := v1.File_yorkie_v1_yorkie_proto.Services().ByName("YorkieService").Methods()
 	return &yorkieServiceClient{
 		activateClient: connect.NewClient[v1.ActivateClientRequest, v1.ActivateClientResponse](
 			httpClient,
 			baseURL+YorkieServiceActivateClientProcedure,
-			opts...,
+			connect.WithSchema(yorkieServiceMethods.ByName("ActivateClient")),
+			connect.WithClientOptions(opts...),
 		),
 		deactivateClient: connect.NewClient[v1.DeactivateClientRequest, v1.DeactivateClientResponse](
 			httpClient,
 			baseURL+YorkieServiceDeactivateClientProcedure,
-			opts...,
+			connect.WithSchema(yorkieServiceMethods.ByName("DeactivateClient")),
+			connect.WithClientOptions(opts...),
 		),
 		attachDocument: connect.NewClient[v1.AttachDocumentRequest, v1.AttachDocumentResponse](
 			httpClient,
 			baseURL+YorkieServiceAttachDocumentProcedure,
-			opts...,
+			connect.WithSchema(yorkieServiceMethods.ByName("AttachDocument")),
+			connect.WithClientOptions(opts...),
 		),
 		detachDocument: connect.NewClient[v1.DetachDocumentRequest, v1.DetachDocumentResponse](
 			httpClient,
 			baseURL+YorkieServiceDetachDocumentProcedure,
-			opts...,
+			connect.WithSchema(yorkieServiceMethods.ByName("DetachDocument")),
+			connect.WithClientOptions(opts...),
 		),
 		removeDocument: connect.NewClient[v1.RemoveDocumentRequest, v1.RemoveDocumentResponse](
 			httpClient,
 			baseURL+YorkieServiceRemoveDocumentProcedure,
-			opts...,
+			connect.WithSchema(yorkieServiceMethods.ByName("RemoveDocument")),
+			connect.WithClientOptions(opts...),
 		),
 		pushPullChanges: connect.NewClient[v1.PushPullChangesRequest, v1.PushPullChangesResponse](
 			httpClient,
 			baseURL+YorkieServicePushPullChangesProcedure,
-			opts...,
+			connect.WithSchema(yorkieServiceMethods.ByName("PushPullChanges")),
+			connect.WithClientOptions(opts...),
 		),
 		watch: connect.NewClient[v1.WatchRequest, v1.WatchResponse](
 			httpClient,
 			baseURL+YorkieServiceWatchProcedure,
-			opts...,
+			connect.WithSchema(yorkieServiceMethods.ByName("Watch")),
+			connect.WithClientOptions(opts...),
 		),
 		watchDocument: connect.NewClient[v1.WatchDocumentRequest, v1.WatchDocumentResponse](
 			httpClient,
 			baseURL+YorkieServiceWatchDocumentProcedure,
-			opts...,
+			connect.WithSchema(yorkieServiceMethods.ByName("WatchDocument")),
+			connect.WithClientOptions(opts...),
 		),
 		watchChannel: connect.NewClient[v1.WatchChannelRequest, v1.WatchChannelResponse](
 			httpClient,
 			baseURL+YorkieServiceWatchChannelProcedure,
-			opts...,
+			connect.WithSchema(yorkieServiceMethods.ByName("WatchChannel")),
+			connect.WithClientOptions(opts...),
 		),
 		createRevision: connect.NewClient[v1.CreateRevisionRequest, v1.CreateRevisionResponse](
 			httpClient,
 			baseURL+YorkieServiceCreateRevisionProcedure,
-			opts...,
+			connect.WithSchema(yorkieServiceMethods.ByName("CreateRevision")),
+			connect.WithClientOptions(opts...),
 		),
 		getRevision: connect.NewClient[v1.GetRevisionRequest, v1.GetRevisionResponse](
 			httpClient,
 			baseURL+YorkieServiceGetRevisionProcedure,
-			opts...,
+			connect.WithSchema(yorkieServiceMethods.ByName("GetRevision")),
+			connect.WithClientOptions(opts...),
 		),
 		listRevisions: connect.NewClient[v1.ListRevisionsRequest, v1.ListRevisionsResponse](
 			httpClient,
 			baseURL+YorkieServiceListRevisionsProcedure,
-			opts...,
+			connect.WithSchema(yorkieServiceMethods.ByName("ListRevisions")),
+			connect.WithClientOptions(opts...),
 		),
 		restoreRevision: connect.NewClient[v1.RestoreRevisionRequest, v1.RestoreRevisionResponse](
 			httpClient,
 			baseURL+YorkieServiceRestoreRevisionProcedure,
-			opts...,
+			connect.WithSchema(yorkieServiceMethods.ByName("RestoreRevision")),
+			connect.WithClientOptions(opts...),
 		),
 		attachChannel: connect.NewClient[v1.AttachChannelRequest, v1.AttachChannelResponse](
 			httpClient,
 			baseURL+YorkieServiceAttachChannelProcedure,
-			opts...,
+			connect.WithSchema(yorkieServiceMethods.ByName("AttachChannel")),
+			connect.WithClientOptions(opts...),
 		),
 		detachChannel: connect.NewClient[v1.DetachChannelRequest, v1.DetachChannelResponse](
 			httpClient,
 			baseURL+YorkieServiceDetachChannelProcedure,
-			opts...,
+			connect.WithSchema(yorkieServiceMethods.ByName("DetachChannel")),
+			connect.WithClientOptions(opts...),
 		),
 		refreshChannel: connect.NewClient[v1.RefreshChannelRequest, v1.RefreshChannelResponse](
 			httpClient,
 			baseURL+YorkieServiceRefreshChannelProcedure,
-			opts...,
+			connect.WithSchema(yorkieServiceMethods.ByName("RefreshChannel")),
+			connect.WithClientOptions(opts...),
+		),
+		peekChannel: connect.NewClient[v1.PeekChannelRequest, v1.PeekChannelResponse](
+			httpClient,
+			baseURL+YorkieServicePeekChannelProcedure,
+			connect.WithSchema(yorkieServiceMethods.ByName("PeekChannel")),
+			connect.WithClientOptions(opts...),
 		),
 		broadcast: connect.NewClient[v1.BroadcastRequest, v1.BroadcastResponse](
 			httpClient,
 			baseURL+YorkieServiceBroadcastProcedure,
-			opts...,
+			connect.WithSchema(yorkieServiceMethods.ByName("Broadcast")),
+			connect.WithClientOptions(opts...),
 		),
 	}
 }
@@ -238,6 +266,7 @@ type yorkieServiceClient struct {
 	attachChannel    *connect.Client[v1.AttachChannelRequest, v1.AttachChannelResponse]
 	detachChannel    *connect.Client[v1.DetachChannelRequest, v1.DetachChannelResponse]
 	refreshChannel   *connect.Client[v1.RefreshChannelRequest, v1.RefreshChannelResponse]
+	peekChannel      *connect.Client[v1.PeekChannelRequest, v1.PeekChannelResponse]
 	broadcast        *connect.Client[v1.BroadcastRequest, v1.BroadcastResponse]
 }
 
@@ -321,6 +350,11 @@ func (c *yorkieServiceClient) RefreshChannel(ctx context.Context, req *connect.R
 	return c.refreshChannel.CallUnary(ctx, req)
 }
 
+// PeekChannel calls yorkie.v1.YorkieService.PeekChannel.
+func (c *yorkieServiceClient) PeekChannel(ctx context.Context, req *connect.Request[v1.PeekChannelRequest]) (*connect.Response[v1.PeekChannelResponse], error) {
+	return c.peekChannel.CallUnary(ctx, req)
+}
+
 // Broadcast calls yorkie.v1.YorkieService.Broadcast.
 func (c *yorkieServiceClient) Broadcast(ctx context.Context, req *connect.Request[v1.BroadcastRequest]) (*connect.Response[v1.BroadcastResponse], error) {
 	return c.broadcast.CallUnary(ctx, req)
@@ -346,6 +380,7 @@ type YorkieServiceHandler interface {
 	AttachChannel(context.Context, *connect.Request[v1.AttachChannelRequest]) (*connect.Response[v1.AttachChannelResponse], error)
 	DetachChannel(context.Context, *connect.Request[v1.DetachChannelRequest]) (*connect.Response[v1.DetachChannelResponse], error)
 	RefreshChannel(context.Context, *connect.Request[v1.RefreshChannelRequest]) (*connect.Response[v1.RefreshChannelResponse], error)
+	PeekChannel(context.Context, *connect.Request[v1.PeekChannelRequest]) (*connect.Response[v1.PeekChannelResponse], error)
 	Broadcast(context.Context, *connect.Request[v1.BroadcastRequest]) (*connect.Response[v1.BroadcastResponse], error)
 }
 
@@ -355,90 +390,114 @@ type YorkieServiceHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewYorkieServiceHandler(svc YorkieServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	yorkieServiceMethods := v1.File_yorkie_v1_yorkie_proto.Services().ByName("YorkieService").Methods()
 	yorkieServiceActivateClientHandler := connect.NewUnaryHandler(
 		YorkieServiceActivateClientProcedure,
 		svc.ActivateClient,
-		opts...,
+		connect.WithSchema(yorkieServiceMethods.ByName("ActivateClient")),
+		connect.WithHandlerOptions(opts...),
 	)
 	yorkieServiceDeactivateClientHandler := connect.NewUnaryHandler(
 		YorkieServiceDeactivateClientProcedure,
 		svc.DeactivateClient,
-		opts...,
+		connect.WithSchema(yorkieServiceMethods.ByName("DeactivateClient")),
+		connect.WithHandlerOptions(opts...),
 	)
 	yorkieServiceAttachDocumentHandler := connect.NewUnaryHandler(
 		YorkieServiceAttachDocumentProcedure,
 		svc.AttachDocument,
-		opts...,
+		connect.WithSchema(yorkieServiceMethods.ByName("AttachDocument")),
+		connect.WithHandlerOptions(opts...),
 	)
 	yorkieServiceDetachDocumentHandler := connect.NewUnaryHandler(
 		YorkieServiceDetachDocumentProcedure,
 		svc.DetachDocument,
-		opts...,
+		connect.WithSchema(yorkieServiceMethods.ByName("DetachDocument")),
+		connect.WithHandlerOptions(opts...),
 	)
 	yorkieServiceRemoveDocumentHandler := connect.NewUnaryHandler(
 		YorkieServiceRemoveDocumentProcedure,
 		svc.RemoveDocument,
-		opts...,
+		connect.WithSchema(yorkieServiceMethods.ByName("RemoveDocument")),
+		connect.WithHandlerOptions(opts...),
 	)
 	yorkieServicePushPullChangesHandler := connect.NewUnaryHandler(
 		YorkieServicePushPullChangesProcedure,
 		svc.PushPullChanges,
-		opts...,
+		connect.WithSchema(yorkieServiceMethods.ByName("PushPullChanges")),
+		connect.WithHandlerOptions(opts...),
 	)
 	yorkieServiceWatchHandler := connect.NewServerStreamHandler(
 		YorkieServiceWatchProcedure,
 		svc.Watch,
-		opts...,
+		connect.WithSchema(yorkieServiceMethods.ByName("Watch")),
+		connect.WithHandlerOptions(opts...),
 	)
 	yorkieServiceWatchDocumentHandler := connect.NewServerStreamHandler(
 		YorkieServiceWatchDocumentProcedure,
 		svc.WatchDocument,
-		opts...,
+		connect.WithSchema(yorkieServiceMethods.ByName("WatchDocument")),
+		connect.WithHandlerOptions(opts...),
 	)
 	yorkieServiceWatchChannelHandler := connect.NewServerStreamHandler(
 		YorkieServiceWatchChannelProcedure,
 		svc.WatchChannel,
-		opts...,
+		connect.WithSchema(yorkieServiceMethods.ByName("WatchChannel")),
+		connect.WithHandlerOptions(opts...),
 	)
 	yorkieServiceCreateRevisionHandler := connect.NewUnaryHandler(
 		YorkieServiceCreateRevisionProcedure,
 		svc.CreateRevision,
-		opts...,
+		connect.WithSchema(yorkieServiceMethods.ByName("CreateRevision")),
+		connect.WithHandlerOptions(opts...),
 	)
 	yorkieServiceGetRevisionHandler := connect.NewUnaryHandler(
 		YorkieServiceGetRevisionProcedure,
 		svc.GetRevision,
-		opts...,
+		connect.WithSchema(yorkieServiceMethods.ByName("GetRevision")),
+		connect.WithHandlerOptions(opts...),
 	)
 	yorkieServiceListRevisionsHandler := connect.NewUnaryHandler(
 		YorkieServiceListRevisionsProcedure,
 		svc.ListRevisions,
-		opts...,
+		connect.WithSchema(yorkieServiceMethods.ByName("ListRevisions")),
+		connect.WithHandlerOptions(opts...),
 	)
 	yorkieServiceRestoreRevisionHandler := connect.NewUnaryHandler(
 		YorkieServiceRestoreRevisionProcedure,
 		svc.RestoreRevision,
-		opts...,
+		connect.WithSchema(yorkieServiceMethods.ByName("RestoreRevision")),
+		connect.WithHandlerOptions(opts...),
 	)
 	yorkieServiceAttachChannelHandler := connect.NewUnaryHandler(
 		YorkieServiceAttachChannelProcedure,
 		svc.AttachChannel,
-		opts...,
+		connect.WithSchema(yorkieServiceMethods.ByName("AttachChannel")),
+		connect.WithHandlerOptions(opts...),
 	)
 	yorkieServiceDetachChannelHandler := connect.NewUnaryHandler(
 		YorkieServiceDetachChannelProcedure,
 		svc.DetachChannel,
-		opts...,
+		connect.WithSchema(yorkieServiceMethods.ByName("DetachChannel")),
+		connect.WithHandlerOptions(opts...),
 	)
 	yorkieServiceRefreshChannelHandler := connect.NewUnaryHandler(
 		YorkieServiceRefreshChannelProcedure,
 		svc.RefreshChannel,
-		opts...,
+		connect.WithSchema(yorkieServiceMethods.ByName("RefreshChannel")),
+		connect.WithHandlerOptions(opts...),
+	)
+	yorkieServicePeekChannelHandler := connect.NewUnaryHandler(
+		YorkieServicePeekChannelProcedure,
+		svc.PeekChannel,
+		connect.WithSchema(yorkieServiceMethods.ByName("PeekChannel")),
+		connect.WithHandlerOptions(opts...),
 	)
 	yorkieServiceBroadcastHandler := connect.NewUnaryHandler(
 		YorkieServiceBroadcastProcedure,
 		svc.Broadcast,
-		opts...,
+		connect.WithSchema(yorkieServiceMethods.ByName("Broadcast")),
+		connect.WithHandlerOptions(opts...),
 	)
 	return "/yorkie.v1.YorkieService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -474,6 +533,8 @@ func NewYorkieServiceHandler(svc YorkieServiceHandler, opts ...connect.HandlerOp
 			yorkieServiceDetachChannelHandler.ServeHTTP(w, r)
 		case YorkieServiceRefreshChannelProcedure:
 			yorkieServiceRefreshChannelHandler.ServeHTTP(w, r)
+		case YorkieServicePeekChannelProcedure:
+			yorkieServicePeekChannelHandler.ServeHTTP(w, r)
 		case YorkieServiceBroadcastProcedure:
 			yorkieServiceBroadcastHandler.ServeHTTP(w, r)
 		default:
@@ -547,6 +608,10 @@ func (UnimplementedYorkieServiceHandler) DetachChannel(context.Context, *connect
 
 func (UnimplementedYorkieServiceHandler) RefreshChannel(context.Context, *connect.Request[v1.RefreshChannelRequest]) (*connect.Response[v1.RefreshChannelResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("yorkie.v1.YorkieService.RefreshChannel is not implemented"))
+}
+
+func (UnimplementedYorkieServiceHandler) PeekChannel(context.Context, *connect.Request[v1.PeekChannelRequest]) (*connect.Response[v1.PeekChannelResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("yorkie.v1.YorkieService.PeekChannel is not implemented"))
 }
 
 func (UnimplementedYorkieServiceHandler) Broadcast(context.Context, *connect.Request[v1.BroadcastRequest]) (*connect.Response[v1.BroadcastResponse], error) {

--- a/api/yorkie/v1/yorkie.pb.go
+++ b/api/yorkie/v1/yorkie.pb.go
@@ -2370,10 +2370,16 @@ func (x *DetachChannelResponse) GetSessionCount() int64 {
 }
 
 type RefreshChannelRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	ClientId      string                 `protobuf:"bytes,1,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
-	ChannelKey    string                 `protobuf:"bytes,2,opt,name=channel_key,json=channelKey,proto3" json:"channel_key,omitempty"`
-	SessionId     string                 `protobuf:"bytes,3,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	state      protoimpl.MessageState `protogen:"open.v1"`
+	ClientId   string                 `protobuf:"bytes,1,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
+	ChannelKey string                 `protobuf:"bytes,2,opt,name=channel_key,json=channelKey,proto3" json:"channel_key,omitempty"`
+	SessionId  string                 `protobuf:"bytes,3,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	// client_key and metadata are used only on the first call (when session_id
+	// is empty). The server activates the client and attaches it to the channel
+	// before refreshing, collapsing ActivateClient + AttachChannel + RefreshChannel
+	// into a single round trip.
+	ClientKey     string            `protobuf:"bytes,4,opt,name=client_key,json=clientKey,proto3" json:"client_key,omitempty"`
+	Metadata      map[string]string `protobuf:"bytes,5,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2429,9 +2435,28 @@ func (x *RefreshChannelRequest) GetSessionId() string {
 	return ""
 }
 
+func (x *RefreshChannelRequest) GetClientKey() string {
+	if x != nil {
+		return x.ClientKey
+	}
+	return ""
+}
+
+func (x *RefreshChannelRequest) GetMetadata() map[string]string {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type RefreshChannelResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	SessionCount  int64                  `protobuf:"varint,1,opt,name=session_count,json=sessionCount,proto3" json:"session_count,omitempty"`
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	SessionCount int64                  `protobuf:"varint,1,opt,name=session_count,json=sessionCount,proto3" json:"session_count,omitempty"`
+	// client_id and session_id are populated only when the request was a
+	// first-call (i.e. session_id was empty). Subsequent heartbeats leave
+	// these empty.
+	ClientId      string `protobuf:"bytes,2,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
+	SessionId     string `protobuf:"bytes,3,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2471,6 +2496,20 @@ func (x *RefreshChannelResponse) GetSessionCount() int64 {
 		return x.SessionCount
 	}
 	return 0
+}
+
+func (x *RefreshChannelResponse) GetClientId() string {
+	if x != nil {
+		return x.ClientId
+	}
+	return ""
+}
+
+func (x *RefreshChannelResponse) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
 }
 
 type BroadcastRequest struct {
@@ -2798,15 +2837,24 @@ const file_yorkie_v1_yorkie_proto_rawDesc = "" +
 	"\n" +
 	"session_id\x18\x03 \x01(\tR\tsessionId\"<\n" +
 	"\x15DetachChannelResponse\x12#\n" +
-	"\rsession_count\x18\x01 \x01(\x03R\fsessionCount\"t\n" +
+	"\rsession_count\x18\x01 \x01(\x03R\fsessionCount\"\x9c\x02\n" +
 	"\x15RefreshChannelRequest\x12\x1b\n" +
 	"\tclient_id\x18\x01 \x01(\tR\bclientId\x12\x1f\n" +
 	"\vchannel_key\x18\x02 \x01(\tR\n" +
 	"channelKey\x12\x1d\n" +
 	"\n" +
-	"session_id\x18\x03 \x01(\tR\tsessionId\"=\n" +
+	"session_id\x18\x03 \x01(\tR\tsessionId\x12\x1d\n" +
+	"\n" +
+	"client_key\x18\x04 \x01(\tR\tclientKey\x12J\n" +
+	"\bmetadata\x18\x05 \x03(\v2..yorkie.v1.RefreshChannelRequest.MetadataEntryR\bmetadata\x1a;\n" +
+	"\rMetadataEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"y\n" +
 	"\x16RefreshChannelResponse\x12#\n" +
-	"\rsession_count\x18\x01 \x01(\x03R\fsessionCount\"\x80\x01\n" +
+	"\rsession_count\x18\x01 \x01(\x03R\fsessionCount\x12\x1b\n" +
+	"\tclient_id\x18\x02 \x01(\tR\bclientId\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x03 \x01(\tR\tsessionId\"\x80\x01\n" +
 	"\x10BroadcastRequest\x12\x1b\n" +
 	"\tclient_id\x18\x01 \x01(\tR\bclientId\x12\x1f\n" +
 	"\vchannel_key\x18\x02 \x01(\tR\n" +
@@ -2846,7 +2894,7 @@ func file_yorkie_v1_yorkie_proto_rawDescGZIP() []byte {
 	return file_yorkie_v1_yorkie_proto_rawDescData
 }
 
-var file_yorkie_v1_yorkie_proto_msgTypes = make([]protoimpl.MessageInfo, 47)
+var file_yorkie_v1_yorkie_proto_msgTypes = make([]protoimpl.MessageInfo, 48)
 var file_yorkie_v1_yorkie_proto_goTypes = []any{
 	(*ActivateClientRequest)(nil),                // 0: yorkie.v1.ActivateClientRequest
 	(*ActivateClientResponse)(nil),               // 1: yorkie.v1.ActivateClientResponse
@@ -2895,19 +2943,20 @@ var file_yorkie_v1_yorkie_proto_goTypes = []any{
 	(*BroadcastResponse)(nil),                    // 44: yorkie.v1.BroadcastResponse
 	nil,                                          // 45: yorkie.v1.ActivateClientRequest.MetadataEntry
 	(*WatchDocumentResponse_Initialization)(nil), // 46: yorkie.v1.WatchDocumentResponse.Initialization
-	(*ChangePack)(nil),                           // 47: yorkie.v1.ChangePack
-	(*Rule)(nil),                                 // 48: yorkie.v1.Rule
-	(*DocEvent)(nil),                             // 49: yorkie.v1.DocEvent
-	(*ChannelEvent)(nil),                         // 50: yorkie.v1.ChannelEvent
-	(*RevisionSummary)(nil),                      // 51: yorkie.v1.RevisionSummary
+	nil,                     // 47: yorkie.v1.RefreshChannelRequest.MetadataEntry
+	(*ChangePack)(nil),      // 48: yorkie.v1.ChangePack
+	(*Rule)(nil),            // 49: yorkie.v1.Rule
+	(*DocEvent)(nil),        // 50: yorkie.v1.DocEvent
+	(*ChannelEvent)(nil),    // 51: yorkie.v1.ChannelEvent
+	(*RevisionSummary)(nil), // 52: yorkie.v1.RevisionSummary
 }
 var file_yorkie_v1_yorkie_proto_depIdxs = []int32{
 	45, // 0: yorkie.v1.ActivateClientRequest.metadata:type_name -> yorkie.v1.ActivateClientRequest.MetadataEntry
-	47, // 1: yorkie.v1.AttachDocumentRequest.change_pack:type_name -> yorkie.v1.ChangePack
-	47, // 2: yorkie.v1.AttachDocumentResponse.change_pack:type_name -> yorkie.v1.ChangePack
-	48, // 3: yorkie.v1.AttachDocumentResponse.schema_rules:type_name -> yorkie.v1.Rule
-	47, // 4: yorkie.v1.DetachDocumentRequest.change_pack:type_name -> yorkie.v1.ChangePack
-	47, // 5: yorkie.v1.DetachDocumentResponse.change_pack:type_name -> yorkie.v1.ChangePack
+	48, // 1: yorkie.v1.AttachDocumentRequest.change_pack:type_name -> yorkie.v1.ChangePack
+	48, // 2: yorkie.v1.AttachDocumentResponse.change_pack:type_name -> yorkie.v1.ChangePack
+	49, // 3: yorkie.v1.AttachDocumentResponse.schema_rules:type_name -> yorkie.v1.Rule
+	48, // 4: yorkie.v1.DetachDocumentRequest.change_pack:type_name -> yorkie.v1.ChangePack
+	48, // 5: yorkie.v1.DetachDocumentResponse.change_pack:type_name -> yorkie.v1.ChangePack
 	9,  // 6: yorkie.v1.WatchRequest.resources:type_name -> yorkie.v1.ResourceDescriptor
 	10, // 7: yorkie.v1.ResourceDescriptor.document:type_name -> yorkie.v1.DocumentDescriptor
 	11, // 8: yorkie.v1.ResourceDescriptor.channel:type_name -> yorkie.v1.ChannelDescriptor
@@ -2918,58 +2967,59 @@ var file_yorkie_v1_yorkie_proto_depIdxs = []int32{
 	16, // 13: yorkie.v1.ResourceInit.channel_init:type_name -> yorkie.v1.ChannelInit
 	18, // 14: yorkie.v1.WatchEvent.doc_event:type_name -> yorkie.v1.DocWatchEvent
 	19, // 15: yorkie.v1.WatchEvent.channel_event:type_name -> yorkie.v1.ChannelWatchEvent
-	49, // 16: yorkie.v1.DocWatchEvent.event:type_name -> yorkie.v1.DocEvent
-	50, // 17: yorkie.v1.ChannelWatchEvent.event:type_name -> yorkie.v1.ChannelEvent
+	50, // 16: yorkie.v1.DocWatchEvent.event:type_name -> yorkie.v1.DocEvent
+	51, // 17: yorkie.v1.ChannelWatchEvent.event:type_name -> yorkie.v1.ChannelEvent
 	46, // 18: yorkie.v1.WatchDocumentResponse.initialization:type_name -> yorkie.v1.WatchDocumentResponse.Initialization
-	49, // 19: yorkie.v1.WatchDocumentResponse.event:type_name -> yorkie.v1.DocEvent
+	50, // 19: yorkie.v1.WatchDocumentResponse.event:type_name -> yorkie.v1.DocEvent
 	24, // 20: yorkie.v1.WatchChannelResponse.initialized:type_name -> yorkie.v1.WatchChannelInitialized
-	50, // 21: yorkie.v1.WatchChannelResponse.event:type_name -> yorkie.v1.ChannelEvent
-	47, // 22: yorkie.v1.RemoveDocumentRequest.change_pack:type_name -> yorkie.v1.ChangePack
-	47, // 23: yorkie.v1.RemoveDocumentResponse.change_pack:type_name -> yorkie.v1.ChangePack
-	47, // 24: yorkie.v1.PushPullChangesRequest.change_pack:type_name -> yorkie.v1.ChangePack
-	47, // 25: yorkie.v1.PushPullChangesResponse.change_pack:type_name -> yorkie.v1.ChangePack
-	51, // 26: yorkie.v1.CreateRevisionResponse.revision:type_name -> yorkie.v1.RevisionSummary
-	51, // 27: yorkie.v1.GetRevisionResponse.revision:type_name -> yorkie.v1.RevisionSummary
-	51, // 28: yorkie.v1.ListRevisionsResponse.revisions:type_name -> yorkie.v1.RevisionSummary
-	0,  // 29: yorkie.v1.YorkieService.ActivateClient:input_type -> yorkie.v1.ActivateClientRequest
-	2,  // 30: yorkie.v1.YorkieService.DeactivateClient:input_type -> yorkie.v1.DeactivateClientRequest
-	4,  // 31: yorkie.v1.YorkieService.AttachDocument:input_type -> yorkie.v1.AttachDocumentRequest
-	6,  // 32: yorkie.v1.YorkieService.DetachDocument:input_type -> yorkie.v1.DetachDocumentRequest
-	25, // 33: yorkie.v1.YorkieService.RemoveDocument:input_type -> yorkie.v1.RemoveDocumentRequest
-	27, // 34: yorkie.v1.YorkieService.PushPullChanges:input_type -> yorkie.v1.PushPullChangesRequest
-	8,  // 35: yorkie.v1.YorkieService.Watch:input_type -> yorkie.v1.WatchRequest
-	20, // 36: yorkie.v1.YorkieService.WatchDocument:input_type -> yorkie.v1.WatchDocumentRequest
-	22, // 37: yorkie.v1.YorkieService.WatchChannel:input_type -> yorkie.v1.WatchChannelRequest
-	29, // 38: yorkie.v1.YorkieService.CreateRevision:input_type -> yorkie.v1.CreateRevisionRequest
-	31, // 39: yorkie.v1.YorkieService.GetRevision:input_type -> yorkie.v1.GetRevisionRequest
-	33, // 40: yorkie.v1.YorkieService.ListRevisions:input_type -> yorkie.v1.ListRevisionsRequest
-	35, // 41: yorkie.v1.YorkieService.RestoreRevision:input_type -> yorkie.v1.RestoreRevisionRequest
-	37, // 42: yorkie.v1.YorkieService.AttachChannel:input_type -> yorkie.v1.AttachChannelRequest
-	39, // 43: yorkie.v1.YorkieService.DetachChannel:input_type -> yorkie.v1.DetachChannelRequest
-	41, // 44: yorkie.v1.YorkieService.RefreshChannel:input_type -> yorkie.v1.RefreshChannelRequest
-	43, // 45: yorkie.v1.YorkieService.Broadcast:input_type -> yorkie.v1.BroadcastRequest
-	1,  // 46: yorkie.v1.YorkieService.ActivateClient:output_type -> yorkie.v1.ActivateClientResponse
-	3,  // 47: yorkie.v1.YorkieService.DeactivateClient:output_type -> yorkie.v1.DeactivateClientResponse
-	5,  // 48: yorkie.v1.YorkieService.AttachDocument:output_type -> yorkie.v1.AttachDocumentResponse
-	7,  // 49: yorkie.v1.YorkieService.DetachDocument:output_type -> yorkie.v1.DetachDocumentResponse
-	26, // 50: yorkie.v1.YorkieService.RemoveDocument:output_type -> yorkie.v1.RemoveDocumentResponse
-	28, // 51: yorkie.v1.YorkieService.PushPullChanges:output_type -> yorkie.v1.PushPullChangesResponse
-	12, // 52: yorkie.v1.YorkieService.Watch:output_type -> yorkie.v1.WatchResponse
-	21, // 53: yorkie.v1.YorkieService.WatchDocument:output_type -> yorkie.v1.WatchDocumentResponse
-	23, // 54: yorkie.v1.YorkieService.WatchChannel:output_type -> yorkie.v1.WatchChannelResponse
-	30, // 55: yorkie.v1.YorkieService.CreateRevision:output_type -> yorkie.v1.CreateRevisionResponse
-	32, // 56: yorkie.v1.YorkieService.GetRevision:output_type -> yorkie.v1.GetRevisionResponse
-	34, // 57: yorkie.v1.YorkieService.ListRevisions:output_type -> yorkie.v1.ListRevisionsResponse
-	36, // 58: yorkie.v1.YorkieService.RestoreRevision:output_type -> yorkie.v1.RestoreRevisionResponse
-	38, // 59: yorkie.v1.YorkieService.AttachChannel:output_type -> yorkie.v1.AttachChannelResponse
-	40, // 60: yorkie.v1.YorkieService.DetachChannel:output_type -> yorkie.v1.DetachChannelResponse
-	42, // 61: yorkie.v1.YorkieService.RefreshChannel:output_type -> yorkie.v1.RefreshChannelResponse
-	44, // 62: yorkie.v1.YorkieService.Broadcast:output_type -> yorkie.v1.BroadcastResponse
-	46, // [46:63] is the sub-list for method output_type
-	29, // [29:46] is the sub-list for method input_type
-	29, // [29:29] is the sub-list for extension type_name
-	29, // [29:29] is the sub-list for extension extendee
-	0,  // [0:29] is the sub-list for field type_name
+	51, // 21: yorkie.v1.WatchChannelResponse.event:type_name -> yorkie.v1.ChannelEvent
+	48, // 22: yorkie.v1.RemoveDocumentRequest.change_pack:type_name -> yorkie.v1.ChangePack
+	48, // 23: yorkie.v1.RemoveDocumentResponse.change_pack:type_name -> yorkie.v1.ChangePack
+	48, // 24: yorkie.v1.PushPullChangesRequest.change_pack:type_name -> yorkie.v1.ChangePack
+	48, // 25: yorkie.v1.PushPullChangesResponse.change_pack:type_name -> yorkie.v1.ChangePack
+	52, // 26: yorkie.v1.CreateRevisionResponse.revision:type_name -> yorkie.v1.RevisionSummary
+	52, // 27: yorkie.v1.GetRevisionResponse.revision:type_name -> yorkie.v1.RevisionSummary
+	52, // 28: yorkie.v1.ListRevisionsResponse.revisions:type_name -> yorkie.v1.RevisionSummary
+	47, // 29: yorkie.v1.RefreshChannelRequest.metadata:type_name -> yorkie.v1.RefreshChannelRequest.MetadataEntry
+	0,  // 30: yorkie.v1.YorkieService.ActivateClient:input_type -> yorkie.v1.ActivateClientRequest
+	2,  // 31: yorkie.v1.YorkieService.DeactivateClient:input_type -> yorkie.v1.DeactivateClientRequest
+	4,  // 32: yorkie.v1.YorkieService.AttachDocument:input_type -> yorkie.v1.AttachDocumentRequest
+	6,  // 33: yorkie.v1.YorkieService.DetachDocument:input_type -> yorkie.v1.DetachDocumentRequest
+	25, // 34: yorkie.v1.YorkieService.RemoveDocument:input_type -> yorkie.v1.RemoveDocumentRequest
+	27, // 35: yorkie.v1.YorkieService.PushPullChanges:input_type -> yorkie.v1.PushPullChangesRequest
+	8,  // 36: yorkie.v1.YorkieService.Watch:input_type -> yorkie.v1.WatchRequest
+	20, // 37: yorkie.v1.YorkieService.WatchDocument:input_type -> yorkie.v1.WatchDocumentRequest
+	22, // 38: yorkie.v1.YorkieService.WatchChannel:input_type -> yorkie.v1.WatchChannelRequest
+	29, // 39: yorkie.v1.YorkieService.CreateRevision:input_type -> yorkie.v1.CreateRevisionRequest
+	31, // 40: yorkie.v1.YorkieService.GetRevision:input_type -> yorkie.v1.GetRevisionRequest
+	33, // 41: yorkie.v1.YorkieService.ListRevisions:input_type -> yorkie.v1.ListRevisionsRequest
+	35, // 42: yorkie.v1.YorkieService.RestoreRevision:input_type -> yorkie.v1.RestoreRevisionRequest
+	37, // 43: yorkie.v1.YorkieService.AttachChannel:input_type -> yorkie.v1.AttachChannelRequest
+	39, // 44: yorkie.v1.YorkieService.DetachChannel:input_type -> yorkie.v1.DetachChannelRequest
+	41, // 45: yorkie.v1.YorkieService.RefreshChannel:input_type -> yorkie.v1.RefreshChannelRequest
+	43, // 46: yorkie.v1.YorkieService.Broadcast:input_type -> yorkie.v1.BroadcastRequest
+	1,  // 47: yorkie.v1.YorkieService.ActivateClient:output_type -> yorkie.v1.ActivateClientResponse
+	3,  // 48: yorkie.v1.YorkieService.DeactivateClient:output_type -> yorkie.v1.DeactivateClientResponse
+	5,  // 49: yorkie.v1.YorkieService.AttachDocument:output_type -> yorkie.v1.AttachDocumentResponse
+	7,  // 50: yorkie.v1.YorkieService.DetachDocument:output_type -> yorkie.v1.DetachDocumentResponse
+	26, // 51: yorkie.v1.YorkieService.RemoveDocument:output_type -> yorkie.v1.RemoveDocumentResponse
+	28, // 52: yorkie.v1.YorkieService.PushPullChanges:output_type -> yorkie.v1.PushPullChangesResponse
+	12, // 53: yorkie.v1.YorkieService.Watch:output_type -> yorkie.v1.WatchResponse
+	21, // 54: yorkie.v1.YorkieService.WatchDocument:output_type -> yorkie.v1.WatchDocumentResponse
+	23, // 55: yorkie.v1.YorkieService.WatchChannel:output_type -> yorkie.v1.WatchChannelResponse
+	30, // 56: yorkie.v1.YorkieService.CreateRevision:output_type -> yorkie.v1.CreateRevisionResponse
+	32, // 57: yorkie.v1.YorkieService.GetRevision:output_type -> yorkie.v1.GetRevisionResponse
+	34, // 58: yorkie.v1.YorkieService.ListRevisions:output_type -> yorkie.v1.ListRevisionsResponse
+	36, // 59: yorkie.v1.YorkieService.RestoreRevision:output_type -> yorkie.v1.RestoreRevisionResponse
+	38, // 60: yorkie.v1.YorkieService.AttachChannel:output_type -> yorkie.v1.AttachChannelResponse
+	40, // 61: yorkie.v1.YorkieService.DetachChannel:output_type -> yorkie.v1.DetachChannelResponse
+	42, // 62: yorkie.v1.YorkieService.RefreshChannel:output_type -> yorkie.v1.RefreshChannelResponse
+	44, // 63: yorkie.v1.YorkieService.Broadcast:output_type -> yorkie.v1.BroadcastResponse
+	47, // [47:64] is the sub-list for method output_type
+	30, // [30:47] is the sub-list for method input_type
+	30, // [30:30] is the sub-list for extension type_name
+	30, // [30:30] is the sub-list for extension extendee
+	0,  // [0:30] is the sub-list for field type_name
 }
 
 func init() { file_yorkie_v1_yorkie_proto_init() }
@@ -3008,7 +3058,7 @@ func file_yorkie_v1_yorkie_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_yorkie_v1_yorkie_proto_rawDesc), len(file_yorkie_v1_yorkie_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   47,
+			NumMessages:   48,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/yorkie/v1/yorkie.pb.go
+++ b/api/yorkie/v1/yorkie.pb.go
@@ -2512,6 +2512,98 @@ func (x *RefreshChannelResponse) GetSessionId() string {
 	return ""
 }
 
+// PeekChannel reads the current session_count of a channel without creating
+// a session on the server. Use this when a client only needs to display the
+// count (e.g. "N people writing") without contributing to it and without
+// receiving broadcasts. Caller polls on its own cadence.
+type PeekChannelRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ChannelKey    string                 `protobuf:"bytes,1,opt,name=channel_key,json=channelKey,proto3" json:"channel_key,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PeekChannelRequest) Reset() {
+	*x = PeekChannelRequest{}
+	mi := &file_yorkie_v1_yorkie_proto_msgTypes[43]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PeekChannelRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PeekChannelRequest) ProtoMessage() {}
+
+func (x *PeekChannelRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_yorkie_v1_yorkie_proto_msgTypes[43]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PeekChannelRequest.ProtoReflect.Descriptor instead.
+func (*PeekChannelRequest) Descriptor() ([]byte, []int) {
+	return file_yorkie_v1_yorkie_proto_rawDescGZIP(), []int{43}
+}
+
+func (x *PeekChannelRequest) GetChannelKey() string {
+	if x != nil {
+		return x.ChannelKey
+	}
+	return ""
+}
+
+type PeekChannelResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SessionCount  int64                  `protobuf:"varint,1,opt,name=session_count,json=sessionCount,proto3" json:"session_count,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PeekChannelResponse) Reset() {
+	*x = PeekChannelResponse{}
+	mi := &file_yorkie_v1_yorkie_proto_msgTypes[44]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PeekChannelResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PeekChannelResponse) ProtoMessage() {}
+
+func (x *PeekChannelResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_yorkie_v1_yorkie_proto_msgTypes[44]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PeekChannelResponse.ProtoReflect.Descriptor instead.
+func (*PeekChannelResponse) Descriptor() ([]byte, []int) {
+	return file_yorkie_v1_yorkie_proto_rawDescGZIP(), []int{44}
+}
+
+func (x *PeekChannelResponse) GetSessionCount() int64 {
+	if x != nil {
+		return x.SessionCount
+	}
+	return 0
+}
+
 type BroadcastRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	ClientId      string                 `protobuf:"bytes,1,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
@@ -2524,7 +2616,7 @@ type BroadcastRequest struct {
 
 func (x *BroadcastRequest) Reset() {
 	*x = BroadcastRequest{}
-	mi := &file_yorkie_v1_yorkie_proto_msgTypes[43]
+	mi := &file_yorkie_v1_yorkie_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2536,7 +2628,7 @@ func (x *BroadcastRequest) String() string {
 func (*BroadcastRequest) ProtoMessage() {}
 
 func (x *BroadcastRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_yorkie_proto_msgTypes[43]
+	mi := &file_yorkie_v1_yorkie_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2549,7 +2641,7 @@ func (x *BroadcastRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BroadcastRequest.ProtoReflect.Descriptor instead.
 func (*BroadcastRequest) Descriptor() ([]byte, []int) {
-	return file_yorkie_v1_yorkie_proto_rawDescGZIP(), []int{43}
+	return file_yorkie_v1_yorkie_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *BroadcastRequest) GetClientId() string {
@@ -2588,7 +2680,7 @@ type BroadcastResponse struct {
 
 func (x *BroadcastResponse) Reset() {
 	*x = BroadcastResponse{}
-	mi := &file_yorkie_v1_yorkie_proto_msgTypes[44]
+	mi := &file_yorkie_v1_yorkie_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2600,7 +2692,7 @@ func (x *BroadcastResponse) String() string {
 func (*BroadcastResponse) ProtoMessage() {}
 
 func (x *BroadcastResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_yorkie_proto_msgTypes[44]
+	mi := &file_yorkie_v1_yorkie_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2613,7 +2705,7 @@ func (x *BroadcastResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BroadcastResponse.ProtoReflect.Descriptor instead.
 func (*BroadcastResponse) Descriptor() ([]byte, []int) {
-	return file_yorkie_v1_yorkie_proto_rawDescGZIP(), []int{44}
+	return file_yorkie_v1_yorkie_proto_rawDescGZIP(), []int{46}
 }
 
 type WatchDocumentResponse_Initialization struct {
@@ -2625,7 +2717,7 @@ type WatchDocumentResponse_Initialization struct {
 
 func (x *WatchDocumentResponse_Initialization) Reset() {
 	*x = WatchDocumentResponse_Initialization{}
-	mi := &file_yorkie_v1_yorkie_proto_msgTypes[46]
+	mi := &file_yorkie_v1_yorkie_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2637,7 +2729,7 @@ func (x *WatchDocumentResponse_Initialization) String() string {
 func (*WatchDocumentResponse_Initialization) ProtoMessage() {}
 
 func (x *WatchDocumentResponse_Initialization) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_yorkie_proto_msgTypes[46]
+	mi := &file_yorkie_v1_yorkie_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2854,14 +2946,19 @@ const file_yorkie_v1_yorkie_proto_rawDesc = "" +
 	"\rsession_count\x18\x01 \x01(\x03R\fsessionCount\x12\x1b\n" +
 	"\tclient_id\x18\x02 \x01(\tR\bclientId\x12\x1d\n" +
 	"\n" +
-	"session_id\x18\x03 \x01(\tR\tsessionId\"\x80\x01\n" +
+	"session_id\x18\x03 \x01(\tR\tsessionId\"5\n" +
+	"\x12PeekChannelRequest\x12\x1f\n" +
+	"\vchannel_key\x18\x01 \x01(\tR\n" +
+	"channelKey\":\n" +
+	"\x13PeekChannelResponse\x12#\n" +
+	"\rsession_count\x18\x01 \x01(\x03R\fsessionCount\"\x80\x01\n" +
 	"\x10BroadcastRequest\x12\x1b\n" +
 	"\tclient_id\x18\x01 \x01(\tR\bclientId\x12\x1f\n" +
 	"\vchannel_key\x18\x02 \x01(\tR\n" +
 	"channelKey\x12\x14\n" +
 	"\x05topic\x18\x03 \x01(\tR\x05topic\x12\x18\n" +
 	"\apayload\x18\x04 \x01(\fR\apayload\"\x13\n" +
-	"\x11BroadcastResponse2\xc5\v\n" +
+	"\x11BroadcastResponse2\x95\f\n" +
 	"\rYorkieService\x12W\n" +
 	"\x0eActivateClient\x12 .yorkie.v1.ActivateClientRequest\x1a!.yorkie.v1.ActivateClientResponse\"\x00\x12]\n" +
 	"\x10DeactivateClient\x12\".yorkie.v1.DeactivateClientRequest\x1a#.yorkie.v1.DeactivateClientResponse\"\x00\x12W\n" +
@@ -2878,7 +2975,8 @@ const file_yorkie_v1_yorkie_proto_rawDesc = "" +
 	"\x0fRestoreRevision\x12!.yorkie.v1.RestoreRevisionRequest\x1a\".yorkie.v1.RestoreRevisionResponse\"\x00\x12T\n" +
 	"\rAttachChannel\x12\x1f.yorkie.v1.AttachChannelRequest\x1a .yorkie.v1.AttachChannelResponse\"\x00\x12T\n" +
 	"\rDetachChannel\x12\x1f.yorkie.v1.DetachChannelRequest\x1a .yorkie.v1.DetachChannelResponse\"\x00\x12W\n" +
-	"\x0eRefreshChannel\x12 .yorkie.v1.RefreshChannelRequest\x1a!.yorkie.v1.RefreshChannelResponse\"\x00\x12H\n" +
+	"\x0eRefreshChannel\x12 .yorkie.v1.RefreshChannelRequest\x1a!.yorkie.v1.RefreshChannelResponse\"\x00\x12N\n" +
+	"\vPeekChannel\x12\x1d.yorkie.v1.PeekChannelRequest\x1a\x1e.yorkie.v1.PeekChannelResponse\"\x00\x12H\n" +
 	"\tBroadcast\x12\x1b.yorkie.v1.BroadcastRequest\x1a\x1c.yorkie.v1.BroadcastResponse\"\x00BE\n" +
 	"\x11dev.yorkie.api.v1P\x01Z.github.com/yorkie-team/yorkie/api/yorkie/v1;v1b\x06proto3"
 
@@ -2894,7 +2992,7 @@ func file_yorkie_v1_yorkie_proto_rawDescGZIP() []byte {
 	return file_yorkie_v1_yorkie_proto_rawDescData
 }
 
-var file_yorkie_v1_yorkie_proto_msgTypes = make([]protoimpl.MessageInfo, 48)
+var file_yorkie_v1_yorkie_proto_msgTypes = make([]protoimpl.MessageInfo, 50)
 var file_yorkie_v1_yorkie_proto_goTypes = []any{
 	(*ActivateClientRequest)(nil),                // 0: yorkie.v1.ActivateClientRequest
 	(*ActivateClientResponse)(nil),               // 1: yorkie.v1.ActivateClientResponse
@@ -2939,24 +3037,26 @@ var file_yorkie_v1_yorkie_proto_goTypes = []any{
 	(*DetachChannelResponse)(nil),                // 40: yorkie.v1.DetachChannelResponse
 	(*RefreshChannelRequest)(nil),                // 41: yorkie.v1.RefreshChannelRequest
 	(*RefreshChannelResponse)(nil),               // 42: yorkie.v1.RefreshChannelResponse
-	(*BroadcastRequest)(nil),                     // 43: yorkie.v1.BroadcastRequest
-	(*BroadcastResponse)(nil),                    // 44: yorkie.v1.BroadcastResponse
-	nil,                                          // 45: yorkie.v1.ActivateClientRequest.MetadataEntry
-	(*WatchDocumentResponse_Initialization)(nil), // 46: yorkie.v1.WatchDocumentResponse.Initialization
-	nil,                     // 47: yorkie.v1.RefreshChannelRequest.MetadataEntry
-	(*ChangePack)(nil),      // 48: yorkie.v1.ChangePack
-	(*Rule)(nil),            // 49: yorkie.v1.Rule
-	(*DocEvent)(nil),        // 50: yorkie.v1.DocEvent
-	(*ChannelEvent)(nil),    // 51: yorkie.v1.ChannelEvent
-	(*RevisionSummary)(nil), // 52: yorkie.v1.RevisionSummary
+	(*PeekChannelRequest)(nil),                   // 43: yorkie.v1.PeekChannelRequest
+	(*PeekChannelResponse)(nil),                  // 44: yorkie.v1.PeekChannelResponse
+	(*BroadcastRequest)(nil),                     // 45: yorkie.v1.BroadcastRequest
+	(*BroadcastResponse)(nil),                    // 46: yorkie.v1.BroadcastResponse
+	nil,                                          // 47: yorkie.v1.ActivateClientRequest.MetadataEntry
+	(*WatchDocumentResponse_Initialization)(nil), // 48: yorkie.v1.WatchDocumentResponse.Initialization
+	nil,                     // 49: yorkie.v1.RefreshChannelRequest.MetadataEntry
+	(*ChangePack)(nil),      // 50: yorkie.v1.ChangePack
+	(*Rule)(nil),            // 51: yorkie.v1.Rule
+	(*DocEvent)(nil),        // 52: yorkie.v1.DocEvent
+	(*ChannelEvent)(nil),    // 53: yorkie.v1.ChannelEvent
+	(*RevisionSummary)(nil), // 54: yorkie.v1.RevisionSummary
 }
 var file_yorkie_v1_yorkie_proto_depIdxs = []int32{
-	45, // 0: yorkie.v1.ActivateClientRequest.metadata:type_name -> yorkie.v1.ActivateClientRequest.MetadataEntry
-	48, // 1: yorkie.v1.AttachDocumentRequest.change_pack:type_name -> yorkie.v1.ChangePack
-	48, // 2: yorkie.v1.AttachDocumentResponse.change_pack:type_name -> yorkie.v1.ChangePack
-	49, // 3: yorkie.v1.AttachDocumentResponse.schema_rules:type_name -> yorkie.v1.Rule
-	48, // 4: yorkie.v1.DetachDocumentRequest.change_pack:type_name -> yorkie.v1.ChangePack
-	48, // 5: yorkie.v1.DetachDocumentResponse.change_pack:type_name -> yorkie.v1.ChangePack
+	47, // 0: yorkie.v1.ActivateClientRequest.metadata:type_name -> yorkie.v1.ActivateClientRequest.MetadataEntry
+	50, // 1: yorkie.v1.AttachDocumentRequest.change_pack:type_name -> yorkie.v1.ChangePack
+	50, // 2: yorkie.v1.AttachDocumentResponse.change_pack:type_name -> yorkie.v1.ChangePack
+	51, // 3: yorkie.v1.AttachDocumentResponse.schema_rules:type_name -> yorkie.v1.Rule
+	50, // 4: yorkie.v1.DetachDocumentRequest.change_pack:type_name -> yorkie.v1.ChangePack
+	50, // 5: yorkie.v1.DetachDocumentResponse.change_pack:type_name -> yorkie.v1.ChangePack
 	9,  // 6: yorkie.v1.WatchRequest.resources:type_name -> yorkie.v1.ResourceDescriptor
 	10, // 7: yorkie.v1.ResourceDescriptor.document:type_name -> yorkie.v1.DocumentDescriptor
 	11, // 8: yorkie.v1.ResourceDescriptor.channel:type_name -> yorkie.v1.ChannelDescriptor
@@ -2967,20 +3067,20 @@ var file_yorkie_v1_yorkie_proto_depIdxs = []int32{
 	16, // 13: yorkie.v1.ResourceInit.channel_init:type_name -> yorkie.v1.ChannelInit
 	18, // 14: yorkie.v1.WatchEvent.doc_event:type_name -> yorkie.v1.DocWatchEvent
 	19, // 15: yorkie.v1.WatchEvent.channel_event:type_name -> yorkie.v1.ChannelWatchEvent
-	50, // 16: yorkie.v1.DocWatchEvent.event:type_name -> yorkie.v1.DocEvent
-	51, // 17: yorkie.v1.ChannelWatchEvent.event:type_name -> yorkie.v1.ChannelEvent
-	46, // 18: yorkie.v1.WatchDocumentResponse.initialization:type_name -> yorkie.v1.WatchDocumentResponse.Initialization
-	50, // 19: yorkie.v1.WatchDocumentResponse.event:type_name -> yorkie.v1.DocEvent
+	52, // 16: yorkie.v1.DocWatchEvent.event:type_name -> yorkie.v1.DocEvent
+	53, // 17: yorkie.v1.ChannelWatchEvent.event:type_name -> yorkie.v1.ChannelEvent
+	48, // 18: yorkie.v1.WatchDocumentResponse.initialization:type_name -> yorkie.v1.WatchDocumentResponse.Initialization
+	52, // 19: yorkie.v1.WatchDocumentResponse.event:type_name -> yorkie.v1.DocEvent
 	24, // 20: yorkie.v1.WatchChannelResponse.initialized:type_name -> yorkie.v1.WatchChannelInitialized
-	51, // 21: yorkie.v1.WatchChannelResponse.event:type_name -> yorkie.v1.ChannelEvent
-	48, // 22: yorkie.v1.RemoveDocumentRequest.change_pack:type_name -> yorkie.v1.ChangePack
-	48, // 23: yorkie.v1.RemoveDocumentResponse.change_pack:type_name -> yorkie.v1.ChangePack
-	48, // 24: yorkie.v1.PushPullChangesRequest.change_pack:type_name -> yorkie.v1.ChangePack
-	48, // 25: yorkie.v1.PushPullChangesResponse.change_pack:type_name -> yorkie.v1.ChangePack
-	52, // 26: yorkie.v1.CreateRevisionResponse.revision:type_name -> yorkie.v1.RevisionSummary
-	52, // 27: yorkie.v1.GetRevisionResponse.revision:type_name -> yorkie.v1.RevisionSummary
-	52, // 28: yorkie.v1.ListRevisionsResponse.revisions:type_name -> yorkie.v1.RevisionSummary
-	47, // 29: yorkie.v1.RefreshChannelRequest.metadata:type_name -> yorkie.v1.RefreshChannelRequest.MetadataEntry
+	53, // 21: yorkie.v1.WatchChannelResponse.event:type_name -> yorkie.v1.ChannelEvent
+	50, // 22: yorkie.v1.RemoveDocumentRequest.change_pack:type_name -> yorkie.v1.ChangePack
+	50, // 23: yorkie.v1.RemoveDocumentResponse.change_pack:type_name -> yorkie.v1.ChangePack
+	50, // 24: yorkie.v1.PushPullChangesRequest.change_pack:type_name -> yorkie.v1.ChangePack
+	50, // 25: yorkie.v1.PushPullChangesResponse.change_pack:type_name -> yorkie.v1.ChangePack
+	54, // 26: yorkie.v1.CreateRevisionResponse.revision:type_name -> yorkie.v1.RevisionSummary
+	54, // 27: yorkie.v1.GetRevisionResponse.revision:type_name -> yorkie.v1.RevisionSummary
+	54, // 28: yorkie.v1.ListRevisionsResponse.revisions:type_name -> yorkie.v1.RevisionSummary
+	49, // 29: yorkie.v1.RefreshChannelRequest.metadata:type_name -> yorkie.v1.RefreshChannelRequest.MetadataEntry
 	0,  // 30: yorkie.v1.YorkieService.ActivateClient:input_type -> yorkie.v1.ActivateClientRequest
 	2,  // 31: yorkie.v1.YorkieService.DeactivateClient:input_type -> yorkie.v1.DeactivateClientRequest
 	4,  // 32: yorkie.v1.YorkieService.AttachDocument:input_type -> yorkie.v1.AttachDocumentRequest
@@ -2997,26 +3097,28 @@ var file_yorkie_v1_yorkie_proto_depIdxs = []int32{
 	37, // 43: yorkie.v1.YorkieService.AttachChannel:input_type -> yorkie.v1.AttachChannelRequest
 	39, // 44: yorkie.v1.YorkieService.DetachChannel:input_type -> yorkie.v1.DetachChannelRequest
 	41, // 45: yorkie.v1.YorkieService.RefreshChannel:input_type -> yorkie.v1.RefreshChannelRequest
-	43, // 46: yorkie.v1.YorkieService.Broadcast:input_type -> yorkie.v1.BroadcastRequest
-	1,  // 47: yorkie.v1.YorkieService.ActivateClient:output_type -> yorkie.v1.ActivateClientResponse
-	3,  // 48: yorkie.v1.YorkieService.DeactivateClient:output_type -> yorkie.v1.DeactivateClientResponse
-	5,  // 49: yorkie.v1.YorkieService.AttachDocument:output_type -> yorkie.v1.AttachDocumentResponse
-	7,  // 50: yorkie.v1.YorkieService.DetachDocument:output_type -> yorkie.v1.DetachDocumentResponse
-	26, // 51: yorkie.v1.YorkieService.RemoveDocument:output_type -> yorkie.v1.RemoveDocumentResponse
-	28, // 52: yorkie.v1.YorkieService.PushPullChanges:output_type -> yorkie.v1.PushPullChangesResponse
-	12, // 53: yorkie.v1.YorkieService.Watch:output_type -> yorkie.v1.WatchResponse
-	21, // 54: yorkie.v1.YorkieService.WatchDocument:output_type -> yorkie.v1.WatchDocumentResponse
-	23, // 55: yorkie.v1.YorkieService.WatchChannel:output_type -> yorkie.v1.WatchChannelResponse
-	30, // 56: yorkie.v1.YorkieService.CreateRevision:output_type -> yorkie.v1.CreateRevisionResponse
-	32, // 57: yorkie.v1.YorkieService.GetRevision:output_type -> yorkie.v1.GetRevisionResponse
-	34, // 58: yorkie.v1.YorkieService.ListRevisions:output_type -> yorkie.v1.ListRevisionsResponse
-	36, // 59: yorkie.v1.YorkieService.RestoreRevision:output_type -> yorkie.v1.RestoreRevisionResponse
-	38, // 60: yorkie.v1.YorkieService.AttachChannel:output_type -> yorkie.v1.AttachChannelResponse
-	40, // 61: yorkie.v1.YorkieService.DetachChannel:output_type -> yorkie.v1.DetachChannelResponse
-	42, // 62: yorkie.v1.YorkieService.RefreshChannel:output_type -> yorkie.v1.RefreshChannelResponse
-	44, // 63: yorkie.v1.YorkieService.Broadcast:output_type -> yorkie.v1.BroadcastResponse
-	47, // [47:64] is the sub-list for method output_type
-	30, // [30:47] is the sub-list for method input_type
+	43, // 46: yorkie.v1.YorkieService.PeekChannel:input_type -> yorkie.v1.PeekChannelRequest
+	45, // 47: yorkie.v1.YorkieService.Broadcast:input_type -> yorkie.v1.BroadcastRequest
+	1,  // 48: yorkie.v1.YorkieService.ActivateClient:output_type -> yorkie.v1.ActivateClientResponse
+	3,  // 49: yorkie.v1.YorkieService.DeactivateClient:output_type -> yorkie.v1.DeactivateClientResponse
+	5,  // 50: yorkie.v1.YorkieService.AttachDocument:output_type -> yorkie.v1.AttachDocumentResponse
+	7,  // 51: yorkie.v1.YorkieService.DetachDocument:output_type -> yorkie.v1.DetachDocumentResponse
+	26, // 52: yorkie.v1.YorkieService.RemoveDocument:output_type -> yorkie.v1.RemoveDocumentResponse
+	28, // 53: yorkie.v1.YorkieService.PushPullChanges:output_type -> yorkie.v1.PushPullChangesResponse
+	12, // 54: yorkie.v1.YorkieService.Watch:output_type -> yorkie.v1.WatchResponse
+	21, // 55: yorkie.v1.YorkieService.WatchDocument:output_type -> yorkie.v1.WatchDocumentResponse
+	23, // 56: yorkie.v1.YorkieService.WatchChannel:output_type -> yorkie.v1.WatchChannelResponse
+	30, // 57: yorkie.v1.YorkieService.CreateRevision:output_type -> yorkie.v1.CreateRevisionResponse
+	32, // 58: yorkie.v1.YorkieService.GetRevision:output_type -> yorkie.v1.GetRevisionResponse
+	34, // 59: yorkie.v1.YorkieService.ListRevisions:output_type -> yorkie.v1.ListRevisionsResponse
+	36, // 60: yorkie.v1.YorkieService.RestoreRevision:output_type -> yorkie.v1.RestoreRevisionResponse
+	38, // 61: yorkie.v1.YorkieService.AttachChannel:output_type -> yorkie.v1.AttachChannelResponse
+	40, // 62: yorkie.v1.YorkieService.DetachChannel:output_type -> yorkie.v1.DetachChannelResponse
+	42, // 63: yorkie.v1.YorkieService.RefreshChannel:output_type -> yorkie.v1.RefreshChannelResponse
+	44, // 64: yorkie.v1.YorkieService.PeekChannel:output_type -> yorkie.v1.PeekChannelResponse
+	46, // 65: yorkie.v1.YorkieService.Broadcast:output_type -> yorkie.v1.BroadcastResponse
+	48, // [48:66] is the sub-list for method output_type
+	30, // [30:48] is the sub-list for method input_type
 	30, // [30:30] is the sub-list for extension type_name
 	30, // [30:30] is the sub-list for extension extendee
 	0,  // [0:30] is the sub-list for field type_name
@@ -3058,7 +3160,7 @@ func file_yorkie_v1_yorkie_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_yorkie_v1_yorkie_proto_rawDesc), len(file_yorkie_v1_yorkie_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   48,
+			NumMessages:   50,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/yorkie/v1/yorkie.proto
+++ b/api/yorkie/v1/yorkie.proto
@@ -282,10 +282,21 @@ message RefreshChannelRequest {
   string client_id = 1;
   string channel_key = 2;
   string session_id = 3;
+  // client_key and metadata are used only on the first call (when session_id
+  // is empty). The server activates the client and attaches it to the channel
+  // before refreshing, collapsing ActivateClient + AttachChannel + RefreshChannel
+  // into a single round trip.
+  string client_key = 4;
+  map<string, string> metadata = 5;
 }
 
 message RefreshChannelResponse {
   int64 session_count = 1;
+  // client_id and session_id are populated only when the request was a
+  // first-call (i.e. session_id was empty). Subsequent heartbeats leave
+  // these empty.
+  string client_id = 2;
+  string session_id = 3;
 }
 
 message BroadcastRequest {

--- a/api/yorkie/v1/yorkie.proto
+++ b/api/yorkie/v1/yorkie.proto
@@ -47,6 +47,7 @@ service YorkieService {
   rpc AttachChannel (AttachChannelRequest) returns (AttachChannelResponse) {}
   rpc DetachChannel (DetachChannelRequest) returns (DetachChannelResponse) {}
   rpc RefreshChannel (RefreshChannelRequest) returns (RefreshChannelResponse) {}
+  rpc PeekChannel (PeekChannelRequest) returns (PeekChannelResponse) {}
   rpc Broadcast (BroadcastRequest) returns (BroadcastResponse) {}
 }
 
@@ -297,6 +298,18 @@ message RefreshChannelResponse {
   // these empty.
   string client_id = 2;
   string session_id = 3;
+}
+
+// PeekChannel reads the current session_count of a channel without creating
+// a session on the server. Use this when a client only needs to display the
+// count (e.g. "N people writing") without contributing to it and without
+// receiving broadcasts. Caller polls on its own cadence.
+message PeekChannelRequest {
+  string channel_key = 1;
+}
+
+message PeekChannelResponse {
+  int64 session_count = 1;
 }
 
 message BroadcastRequest {

--- a/docs/design/presence.md
+++ b/docs/design/presence.md
@@ -140,20 +140,22 @@ The server exposes dedicated RPC methods for channel operations:
 
 - `AttachChannel`: Attach to a channel
 - `DetachChannel`: Detach from a channel
-- `RefreshChannel`: Refresh TTL of an active session
+- `RefreshChannel`: Refresh TTL of an active session. On the first call (empty `session_id`), the request also carries `client_key` and `metadata`, and the server collapses `ActivateClient` + `AttachChannel` + `RefreshChannel` into a single round trip, returning the assigned `client_id` and `session_id` in the response.
 - `WatchChannel`: Stream real-time count updates and broadcast messages
 - `Broadcast`: Send messages to all channel subscribers
+- `PeekChannel`: Stateless read of a channel's `session_count` without creating a server-side session. Used for read-only display of "N people active" without joining the channel or receiving broadcasts.
 
 ### How It Works
 
 #### Channel Flow
 
-1. **Attach**: Client → AttachChannel RPC → Server generates sessionID → PubSub broadcasts count
+1. **First-call attach**: Client → RefreshChannel RPC (empty `session_id`, populated `client_key` + `metadata`) → Server runs `ActivateClient` + `AttachChannel` + `RefreshChannel` in one handler → Returns `client_id` + `session_id` → PubSub broadcasts count
 2. **Subscribe**: Client → WatchChannel RPC → Server creates subscription → Streams count updates and broadcast events
 3. **Broadcast**: Client → Broadcast RPC → Server routes message to all subscribers (except sender)
-4. **Heartbeat**: Client timer (30s) → RefreshChannel RPC → Server updates timestamp
+4. **Heartbeat**: Client timer (heartbeat interval ≤ TTL/3) → RefreshChannel RPC (populated `session_id`) → Server updates timestamp; no MongoDB read on this path — the in-memory channel session map is the sole liveness proof
 5. **Cleanup**: Server timer (10s) → Scans expired sessions → Detach and broadcast updates
 6. **Detach**: Client → DetachChannel RPC → Server removes session → Broadcasts count update
+7. **Peek (read-only)**: Client → PeekChannel RPC → Server returns `session_count` without creating a session or fan-out subscriber
 
 #### Document Presence Flow (Existing)
 
@@ -168,15 +170,16 @@ To handle abnormal disconnections (crashes, network failures), the Channel uses 
 **Server-Side:**
 
 - Each `SessionInfo` has an `UpdatedAt` timestamp
-- Default TTL: 60 seconds
+- Default TTL: 15 seconds (configurable via `ChannelSessionTTL`)
 - Cleanup runs every 10 seconds
 - Sessions expire when `now - UpdatedAt > TTL`
 
 **Client-Side:**
 
-- Heartbeat timer fires every 30 seconds (default)
+- Heartbeat timer fires at TTL/3 by default (5s when server TTL is 15s)
 - Calls `RefreshChannel()` to update server timestamp
 - Continues until detachment or context cancellation
+- SDK and server defaults must be co-tuned: heartbeat > TTL would cause healthy clients to flap
 
 **Design Choices:**
 

--- a/server/backend/channel/manager.go
+++ b/server/backend/channel/manager.go
@@ -146,7 +146,7 @@ func NewManager(
 	db database.Database,
 ) *Manager {
 	if ttl == 0 {
-		ttl = 60 * gotime.Second
+		ttl = 15 * gotime.Second
 	}
 
 	if cleanupInterval == 0 {

--- a/server/backend/channel/manager_test.go
+++ b/server/backend/channel/manager_test.go
@@ -253,7 +253,7 @@ func TestChannelManager_RefreshAndCleanup(t *testing.T) {
 	t.Run("default TTL is applied when zero", func(t *testing.T) {
 		manager, _, _ := createManager(t, 0, 0)
 
-		// Manager should have default TTL (60s)
+		// Manager should have default TTL (15s)
 		// We can't directly check the internal field, but we can verify it works
 		stats := manager.Stats()
 		assert.NotNil(t, stats)

--- a/server/config.go
+++ b/server/config.go
@@ -64,7 +64,7 @@ const (
 	DefaultKafkaSessionEventsTopic  = "session-events"
 	DefaultKafkaWriteTimeout        = 5 * time.Second
 
-	DefaultChannelSessionTTL             = 60 * time.Second
+	DefaultChannelSessionTTL             = 15 * time.Second
 	DefaultChannelSessionCleanupInterval = 10 * time.Second
 	DefaultChannelSessionCountCacheTTL   = 30 * time.Second
 	DefaultChannelSessionCountCacheSize  = 10000

--- a/server/rpc/yorkie_server.go
+++ b/server/rpc/yorkie_server.go
@@ -387,13 +387,111 @@ func (s *yorkieServer) RefreshChannel(
 	ctx context.Context,
 	req *connect.Request[api.RefreshChannelRequest],
 ) (*connect.Response[api.RefreshChannelResponse], error) {
-	// 01. Validate the request and verify access
-	actorID, err := time.ActorIDFromHex(req.Msg.ClientId)
+	channelKey := key.Key(req.Msg.ChannelKey)
+	if err := channelKey.Validate(); err != nil {
+		return nil, err
+	}
+
+	// First-call path: when session_id is empty, this RPC subsumes
+	// ActivateClient + AttachChannel + RefreshChannel into a single round trip.
+	// Subsequent heartbeats keep the prior session_id and skip activate/attach.
+	if req.Msg.SessionId == "" {
+		return s.firstChannelRefresh(ctx, req, channelKey)
+	}
+
+	// Heartbeat path: refresh the TTL of an existing session.
+	return s.heartbeatChannelRefresh(ctx, req, channelKey)
+}
+
+// firstChannelRefresh handles the first RefreshChannel call from a client.
+// It activates the client (if needed), attaches it to the channel, and
+// refreshes the TTL — returning the freshly allocated client_id and
+// session_id so the client can include them in subsequent heartbeats.
+func (s *yorkieServer) firstChannelRefresh(
+	ctx context.Context,
+	req *connect.Request[api.RefreshChannelRequest],
+	channelKey key.Key,
+) (*connect.Response[api.RefreshChannelResponse], error) {
+	if req.Msg.ClientKey == "" {
+		return nil, clients.ErrInvalidClientKey
+	}
+
+	if err := auth.VerifyAccess(ctx, s.backend, &types.AccessInfo{
+		Method: types.ActivateClient,
+	}); err != nil {
+		return nil, err
+	}
+	if err := auth.VerifyAccess(ctx, s.backend, &types.AccessInfo{
+		Method:     types.AttachChannel,
+		Attributes: types.NewAccessAttributes([]key.Key{channelKey}, types.ReadWrite),
+	}); err != nil {
+		return nil, err
+	}
+
+	project := projects.From(ctx)
+	cli, err := clients.Activate(ctx, s.backend, project, req.Msg.ClientKey, req.Msg.Metadata)
 	if err != nil {
 		return nil, err
 	}
-	channelKey := key.Key(req.Msg.ChannelKey)
-	if err := channelKey.Validate(); err != nil {
+
+	if err := s.backend.MsgBroker.Produce(
+		ctx,
+		messaging.ClientEventMessage{
+			ProjectID: project.ID.String(),
+			ClientID:  cli.ID.String(),
+			Timestamp: gotime.Now(),
+			EventType: events.ClientActivatedEvent,
+		},
+	); err != nil {
+		logging.From(ctx).Errorf("failed to produce client event: %v", err)
+	}
+
+	if userID, exist := req.Msg.Metadata["userID"]; exist && userID != "" {
+		if err := s.backend.MsgBroker.Produce(
+			ctx,
+			messaging.UserEventMessage{
+				UserID:    userID,
+				Timestamp: gotime.Now(),
+				EventType: events.ClientActivatedEvent,
+				ProjectID: project.ID.String(),
+				UserAgent: req.Header().Get("x-yorkie-user-agent"),
+			},
+		); err != nil {
+			logging.From(ctx).Errorf("failed to produce user event: %v", err)
+		}
+	}
+
+	actorID, err := cli.ID.ToActorID()
+	if err != nil {
+		return nil, err
+	}
+
+	refKey := types.ChannelRefKey{
+		ProjectID:  project.ID,
+		ChannelKey: channelKey,
+	}
+	sessionID, sessionCount, err := s.backend.Channel.Attach(ctx, refKey, actorID)
+	if err != nil {
+		return nil, err
+	}
+
+	return connect.NewResponse(&api.RefreshChannelResponse{
+		SessionCount: sessionCount,
+		ClientId:     cli.ID.String(),
+		SessionId:    sessionID.String(),
+	}), nil
+}
+
+// heartbeatChannelRefresh handles subsequent RefreshChannel calls that carry
+// an existing session_id. It preserves the prior behavior, including the
+// FindActiveClientInfo MongoDB read.
+func (s *yorkieServer) heartbeatChannelRefresh(
+	ctx context.Context,
+	req *connect.Request[api.RefreshChannelRequest],
+	channelKey key.Key,
+) (*connect.Response[api.RefreshChannelResponse], error) {
+	actorID, err := time.ActorIDFromHex(req.Msg.ClientId)
+	if err != nil {
 		return nil, err
 	}
 	sessionID := types.ID(req.Msg.SessionId)
@@ -416,22 +514,19 @@ func (s *yorkieServer) RefreshChannel(
 		return nil, err
 	}
 
-	// 02. Refresh presence using presence ID
 	if err := s.backend.Channel.Refresh(ctx, sessionID); err != nil {
 		return nil, err
 	}
 
-	// 03. Get current count from backend
 	refKey := types.ChannelRefKey{
 		ProjectID:  project.ID,
 		ChannelKey: channelKey,
 	}
 	sessionCount := s.backend.Channel.SessionCount(refKey, false)
 
-	response := &api.RefreshChannelResponse{
+	return connect.NewResponse(&api.RefreshChannelResponse{
 		SessionCount: sessionCount,
-	}
-	return connect.NewResponse(response), nil
+	}), nil
 }
 
 // taggedEvent wraps a doc or channel event for fan-in multiplexing.

--- a/server/rpc/yorkie_server.go
+++ b/server/rpc/yorkie_server.go
@@ -1065,6 +1065,36 @@ func (s *yorkieServer) WatchChannel(
 	)
 }
 
+// PeekChannel returns the current session_count of a channel without
+// creating a session on the server. Use when the caller only needs to
+// display the count and does not need to receive broadcasts or contribute
+// to the count itself. Polled by the client at its own cadence; no
+// per-caller server state, no pubsub fan-out.
+func (s *yorkieServer) PeekChannel(
+	ctx context.Context,
+	req *connect.Request[api.PeekChannelRequest],
+) (*connect.Response[api.PeekChannelResponse], error) {
+	channelKey := key.Key(req.Msg.ChannelKey)
+	if err := channelKey.Validate(); err != nil {
+		return nil, err
+	}
+
+	if err := auth.VerifyAccess(ctx, s.backend, &types.AccessInfo{
+		Method:     types.PeekChannel,
+		Attributes: types.NewAccessAttributes([]key.Key{channelKey}, types.Read),
+	}); err != nil {
+		return nil, err
+	}
+
+	refKey := types.ChannelRefKey{
+		ProjectID:  projects.From(ctx).ID,
+		ChannelKey: channelKey,
+	}
+	return connect.NewResponse(&api.PeekChannelResponse{
+		SessionCount: s.backend.Channel.SessionCount(refKey, false),
+	}), nil
+}
+
 // Broadcast broadcasts a message to all clients watching the presence.
 func (s *yorkieServer) Broadcast(
 	ctx context.Context,

--- a/server/rpc/yorkie_server.go
+++ b/server/rpc/yorkie_server.go
@@ -483,15 +483,18 @@ func (s *yorkieServer) firstChannelRefresh(
 }
 
 // heartbeatChannelRefresh handles subsequent RefreshChannel calls that carry
-// an existing session_id. It preserves the prior behavior, including the
-// FindActiveClientInfo MongoDB read.
+// an existing session_id. Liveness is proven by the session_id itself —
+// the server issued it at first-call time, and the channel manager keeps
+// it in an in-memory map — so there is no per-heartbeat MongoDB read.
+// If the session has already been swept by the cleanup ticker, the
+// in-memory Refresh returns ErrSessionNotFound and the caller is expected
+// to start a new first-call cycle.
 func (s *yorkieServer) heartbeatChannelRefresh(
 	ctx context.Context,
 	req *connect.Request[api.RefreshChannelRequest],
 	channelKey key.Key,
 ) (*connect.Response[api.RefreshChannelResponse], error) {
-	actorID, err := time.ActorIDFromHex(req.Msg.ClientId)
-	if err != nil {
+	if _, err := time.ActorIDFromHex(req.Msg.ClientId); err != nil {
 		return nil, err
 	}
 	sessionID := types.ID(req.Msg.SessionId)
@@ -505,21 +508,12 @@ func (s *yorkieServer) heartbeatChannelRefresh(
 		return nil, err
 	}
 
-	project := projects.From(ctx)
-	_, err = clients.FindActiveClientInfo(ctx, s.backend, types.ClientRefKey{
-		ProjectID: project.ID,
-		ClientID:  types.IDFromActorID(actorID),
-	})
-	if err != nil {
-		return nil, err
-	}
-
 	if err := s.backend.Channel.Refresh(ctx, sessionID); err != nil {
 		return nil, err
 	}
 
 	refKey := types.ChannelRefKey{
-		ProjectID:  project.ID,
+		ProjectID:  projects.From(ctx).ID,
 		ChannelKey: channelKey,
 	}
 	sessionCount := s.backend.Channel.SessionCount(refKey, false)


### PR DESCRIPTION
## Summary

Consolidates the channel-RPC-rework experiments and adds `PeekChannel`, a stateless read of a channel's `session_count`. This bundles the previously-stacked PRs into a single change against `main` for review and merge.

## What's included

| Source PR | Commit | What |
|---|---|---|
| #1799 | `33491c43` | Collapse 5 channel-lifecycle RPCs into a single `RefreshChannel` first-call (`ActivateClient` + `AttachChannel` + `RefreshChannel` → one round trip) |
| #1800 | `5a1bbed0` | Remove the per-heartbeat `FindActiveClientInfo` MongoDB read — liveness is proven by the in-memory channel session map |
| #1798 | `a620503d` | Reduce default `ChannelSessionTTL` from 60s to 15s |
| #1805 | `a7213011` | **PeekChannel**: stateless read of `session_count`, no session created, no broadcasts, no pubsub fan-out |
| #1804 | `06dfe335` `8de5cdf8` | Skip leadership write when an active leader exists — eliminates ~155K MongoDB duplicate-key errors/day at 10 nodes |

PRs #1798–1802 were a benchmark matrix to compare RPC-collapse / Mongo-read / TTL variants. The configuration in this PR is the most aggressive variant (collapse + no Mongo read + 15s TTL).

## PeekChannel (the new RPC)

```proto
rpc PeekChannel (PeekChannelRequest) returns (PeekChannelResponse) {}

message PeekChannelRequest  { string channel_key = 1; }
message PeekChannelResponse { int64  session_count = 1; }
```

Server handler:
- Validates `channel_key`
- Verifies access (`types.PeekChannel`, `Read` verb — lighter than `AttachChannel`'s `ReadWrite`)
- Returns `Manager.SessionCount(refKey, includeSubPath=false)`

No write paths touched: no Session created, no `clientToSession` mutated, no pubsub event, no TTL registration, no goroutine, no DB I/O. Pure in-memory O(1) lookup.

### Why a separate RPC

`AttachChannel` lets a caller observe the count, but the caller becomes a member of the channel: a `Session` entry is allocated, pubsub events fan out to it, heartbeat RPCs are required to keep it alive. For a globally-displayed counter (e.g. a "N people writing" badge shown on every surrounding page) this scales poorly — every viewer of every surrounding page becomes a channel member.

`PeekChannel` decouples count display from membership:

| | `AttachChannel` | `PeekChannel` |
|---|---|---|
| Server state per caller | `Session` + cmap + indexes | none |
| Pubsub fan-out cost | O(viewers + participants) | O(participants) only |
| Network cost | heartbeat at TTL/3 cadence | one RPC per call |
| Push semantics | yes (events) | no (one-shot) |
| Use case | participate + receive broadcasts | display count only |

### Auth

`PeekChannel` requires the `Read` verb on the target channel key, where `AttachChannel` requires `ReadWrite`. This allows policies that grant *read-the-count* permission without granting *be-a-member* permission — the natural separation for a public counter that anyone may display but only some may join.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] Smoke test via `curl`:
  - `PeekChannel` on a non-existent channel → `{}` (count 0)
  - `PeekChannel` on a channel with 1 attached client → `{"sessionCount":"1"}`
  - Repeated `PeekChannel` does not change the count
  - First-call `RefreshChannel` activates + attaches in one round trip (collapse from #1799)
  - Heartbeat `RefreshChannel` does not hit MongoDB (#1800)
- [x] Manager unit tests pass (channel package)

## Companion / dependencies

- SDK: yorkie-team/yorkie-js-sdk#1256 — `usePeekChannel` React hook and `client.peekChannel(channelKey)` method.

## Supersedes / replaces

- #1798, #1799, #1800, #1801, #1802 — benchmark matrix experiments; the chosen variant (this PR) bundles them.
- #1803 — read-only attach approach; superseded by `PeekChannel` which addresses the same UX with better scaling characteristics.
- #1804 (raararaara's) — leader election fix bundled here via cherry-pick (commit author preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PeekChannel RPC to read a channel's current session count without creating a session.
  * Enhanced RefreshChannel to allow one-call client activation using new clientKey and metadata, returning clientId and sessionId on initial activation.

* **Changes**
  * Default channel session TTL reduced to 10 seconds.

* **Chores**
  * API specification version bumped to v0.7.8.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yorkie-team/yorkie/pull/1805)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->