### PR TITLE
Fix flaky leadership revocation and LRU hit-rate tests

### DIFF
--- a/docs/tasks/active/20260527-clusternodes-flaky-test-lessons.md
+++ b/docs/tasks/active/20260527-clusternodes-flaky-test-lessons.md
@@ -60,6 +60,48 @@ disconnect switch, narrowing the race window from
 when you compare a captured value against a live one, capture the
 captured value as close to the change-of-state as possible.
 
+## A test cache size below the shard count is a process-dependent flake
+
+`pkg/cache.LRU` is sharded across 16 fixed shards, with per-shard
+capacity computed as `size / numShards` and floored at 1. A test that
+constructs the cache with `size=5` therefore gets a 16-shard cache
+with one slot per shard — a 16-slot pool with the strict additional
+constraint that no shard may hold more than one entry.
+
+The shard mapping is `maphash.Comparable(hashSeed, key)`, and
+`hashSeed` is initialized once per process via `maphash.MakeSeed()`.
+That means: within a single process the shard assignment is stable
+(so `-count=N` cannot reproduce the flake), but across processes it
+is random. Three keys hashed into 16 shards with seed-determined
+positions have probability `1 − (16·15·14)/16³ ≈ 18%` of producing at
+least one collision, which on a single-slot shard is an eviction.
+
+`go test` caches results aggressively, so the apparent stability under
+`-count=N` or `for ... go test` loops is misleading. Reproducing this
+class of flake requires `go clean -testcache` (or matching) between
+iterations so each iteration is a fresh process with a fresh seed.
+
+**Rule**: when a test under `pkg/cache` (or any sharded structure)
+sizes the cache, the size must be chosen with the shard count in mind.
+Pick a size such that per-shard capacity is at least the number of
+keys you expect to coexist, otherwise hash collisions become silent
+test fragility.
+
+## `go test` result caching can hide process-seed-dependent flakes
+
+`go test ./pkg/cache -count=100` produces 100 identical results because
+the cache key is `(package, source, env)` and not "actual stochastic
+output". Even worse, `for i in 1..N; do go test ...; done` without
+`go clean -testcache` between iterations also reuses the cached
+result. The flake only surfaces when the seed is regenerated, which
+happens at process start, which happens when `go test` actually
+re-runs (cache miss).
+
+**Rule**: when debugging a flake that varies across CI runs but not
+local re-runs, suspect `go test` caching. Use `go clean -testcache`
+between iterations or check for randomized seeds in package-level
+`var` declarations.
+
 ## `assert.Eventually` timeout should cover the slowest legitimate path
 
 The original 1s timeout was tight against the worst-case acquire delay

--- a/docs/tasks/active/20260527-clusternodes-flaky-test-lessons.md
+++ b/docs/tasks/active/20260527-clusternodes-flaky-test-lessons.md
@@ -1,0 +1,78 @@
+**Created**: 2026-05-27
+
+# ClusterNodes Leadership Revocation Flaky Test — Lessons
+
+## Check whether a recent production change redefined the invariant the test asserts
+
+The test was written assuming that "DB reconnect → next cycle → new
+lease token". #1804 ("Skip leadership write when active leader exists")
+later added a `CountDocuments` pre-check that intentionally counts the
+caller's own row, so a node with no in-memory lease but a still-valid
+row in MongoDB waits for natural expiry instead of racing to refresh.
+The test was not updated, and the small window between `updated_at`
+expiry (200ms) and lease expiry (300ms) became a race that surfaced
+intermittently.
+
+**Rule**: when a test starts flaking after a production change, read
+the commit that touched the relevant invariant before adjusting the
+test. The test's wrong assumption may have been correct against the
+old behavior.
+
+## In-memory and on-disk leadership state can diverge
+
+`becomeFollower()` clears `isLeader` and `lease` in memory but does
+not touch MongoDB. The on-disk row keeps `is_leader=true` and the old
+`lease_token` until the lease expires or another node takes over.
+`FindClusterNodes` filters by `updated_at` window, so the row becomes
+invisible without being cleared, and `updateClusterFollower`'s
+`$setOnInsert` clause means a re-floated row is silently restored to
+visibility with its old leadership fields intact.
+
+When the predicate is "leader exists and looks healthy", a resurfaced
+stale row trivially passes it. The fix was to widen the predicate to
+include "and the token is different from what we last saw", which is
+the property the test actually wanted to assert.
+
+## Strengthen `Eventually` predicates with the property you are testing, not just liveness
+
+The original predicate `len(infos) > 0 && infos[0].IsLeader` is true
+for any leader-looking row, including a stale one. Adding
+`infos[0].LeaseToken != prvToken` makes the predicate match the test's
+intent: "a new leadership was acquired", not just "there is a leader".
+
+The general pattern: if the test is verifying that state X changed,
+the `Eventually` predicate should check for the change, not for the
+post-change state alone. Otherwise a stuck pre-state that happens to
+look like post-state passes.
+
+## Snapshot timing matters when comparing against a live value
+
+The first version of the fix captured `prvToken` from the result of
+the first `Eventually`, but `Eventually`'s predicate read MongoDB at
+some earlier point and a renewal cycle could have rotated the token
+between that read and `SetDisconnected(true)`. A resurfaced stale row
+holding the post-read token would then satisfy `LeaseToken != prvToken`
+falsely.
+
+The fix is to re-read the live row immediately before flipping the
+disconnect switch, narrowing the race window from
+`~renewalInterval` (100ms) to a few microseconds. The general rule:
+when you compare a captured value against a live one, capture the
+captured value as close to the change-of-state as possible.
+
+## `assert.Eventually` timeout should cover the slowest legitimate path
+
+The original 1s timeout was tight against the worst-case acquire delay
+after reconnect:
+
+```
+worst case = renewalInterval (renewal phase) + leaseDuration
+           + renewalInterval (acquire cycle) + window (200ms for row
+             to reappear in FindClusterNodes) + polling jitter (50ms)
+         ≈ 750ms
+```
+
+That left little headroom for GC pauses or MongoDB latency on loaded
+CI. Bumping to 2s is generous but defensible. The rule is to size the
+timeout from the slowest legitimate path the system is allowed to
+take, not from the median.

