### PR TITLE
Log session-not-found events at info level

### DIFF
--- a/server/backend/channel/manager.go
+++ b/server/backend/channel/manager.go
@@ -19,6 +19,7 @@ package channel
 
 import (
 	"context"
+	goerrors "errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -503,11 +504,18 @@ func classifyExpiredSessions(
 func cleanUpExpiredSessions(ctx context.Context, manager *Manager, expiredSessionIDs []types.ID) int {
 	cleanedCount := 0
 	for _, id := range expiredSessionIDs {
-		if _, err := manager.Detach(ctx, id); err != nil {
-			logging.From(ctx).Warnf("detach expired session of %s: %v", id, err)
+		_, err := manager.Detach(ctx, id)
+		if err == nil {
+			cleanedCount++
 			continue
 		}
-		cleanedCount++
+		// Client may have detached the session concurrently with the cleanup
+		// tick; treat the resulting race as expected and log at info.
+		if goerrors.Is(err, ErrSessionNotFound) {
+			logging.From(ctx).Infof("detach expired session of %s: %v", id, err)
+			continue
+		}
+		logging.From(ctx).Warnf("detach expired session of %s: %v", id, err)
 	}
 	return cleanedCount
 }

--- a/server/rpc/connecthelper/errors.go
+++ b/server/rpc/connecthelper/errors.go
@@ -169,7 +169,10 @@ func badRequestFromError(err error) (*errdetails.BadRequest, bool) {
 	return br, true
 }
 
-// LogLevelOf returns logging.Level corresponding to the given connect.Error.
+// LogLevelOf returns logging.Level corresponding to the given error.
+// Recognizes both connect.Error and pkg/errors.StatusError so the logging
+// interceptor can pick the right level whether the handler returned the
+// raw status error or it was already converted to connect.Error.
 func LogLevelOf(err error) logging.Level {
 	if err == nil {
 		return logging.Debug
@@ -180,36 +183,50 @@ func LogLevelOf(err error) logging.Level {
 		return logging.Debug
 	}
 
-	// Convert to connect error to get the code
-	if connectErr := new(connect.Error); goerrors.As(err, &connectErr) {
-		switch connectErr.Code() {
-		case connect.CodeCanceled:
-			// Client canceled request - usually not an issue
-			return logging.Debug
-		case connect.CodeInvalidArgument, connect.CodeNotFound, connect.CodeAlreadyExists, connect.CodeFailedPrecondition:
-			// Client-side errors - usually expected validation or business logic errors
-			return logging.Info
-		case connect.CodeUnimplemented:
-			// Client called unsupported feature - not a server issue
-			return logging.Info
-		case connect.CodeUnauthenticated, connect.CodePermissionDenied:
-			// Security-related errors - worth noting but not alarming
-			return logging.Warn
-		case connect.CodeResourceExhausted:
-			// Rate limiting or resource issues - worth noting
-			return logging.Warn
-		case connect.CodeInternal, connect.CodeDataLoss, connect.CodeUnknown:
-			// Server-side errors - need immediate attention
-			return logging.Error
-		case connect.CodeUnavailable, connect.CodeDeadlineExceeded:
-			// Service availability issues - should be monitored
-			return logging.Error
-		default:
-			// Unknown codes - treat as potential issues
-			return logging.Warn
-		}
+	code, ok := connectCodeOf(err)
+	if !ok {
+		// For non-connect, non-StatusError errors, use warn as default
+		return logging.Warn
 	}
 
-	// For non-connect errors, use warn as default
-	return logging.Warn
+	switch code {
+	case connect.CodeCanceled:
+		// Client canceled request - usually not an issue
+		return logging.Debug
+	case connect.CodeInvalidArgument, connect.CodeNotFound, connect.CodeAlreadyExists, connect.CodeFailedPrecondition:
+		// Client-side errors - usually expected validation or business logic errors
+		return logging.Info
+	case connect.CodeUnimplemented:
+		// Client called unsupported feature - not a server issue
+		return logging.Info
+	case connect.CodeUnauthenticated, connect.CodePermissionDenied:
+		// Security-related errors - worth noting but not alarming
+		return logging.Warn
+	case connect.CodeResourceExhausted:
+		// Rate limiting or resource issues - worth noting
+		return logging.Warn
+	case connect.CodeInternal, connect.CodeDataLoss, connect.CodeUnknown:
+		// Server-side errors - need immediate attention
+		return logging.Error
+	case connect.CodeUnavailable, connect.CodeDeadlineExceeded:
+		// Service availability issues - should be monitored
+		return logging.Error
+	default:
+		// Unknown codes - treat as potential issues
+		return logging.Warn
+	}
+}
+
+// connectCodeOf extracts a connect.Code from either a wrapped connect.Error
+// or a pkg/errors.StatusError. Returns (code, true) on success.
+func connectCodeOf(err error) (connect.Code, bool) {
+	if connectErr := new(connect.Error); goerrors.As(err, &connectErr) {
+		return connectErr.Code(), true
+	}
+	if isStatusError(err) {
+		if status := errors.StatusOf(err); status != 0 {
+			return connect.Code(status), true
+		}
+	}
+	return 0, false
 }

--- a/server/rpc/connecthelper/errors_test.go
+++ b/server/rpc/connecthelper/errors_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/yorkie-team/yorkie/api/converter"
 	"github.com/yorkie-team/yorkie/pkg/errors"
+	"github.com/yorkie-team/yorkie/server/logging"
 )
 
 func TestStatus(t *testing.T) {
@@ -327,5 +328,38 @@ func TestToConnectErrorNewSystemPriority(t *testing.T) {
 		assert.True(t, ok)
 		// Should be treated as internal since it's not recognized by legacy system
 		assert.Equal(t, connect.CodeInternal, connectErr.Code())
+	})
+}
+
+func TestLogLevelOf(t *testing.T) {
+	t.Run("StatusError NotFound maps to Info", func(t *testing.T) {
+		// Raw StatusError, as returned from manager.Refresh before
+		// ToConnectError conversion in the RPC interceptor.
+		err := errors.NotFound("session not found").WithCode("ErrSessionNotFound")
+		assert.Equal(t, logging.Info, LogLevelOf(err))
+	})
+
+	t.Run("Wrapped StatusError NotFound maps to Info", func(t *testing.T) {
+		base := errors.NotFound("session not found").WithCode("ErrSessionNotFound")
+		err := fmt.Errorf("refresh %s: %w", "abc", base)
+		assert.Equal(t, logging.Info, LogLevelOf(err))
+	})
+
+	t.Run("connect.Error NotFound maps to Info", func(t *testing.T) {
+		err := connect.NewError(connect.CodeNotFound, goerrors.New("session not found"))
+		assert.Equal(t, logging.Info, LogLevelOf(err))
+	})
+
+	t.Run("StatusError Internal maps to Error", func(t *testing.T) {
+		err := errors.Internal("boom")
+		assert.Equal(t, logging.Error, LogLevelOf(err))
+	})
+
+	t.Run("Plain error falls back to Warn", func(t *testing.T) {
+		assert.Equal(t, logging.Warn, LogLevelOf(goerrors.New("unstructured")))
+	})
+
+	t.Run("Nil error returns Debug", func(t *testing.T) {
+		assert.Equal(t, logging.Debug, LogLevelOf(nil))
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

`ErrSessionNotFound` shows up in two places under normal high-concurrency
load — neither is a server problem, but both currently log at `warn` and
generate noise:

1. **RPC response path** — `manager.{Refresh,Detach,Attach}` return
   `fmt.Errorf("...: %w", ErrSessionNotFound)`, which is a
   `pkg/errors.StatusError` with `ErrCodeNotFound`. The default
   interceptor logs the raw handler error before `ToConnectError`
   converts it, so `LogLevelOf` saw a non-`*connect.Error` and fell
   through to the `warn` fallback — even though the code-to-level table
   already maps `CodeNotFound` to `info`. This surfaces in prod as:

   RPC : "/yorkie.v1.YorkieService/RefreshChannel" 11.683µs
     => "refresh 6a0fcbe57dd6e60decfd1f96: session not found"

2. **Background cleanup loop** — `cleanUpExpiredSessions` racing with a
client-driven detach surfaces as `ErrSessionNotFound` from
`manager.Detach`. The cleanup tick can't observe a session that the
client already removed; this is expected behavior, but it was logged
at `warn` regardless.

This PR addresses both:

- Extend `LogLevelOf` to also extract the `connect.Code` from
  `pkg/errors.StatusError` via a new `connectCodeOf` helper. The
  status-code → level table itself is unchanged; only the previously
  unreachable `StatusError` path is now routed through it. `pkg/errors`
  status numbers already match the gRPC / connect scheme (e.g.
  `ErrCodeNotFound` = 5 = `CodeNotFound`), and the same cast is used by
  `CodeOf` in the file.
- In `cleanUpExpiredSessions`, branch on
  `errors.Is(err, ErrSessionNotFound)` and log that case at `info`;
  unexpected detach failures still log at `warn`.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

- `connect.Error` callers are unaffected; the first branch of
  `connectCodeOf` is the original `errors.As` lookup.
- Other client-side `StatusError`s (`InvalidArgument`, `AlreadyExists`,
  `FailedPrecondition`, `Unimplemented`) returned as raw status errors
  also benefit and now log at `info`, but the user-visible motivation
  here is the `session not found` warn noise.
- `manager.Detach` currently only returns `ErrSessionNotFound`-wrapped
  errors, but the explicit `errors.Is` branch in `cleanUpExpiredSessions`
  keeps the warn fallback intact for any future failure modes.

**Does this PR introduce a user-facing change?**:

```release-note
Log expected `session not found` events at `info` instead of `warn`,
both on the RPC response path (`Refresh`/`Detach`/`Attach`) and inside
the background expired-session cleanup loop.
```

Additional documentation:



**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for concurrent operations to properly manage expected race conditions.

* **Refactor**
  * Enhanced error severity mapping for more comprehensive error classification.

* **Tests**
  * Added test coverage for error logging behavior across different error types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yorkie-team/yorkie/pull/1814?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->