### PR TITLE
Add disable_gc opt-out for GC-free attach workloads

### DIFF
--- a/api/yorkie/v1/yorkie.pb.go
+++ b/api/yorkie/v1/yorkie.pb.go
@@ -221,10 +221,15 @@ func (*DeactivateClientResponse) Descriptor() ([]byte, []int) {
 }
 
 type AttachDocumentRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	ClientId      string                 `protobuf:"bytes,1,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
-	ChangePack    *ChangePack            `protobuf:"bytes,2,opt,name=change_pack,json=changePack,proto3" json:"change_pack,omitempty"`
-	SchemaKey     string                 `protobuf:"bytes,3,opt,name=schema_key,json=schemaKey,proto3" json:"schema_key,omitempty"`
+	state      protoimpl.MessageState `protogen:"open.v1"`
+	ClientId   string                 `protobuf:"bytes,1,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
+	ChangePack *ChangePack            `protobuf:"bytes,2,opt,name=change_pack,json=changePack,proto3" json:"change_pack,omitempty"`
+	SchemaKey  string                 `protobuf:"bytes,3,opt,name=schema_key,json=schemaKey,proto3" json:"schema_key,omitempty"`
+	// disable_gc declares that this attachment will not produce or consume
+	// tombstones. The server skips minVV tracking and omits the response
+	// VersionVector for this client. Use only with Counter / primitive
+	// workloads; misuse leads to undefined GC behavior on this client.
+	DisableGc     bool `protobuf:"varint,4,opt,name=disable_gc,json=disableGc,proto3" json:"disable_gc,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -278,6 +283,13 @@ func (x *AttachDocumentRequest) GetSchemaKey() string {
 		return x.SchemaKey
 	}
 	return ""
+}
+
+func (x *AttachDocumentRequest) GetDisableGc() bool {
+	if x != nil {
+		return x.DisableGc
+	}
+	return false
 }
 
 type AttachDocumentResponse struct {
@@ -1618,11 +1630,17 @@ func (x *RemoveDocumentResponse) GetChangePack() *ChangePack {
 }
 
 type PushPullChangesRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	ClientId      string                 `protobuf:"bytes,1,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
-	DocumentId    string                 `protobuf:"bytes,2,opt,name=document_id,json=documentId,proto3" json:"document_id,omitempty"`
-	ChangePack    *ChangePack            `protobuf:"bytes,3,opt,name=change_pack,json=changePack,proto3" json:"change_pack,omitempty"`
-	PushOnly      bool                   `protobuf:"varint,4,opt,name=push_only,json=pushOnly,proto3" json:"push_only,omitempty"`
+	state      protoimpl.MessageState `protogen:"open.v1"`
+	ClientId   string                 `protobuf:"bytes,1,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
+	DocumentId string                 `protobuf:"bytes,2,opt,name=document_id,json=documentId,proto3" json:"document_id,omitempty"`
+	ChangePack *ChangePack            `protobuf:"bytes,3,opt,name=change_pack,json=changePack,proto3" json:"change_pack,omitempty"`
+	PushOnly   bool                   `protobuf:"varint,4,opt,name=push_only,json=pushOnly,proto3" json:"push_only,omitempty"`
+	// disable_gc declares that this PushPull will not produce or consume
+	// tombstones. The server skips minVV tracking and omits the response
+	// VersionVector. Clients that attached with disable_gc=true must keep
+	// setting this on every subsequent PushPullChanges. See
+	// docs/design/disable-gc-on-attach.md.
+	DisableGc     bool `protobuf:"varint,5,opt,name=disable_gc,json=disableGc,proto3" json:"disable_gc,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1681,6 +1699,13 @@ func (x *PushPullChangesRequest) GetChangePack() *ChangePack {
 func (x *PushPullChangesRequest) GetPushOnly() bool {
 	if x != nil {
 		return x.PushOnly
+	}
+	return false
+}
+
+func (x *PushPullChangesRequest) GetDisableGc() bool {
+	if x != nil {
+		return x.DisableGc
 	}
 	return false
 }
@@ -2769,13 +2794,15 @@ const file_yorkie_v1_yorkie_proto_rawDesc = "" +
 	"\x17DeactivateClientRequest\x12\x1b\n" +
 	"\tclient_id\x18\x01 \x01(\tR\bclientId\x12 \n" +
 	"\vsynchronous\x18\x02 \x01(\bR\vsynchronous\"\x1a\n" +
-	"\x18DeactivateClientResponse\"\x8b\x01\n" +
+	"\x18DeactivateClientResponse\"\xaa\x01\n" +
 	"\x15AttachDocumentRequest\x12\x1b\n" +
 	"\tclient_id\x18\x01 \x01(\tR\bclientId\x126\n" +
 	"\vchange_pack\x18\x02 \x01(\v2\x15.yorkie.v1.ChangePackR\n" +
 	"changePack\x12\x1d\n" +
 	"\n" +
-	"schema_key\x18\x03 \x01(\tR\tschemaKey\"\xd8\x01\n" +
+	"schema_key\x18\x03 \x01(\tR\tschemaKey\x12\x1d\n" +
+	"\n" +
+	"disable_gc\x18\x04 \x01(\bR\tdisableGc\"\xd8\x01\n" +
 	"\x16AttachDocumentResponse\x12\x1f\n" +
 	"\vdocument_id\x18\x01 \x01(\tR\n" +
 	"documentId\x126\n" +
@@ -2870,14 +2897,16 @@ const file_yorkie_v1_yorkie_proto_rawDesc = "" +
 	"changePack\"P\n" +
 	"\x16RemoveDocumentResponse\x126\n" +
 	"\vchange_pack\x18\x01 \x01(\v2\x15.yorkie.v1.ChangePackR\n" +
-	"changePack\"\xab\x01\n" +
+	"changePack\"\xca\x01\n" +
 	"\x16PushPullChangesRequest\x12\x1b\n" +
 	"\tclient_id\x18\x01 \x01(\tR\bclientId\x12\x1f\n" +
 	"\vdocument_id\x18\x02 \x01(\tR\n" +
 	"documentId\x126\n" +
 	"\vchange_pack\x18\x03 \x01(\v2\x15.yorkie.v1.ChangePackR\n" +
 	"changePack\x12\x1b\n" +
-	"\tpush_only\x18\x04 \x01(\bR\bpushOnly\"Q\n" +
+	"\tpush_only\x18\x04 \x01(\bR\bpushOnly\x12\x1d\n" +
+	"\n" +
+	"disable_gc\x18\x05 \x01(\bR\tdisableGc\"Q\n" +
 	"\x17PushPullChangesResponse\x126\n" +
 	"\vchange_pack\x18\x01 \x01(\v2\x15.yorkie.v1.ChangePackR\n" +
 	"changePack\"\x8d\x01\n" +

