### PR TITLE
Fix close-of-closed-channel and nil deref panics in test/bench

### DIFF
--- a/docs/tasks/active/20260527-bench-flaky-panics-todo.md
+++ b/docs/tasks/active/20260527-bench-flaky-panics-todo.md
@@ -1,0 +1,82 @@
+**Created**: 2026-05-27
+
+# Flaky Test Fixes: Bench Panics in GetDocuments and ListWhileModifying
+
+Branch: `fix/bench-flaky-panics`
+
+## Goal
+
+Eliminate two pre-existing panics in `test/bench` that intermittently
+break CI. Both are bugs in the bench test code itself, not in
+production code.
+
+1. `BenchmarkGetDocuments/with_root_presence_1000` panics with
+   `nil pointer dereference` at
+   `test/bench/get_documents_bench_test.go:60`.
+   Seen on CI run 26515547459 (commit 449b2c44).
+2. `BenchmarkChannelConcurrency_ListWhileModifying/50r_10w` panics
+   with `close of closed channel` at
+   `test/bench/channel_concurrency_bench_test.go:446`.
+   Seen on CI run 26515489677 (commit 098b521f). Previously reported
+   as #1703 and closed under the assumption that PR #1745 had fixed
+   the underlying race — but #1745 only adjusted server-side lock
+   order in `pushpull.go`; the test-side race was never patched and
+   has now reoccurred.
+
+## Root causes
+
+### A. Nil response dereference in GetDocuments bench
+
+`get_documents_bench_test.go` uses `assert.NoError(b, err)` followed
+by `assert.NotNil(b, resp.Msg)`. `assert.NoError` is non-fatal — it
+records the failure on `b` but lets execution continue, so when the
+RPC returns `(nil, err)` the next line dereferences a nil `resp`
+and SEGVs.
+
+The trigger is `with root presence 1000`, where
+`documents.GetDocumentSummaries` spawns 1000 cluster-RPC goroutines
+per benchmark iteration multiplexed over a single HTTP/2 connection
+(default `ClusterClientPoolSize=1`). Under sustained `b.Loop()`
+pressure a transient cluster RPC error eventually surfaces. The
+correct test behavior is to fail cleanly with the RPC error, not to
+panic.
+
+### B. Race on `close(done)` in ListWhileModifying
+
+Each writer goroutine does:
+
+```go
+atomic.AddInt32(&writeCount, 1)
+if atomic.LoadInt32(&writeCount) >= int32(tc.writers) {
+    close(done)
+}
+```
+
+Several writers can pass the threshold concurrently and call
+`close(done)` more than once. The same file already guards the
+identical pattern in `BenchmarkChannelConcurrency_SessionCountWhileModifying`
+with `var closeOnce sync.Once`; `ListWhileModifying` is a copy-paste
+of that block that lost the guard.
+
+## Plan
+
+- [ ] Apply fixes:
+  - [ ] `get_documents_bench_test.go`: use `require.NoError` (or
+        `b.Fatal`) so an RPC failure stops the goroutine instead of
+        falling through to a nil deref. Apply at all call sites in
+        `benchmarkGetDocuments` and in setup.
+  - [ ] `channel_concurrency_bench_test.go`: add `var closeOnce sync.Once`
+        in `ListWhileModifying` and wrap the `close(done)` in
+        `closeOnce.Do(...)`, matching `SessionCountWhileModifying`.
+- [ ] Verify: `make lint` green; sanity-run the two bench subtests
+      locally with `-count` to confirm the panics are gone.
+- [ ] Self-review via code-review subagent.
+- [ ] Open PR, link issue #1703 for context.
+
+## Notes
+
+- The bench RPC concurrency story (1000 goroutines per iter) is a
+  separate optimization question. This change only makes the test
+  fail gracefully when an error does occur; it does not try to
+  prevent the error.
+- Production code is not modified.

--- a/test/bench/channel_concurrency_bench_test.go
+++ b/test/bench/channel_concurrency_bench_test.go
@@ -405,6 +405,7 @@ func BenchmarkChannelConcurrency_ListWhileModifying(b *testing.B) {
 
 				var wg sync.WaitGroup
 				done := make(chan struct{})
+				var closeOnce sync.Once
 				var listCount int64
 
 				// Start readers (List operations)
@@ -443,7 +444,9 @@ func BenchmarkChannelConcurrency_ListWhileModifying(b *testing.B) {
 						atomic.AddInt32(&writeCount, 1)
 
 						if atomic.LoadInt32(&writeCount) >= int32(tc.writers) {
-							close(done)
+							closeOnce.Do(func() {
+								close(done)
+							})
 						}
 					}(w)
 				}