--- a/docs/tasks/active/20260527-clusternodes-flaky-test-lessons.md
+++ b/docs/tasks/active/20260527-clusternodes-flaky-test-lessons.md
@@ -90,8 +90,9 @@ test fragility.
 ## `go test` result caching can hide process-seed-dependent flakes
 
 `go test ./pkg/cache -count=100` produces 100 identical results because
-the cache key is `(package, source, env)` and not "actual stochastic
-output". Even worse, `for i in 1..N; do go test ...; done` without
+the cache key is `(package, source, env, flags)` and not "actual
+stochastic output". Even worse, `for i in 1..N; do go test ...; done`
+without
 `go clean -testcache` between iterations also reuses the cached
 result. The flake only surfaces when the seed is regenerated, which
 happens at process start, which happens when `go test` actually

--- a/docs/tasks/active/20260527-clusternodes-flaky-test-todo.md
+++ b/docs/tasks/active/20260527-clusternodes-flaky-test-todo.md
@@ -1,0 +1,54 @@
+**Created**: 2026-05-27
+
+# ClusterNodes Leadership Revocation Flaky Test
+
+Branch: `fix-clusternodes-flaky-test`
+
+## Goal
+
+Eliminate the ~25–35% flake rate of
+`TestClusterNodes/Leadership_revocation_and_reacquisition_after_temporary_DB_disconnection_test`
+without touching production code, since the underlying behavior was
+deliberately introduced by #1804 and the test's assumption was the
+incorrect side.
+
+## Done
+
+- [x] Root-cause investigation:
+  - [x] Confirm `becomeFollower()` only mutates in-memory state and does
+        not clean up the node's own row in MongoDB
+  - [x] Confirm `tryAcquireLeadership` pre-check counts the caller's own
+        row as an active leader (intentional per #1804)
+  - [x] Confirm `updateClusterFollower` uses `$setOnInsert`, so a
+        re-floated row keeps the old `lease_token` and `is_leader=true`
+  - [x] Confirm the race window: `updated_at` window (200ms) expires
+        before lease (300ms), so the test reconnects while the old lease
+        is still considered active
+- [x] Test fix in `test/integration/clusternodes_test.go`:
+  - [x] Strengthen second `Eventually` predicate with
+        `infos[0].LeaseToken != prvToken`
+  - [x] Bump second `Eventually` timeout from 1s to 2s to cover natural
+        lease expiry plus next renewal cycle
+  - [x] Add NOTE comment explaining the design constraint
+  - [x] Re-read leader immediately before `SetDisconnected(true)` so
+        `prvToken` reflects MongoDB's live value (eliminates the
+        secondary race noted in self-review)
+- [x] Verify: 30 consecutive runs of the subtest pass; 3× full
+      `TestClusterNodes` pass; `make lint` clean
+- [x] Self-review via code-review subagent (no Critical/Important; one
+      Minor applied)
+
+## Remaining
+
+- [ ] PR review and merge
+
+## Notes
+
+- Production code is intentionally not modified. #1804 explicitly
+  documents that a node with empty in-memory token waits for natural
+  lease expiry instead of racing to refresh, to preserve the
+  "at most one process believes it holds the lease" invariant.
+- A future enhancement could let a node skip the wait for its own row
+  (e.g., exclude `rpc_addr == self` from the pre-check, or have
+  `becomeFollower` clear the row), but that would touch a recently
+  hardened code path and needs its own design discussion.

