### PR TITLE
Reduce channel session TTL from 15s to 10s

### DIFF
--- a/server/backend/channel/manager.go
+++ b/server/backend/channel/manager.go
@@ -146,7 +146,7 @@ func NewManager(
 	db database.Database,
 ) *Manager {
 	if ttl == 0 {
-		ttl = 15 * gotime.Second
+		ttl = 10 * gotime.Second
 	}
 
 	if cleanupInterval == 0 {

--- a/server/config.go
+++ b/server/config.go
@@ -64,7 +64,7 @@ const (
 	DefaultKafkaSessionEventsTopic  = "session-events"
 	DefaultKafkaWriteTimeout        = 5 * time.Second
 
-	DefaultChannelSessionTTL             = 15 * time.Second
+	DefaultChannelSessionTTL             = 10 * time.Second
 	DefaultChannelSessionCleanupInterval = 10 * time.Second
 	DefaultChannelSessionCountCacheTTL   = 30 * time.Second
 	DefaultChannelSessionCountCacheSize  = 10000


### PR DESCRIPTION
## Summary

Stacked on #1805. Lowers `DefaultChannelSessionTTL` from 15s to 10s to further shrink the stale-membership window after a silent disconnect (browser tab close, network drop).

| | TTL | Cleanup ticker | End-to-end stale window |
|---|---|---|---|
| `main` | 60s | 10s | 60–70s |
| #1798 / #1805 (this stack) | 15s | 10s | 15–25s |
| **this PR** | **10s** | 10s | **10–20s** |

## Changes

- `server/backend/channel/manager.go`: default `ttl` in `NewManager` 15s → 10s.
- `server/config.go`: `DefaultChannelSessionTTL` 15s → 10s.

## SDK heartbeat compatibility

The SDK heartbeat interval must remain comfortably below the server TTL for a session to stay live.

| Mode | SDK default heartbeat | Safe against 10s TTL? |
|---|---|---|
| Polling | 3000ms | ✓ (3.3× margin) |
| Realtime | 30000ms | ✗ — would flap. Override via `channelHeartbeatInterval` to ≤ ~3s or keep server TTL ≥ 90s. |

Rollouts using `SyncMode.Realtime` must either:
1. Override `--channel-session-ttl` on the server to ≥ 3× the SDK heartbeat, or
2. Lower the SDK's `channelHeartbeatInterval` in lockstep.

## Test plan

- [x] `go build ./...` clean
- [ ] Benchmark suite re-run to compare TTL=15s vs TTL=10s tail latency and cleanup ticker pressure

🤖 Generated with [Claude Code](https://claude.com/claude-code)