--- a/api/yorkie/v1/yorkie.proto
+++ b/api/yorkie/v1/yorkie.proto
@@ -72,6 +72,11 @@ message AttachDocumentRequest {
   string client_id = 1;
   ChangePack change_pack = 2;
   string schema_key = 3;
+  // disable_gc declares that this attachment will not produce or consume
+  // tombstones. The server skips minVV tracking and omits the response
+  // VersionVector for this client. Use only with Counter / primitive
+  // workloads; misuse leads to undefined GC behavior on this client.
+  bool disable_gc = 4;
 }
 
 message AttachDocumentResponse {
@@ -211,6 +216,12 @@ message PushPullChangesRequest {
   string document_id = 2;
   ChangePack change_pack = 3;
   bool push_only = 4;
+  // disable_gc declares that this PushPull will not produce or consume
+  // tombstones. The server skips minVV tracking and omits the response
+  // VersionVector. Clients that attached with disable_gc=true must keep
+  // setting this on every subsequent PushPullChanges. See
+  // docs/design/disable-gc-on-attach.md.
+  bool disable_gc = 5;
 }
 
 message PushPullChangesResponse {

--- a/client/attachment.go
+++ b/client/attachment.go
@@ -56,6 +56,12 @@ type Attachment struct {
 	syncMode            SyncMode
 	changeEventReceived bool
 	lastSyncTime        gotime.Time
+
+	// disableGC is set when the document was attached with
+	// WithDisableGC. The client sets the matching wire field on every
+	// PushPullChanges so the server can skip minVV tracking and omit the
+	// response VersionVector. See docs/design/disable-gc-on-attach.md.
+	disableGC bool
 }
 
 func (a *Attachment) Is(resourceType attachable.ResourceType) bool {

--- a/client/client.go
+++ b/client/client.go
@@ -491,6 +491,7 @@ func (c *Client) attachDocument(ctx context.Context, d *document.Document, opts 
 			ClientId:   c.id.String(),
 			ChangePack: pbChangePack,
 			SchemaKey:  opts.Schema,
+			DisableGc:  opts.DisableGC,
 		}), c.options.APIKey, d.Key().String()),
 	)
 	if err != nil {
@@ -540,6 +541,7 @@ func (c *Client) attachDocument(ctx context.Context, d *document.Document, opts 
 		closeWatchStream:    cancelFunc,
 		syncMode:            syncMode,
 		changeEventReceived: false,
+		disableGC:           opts.DisableGC,
 	})
 	if opts.IsRealtime {
 		if err = c.runWatchLoop(watchCtx, d); err != nil {
@@ -1068,6 +1070,7 @@ func (c *Client) pushPullChanges(ctx context.Context, opt SyncOptions) error {
 			DocumentId: attachment.resourceID.String(),
 			ChangePack: pbChangePack,
 			PushOnly:   opt.mode == types.SyncModePushOnly,
+			DisableGc:  attachment.disableGC,
 		}), c.options.APIKey, opt.key.String()))
 	if err != nil {
 		return err

--- a/client/options.go
+++ b/client/options.go
@@ -136,6 +136,12 @@ type AttachOptions struct {
 	Presence    presence.Data
 	InitialRoot yson.Object
 	Schema      string
+
+	// DisableGC declares that this attachment will not produce or consume
+	// tombstones. The server skips minVV tracking and omits the response
+	// VersionVector for this client. Use only with Counter / primitive
+	// workloads; misuse leads to undefined GC behavior on this client.
+	DisableGC bool
 }
 
 // WithRealtimeSync configures the manual sync of the client.
@@ -160,6 +166,19 @@ func WithInitialRoot(root yson.Object) AttachOption {
 // WithSchema configures the schema of the document.
 func WithSchema(schema string) AttachOption {
 	return func(o *AttachOptions) { o.Schema = schema }
+}
+
+// WithDisableGC declares that this attachment will not produce or consume
+// tombstones. The server skips minVV tracking and omits the response
+// VersionVector for this client. Use only with Counter / primitive
+// workloads; misuse leads to undefined GC behavior on this client. See
+// docs/design/disable-gc-on-attach.md.
+//
+// This option controls the wire contract with the server. It is distinct
+// from the package-level document.WithDisableGC option, which disables
+// the document's local GC pass regardless of what the server sends.
+func WithDisableGC() AttachOption {
+	return func(o *AttachOptions) { o.DisableGC = true }
 }
 
 // AttachChannelOption configures AttachChannelOptions.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -18,6 +18,7 @@ New design documents should be based on [TEMPLATE.md](TEMPLATE.md).
 - [Tree Split Undo/Redo](tree-split-undo-redo.md): Boundary-deletion reverse ops for `Tree.Edit` with `splitLevel >= 1` plus pre-tombstoned descendant filtering
 - [VersionVector](version-vector.md): VersionVector for GC and Resolving conflicts in CRDT
 - [VV Cleanup](vv-cleanup.md): Remove detached client's lamport from version vectors
+- [Disable GC on Attach](disable-gc-on-attach.md): Per-attachment opt-out from VV exchange and `minVV` tracking for GC-free workloads
 - [Garbage Collection](garbage-collection.md): Removing tombstones in CRDT
 - [Garbage Collection for Text Type](gc-for-text-type.md): Garbage collection for text type CRDT
 - [GC Registration on Set Conflict](gc-registration-on-set-conflict.md): Fix missing GC registration when new element loses LWW conflict

--- a/docs/design/disable-gc-on-attach.md
+++ b/docs/design/disable-gc-on-attach.md
@@ -1,0 +1,252 @@
+---
+title: disable-gc-on-attach
+target-version: 0.7.10
+---
+
+# Disable GC on Attach
+
+## Problem
+
+`ChangePack.VersionVector` (VV) is included in every PushPull response so the
+client can run tombstone GC against the server-computed `minVV`. The VV size
+grows with the number of unique actors that have ever written to the document,
+not with the CRDT types in use.
+
+For documents that only use commutative CRDTs (Counter, primitive value
+replacement), the client never produces tombstones, so the response VV serves
+no purpose on the receiving end. Three costs are paid for nothing:
+
+1. **Response payload** — every PushPull response carries a VV of
+   `O(num_actors)` entries.
+2. **Server compute** — `UpdateMinVersionVector` is called on every PushPull;
+   it reads every attached client's stored VV and recomputes the min. For a
+   high-fan-out Counter document (live polls, telemetry, voting), this is
+   `O(num_clients * num_actors)` work per push, with the result discarded.
+3. **Server storage** — every client's VV is persisted in the
+   `versionvectors` collection even when no client consumes it.
+
+A use case driving this is high-fan-out Counter documents where dozens or
+hundreds of clients are attached at once and none of them need tombstone GC.
+
+### Goals
+
+- Let a client opt out of receiving the response VV and participating in
+  server-side `minVV` tracking, on a per-attachment basis.
+- Eliminate the server-side `UpdateMinVersionVector` cost contributed by
+  opted-out clients.
+- Stay wire-compatible: existing clients keep the current behavior.
+
+### Non-Goals
+
+- Automatic detection of "GC-free" documents. A later schema-based mechanism
+  (see [Schema Validation](schema-validation.md)) can drive the same flag, but
+  static detection is out of scope here.
+- Removing VV from `Change` IDs. Per-operation VV is required for causality
+  detection in Tree/Text/Array and is not affected.
+- Project-level toggle in the Dashboard. The flag lives on the attach call so
+  documents within the same project can mix opt-out and opt-in clients.
+
+## Design
+
+### Contract
+
+A client attaches with `disableGC = true` to declare:
+
+> "I will not produce or consume tombstones on this document. I do not need
+> the response VV, and the server does not need to track my VV for any other
+> client's GC."
+
+The server honors this declaration. It is the client's responsibility to keep
+the promise; using Tree/Text/Array deletions on a `disableGC` attachment leads
+to undefined GC behavior on that client (tombstones may not be reclaimed) and
+may cause other clients to GC tombstones this client has not yet seen.
+
+Counter, presence updates, and primitive (`LWW`) value replacement are safe.
+
+### SDK API
+
+```ts
+// JS SDK
+await client.attach(doc, { disableGC: true });
+```
+
+```go
+// Go SDK
+err := client.Attach(ctx, doc, client.WithDisableGC())
+```
+
+Default is `false`. The naming mirrors the existing server-side
+`SnapshotDisableGC` configuration, so the intent ("this attachment does not
+participate in GC") is consistent across the codebase.
+
+### Wire Protocol
+
+Add the flag to the two RPCs that drive a PushPull on behalf of an end
+client:
+
+```protobuf
+message AttachDocumentRequest {
+  string client_id = 1;
+  ChangePack change_pack = 2;
+  string schema_key = 3;
+  bool disable_gc = 4;  // NEW
+}
+
+message PushPullChangesRequest {
+  string client_id = 1;
+  string document_id = 2;
+  ChangePack change_pack = 3;
+  bool push_only = 4;
+  bool disable_gc = 5;  // NEW
+}
+```
+
+`DetachDocument` and `RemoveDocument` deliberately do not carry the flag.
+Both call PushPull at most once per session and a single extra minVV
+write at terminus is negligible; carrying the flag there would force
+clients to remember and resend it on a path that no longer matters.
+
+The fields are additive; older servers ignore them, and older clients
+never set them.
+
+### Server Behavior
+
+The flag flows through `PushPullOptions` from each RPC handler into
+`server/packs/pushpull.go`:
+
+```go
+// in yorkie_server.AttachDocument / yorkie_server.PushPullChanges
+pulled, err := packs.PushPull(ctx, s.backend, project, clientInfo, docKey, pack, packs.PushPullOptions{
+    Mode:      ...,
+    Status:    ...,
+    DisableGC: req.Msg.DisableGc,
+})
+
+// in packs.pullPack
+if opts.DisableGC {
+    resPack.VersionVector = nil
+} else {
+    minVersionVector, err := be.DB.UpdateMinVersionVector(
+        ctx, clientInfo, docInfo.RefKey(), reqPack.VersionVector,
+    )
+    if err != nil {
+        return nil, err
+    }
+    if resPack.SnapshotLen() == 0 {
+        resPack.VersionVector = minVersionVector
+    }
+}
+```
+
+The flag is **not persisted** on `ClientDocInfo` or anywhere else on the
+server. Each PushPull reads it from the request alone. The cost is one
+bool per request; the savings are no schema field, no migration, no
+cache invalidation logic, and no risk of persisted state drifting out
+of sync with client intent.
+
+Two effects:
+
+1. **No write to `versionvectors`** for this client. The server never stores
+   the opt-out client's VV, so it does not appear in any future
+   `GetMinVersionVector` query.
+2. **`minVV` is computed over participating clients only.** Non-opted-out
+   clients see a `minVV` that ignores opt-out attachments, which is correct
+   because opted-out clients will not consume tombstones — there is no need
+   to keep tombstones alive for them.
+
+`GetMinVersionVector` already returns the min over the rows present in
+`versionvectors`. Because we never insert rows for opted-out clients, the
+existing query is correct without modification.
+
+The request-side `reqPack.VersionVector` from an opt-out client may be empty;
+the server does not read it for any other purpose, so this is safe.
+
+### Client Behavior
+
+Opted-out client (this iteration):
+
+- Sends `disable_gc = true` in `AttachDocumentRequest`.
+- Continues to maintain its own per-change VV for causality of operations it
+  produces — `disableGC` controls GC participation, not change construction.
+  For Counter-only workloads this VV stays trivial.
+- Receives an empty `VersionVector` in the response. Calling
+  `GarbageCollect(emptyVV)` is a safe no-op (no key meets the threshold),
+  so no client-side change is required for correctness in this iteration.
+
+Deferred client-side optimizations (future work):
+
+- Skip serializing the request-side VV (`reqPack.VersionVector`) when the
+  attachment is opt-out. The server already does not read it for opt-out
+  clients, so the only cost today is wire bandwidth proportional to actor
+  count.
+- Skip the local `GarbageCollect` traversal entirely when the response VV
+  is empty. The current no-op behavior is correct but walks the tombstone
+  list once per pull.
+
+Opt-in (default) client behavior is unchanged.
+
+### Snapshot GC Edge Case
+
+`server/packs/pushpull.go` calls `GetMinVersionVector` inside `pullSnapshot`
+to GC tombstones from the snapshot it builds:
+
+```go
+if !be.Config.SnapshotDisableGC {
+    vector, err := be.DB.GetMinVersionVector(ctx, docInfo.RefKey(), doc.VersionVector())
+    if err != nil {
+        return nil, err
+    }
+    if _, err := doc.GarbageCollect(vector); err != nil {
+        return nil, err
+    }
+}
+```
+
+When every attached client is opted out, `versionvectors` has no rows for the
+document. `MinVersionVector` is then called with only the caller-supplied
+`doc.VersionVector()`. Because every key it contains is also the key with the
+single minimum, the result equals `doc.VersionVector()` unchanged. Snapshot
+GC therefore runs against the document's current max VV — the aggressive
+case — and collects all reclaimable tombstones in the snapshot. This falls
+out of the existing `MinVersionVector` semantics; no extra code is needed.
+
+If at least one opt-in client is attached and has pushed a VV row, that
+row's lamports anchor the min, restoring the normal (potentially
+conservative) GC behavior for clients that need to see tombstones.
+
+### Risks and Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| Client enables `disableGC` then performs tombstone-producing operations (Tree.Edit, Text.Edit, Array remove) | SDK documents the contract clearly. Misuse degrades that client's GC only; other clients' GC remains correct as long as they keep `disableGC = false`. |
+| Mixed attach states on the same document | Supported by design. Min VV is computed over participating clients; opt-out clients neither contribute to nor consume the min. Tombstone GC proceeds at the pace of the slowest opt-in client. |
+| Operator forgets the contract during code review | Schema-driven auto-application (future work, see Non-Goals) closes this. For now, the flag is per-attach and explicit in code. |
+| Backward compatibility | New proto fields are additive; older clients never set them and older servers ignore them. |
+| Client changes intent across requests | The flag is per-request. If a client sends opt-out one call and opt-in the next, each call honors the value it carried. Since the SDK derives the flag from the attachment, this is not a concern for the official client; third-party clients control their own behavior. |
+
+### Design Decisions
+
+| Decision | Reason |
+|----------|--------|
+| Per-attachment flag, not per-project | Project is a workspace boundary in Yorkie, not a schema boundary. Documents within one project can have different CRDT usage profiles. |
+| Per-request wire field, no server persistence | The flag travels on `AttachDocumentRequest` and `PushPullChangesRequest` and is read by the handler into `PushPullOptions`. The server does not persist it on `ClientDocInfo`. Persistence would add a BSON field (forever, in production data), test churn through the `AttachDocument` signature change, DeepCopy and cache-coherence updates — all to save one bool on the wire. Per-request is genuinely smaller end-to-end. |
+| Skip `UpdateMinVersionVector` entirely for opt-out PushPulls | The min over participating clients is what opt-in clients need; opt-out clients should not gate GC for others. Skipping is correct and is the main compute win. |
+| Field name `DisableGC` | Matches existing `SnapshotDisableGC` server option; describes the user-visible behavior (no GC) rather than the wire-level optimization (no VV in response). |
+| Flag is on `AttachDocumentRequest` + `PushPullChangesRequest` only | These are the two RPCs that drive a PushPull on behalf of an end client. `DetachDocument` and `RemoveDocument` call PushPull at most once per session; carrying the flag there would burden every client to track a small one-time cost. |
+| Snapshot GC uses `MinVersionVector` unchanged | When all clients are opt-out, the function returns the caller's `doc.VersionVector()` and the snapshot is GC'd aggressively. When at least one opt-in client has a stored row, that row anchors the min. Both regimes fall out of existing semantics with no extra code. |
+
+## Alternatives Considered
+
+| Alternative | Why not |
+|-------------|---------|
+| Project-level Dashboard toggle | Coarse-grained. Any non-Counter document in the project would be at risk. Project is not a schema boundary. |
+| Server auto-detects "Counter-only" document | Requires runtime tracking of CRDT type usage per document, with re-evaluation on every operation. High complexity; race-prone when types are added. Better as a future schema-driven optimization. |
+| Persist `disable_gc` on `ClientDocInfo` | Conceptually clean — set once, read everywhere — but ends up touching the schema, the `AttachDocument` signature, ~30 test call sites, DeepCopy, the memory and mongo `UpdateClientInfoAfterPushPull` paths, and the mongo client cache equality check. The per-request alternative carries 1 bool on the wire and touches none of that. |
+| Per-request flag in `ChangePack` | The `ChangePack` is a payload object shared by many flows; sticking the wire-level flag in a top-level request field keeps responsibilities clean. |
+| Send VV only when document has tombstones | Requires the server to know the tombstone state of every document, which adds bookkeeping for a narrower benefit than the per-attach opt-out. |
+| Lazy/diff VV transmission | Cross-cutting wire change. Helps all docs marginally but does not eliminate `UpdateMinVersionVector` cost for Counter docs. Can be pursued independently. |
+| Drop response VV but keep `UpdateMinVersionVector` | Saves only response bandwidth. Misses the larger server-side compute and storage win for high-fan-out Counter docs. |
+
+## Tasks
+
+Track execution plans in `docs/tasks/active/` as separate task documents.

--- a/docs/tasks/active/20260527-disable-gc-on-attach-lessons.md
+++ b/docs/tasks/active/20260527-disable-gc-on-attach-lessons.md
@@ -1,0 +1,82 @@
+**Created**: 2026-05-27
+
+# Disable GC on Attach — Lessons
+
+## Question persistence before reaching for it
+
+The first cut persisted `disable_gc` on `ClientDocInfo`. The reasoning at the
+time was that four RPCs reach `packs.PushPull` (`AttachDocument`,
+`PushPullChanges`, `DetachDocument`, `RemoveDocument`, plus the cluster
+server) and centralising the flag would avoid fan-out. That reasoning was
+sloppy in two ways:
+
+- `DetachDocument` and `RemoveDocument` are terminal: one extra `minVV`
+  write per session is not worth carrying state for.
+- Only `AttachDocument` and `PushPullChanges` are hot paths, and adding
+  the flag to two proto messages is a much smaller surface than the
+  persistence path (new BSON field, signature change on `AttachDocument`,
+  ~30 test call-site updates, `DeepCopy` update, memory backend write
+  preservation, mongo `$set`, mongo cache short-circuit equality).
+
+**Rule**: when choosing between request-time and persisted state for a
+boolean, count the actual touch points on both sides. "Centralised" is
+not the same as "smaller." Persisted schema fields are forever; per-request
+state isn't.
+
+The user prompted the rework with one short question. That cost zero
+review cycles compared to landing the persisted version. Cheap questions
+beat expensive cleanup.
+
+## Don't reset `DisableGC` on Detach when re-attach already overwrites it
+
+(Captured against the persisted version of the design and superseded by
+the per-request approach; kept here because the principle is general.)
+
+The first persisted cut explicitly cleared `DisableGC` in
+`DetachDocument` and `RemoveDocument` as defense-in-depth. The clear was
+redundant: `AttachDocument` replaces the entire `ClientDocInfo` struct,
+and `$set` on mongo overwrites the persisted field on the next PushPull.
+
+**Rule**: when a struct field is read only between two state
+transitions that both fully rewrite the struct, an explicit clear in
+between is dead code. Lean on the rewrite invariant; comment the
+reasoning instead of duplicating the clear.
+
+## `GetMinVersionVector` with no stored rows returns the caller's VV unchanged
+
+`MinVersionVector` ignores missing keys by yielding 0, but when only
+one vector is supplied (the caller's `doc.VersionVector()`), every key
+present in it survives the min computation. The original design note
+that all-opt-out documents would GC "conservatively (collects nothing)"
+was wrong: with no stored rows the server-side snapshot GC actually
+runs against the document's max VV, which is the aggressive behavior
+we wanted. Useful to know if anyone later tries to design an explicit
+aggressive path — it already exists for free.
+
+## `make proto` regenerates files my proto change did not touch
+
+Running `buf generate` regenerated `yorkie.connect.go` with a
+different `connect.IsAtLeastVersion` marker and added `PeekChannel`
+entries to `yorkie.openapi.yaml` that did not exist in the committed
+file. The local toolchain version differs from whatever produced the
+committed artifacts. Restored those files to `HEAD` and committed only
+the `.proto` and `.pb.go` that the new field genuinely required.
+
+## Open follow-ups
+
+- Wire-compat behavior (old/new client × old/new server) not yet
+  exercised against a real release pair. Worth a smoke test before the
+  JS SDK PR.
+- `vv-cleanup` interaction (detached-actor signaling) was not tested
+  in the presence of opt-out attachments. Likely safe because
+  `detached_actors` signaling is independent of stored VV rows, but
+  worth confirming.
+- Go SDK option lives next to existing `document.WithDisableGC`. The
+  package qualifier disambiguates, but the two flags do different
+  things and a future reader could confuse them. Mention this in the
+  JS SDK PR so the JS naming explicitly distinguishes the wire flag
+  from any local-GC option.
+- Deferred client-side optimizations: skip serializing `reqPack.VersionVector`
+  when `disableGC=true`, and skip the local `GarbageCollect` traversal
+  when the response VV is empty. Both are correctness-preserving with
+  the current code but worth picking up if profiling shows the cost.

--- a/docs/tasks/active/20260527-disable-gc-on-attach-todo.md
+++ b/docs/tasks/active/20260527-disable-gc-on-attach-todo.md
@@ -1,0 +1,447 @@
+**Created**: 2026-05-27
+
+# Disable GC on Attach Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a per-attachment `disableGC` flag so a client can opt out
+of receiving the response VersionVector and participating in server-side
+`minVV` tracking. Targets high-fan-out Counter/primitive workloads where
+no client consumes tombstones.
+
+**Architecture:** Add `bool disable_gc` to `AttachDocumentRequest`,
+persist on `ClientDocInfo`, branch the `UpdateMinVersionVector` call in
+`server/packs/pushpull.go`, surface the option on Go and JS SDK
+`Attach`. Two PRs: Go server + Go SDK first, JS SDK after.
+
+**Spec:** `docs/design/disable-gc-on-attach.md`
+
+Branch: `disable-gc-on-attach`
+
+---
+
+## File Map
+
+### Go (single PR: server + Go SDK)
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `api/yorkie/v1/yorkie.proto` | Add `bool disable_gc = 4` to `AttachDocumentRequest` |
+| Modify | `api/yorkie/v1/yorkie.pb.go` | Regenerated via `make proto` |
+| Modify | `server/backend/database/client_info.go` | Add `DisableGC bool` to `ClientDocInfo`; thread through `AttachDocument`/`DetachDocument` |
+| Modify | `server/backend/database/mongo/client.go` | Persist `DisableGC` in attach update |
+| Modify | `server/backend/database/memory/database.go` | Same for memory backend |
+| Modify | `server/rpc/yorkie_server.go` | Pass `disable_gc` from request into `AttachDocument` |
+| Modify | `server/packs/pushpull.go` | Guard `UpdateMinVersionVector` and `resPack.VersionVector` assignment on the flag |
+| Modify | `client/client.go` | Add `WithDisableGC()` option; store on attached doc state |
+| Modify | `client/attachment.go` (or equivalent) | Hold per-attachment `disableGC` flag |
+| Modify | `client/client.go` PushPull path | Skip sending VV in request when `disableGC`; skip local GC when response VV empty |
+| Create | `test/integration/disable_gc_test.go` | Integration coverage |
+| Modify | `server/backend/database/testcases/testcases.go` | Cover `DisableGC` round-trip if existing table-driven tests touch `ClientDocInfo` |
+
+### JS SDK (follow-up PR after Go merges)
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `packages/sdk/src/client/client.ts` | Accept `{ disableGC?: boolean }` on `attach` |
+| Modify | `packages/sdk/src/document/document.ts` (or attachment store) | Hold per-attachment flag |
+| Modify | `packages/sdk/src/api/converter.ts` | Set `disable_gc` on `AttachDocumentRequest`; skip VV serialization on push when set |
+| Modify | `packages/sdk/src/document/document.ts` (sync path) | Skip GC when response VV is empty |
+| Modify | `packages/sdk/test/integration/*` | Coverage mirroring the Go integration test |
+
+---
+
+## Task 1: Proto — add `disable_gc` to AttachDocumentRequest
+
+**Files:**
+- Modify: `api/yorkie/v1/yorkie.proto`
+
+- [ ] **Step 1: Add the field**
+
+In `AttachDocumentRequest`:
+
+```protobuf
+message AttachDocumentRequest {
+  string client_id = 1;
+  ChangePack change_pack = 2;
+  string schema_key = 3;
+  bool disable_gc = 4;  // NEW
+}
+```
+
+- [ ] **Step 2: Regenerate**
+
+Run: `make proto`
+Expected: `api/yorkie/v1/yorkie.pb.go` updated; no other generated files
+change unexpectedly.
+
+- [ ] **Step 3: Commit**
+
+```sh
+git add api/yorkie/v1/yorkie.proto api/yorkie/v1/yorkie.pb.go
+git commit -m "Add disable_gc field to AttachDocumentRequest"
+```
+
+---
+
+## Task 2: Persist `DisableGC` on `ClientDocInfo`
+
+**Files:**
+- Modify: `server/backend/database/client_info.go`
+- Modify: `server/backend/database/mongo/client.go`
+- Modify: `server/backend/database/memory/database.go`
+
+- [ ] **Step 1: Extend the struct**
+
+In `client_info.go`:
+
+```go
+type ClientDocInfo struct {
+    Status    string `bson:"status"`
+    ServerSeq int64  `bson:"server_seq"`
+    ClientSeq uint32 `bson:"client_seq"`
+    Epoch     int64  `bson:"epoch"`
+    DisableGC bool   `bson:"disable_gc,omitempty"`
+}
+```
+
+- [ ] **Step 2: Thread through Attach/Detach**
+
+Update `ClientInfo.AttachDocument(docID, alreadyAttached, epoch, disableGC bool)`
+to set `DisableGC` on the new `ClientDocInfo`. Call sites must pass the
+value through.
+
+`DetachDocument(docID)` clears it to `false` alongside the other reset
+fields so a re-attach is not contaminated by a stale flag.
+
+- [ ] **Step 3: Backend writes**
+
+In `mongo/client.go` and `memory/database.go`, ensure the
+`UpdateClientInfoAfterPushPull` and any attach-time updates include the
+new field. Because `omitempty` is set, no migration is needed; absent
+values deserialize as `false`.
+
+- [ ] **Step 4: Unit tests**
+
+Add a table case (or extend the existing client_info tests) that
+round-trips `DisableGC=true` through the chosen backend.
+
+- [ ] **Step 5: Verify**
+
+Run: `go test ./server/backend/database/...`
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```sh
+git add server/backend/database/
+git commit -m "Persist DisableGC on ClientDocInfo for per-attachment opt-out"
+```
+
+---
+
+## Task 3: RPC handler passes the flag
+
+**Files:**
+- Modify: `server/rpc/yorkie_server.go` (AttachDocument handler)
+
+- [ ] **Step 1: Forward `request.DisableGc` into `AttachDocument`**
+
+Where the handler currently calls `clientInfo.AttachDocument(...)`, pass
+the new boolean. Keep the existing validation and authorization paths
+unchanged.
+
+- [ ] **Step 2: Verify**
+
+Run: `go build ./...` and `go test ./server/rpc/...`
+Expected: build OK; tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```sh
+git add server/rpc/yorkie_server.go
+git commit -m "Forward disable_gc from AttachDocument RPC to ClientInfo"
+```
+
+---
+
+## Task 4: Server-side branch in `pushpull.go`
+
+**Files:**
+- Modify: `server/packs/pushpull.go`
+
+- [ ] **Step 1: Skip `UpdateMinVersionVector` for opt-out clients**
+
+Around the existing call:
+
+```go
+disableGC := false
+if doc := clientInfo.Documents[docInfo.ID]; doc != nil {
+    disableGC = doc.DisableGC
+}
+
+if !disableGC {
+    minVersionVector, err := be.DB.UpdateMinVersionVector(
+        ctx, clientInfo, docInfo.RefKey(), reqPack.VersionVector,
+    )
+    if err != nil {
+        return nil, err
+    }
+    if resPack.SnapshotLen() == 0 {
+        resPack.VersionVector = minVersionVector
+    }
+}
+// disableGC = true: resPack.VersionVector stays nil; converter
+// serializes it as an empty VersionVector.
+```
+
+- [ ] **Step 2: Confirm `GetMinVersionVector` semantics unchanged**
+
+`pullSnapshot`'s `GetMinVersionVector` call queries the
+`versionvectors` collection directly. Since opt-out clients were never
+inserted (Task 4 Step 1 skipped the write), the min is naturally
+computed over participating clients only. No change needed here.
+
+When all attached clients are opt-out, `GetMinVersionVector` returns an
+empty vector and `GarbageCollect(emptyVV)` collects nothing — safe and
+documented in the spec.
+
+- [ ] **Step 3: Verify**
+
+Run: `go test ./server/packs/...`
+Expected: existing tests PASS; opt-out path is exercised by the
+integration test in Task 6.
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add server/packs/pushpull.go
+git commit -m "Skip minVV update and response VV for disable_gc clients"
+```
+
+Commit body should explain that the opt-out client neither writes to
+`versionvectors` nor receives `minVV`, eliminating per-push cost in
+GC-free workloads.
+
+---
+
+## Task 5: Go SDK `WithDisableGC` option
+
+**Files:**
+- Modify: `client/client.go`
+- Modify: `client/attachment.go` (or wherever per-doc client state lives)
+
+- [ ] **Step 1: Define the option**
+
+```go
+type attachOptions struct {
+    // ... existing fields
+    disableGC bool
+}
+
+// WithDisableGC declares that this attachment will not produce or consume
+// tombstones. The server will skip minVV tracking and omit the response
+// version vector for this client. Use only with Counter / primitive
+// workloads; misuse leads to undefined GC behavior on this client.
+func WithDisableGC() AttachOption {
+    return func(o *attachOptions) { o.disableGC = true }
+}
+```
+
+- [ ] **Step 2: Send in `AttachDocument` RPC**
+
+Populate `request.DisableGc` from the option. Persist the flag on the
+attached document's local state so subsequent PushPull paths can read it.
+
+- [ ] **Step 3: Request-side VV omission**
+
+When the attachment has `disableGC=true`, send an empty
+`VersionVector` in `PushPull` (skip serialization). The client still
+maintains its own per-change VV for causality but never uploads its
+document-level VV.
+
+- [ ] **Step 4: Response-side GC skip**
+
+After receiving a `ChangePack`, if `VersionVector` is empty, skip the
+local `GarbageCollect` call. The behavior is identical to receiving a
+zero min VV today (nothing reclaimable) but avoids the traversal cost.
+
+- [ ] **Step 5: Verify**
+
+Run: `go test ./client/...`
+Expected: existing tests PASS; integration test (Task 6) covers the
+new path end-to-end.
+
+- [ ] **Step 6: Commit**
+
+```sh
+git add client/
+git commit -m "Add WithDisableGC attach option to Go client"
+```
+
+---
+
+## Task 6: Go integration test
+
+**Files:**
+- Create: `test/integration/disable_gc_test.go`
+
+- [ ] **Step 1: Write the test**
+
+Build tag `integration`. Coverage:
+
+1. **Response VV is empty** — client attaches with `WithDisableGC()`,
+   makes a Counter increment, syncs; assert the received `ChangePack`
+   has an empty `VersionVector`.
+2. **`versionvectors` row is not written** — query the backend
+   (memory or mongo) and confirm no row exists for the opt-out client
+   on this document.
+3. **Mixed-mode coexistence** — one client opt-out, one client opt-in
+   on the same document, both performing Counter increments;
+   opt-in client's `minVV` correctly reflects only its own VV (since
+   it is the only participant).
+4. **Re-attach clears the flag** — opt-out client detaches and
+   re-attaches without the option; `DisableGC` is `false` after
+   re-attach.
+
+Follow patterns in `test/integration/counter_test.go` and
+`test/integration/gc_test.go` for client setup and assertions.
+
+- [ ] **Step 2: Verify**
+
+Bring up the integration env:
+
+```sh
+docker compose -f build/docker/docker-compose.yml up --build -d
+go test -tags integration ./test/integration/ -run TestDisableGC -v
+```
+
+Expected: all subtests PASS.
+
+- [ ] **Step 3: Run the full integration suite**
+
+```sh
+make test
+```
+
+Expected: no regressions in existing tests (GC, snapshot, vv-cleanup).
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add test/integration/disable_gc_test.go
+git commit -m "Add integration tests for disable_gc attach option"
+```
+
+---
+
+## Task 7: Self-review and PR (Go)
+
+- [ ] **Step 1: Lint and unit tests**
+
+```sh
+make lint
+go test ./...
+```
+
+Expected: clean.
+
+- [ ] **Step 2: Self-review**
+
+Dispatch `superpowers:requesting-code-review` (or `/code-review`) over
+the full branch diff. Apply Critical/Important findings; capture
+non-blocking notes in the lessons file.
+
+- [ ] **Step 3: Rebase on main and open PR**
+
+```sh
+git fetch && git rebase origin/main
+git push -u origin disable-gc-on-attach
+gh pr create --title "Disable GC on attach for Counter-only workloads" \
+  --body-file <(cat <<'EOF'
+## Summary
+- Add `disable_gc` to `AttachDocumentRequest` and `ClientDocInfo`
+- Skip `UpdateMinVersionVector` and response VV for opt-out clients
+- Expose `WithDisableGC()` on the Go client
+
+## Test plan
+- [ ] `make lint`
+- [ ] `go test ./...`
+- [ ] `go test -tags integration ./test/integration/...`
+- [ ] New `TestDisableGC` covers response VV, storage skip, mixed mode, re-attach
+EOF
+)
+```
+
+- [ ] **Step 4: Address review and merge**
+
+Resolve CodeRabbit + maintainer comments; rebase if `main` moved.
+
+---
+
+## Task 8: JS SDK follow-up (separate PR after Go merges)
+
+**Files:**
+- Modify: `packages/sdk/src/client/client.ts`
+- Modify: `packages/sdk/src/document/document.ts` (or attachment store)
+- Modify: `packages/sdk/src/api/converter.ts`
+- Add tests under `packages/sdk/test/integration/`
+
+- [ ] **Step 1: API surface**
+
+`client.attach(doc, { disableGC: true })`. Store the flag on the
+attachment state.
+
+- [ ] **Step 2: Converter**
+
+`toAttachDocumentRequest` sets `disable_gc` from attachment state.
+PushPull path uses empty VV when the flag is set.
+
+- [ ] **Step 3: Sync path**
+
+When the inbound `ChangePack` has an empty `VersionVector`, skip the
+local GC traversal.
+
+- [ ] **Step 4: Integration test**
+
+Mirror the Go integration test against a running server built from the
+Go PR. Assert response VV is empty and the doc replicates correctly
+across two opt-out clients exchanging Counter increments.
+
+- [ ] **Step 5: PR**
+
+Title: `Add disableGC option to attach` (≤70 chars). Body includes
+test plan and link to the Go PR.
+
+---
+
+## Task 9: Archive and lessons
+
+- [ ] **Step 1: Capture lessons**
+
+Write findings to `docs/tasks/active/20260527-disable-gc-on-attach-lessons.md`.
+Likely topics:
+
+- How `versionvectors` interacts with `omitempty` rows
+- Anything surprising in the `pullSnapshot` GC path when all clients
+  opt out
+- Wire-compat behavior with mixed old/new client and server versions
+
+- [ ] **Step 2: Archive**
+
+```sh
+bash scripts/tasks-archive.sh
+bash scripts/tasks-index.sh
+```
+
+---
+
+## Remaining
+
+- [ ] All Task 1–9 steps above
+- [ ] Schema integration (future, separate task): when schema lands,
+      let schema declare `gc: false` to auto-apply `disable_gc` so
+      client SDK does not need to opt in manually

--- a/docs/tasks/active/20260527-disable-gc-on-attach-todo.md
+++ b/docs/tasks/active/20260527-disable-gc-on-attach-todo.md
@@ -7,15 +7,27 @@
 > superpowers:executing-plans to implement this plan task-by-task.
 > Steps use checkbox (`- [ ]`) syntax for tracking.
 
+> **Implementation note (post-refactor):** The plan below was written
+> for a persisted design where `disable_gc` lived on `ClientDocInfo`.
+> Mid-implementation it pivoted to a stateless per-request design —
+> the flag travels on `AttachDocumentRequest` and `PushPullChangesRequest`
+> only and is read into `PushPullOptions` by the handler. The sections
+> below referencing `ClientDocInfo.DisableGC`, `AttachDocument`
+> signature changes, `DetachDocument` resets, mongo `$set` for
+> `disable_gc`, and backend persistence are **historical context**, not
+> shipped behavior. See `docs/design/disable-gc-on-attach.md` for the
+> final design and the lessons file for the pivot rationale.
+
 **Goal:** Add a per-attachment `disableGC` flag so a client can opt out
 of receiving the response VersionVector and participating in server-side
 `minVV` tracking. Targets high-fan-out Counter/primitive workloads where
 no client consumes tombstones.
 
-**Architecture:** Add `bool disable_gc` to `AttachDocumentRequest`,
-persist on `ClientDocInfo`, branch the `UpdateMinVersionVector` call in
-`server/packs/pushpull.go`, surface the option on Go and JS SDK
-`Attach`. Two PRs: Go server + Go SDK first, JS SDK after.
+**Architecture (as shipped):** Add `bool disable_gc` to
+`AttachDocumentRequest` and `PushPullChangesRequest`; thread the value
+through `packs.PushPullOptions`; branch the `UpdateMinVersionVector`
+call in `server/packs/pushpull.go`; surface the option on Go and JS
+SDK `Attach`. Two PRs: Go server + Go SDK first, JS SDK after.
 
 **Spec:** `docs/design/disable-gc-on-attach.md`
 

--- a/server/packs/pushpull.go
+++ b/server/packs/pushpull.go
@@ -62,6 +62,12 @@ type PushPullOptions struct {
 
 	// Status represents the status of the document to be updated.
 	Status document.StatusType
+
+	// DisableGC, when true, makes the server skip minVV tracking for this
+	// client and omit the response VersionVector. Set per-request by the
+	// RPC handler from the matching wire field. See
+	// docs/design/disable-gc-on-attach.md.
+	DisableGC bool
 }
 
 var (
@@ -300,12 +306,23 @@ func pullPack(
 	}
 
 	// 03. update client's vector and checkpoint to DB.
-	minVersionVector, err := be.DB.UpdateMinVersionVector(ctx, clientInfo, docInfo.RefKey(), reqPack.VersionVector)
-	if err != nil {
-		return nil, err
-	}
-	if resPack.SnapshotLen() == 0 {
-		resPack.VersionVector = minVersionVector
+	// Skip both minVV tracking and response VV when this PushPull is
+	// flagged as GC-free. The client never consumes the response VV, and
+	// excluding it from minVV is correct because tombstones do not need to
+	// be kept alive for this client. See docs/design/disable-gc-on-attach.md.
+	if opts.DisableGC {
+		// The snapshot path in pullSnapshot populates resPack.VersionVector
+		// unconditionally, so clear it here to keep the wire contract for
+		// opt-out clients consistent across both pull paths.
+		resPack.VersionVector = nil
+	} else {
+		minVersionVector, err := be.DB.UpdateMinVersionVector(ctx, clientInfo, docInfo.RefKey(), reqPack.VersionVector)
+		if err != nil {
+			return nil, err
+		}
+		if resPack.SnapshotLen() == 0 {
+			resPack.VersionVector = minVersionVector
+		}
 	}
 	if !clientInfo.IsServerClient() {
 		if err := be.DB.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo); err != nil {

--- a/server/rpc/yorkie_server.go
+++ b/server/rpc/yorkie_server.go
@@ -252,8 +252,9 @@ func (s *yorkieServer) AttachDocument(
 
 	// 03. Push/Pull between the client and server.
 	pulled, err := packs.PushPull(ctx, s.backend, project, clientInfo, docKey, pack, packs.PushPullOptions{
-		Mode:   types.SyncModePushPull,
-		Status: document.StatusAttached,
+		Mode:      types.SyncModePushPull,
+		Status:    document.StatusAttached,
+		DisableGC: req.Msg.DisableGc,
 	})
 	if err != nil {
 		return nil, err
@@ -1284,8 +1285,9 @@ func (s *yorkieServer) PushPullChanges(
 	// 03. Push/Pull between the client and server.
 	docKey := types.DocRefKey{ProjectID: project.ID, DocID: docID}
 	pulled, err := packs.PushPull(ctx, s.backend, project, clientInfo, docKey, pack, packs.PushPullOptions{
-		Mode:   syncMode,
-		Status: document.StatusAttached,
+		Mode:      syncMode,
+		Status:    document.StatusAttached,
+		DisableGC: req.Msg.DisableGc,
 	})
 	if err != nil {
 		return nil, err

--- a/test/integration/disable_gc_test.go
+++ b/test/integration/disable_gc_test.go
@@ -67,7 +67,8 @@ func TestDisableGCOnAttach(t *testing.T) {
 		c1, c2 := clients[0], clients[1]
 
 		ctx := context.Background()
-		d1 := document.New(helper.TestKey(t))
+		docKey := helper.TestKey(t)
+		d1 := document.New(docKey)
 		assert.NoError(t, c1.Attach(ctx, d1))
 
 		assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
@@ -76,7 +77,7 @@ func TestDisableGCOnAttach(t *testing.T) {
 		}))
 		assert.NoError(t, c1.Sync(ctx))
 
-		d2 := document.New(helper.TestKey(t))
+		d2 := document.New(docKey)
 		assert.NoError(t, c2.Attach(ctx, d2, client.WithDisableGC()))
 
 		assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
@@ -102,9 +103,10 @@ func TestDisableGCOnAttach(t *testing.T) {
 		c1 := clients[0]
 
 		ctx := context.Background()
+		docKey := helper.TestKey(t)
 
 		// First attach with opt-out.
-		d1 := document.New(helper.TestKey(t))
+		d1 := document.New(docKey)
 		assert.NoError(t, c1.Attach(ctx, d1, client.WithDisableGC()))
 		assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
 			root.SetNewCounter("counter", 0).Increase(1)
@@ -113,9 +115,10 @@ func TestDisableGCOnAttach(t *testing.T) {
 		assert.NoError(t, c1.Sync(ctx))
 		assert.NoError(t, c1.Detach(ctx, d1))
 
-		// Re-attach without opt-out. The flag must reset to false; subsequent
-		// PushPulls participate in minVV tracking normally.
-		d2 := document.New(helper.TestKey(t))
+		// Re-attach without opt-out. The SDK derives the per-request flag
+		// from the current attachment only, so subsequent PushPulls
+		// participate in minVV tracking normally.
+		d2 := document.New(docKey)
 		assert.NoError(t, c1.Attach(ctx, d2))
 		assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
 			root.GetCounter("counter").Increase(1)
@@ -123,5 +126,19 @@ func TestDisableGCOnAttach(t *testing.T) {
 		}))
 		assert.NoError(t, c1.Sync(ctx))
 		assert.Equal(t, "2", d2.Root().GetCounter("counter").Marshal())
+
+		// Confirm server-side: re-attached client now appears in the
+		// versionvectors table. The opt-out attach didn't write a row, so
+		// a non-empty minVV after re-attach proves the new attachment is
+		// participating in minVV tracking.
+		be := defaultServer.Backend()
+		project, err := defaultServer.DefaultProject(ctx)
+		assert.NoError(t, err)
+		docInfo, err := be.DB.FindDocInfoByKey(ctx, project.ID, d2.Key())
+		assert.NoError(t, err)
+		minVV, err := be.DB.GetMinVersionVector(ctx, docInfo.RefKey(), time.NewVersionVector())
+		assert.NoError(t, err)
+		assert.NotZero(t, len(minVV),
+			"re-attach without opt-out should resume minVV tracking")
 	})
 }

--- a/test/integration/disable_gc_test.go
+++ b/test/integration/disable_gc_test.go
@@ -1,0 +1,127 @@
+//go:build integration
+
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/client"
+	"github.com/yorkie-team/yorkie/pkg/document"
+	"github.com/yorkie-team/yorkie/pkg/document/json"
+	"github.com/yorkie-team/yorkie/pkg/document/presence"
+	"github.com/yorkie-team/yorkie/pkg/document/time"
+	"github.com/yorkie-team/yorkie/test/helper"
+)
+
+func TestDisableGCOnAttach(t *testing.T) {
+	t.Run("opt-out client writes no versionvectors row", func(t *testing.T) {
+		clients := activeClients(t, 1)
+		defer deactivateAndCloseClients(t, clients)
+		c1 := clients[0]
+
+		ctx := context.Background()
+		d1 := document.New(helper.TestKey(t))
+		assert.NoError(t, c1.Attach(ctx, d1, client.WithDisableGC()))
+		assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewCounter("counter", 0).Increase(1)
+			return nil
+		}))
+		assert.NoError(t, c1.Sync(ctx))
+
+		// Inspect server-side state to confirm the wire contract: no row
+		// must exist in the versionvectors table for this client.
+		be := defaultServer.Backend()
+		project, err := defaultServer.DefaultProject(ctx)
+		assert.NoError(t, err)
+		docInfo, err := be.DB.FindDocInfoByKey(ctx, project.ID, d1.Key())
+		assert.NoError(t, err)
+
+		minVV, err := be.DB.GetMinVersionVector(ctx, docInfo.RefKey(), time.NewVersionVector())
+		assert.NoError(t, err)
+		assert.Len(t, minVV, 0,
+			"opt-out client must not write to the versionvectors table")
+	})
+
+	t.Run("mixed opt-in and opt-out clients converge on counter value", func(t *testing.T) {
+		clients := activeClients(t, 2)
+		defer deactivateAndCloseClients(t, clients)
+		c1, c2 := clients[0], clients[1]
+
+		ctx := context.Background()
+		d1 := document.New(helper.TestKey(t))
+		assert.NoError(t, c1.Attach(ctx, d1))
+
+		assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewCounter("counter", 0)
+			return nil
+		}))
+		assert.NoError(t, c1.Sync(ctx))
+
+		d2 := document.New(helper.TestKey(t))
+		assert.NoError(t, c2.Attach(ctx, d2, client.WithDisableGC()))
+
+		assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetCounter("counter").Increase(1)
+			return nil
+		}))
+		assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetCounter("counter").Increase(1)
+			return nil
+		}))
+
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c1.Sync(ctx))
+
+		assert.Equal(t, "2", d1.Root().GetCounter("counter").Marshal())
+		assert.Equal(t, "2", d2.Root().GetCounter("counter").Marshal())
+	})
+
+	t.Run("re-attach without WithDisableGC restores normal GC participation", func(t *testing.T) {
+		clients := activeClients(t, 1)
+		defer deactivateAndCloseClients(t, clients)
+		c1 := clients[0]
+
+		ctx := context.Background()
+
+		// First attach with opt-out.
+		d1 := document.New(helper.TestKey(t))
+		assert.NoError(t, c1.Attach(ctx, d1, client.WithDisableGC()))
+		assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewCounter("counter", 0).Increase(1)
+			return nil
+		}))
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c1.Detach(ctx, d1))
+
+		// Re-attach without opt-out. The flag must reset to false; subsequent
+		// PushPulls participate in minVV tracking normally.
+		d2 := document.New(helper.TestKey(t))
+		assert.NoError(t, c1.Attach(ctx, d2))
+		assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetCounter("counter").Increase(1)
+			return nil
+		}))
+		assert.NoError(t, c1.Sync(ctx))
+		assert.Equal(t, "2", d2.Root().GetCounter("counter").Marshal())
+	})
+}