--- a/test/bench/get_documents_bench_test.go
+++ b/test/bench/get_documents_bench_test.go
@@ -25,6 +25,8 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/yorkie-team/yorkie/admin"
 	"github.com/yorkie-team/yorkie/api/converter"
 	api "github.com/yorkie-team/yorkie/api/yorkie/v1"
@@ -56,8 +58,8 @@ func benchmarkGetDocuments(
 		connect.NewRequest(docRequest),
 	)
 
-	assert.NoError(b, err)
-	assert.NotNil(b, resp.Msg)
+	require.NoError(b, err)
+	require.NotNil(b, resp.Msg)
 	assert.Len(b, resp.Msg.Documents, cnt)
 }
 
@@ -88,7 +90,7 @@ func BenchmarkGetDocuments(b *testing.B) {
 			Password: helper.AdminPassword,
 		},
 		))
-	assert.NoError(b, err)
+	require.NoError(b, err)
 	testAdminAuthInterceptor.SetToken(resp.Msg.Token)
 
 	resp1, err := testAdminClient.GetProject(
@@ -97,7 +99,7 @@ func BenchmarkGetDocuments(b *testing.B) {
 			Name: "default",
 		},
 		))
-	assert.NoError(b, err)
+	require.NoError(b, err)
 
 	project := converter.FromProject(resp1.Msg.Project)
 	ctx = projects.With(context.Background(), project)
@@ -105,7 +107,7 @@ func BenchmarkGetDocuments(b *testing.B) {
 	var docKeys []string
 	for i := range 1000 {
 		_, doc, err := helper.ClientAndAttachedDoc(ctx, svr.RPCAddr(), helper.TestKey(b, i))
-		assert.NoError(b, err)
+		require.NoError(b, err)
 		docKeys = append(docKeys, doc.Key().String())
 	}
 


### PR DESCRIPTION
## Summary

Two pre-existing flakes in `test/bench` panicked CI on consecutive `main` runs. Both are bugs in the bench test code; production code is unchanged.

- `BenchmarkChannelConcurrency_ListWhileModifying/50r_10w` — `close of closed channel` ([run 26515489677](https://github.com/yorkie-team/yorkie/actions/runs/26515489677/job/78091390863), commit 098b521f). Each writer's `if atomic.LoadInt32(&writeCount) >= tc.writers { close(done) }` is unguarded, so multiple writers race past the threshold and double-close. The same file already guards the identical pattern in `SessionCountWhileModifying` with `sync.Once`; `ListWhileModifying` was a copy-paste that lost the guard. Add `closeOnce.Do(close(done))` to match. (Originally reported as #1703 and closed under the assumption PR #1745 fixed it, but #1745 only adjusted server-side lock order in `pushpull.go`; the test-side race was never patched.)
- `BenchmarkGetDocuments/with_root_presence_1000` — nil pointer dereference at `get_documents_bench_test.go:60` ([run 26515547459](https://github.com/yorkie-team/yorkie/actions/runs/26515547459/job/78091597286), commit 449b2c44). `assert.NoError(b, err)` is non-fatal, so when one of the 1000 cluster-RPC goroutines spawned by `documents.GetDocumentSummaries` returns an error, the admin RPC returns `(nil, err)` and the next line SEGVs on `resp.Msg`. Switch the load-bearing setup and response assertions to `require.NoError` / `require.NotNil` so a real RPC failure surfaces as a clean test failure with the underlying error message.

## Test plan

- [x] `make lint` clean
- [x] `go vet -tags bench ./test/bench/...` clean
- [x] `go test -tags bench -race -bench='ChannelConcurrency_ListWhileModifying' -benchtime=3x -count=10 ./test/bench/` — 30 runs of each subtest pass with no race-detector hits
- [x] Smoke run of `BenchmarkGetDocuments/without_root_presence_10` against a live MongoDB stack passes (happy path untouched)
- [x] CI green

## Out of scope

The underlying reason `with_root_presence_1000` occasionally errors — `GetDocumentSummaries` fans out 1000 cluster-RPC goroutines multiplexed over a single HTTP/2 connection (default `ClusterClientPoolSize=1`) — is a separate optimization story. This PR makes the bench fail gracefully with a useful error message instead of a SEGV; bounding fan-out via `backend.FanOut` or sizing the pool is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Fixed flaky benchmark test failures in channel concurrency and document retrieval tests to improve test suite stability and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yorkie-team/yorkie/pull/1825?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->