--- a/docs/tasks/active/20260527-clusternodes-flaky-test-todo.md
+++ b/docs/tasks/active/20260527-clusternodes-flaky-test-todo.md
@@ -1,16 +1,25 @@
 **Created**: 2026-05-27
 
-# ClusterNodes Leadership Revocation Flaky Test
+# Flaky Test Fixes: Leadership Revocation and LRU Hit Rate
 
 Branch: `fix-clusternodes-flaky-test`
 
 ## Goal
 
-Eliminate the ~25–35% flake rate of
-`TestClusterNodes/Leadership_revocation_and_reacquisition_after_temporary_DB_disconnection_test`
-without touching production code, since the underlying behavior was
-deliberately introduced by #1804 and the test's assumption was the
-incorrect side.
+Eliminate two pre-existing flakes in the test suite, both caused by
+tests making assumptions that hold only under specific timing or
+hashing luck. No production code changes.
+
+1. `TestClusterNodes/Leadership_revocation_and_reacquisition_after_temporary_DB_disconnection_test`
+   flaked ~25–35% due to a race between `FindClusterNodes`'s
+   `updated_at` window (200ms) and `lease_duration` (300ms), combined
+   with the intentional "wait for natural expiry" behavior added in
+   #1804.
+2. `TestLRUWithStats/hit_rate_calculation` flaked ~18% due to using a
+   cache size smaller than the shard count (sharded LRU floors
+   per-shard capacity at 1; `maphash` randomizes shard mapping per
+   process so hash collisions between the three added keys cause
+   evictions in ~18% of CI runs).
 
 ## Done
 
@@ -37,6 +46,20 @@ incorrect side.
       `TestClusterNodes` pass; `make lint` clean
 - [x] Self-review via code-review subagent (no Critical/Important; one
       Minor applied)