### PR DESCRIPTION
## Summary

Adds a per-request `disable_gc` flag so a client can opt out of receiving the response `VersionVector` and participating in server-side `minVV` tracking. Targets high-fan-out Counter / primitive workloads where no client consumes tombstones, eliminating both the per-PushPull `UpdateMinVersionVector` compute and the per-client `versionvectors` row.

- Adds `bool disable_gc` to **both** `AttachDocumentRequest` and `PushPullChangesRequest`. These are the two RPCs that drive a PushPull on behalf of an end client; `DetachDocument` and `RemoveDocument` deliberately do not carry the flag (one final minVV write at terminus is negligible).
- `packs.PushPullOptions.DisableGC` carries the flag from each handler into `pushpull.go`, which skips `UpdateMinVersionVector` and nils the response VV (both the change-info and snapshot pull paths).
- Adds `client.WithDisableGC()` attach option. The SDK records `disableGC` on the local `Attachment` and sends the matching wire field on every subsequent `PushPullChanges`.
- **Not persisted server-side.** Each PushPull reads the flag from the request alone. Persistence on `ClientDocInfo` was considered (centralised, set-once) but the per-request wire form is genuinely smaller end-to-end — no BSON field forever, no signature change on `AttachDocument` cascading through ~30 test call sites, no DeepCopy or cache-equality updates.
- Design: `docs/design/disable-gc-on-attach.md`

Spec covers Goals/Non-Goals, snapshot GC edge case (aggressive GC when all clients opt out — falls out of existing `MinVersionVector` semantics with no extra code), and deferred client-side optimizations (request-VV omission and skip local GC traversal are future work; the server-side wins are the goal of this PR).

JS SDK support is a follow-up PR after this Go side merges.

## Test plan

- [x] `make lint` clean
- [x] `go test ./...` — 1149 unit tests pass
- [x] `go test -tags integration ./test/integration/` — full integration suite green
- [x] `TestDisableGCOnAttach` covers: opt-out client writes no `versionvectors` row, mixed opt-in/opt-out coexistence converges, re-attach without the option restores normal behavior
- [x] Two passes of self-review via subagent; Important findings addressed in each iteration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional "disable GC" attach mode: clients can opt out of garbage-collection participation; syncs for opted-out attachments omit version-vector exchange and skip server min-VV tracking.

* **Documentation**
  * Added design and task docs detailing the opt-out contract, risks, and implementation notes.

* **Tests**
  * Added integration test validating opt-out attach, mixed-mode convergence, and re-attaching to resume GC tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yorkie-team/yorkie/pull/1822?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->