### PR TITLE
fix(mongo): avoid getMore by sizing cursor batch to query limit

### DIFF
--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -1344,7 +1344,10 @@ func (c *Client) FindActiveClients(
 	cursor, err := c.collection(ColClients).Find(ctx, bson.M{
 		"_id":    bson.M{"$gt": lastClientID},
 		"status": database.ClientActivated,
-	}, options.Find().SetSort(bson.M{"_id": 1}).SetLimit(int64(candidatesLimit)))
+	}, options.Find().
+		SetSort(bson.M{"_id": 1}).
+		SetLimit(int64(candidatesLimit)).
+		SetBatchSize(int32(candidatesLimit)))
 	if err != nil {
 		return nil, database.ZeroID, fmt.Errorf("find active clients: %w", err)
 	}
@@ -1792,7 +1795,10 @@ func (c *Client) FindProjectInfosForRefresh(
 	cursor, err := c.collection(ColProjects).Find(
 		ctx,
 		filter,
-		options.Find().SetSort(bson.M{"_id": 1}).SetLimit(int64(limit)),
+		options.Find().
+			SetSort(bson.M{"_id": 1}).
+			SetLimit(int64(limit)).
+			SetBatchSize(int32(limit)),
 	)
 	if err != nil {
 		return nil, database.ZeroID, fmt.Errorf("find projects for refresh: %w", err)
@@ -2100,7 +2106,10 @@ func (c *Client) FindChangeInfosBetweenServerSeqs(
 				"doc_id":     docRefKey.DocID,
 				"server_seq": bson.M{"$gte": current, "$lte": to},
 			}
-			opts := options.Find().SetSort(bson.D{{Key: "server_seq", Value: 1}}).SetLimit(chunkSize)
+			opts := options.Find().
+				SetSort(bson.D{{Key: "server_seq", Value: 1}}).
+				SetLimit(chunkSize).
+				SetBatchSize(int32(chunkSize))
 			cursor, err := c.collection(ColChanges).Find(ctx, filter, opts)
 			if err != nil {
 				return nil, fmt.Errorf("find changes of %s: %w", docRefKey, err)


### PR DESCRIPTION
**What this PR does / why we need it**:

Three paginated `Find` calls — `FindActiveClients` (deactivation
housekeeping), `FindProjectInfosForRefresh` (project-stats refresh
loop introduced in #1819), and the changes fetch inside
`FindChangeInfosBetweenServerSeqs` — set `SetLimit()` but not
`SetBatchSize()`. The mongo Go driver defaults to batch size 101,
so any result set larger than 101 forces a follow-up `getMore`
round-trip after the initial `find` reply.

In a sharded mongos cluster, an intermittent `CursorNotFound` on
that `getMore` was observed in dev:

```
decode projects for refresh: (CursorNotFound) Cursor not found (id: ...)
fetch active clients:        (CursorNotFound) Cursor not found (id: ...)
fetch changes of Document (...): (CursorNotFound) Cursor not found (...)
```

Whenever it hit `RefreshStats` it dropped the whole 5-minute
project-stats cycle (the function returns early without advancing
`statsState`), and the same getMore pattern surfaces on the
deactivation tick and on admin `GetDocuments`.

This PR makes the initial server reply already contain the whole
page by adding `SetBatchSize(int32(limit))` to each of the three
calls. With `cursorId == 0` on the first reply, the driver never
issues a `getMore`, so the failure mode disappears regardless of
its underlying cause.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

- The three call sites already cap their result set with `SetLimit`,
  so matching `BatchSize` to `Limit` does not change semantics —
  it just removes an unnecessary network round-trip when the page
  is already bounded.
- Each call site processes individually small documents
  (`projectInfo`, `clientInfo`, `changeInfo`) and `Limit` is in the
  hundreds (`CandidatesLimit` defaults to 500, the changes chunk
  is 1000), so the resulting first batch stays well under the
  16MB wire-protocol cap.
- The exact root cause of cursor invalidation between `find` and
  `getMore` in a sharded mongos topology is not fully diagnosed —
  candidates include cursor-to-connection pinning being lost
  across pool rotations, mongos failover, or balancer-driven
  cursor cleanup. This PR is intentionally a code-level fix: it
  removes the unnecessary `getMore` rather than chasing the
  cluster-level cause, because for these bounded queries
  `cursor.All` drains immediately and the original code never
  benefited from streaming.
- Verified in a dev environment with 134 projects (default
  pre-fix batch 101 → 2-batch path):

  | Window      | Pre-fix (main) | Post-fix (this PR)                    |
  | ----------- | -------------- | ------------------------------------- |
  | 30 min      | 9 CursorNotFound, 2 dropped project-stats cycles | 0 CursorNotFound, 3 consecutive successful cycles (10-min cadence) |
  | RefreshStats first tick after leadership | failed (CursorNotFound) | succeeded (134/134 in ~450ms)          |

**Does this PR introduce a user-facing change?**:

```release-note
Fix intermittent `CursorNotFound` errors from paginated housekeeping
queries (`FindActiveClients`, `FindProjectInfosForRefresh`,
`FindChangeInfosBetweenServerSeqs`) on sharded mongos clusters by
sizing the cursor batch to match the query limit, eliminating the
follow-up `getMore` round-trip.
```

**Additional documentation**:

```docs
```

**Checklist**:

- [x] Added relevant tests or not required (semantics unchanged; existing tests still cover correctness)
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything (verified in dev: 3 consecutive RefreshStats ticks succeeded with 0 CursorNotFound)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized database query performance by configuring batch size settings for improved efficiency in data retrieval operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yorkie-team/yorkie/pull/1821?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->