+- [x] LRU hit-rate flake investigation:
+  - [x] Confirm sharded structure (`numShards = 16`) and per-shard
+        flooring in `pkg/cache/lru_with_stats.go:40-60`
+  - [x] Confirm `var hashSeed = maphash.MakeSeed()` randomizes per
+        process, explaining CI-only flake
+  - [x] Reproduce locally with `go clean -testcache` between fresh
+        runs: 6/30 fail (20%, matches the 18% theoretical rate)
+- [x] LRU hit-rate fix in `pkg/cache/cache_test.go`:
+  - [x] Bump test cache size from 5 → 64 so per-shard capacity (4) is
+        large enough to hold all three added keys even on worst-case
+        shard collision
+  - [x] Comment explains the sharded sizing constraint
+- [x] Verify LRU fix: 30/30 fresh processes pass; full `pkg/cache`
+      package green; `make lint` clean
 
 ## Remaining
 

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -51,7 +51,13 @@ func TestLRUWithStats(t *testing.T) {
 	})
 
 	t.Run("hit rate calculation", func(t *testing.T) {
-		c, err := cache.NewLRU[string, int](5, "test-cache")
+		// LRU is sharded across 16 shards with per-shard capacity size/16
+		// (floored at 1). With size=5, each shard held one slot, so any
+		// two of the added keys that hashed to the same shard would evict
+		// each other. maphash.MakeSeed randomizes the shard mapping per
+		// process, producing ~18% flake rate. Size 64 gives perShard=4,
+		// enough to hold all three added keys even on worst-case collision.
+		c, err := cache.NewLRU[string, int](64, "test-cache")
 		assert.NoError(t, err)
 
 		// Add some data

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -29,6 +29,9 @@ import (
 
 func TestLRUWithStats(t *testing.T) {
 	t.Run("basic operations", func(t *testing.T) {
+		// Only one key is added, so shard collisions cannot evict
+		// anything; if a second key is ever added here, raise size to
+		// at least 16*N (see the sibling subtest for the reasoning).
 		c, err := cache.NewLRU[string, int](3, "test-cache")
 		assert.NoError(t, err)
 

--- a/test/integration/clusternodes_test.go
+++ b/test/integration/clusternodes_test.go
@@ -227,7 +227,17 @@ func TestClusterNodes(t *testing.T) {
 
 			return false
 		}, 1*gotime.Second, 50*gotime.Millisecond)
-		prvToken := leader.LeaseToken
+
+		// Re-read the leader immediately before disconnect so prvToken reflects
+		// the latest renewal in MongoDB. Without this, a renewal that fires
+		// between the Eventually read and SetDisconnected leaves the captured
+		// token stale, which can let a resurfaced stale row falsely satisfy the
+		// "LeaseToken != prvToken" predicate below.
+		infos, err := svr.Backend().ClusterNodes(ctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, infos)
+		require.True(t, infos[0].IsLeader)
+		prvToken := infos[0].LeaseToken
 
 		mockDB.SetDisconnected(true)
 
@@ -240,17 +250,22 @@ func TestClusterNodes(t *testing.T) {
 
 		mockDB.SetDisconnected(false)
 
+		// NOTE: After reconnect, the node must wait for its own previous lease
+		// to expire naturally before it can reacquire leadership with a new
+		// token. The acquire pre-check in TryLeadership counts the caller's
+		// own row as an active leader, so the predicate also requires a token
+		// change to confirm reacquisition rather than a stale row resurfacing.
 		assert.Eventually(t, func() bool {
 			infos, err := svr.Backend().ClusterNodes(ctx)
 			require.NoError(t, err)
 
-			if len(infos) > 0 && infos[0].IsLeader {
+			if len(infos) > 0 && infos[0].IsLeader && infos[0].LeaseToken != prvToken {
 				leader = infos[0]
 				return true
 			}
 
 			return false
-		}, 1*gotime.Second, 50*gotime.Millisecond)
+		}, 2*gotime.Second, 50*gotime.Millisecond)
 		currToken := leader.LeaseToken
 
 		assert.NotEqual(t, prvToken, currToken)


### PR DESCRIPTION
## Summary

Fix two pre-existing flaky tests, both caused by tests relying on assumptions that only hold under specific timing or hashing luck. Production code unchanged in both cases.

### 1. `TestClusterNodes/Leadership_revocation...` (~25–35% flake)

After #1804 added a pre-check that counts the caller's own row as an active leader, a node that loses in-memory lease on DB disconnect intentionally waits for natural lease expiry before reacquiring. The test assumed immediate new-token reacquisition, so it could observe a resurfaced stale row (same `lease_token`, `is_leader=true`) and fail `assert.NotEqual(prvToken, currToken)`. Also observed on an unrelated dependabot PR.

**Fix:** strengthen the post-reconnect `Eventually` predicate with `LeaseToken != prvToken`, bump its timeout to 2s, and re-read the live leader immediately before `SetDisconnected(true)` so `prvToken` reflects MongoDB's latest renewal.

### 2. `TestLRUWithStats/hit_rate_calculation` (~18% flake)

`pkg/cache.LRU` is sharded across 16 fixed shards with per-shard capacity floored at 1, so the test's `size=5` cache had one slot per shard. The shard mapping uses `maphash` with a process-scoped random seed; three keys hashed into 16 shards collide with probability ~18%, and on a single-slot shard a collision evicts the older entry, observed as expected 3 hits/2 misses vs actual 2/3. Hidden locally by `go test` result caching (within one process the seed is fixed; iterations reuse the cached result).

**Fix:** bump the test cache size to 64 so per-shard capacity is 4 — enough to hold all three added keys even on worst-case shard collision.

## Test plan

- [x] `go test -tags integration -run 'TestClusterNodes/Leadership_revocation' -count=30 ./test/integration/` — 30/30 pass
- [x] `go test -tags integration -run 'TestClusterNodes' -count=3 ./test/integration/` — 18/18 pass (no regressions in other subtests)
- [x] LRU fix repro: 30 fresh processes with `go clean -testcache` between each — 30/30 pass (was 6/30 fail before fix)
- [x] `go test ./pkg/cache/` — 8/8 pass
- [x] `make lint` — clean
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced intermittent CI flakes causing false leader reappearance and cache hit‑rate instability.

* **Tests**
  * Made post-disconnect reacquisition checks require a changed lease token and increased timeouts; increased test cache size to avoid shard-collision flakiness.

* **Documentation**
  * Added investigation notes, verification results, guidance on asserting state transitions, timing adjustments, cache sizing, and avoiding seed-dependent test caching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yorkie-team/yorkie/pull/1820?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->