### PR TITLE
Stop disable_gc clients from accumulating per-Change VV and lamport drift

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -509,6 +509,11 @@ func (c *Client) attachDocument(ctx context.Context, d *document.Document, opts 
 		d.SchemaRules = converter.FromRules(res.Msg.SchemaRules)
 	}
 
+	// Record the opt-out decision before applying the attach response so the
+	// first ApplyChangePack already routes remote changes through the
+	// lamport-only sync path. See docs/design/disable-gc-on-attach.md.
+	d.SetDisableGC(opts.DisableGC)
+
 	if err := d.ApplyChangePack(pack); err != nil {
 		return err
 	}

--- a/pkg/document/change/id.go
+++ b/pkg/document/change/id.go
@@ -120,6 +120,26 @@ func (id ID) SyncClocks(other ID) ID {
 	return newID
 }
 
+// SyncLamport advances the lamport clock against the given ID without
+// merging its version vector into the receiver's. It is the counterpart
+// of SyncClocks for attachments that have opted out of GC participation
+// (see docs/design/disable-gc-on-attach.md): the receiver does not need
+// other actors' entries in its VV because it never produces or consumes
+// tombstones, and dropping them keeps each subsequent local Change's VV
+// at O(1) instead of O(num_actors). Lamport must still advance so that
+// TimeTickets produced locally remain ordered against remote operations.
+func (id ID) SyncLamport(other ID) ID {
+	if !other.HasClocks() {
+		return id
+	}
+
+	lamport := max(id.lamport, other.lamport) + 1
+
+	newID := NewID(id.clientSeq, InitialServerSeq, lamport, id.actorID, id.versionVector)
+	newID.versionVector.Set(id.actorID, lamport)
+	return newID
+}
+
 // SetClocks sets the given clocks to this ID. This is used when the snapshot is
 // given from the server.
 func (id ID) SetClocks(otherLamport int64, vector time.VersionVector) ID {

--- a/pkg/document/disable_gc_test.go
+++ b/pkg/document/disable_gc_test.go
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package document_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/pkg/document"
+	"github.com/yorkie-team/yorkie/pkg/document/json"
+	"github.com/yorkie-team/yorkie/pkg/document/presence"
+	"github.com/yorkie-team/yorkie/pkg/document/time"
+)
+
+// TestDisableGCKeepsChangeVVAtSizeOne pins the contract from
+// docs/design/disable-gc-on-attach.md: under disable_gc, every locally
+// produced Change must carry a version vector of size 1, regardless of how
+// many other actors have been seen via ApplyChanges. Without the
+// SyncLamport branch in InternalDocument.ApplyChanges, the per-Change VV
+// would grow to O(num_actors) and erase the wire savings the opt-out is
+// supposed to deliver.
+func TestDisableGCKeepsChangeVVAtSizeOne(t *testing.T) {
+	const numActors = 5
+
+	docs := make([]*document.Document, numActors)
+	for i := 0; i < numActors; i++ {
+		actor, err := time.ActorIDFromHex(fmt.Sprintf("0000000000000000000000%02d", i+1))
+		assert.NoError(t, err)
+		d := document.New("disable-gc")
+		d.SetActor(actor)
+		d.SetDisableGC(true)
+		docs[i] = d
+	}
+
+	// docs[0] creates the counter and broadcasts the create change to all
+	// peers so they share the root element id.
+	assert.NoError(t, docs[0].Update(func(r *json.Object, _ *presence.Presence) error {
+		r.SetNewCounter("c", 0)
+		return nil
+	}))
+	createPack := docs[0].CreateChangePack()
+	for j := 1; j < numActors; j++ {
+		// CreateChangePack returns pack.VersionVector aliased to the
+		// sender's internal VV; copy per delivery to avoid corruption.
+		pCopy := *createPack
+		pCopy.VersionVector = createPack.VersionVector.DeepCopy()
+		pCopy.VersionVector.Set(docs[j].ActorID(),
+			docs[j].VersionVector().VersionOf(docs[j].ActorID()))
+		assert.NoError(t, docs[j].ApplyChangePack(&pCopy))
+	}
+
+	// Run three rounds of fully-connected fanout. After the very first
+	// round every actor has seen every other actor at least once; if VV
+	// merging were still happening, doc.VV would jump to numActors.
+	for round := 1; round <= 3; round++ {
+		for i := 0; i < numActors; i++ {
+			assert.NoError(t, docs[i].Update(func(r *json.Object, _ *presence.Presence) error {
+				r.GetCounter("c").Increase(1)
+				return nil
+			}))
+
+			pack := docs[i].CreateChangePack()
+			vv := pack.Changes[len(pack.Changes)-1].ID().VersionVector()
+			assert.Equal(t, 1, len(vv),
+				"round=%d actor=%d local Change.VV must stay size 1, got %s",
+				round, i, vv.Marshal())
+
+			for j := 0; j < numActors; j++ {
+				if j == i {
+					continue
+				}
+				pCopy := *pack
+				pCopy.VersionVector = pack.VersionVector.DeepCopy()
+				pCopy.VersionVector.Set(docs[j].ActorID(),
+					docs[j].VersionVector().VersionOf(docs[j].ActorID()))
+				assert.NoError(t, docs[j].ApplyChangePack(&pCopy))
+			}
+		}
+
+		for i := 0; i < numActors; i++ {
+			vv := docs[i].VersionVector()
+			assert.Equal(t, 1, len(vv),
+				"round=%d actor=%d doc.VV must stay size 1, got %s",
+				round, i, vv.Marshal())
+		}
+	}
+}
+
+// TestDisableGCStillAdvancesLamport verifies that opting out of GC does
+// not stop lamport progression — TimeTickets produced after consuming a
+// remote change must still be ordered against it. Without lamport sync,
+// concurrent ticks from this client would collide with remote element ids.
+func TestDisableGCStillAdvancesLamport(t *testing.T) {
+	actorA, err := time.ActorIDFromHex("000000000000000000000001")
+	assert.NoError(t, err)
+	actorB, err := time.ActorIDFromHex("000000000000000000000002")
+	assert.NoError(t, err)
+
+	docA := document.New("lamport")
+	docA.SetActor(actorA)
+	docB := document.New("lamport")
+	docB.SetActor(actorB)
+	docB.SetDisableGC(true)
+
+	// A advances its lamport by writing twice.
+	assert.NoError(t, docA.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.SetNewCounter("c", 0).Increase(1)
+		return nil
+	}))
+	assert.NoError(t, docA.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.GetCounter("c").Increase(1)
+		return nil
+	}))
+	beforeLamport := docB.InternalDocument().Lamport()
+
+	packA := docA.CreateChangePack()
+	pCopy := *packA
+	pCopy.VersionVector = packA.VersionVector.DeepCopy()
+	pCopy.VersionVector.Set(docB.ActorID(), docB.VersionVector().VersionOf(docB.ActorID()))
+	assert.NoError(t, docB.ApplyChangePack(&pCopy))
+
+	assert.Greater(t, docB.InternalDocument().Lamport(), beforeLamport,
+		"disable_gc must still advance lamport on incoming remote changes")
+	assert.Equal(t, 1, len(docB.VersionVector()),
+		"disable_gc must keep doc.VV at size 1 after consuming remote changes")
+}

--- a/pkg/document/disable_gc_test.go
+++ b/pkg/document/disable_gc_test.go
@@ -22,7 +22,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/yorkie-team/yorkie/api/converter"
 	"github.com/yorkie-team/yorkie/pkg/document"
+	"github.com/yorkie-team/yorkie/pkg/document/change"
 	"github.com/yorkie-team/yorkie/pkg/document/json"
 	"github.com/yorkie-team/yorkie/pkg/document/presence"
 	"github.com/yorkie-team/yorkie/pkg/document/time"
@@ -139,4 +141,78 @@ func TestDisableGCStillAdvancesLamport(t *testing.T) {
 		"disable_gc must still advance lamport on incoming remote changes")
 	assert.Equal(t, 1, len(docB.VersionVector()),
 		"disable_gc must keep doc.VV at size 1 after consuming remote changes")
+}
+
+// TestDisableGCSnapshotPullCatchesUpLamport pins the client-side contract
+// for the snapshot pull path under disable_gc: the server sends a snapshot
+// together with a single-entry VV keyed by the receiving client's actor
+// and carrying the doc's max lamport (see server/packs/pushpull.go
+// pullPack). The client's applySnapshot must use that lamport to advance
+// its change clock and keep doc.VV at size 1.
+func TestDisableGCSnapshotPullCatchesUpLamport(t *testing.T) {
+	actorA, err := time.ActorIDFromHex("000000000000000000000001")
+	assert.NoError(t, err)
+	actorB, err := time.ActorIDFromHex("000000000000000000000002")
+	assert.NoError(t, err)
+
+	// 01. docA accumulates lamport by making many local updates.
+	docA := document.New("snap-contract")
+	docA.SetActor(actorA)
+	const numUpdates = 20
+	assert.NoError(t, docA.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.SetNewCounter("c", 0)
+		return nil
+	}))
+	for i := 0; i < numUpdates; i++ {
+		assert.NoError(t, docA.Update(func(r *json.Object, _ *presence.Presence) error {
+			r.GetCounter("c").Increase(1)
+			return nil
+		}))
+	}
+	docALamport := docA.InternalDocument().Lamport()
+	assert.GreaterOrEqual(t, docALamport, int64(numUpdates),
+		"sanity: docA's lamport must reflect its updates")
+
+	// 02. Build the snapshot bytes the server would persist.
+	snapshotBytes, err := converter.SnapshotToBytes(docA.RootObject(), docA.AllPresences())
+	assert.NoError(t, err)
+
+	// 03. Opt-out docB receives the snapshot. Mirror what the server now
+	//     sends: a single-entry VV keyed by the receiving client's actor
+	//     and carrying the doc's max lamport. This keeps the wire footprint
+	//     at one entry while letting the client catch its clock up.
+	docB := document.New("snap-contract")
+	docB.SetActor(actorB)
+	docB.SetDisableGC(true)
+
+	snapshotPack := change.NewPack(
+		docB.Key(),
+		change.InitialCheckpoint,
+		nil,
+		time.VersionVector{docB.ActorID(): docALamport},
+		snapshotBytes,
+	)
+	assert.NoError(t, docB.ApplyChangePack(snapshotPack))
+
+	docBLamport := docB.InternalDocument().Lamport()
+	assert.GreaterOrEqual(t, docBLamport, docALamport,
+		"opt-out client must catch up to the snapshot's lamport (server=%d got=%d)",
+		docALamport, docBLamport)
+	assert.Equal(t, 1, len(docB.VersionVector()),
+		"opt-out doc.VV must stay at size 1 after snapshot pull, got %s",
+		docB.VersionVector().Marshal())
+
+	// 04. The next produced local Change must therefore start at a
+	//     lamport beyond the server's, and still carry a size-1 VV.
+	assert.NoError(t, docB.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.GetCounter("c").Increase(1)
+		return nil
+	}))
+	newPack := docB.CreateChangePack()
+	newChange := newPack.Changes[len(newPack.Changes)-1]
+	assert.Greater(t, newChange.ID().Lamport(), docALamport,
+		"new local Change.lamport must exceed server's previous max")
+	assert.Equal(t, 1, len(newChange.ID().VersionVector()),
+		"new local Change.VV must stay size 1, got %s",
+		newChange.ID().VersionVector().Marshal())
 }

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -288,6 +288,14 @@ func (d *Document) InternalDocument() *InternalDocument {
 	return d.doc
 }
 
+// SetDisableGC records whether this document participates in GC. See
+// InternalDocument.SetDisableGC and docs/design/disable-gc-on-attach.md.
+func (d *Document) SetDisableGC(disableGC bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.doc.SetDisableGC(disableGC)
+}
+
 // Key returns the key of this document.
 func (d *Document) Key() key.Key {
 	return d.doc.key

--- a/pkg/document/internal_document.go
+++ b/pkg/document/internal_document.go
@@ -76,6 +76,13 @@ type InternalDocument struct {
 	// localChanges is the list of the changes that are not yet sent to the
 	// server.
 	localChanges []*change.Change
+
+	// disableGC, when true, declares that this document does not produce or
+	// consume tombstones (see docs/design/disable-gc-on-attach.md). It is set
+	// by the client on Attach and consumed by ApplyChanges to skip merging
+	// remote actors' version vectors into changeID, keeping each subsequent
+	// local Change's VV at O(1) for high-fan-out Counter workloads.
+	disableGC bool
 }
 
 // NewInternalDocument creates a new instance of InternalDocument.
@@ -144,6 +151,13 @@ func (d *InternalDocument) SyncCheckpoint(serverSeq int64, clientSeq uint32) {
 // HasLocalChanges returns whether this document has local changes or not.
 func (d *InternalDocument) HasLocalChanges() bool {
 	return len(d.localChanges) > 0
+}
+
+// SetDisableGC records whether this document participates in GC. The client
+// calls this on Attach so subsequent ApplyChanges runs use the lamport-only
+// sync path described in docs/design/disable-gc-on-attach.md.
+func (d *InternalDocument) SetDisableGC(disableGC bool) {
+	d.disableGC = disableGC
 }
 
 // ApplyChangePack applies the given change pack into this document.
@@ -304,7 +318,11 @@ func (d *InternalDocument) ApplyChanges(changes ...*change.Change) ([]DocEvent, 
 			}
 		}
 
-		d.changeID = d.changeID.SyncClocks(c.ID())
+		if d.disableGC {
+			d.changeID = d.changeID.SyncLamport(c.ID())
+		} else {
+			d.changeID = d.changeID.SyncClocks(c.ID())
+		}
 	}
 
 	return events, nil

--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -2094,13 +2094,26 @@ func (d *DB) CreateSnapshotInfo(
 		snapshotField = nil
 	}
 
+	// If no opt-in client tracks this doc (no versionvectors row), the
+	// stored snapshot VV has no GC consumer. Persist an empty VV so
+	// opt-out-only documents do not accumulate per-actor entries in
+	// snapshot rows. See docs/design/disable-gc-on-attach.md.
+	vv := doc.VersionVector().DeepCopy()
+	hasOptIn, err := d.hasVersionVectorRow(txn, docRefKey)
+	if err != nil {
+		return err
+	}
+	if !hasOptIn {
+		vv = time.NewVersionVector()
+	}
+
 	if err := txn.Insert(tblSnapshots, &database.SnapshotInfo{
 		ID:              newID(),
 		ProjectID:       docRefKey.ProjectID,
 		DocID:           docRefKey.DocID,
 		ServerSeq:       doc.Checkpoint().ServerSeq,
 		Lamport:         doc.Lamport(),
-		VersionVector:   doc.VersionVector().DeepCopy(),
+		VersionVector:   vv,
 		Snapshot:        snapshotField,
 		HasExternalBody: hasExternalBody,
 		CreatedAt:       gotime.Now(),
@@ -2109,6 +2122,16 @@ func (d *DB) CreateSnapshotInfo(
 	}
 	txn.Commit()
 	return nil
+}
+
+// hasVersionVectorRow reports whether any client has stored a version
+// vector row for the given document within the open transaction.
+func (d *DB) hasVersionVectorRow(txn *memdb.Txn, docRefKey types.DocRefKey) (bool, error) {
+	raw, err := txn.First(tblVersionVectors, "doc_id", docRefKey.DocID.String())
+	if err != nil {
+		return false, fmt.Errorf("check version vector row: %w", err)
+	}
+	return raw != nil, nil
 }
 
 // FindSnapshotInfo returns the snapshot info of the given DocRefKey and serverSeq.

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -2154,6 +2154,19 @@ func (c *Client) CreateSnapshotInfo(
 		return fmt.Errorf("compress snapshot of %s: %w", docRefKey, err)
 	}
 
+	// If no opt-in client tracks this doc (i.e., versionvectors has no
+	// row for it), the stored snapshot VV serves no GC purpose. Persist
+	// an empty VV so opt-out-only documents do not accumulate per-actor
+	// entries in snapshot rows. See docs/design/disable-gc-on-attach.md.
+	vv := doc.VersionVector()
+	hasOptIn, err := c.hasVersionVectorRow(ctx, docRefKey)
+	if err != nil {
+		return err
+	}
+	if !hasOptIn {
+		vv = time.NewVersionVector()
+	}
+
 	serverSeq := doc.Checkpoint().ServerSeq
 	hasExternalBody := len(compressed) > database.SnapshotBodyThreshold
 
@@ -2162,7 +2175,7 @@ func (c *Client) CreateSnapshotInfo(
 		"doc_id":            docRefKey.DocID,
 		"server_seq":        serverSeq,
 		"lamport":           doc.Lamport(),
-		"version_vector":    doc.VersionVector(),
+		"version_vector":    vv,
 		"has_external_body": hasExternalBody,
 		"created_at":        gotime.Now(),
 	}
@@ -2188,6 +2201,24 @@ func (c *Client) CreateSnapshotInfo(
 	}
 
 	return nil
+}
+
+// hasVersionVectorRow reports whether any client has stored a version
+// vector row for the given document. It tells the snapshot path whether
+// any opt-in client is tracking this doc; if not, the snapshot VV can
+// be persisted as empty since no GC consumer needs it.
+func (c *Client) hasVersionVectorRow(ctx context.Context, docRefKey types.DocRefKey) (bool, error) {
+	err := c.collection(ColVersionVectors).FindOne(ctx, bson.M{
+		"project_id": docRefKey.ProjectID,
+		"doc_id":     docRefKey.DocID,
+	}, options.FindOne().SetProjection(bson.M{"_id": 1})).Err()
+	if err == mongo.ErrNoDocuments {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("check version vector row: %w", err)
+	}
+	return true, nil
 }
 
 // FindSnapshotInfo returns the snapshot info of the given DocRefKey and serverSeq.

--- a/server/packs/pushpull.go
+++ b/server/packs/pushpull.go
@@ -307,14 +307,32 @@ func pullPack(
 
 	// 03. update client's vector and checkpoint to DB.
 	// Skip both minVV tracking and response VV when this PushPull is
-	// flagged as GC-free. The client never consumes the response VV, and
-	// excluding it from minVV is correct because tombstones do not need to
-	// be kept alive for this client. See docs/design/disable-gc-on-attach.md.
+	// flagged as GC-free. The client never consumes the response VV for
+	// tombstone GC, and excluding it from minVV is correct because
+	// tombstones do not need to be kept alive for this client. See
+	// docs/design/disable-gc-on-attach.md.
 	if opts.DisableGC {
-		// The snapshot path in pullSnapshot populates resPack.VersionVector
-		// unconditionally, so clear it here to keep the wire contract for
-		// opt-out clients consistent across both pull paths.
-		resPack.VersionVector = nil
+		if resPack.SnapshotLen() > 0 {
+			// Snapshot pulls must still carry the doc's max lamport so the
+			// opt-out client's change clock catches up; otherwise its
+			// subsequent local Changes are produced with ticks far behind
+			// the server's actual state. Truncate the full VV that
+			// pullSnapshot populated down to a single entry keyed by the
+			// requesting client's own actor: this preserves lamport
+			// progression via SetClocks while keeping the size-1 invariant
+			// the opt-out client maintains.
+			actorID, err := clientInfo.ID.ToActorID()
+			if err != nil {
+				return nil, err
+			}
+			maxLamport := resPack.VersionVector.MaxLamport()
+			resPack.VersionVector = time.VersionVector{actorID: maxLamport}
+		} else {
+			// Change pulls do not need a pack-level lamport hint: each
+			// Change.ID carries its own lamport that the client uses
+			// directly via SyncLamport.
+			resPack.VersionVector = nil
+		}
 	} else {
 		minVersionVector, err := be.DB.UpdateMinVersionVector(ctx, clientInfo, docInfo.RefKey(), reqPack.VersionVector)
 		if err != nil {

--- a/test/integration/disable_gc_test.go
+++ b/test/integration/disable_gc_test.go
@@ -269,4 +269,119 @@ func TestDisableGCOnAttach(t *testing.T) {
 				"snapshot response; got %d, server is at %d",
 			d2Lamport, d1Lamport)
 	})
+
+	t.Run("snapshot row stores empty VV when every client opts out", func(t *testing.T) {
+		// Server-side regression: with no opt-in client tracking the doc
+		// (no row in versionvectors), the persisted snapshot row's VV has
+		// no GC consumer. CreateSnapshotInfo must therefore store an
+		// empty VV so opt-out-only documents do not accumulate per-actor
+		// entries in snapshot rows. Before the fix, every snapshot row
+		// carried a VV of size O(num_actors_ever).
+		const numClients = 5
+		clients := activeClients(t, numClients)
+		defer deactivateAndCloseClients(t, clients)
+
+		ctx := context.Background()
+		docKey := helper.TestKey(t)
+		docs := make([]*document.Document, numClients)
+		for i := 0; i < numClients; i++ {
+			docs[i] = document.New(docKey)
+			assert.NoError(t, clients[i].Attach(ctx, docs[i], client.WithDisableGC()))
+		}
+
+		// c0 creates the counter; everyone increments enough rounds to
+		// cross the test backend's snapshot threshold (10).
+		assert.NoError(t, docs[0].Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewCounter("c", 0)
+			return nil
+		}))
+		assert.NoError(t, clients[0].Sync(ctx))
+		for i := 1; i < numClients; i++ {
+			assert.NoError(t, clients[i].Sync(ctx))
+		}
+		for round := 0; round < 3; round++ {
+			for i := 0; i < numClients; i++ {
+				assert.NoError(t, docs[i].Update(func(root *json.Object, p *presence.Presence) error {
+					root.GetCounter("c").Increase(1)
+					return nil
+				}))
+				assert.NoError(t, clients[i].Sync(ctx))
+			}
+		}
+		// Flush so storeSnapshot fires in the pubsub goroutine.
+		for i := 0; i < numClients; i++ {
+			assert.NoError(t, clients[i].Sync(ctx))
+		}
+
+		be := defaultServer.Backend()
+		project, err := defaultServer.DefaultProject(ctx)
+		assert.NoError(t, err)
+		docInfo, err := be.DB.FindDocInfoByKey(ctx, project.ID, docKey)
+		assert.NoError(t, err)
+		snapInfo, err := be.DB.FindClosestSnapshotInfo(
+			ctx, docInfo.RefKey(), docInfo.ServerSeq, false,
+		)
+		assert.NoError(t, err)
+		assert.NotEqual(t, int64(0), snapInfo.ServerSeq,
+			"sanity: a snapshot row must exist past serverSeq 0")
+		assert.Equal(t, 0, len(snapInfo.VersionVector),
+			"opt-out-only snapshot row VV must be empty, got %s",
+			snapInfo.VersionVector.Marshal())
+	})
+
+	t.Run("snapshot row preserves VV when at least one client is opt-in", func(t *testing.T) {
+		// Counter test for the previous regression: as soon as a single
+		// opt-in client is tracking the doc, the snapshot VV must be
+		// preserved (with at least that client's entry) so the opt-in
+		// client's GC path keeps working.
+		clients := activeClients(t, 4)
+		defer deactivateAndCloseClients(t, clients)
+
+		ctx := context.Background()
+		docKey := helper.TestKey(t)
+
+		// clients[0] is opt-in; clients[1..3] are opt-out.
+		docs := make([]*document.Document, 4)
+		docs[0] = document.New(docKey)
+		assert.NoError(t, clients[0].Attach(ctx, docs[0]))
+		for i := 1; i < 4; i++ {
+			docs[i] = document.New(docKey)
+			assert.NoError(t, clients[i].Attach(ctx, docs[i], client.WithDisableGC()))
+		}
+
+		assert.NoError(t, docs[0].Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewCounter("c", 0)
+			return nil
+		}))
+		for _, c := range clients {
+			assert.NoError(t, c.Sync(ctx))
+		}
+		for round := 0; round < 3; round++ {
+			for i := 0; i < 4; i++ {
+				assert.NoError(t, docs[i].Update(func(root *json.Object, p *presence.Presence) error {
+					root.GetCounter("c").Increase(1)
+					return nil
+				}))
+				assert.NoError(t, clients[i].Sync(ctx))
+			}
+		}
+		for _, c := range clients {
+			assert.NoError(t, c.Sync(ctx))
+		}
+
+		be := defaultServer.Backend()
+		project, err := defaultServer.DefaultProject(ctx)
+		assert.NoError(t, err)
+		docInfo, err := be.DB.FindDocInfoByKey(ctx, project.ID, docKey)
+		assert.NoError(t, err)
+		snapInfo, err := be.DB.FindClosestSnapshotInfo(
+			ctx, docInfo.RefKey(), docInfo.ServerSeq, false,
+		)
+		assert.NoError(t, err)
+		assert.NotEqual(t, int64(0), snapInfo.ServerSeq,
+			"sanity: a snapshot row must exist past serverSeq 0")
+		assert.NotZero(t, len(snapInfo.VersionVector),
+			"mixed-mode snapshot row VV must be preserved (at least the "+
+				"opt-in client's entry); got empty")
+	})
 }

--- a/test/integration/disable_gc_test.go
+++ b/test/integration/disable_gc_test.go
@@ -97,6 +97,88 @@ func TestDisableGCOnAttach(t *testing.T) {
 		assert.Equal(t, "2", d2.Root().GetCounter("counter").Marshal())
 	})
 
+	t.Run("opt-out clients keep per-Change VV at size 1 under multi-actor fanout", func(t *testing.T) {
+		// Regression for the bug where Change.ID.VersionVector accumulated
+		// O(num_actors) entries on every opt-out client because
+		// ApplyChanges -> SyncClocks merged every remote actor into the
+		// local VV. After the SyncLamport fix the per-Change VV must stay
+		// at size 1 so the on-the-wire savings the opt-out promises
+		// actually materialize.
+		clients := activeClients(t, 3)
+		defer deactivateAndCloseClients(t, clients)
+		c1, c2, c3 := clients[0], clients[1], clients[2]
+
+		ctx := context.Background()
+		docKey := helper.TestKey(t)
+		d1 := document.New(docKey)
+		d2 := document.New(docKey)
+		d3 := document.New(docKey)
+		assert.NoError(t, c1.Attach(ctx, d1, client.WithDisableGC()))
+		assert.NoError(t, c2.Attach(ctx, d2, client.WithDisableGC()))
+		assert.NoError(t, c3.Attach(ctx, d3, client.WithDisableGC()))
+
+		assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewCounter("counter", 0)
+			return nil
+		}))
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c3.Sync(ctx))
+
+		// A few rounds of mutual increments + sync. The second round is
+		// when accumulation used to first show up because every actor has
+		// then seen every other actor at least once.
+		for range 3 {
+			assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+				root.GetCounter("counter").Increase(1)
+				return nil
+			}))
+			assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+				root.GetCounter("counter").Increase(1)
+				return nil
+			}))
+			assert.NoError(t, d3.Update(func(root *json.Object, p *presence.Presence) error {
+				root.GetCounter("counter").Increase(1)
+				return nil
+			}))
+			assert.NoError(t, c1.Sync(ctx))
+			assert.NoError(t, c2.Sync(ctx))
+			assert.NoError(t, c3.Sync(ctx))
+		}
+
+		// Drain remaining pushed changes so every client sees the full
+		// counter. Two extra sync passes are enough for a 3-client mesh.
+		for range 2 {
+			assert.NoError(t, c1.Sync(ctx))
+			assert.NoError(t, c2.Sync(ctx))
+			assert.NoError(t, c3.Sync(ctx))
+		}
+
+		// Convergence sanity check: 3 rounds * 3 actors = 9 increments.
+		assert.Equal(t, "9", d1.Root().GetCounter("counter").Marshal())
+		assert.Equal(t, "9", d2.Root().GetCounter("counter").Marshal())
+		assert.Equal(t, "9", d3.Root().GetCounter("counter").Marshal())
+
+		// The contract assertion: every opt-out doc's VV stays at size 1.
+		for i, d := range []*document.Document{d1, d2, d3} {
+			vv := d.VersionVector()
+			assert.Equal(t, 1, len(vv),
+				"opt-out doc[%d].VersionVector() must stay at size 1, got %s",
+				i, vv.Marshal())
+		}
+
+		// And so does the next produced local Change.
+		assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetCounter("counter").Increase(1)
+			return nil
+		}))
+		pack := d1.CreateChangePack()
+		vv := pack.Changes[len(pack.Changes)-1].ID().VersionVector()
+		assert.Equal(t, 1, len(vv),
+			"new local Change produced under disable_gc must carry size-1 VV, got %s",
+			vv.Marshal())
+	})
+
 	t.Run("re-attach without WithDisableGC restores normal GC participation", func(t *testing.T) {
 		clients := activeClients(t, 1)
 		defer deactivateAndCloseClients(t, clients)

--- a/test/integration/disable_gc_test.go
+++ b/test/integration/disable_gc_test.go
@@ -20,6 +20,7 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -222,5 +223,50 @@ func TestDisableGCOnAttach(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotZero(t, len(minVV),
 			"re-attach without opt-out should resume minVV tracking")
+	})
+
+	t.Run("opt-out client picks up server lamport when attach returns a snapshot", func(t *testing.T) {
+		// Latent issue exposed by the snapshot pull path:
+		// server/packs/pushpull.go nils resPack.VersionVector for opt-out
+		// even when the response is a snapshot, leaving the client without
+		// the lamport info it needs to catch up. Today this test FAILS
+		// because the opt-out client's lamport remains ~1 after the
+		// snapshot pull, while the server doc has advanced far beyond.
+		clients := activeClients(t, 2)
+		defer deactivateAndCloseClients(t, clients)
+		c1, c2 := clients[0], clients[1]
+
+		ctx := context.Background()
+		docKey := helper.TestKey(t)
+
+		// 01. c1 attaches normally and writes past the snapshot threshold
+		// so that any later pull at serverSeq=0 produces a snapshot
+		// response.
+		d1 := document.New(docKey)
+		assert.NoError(t, c1.Attach(ctx, d1))
+		for i := 0; i <= int(helper.SnapshotThreshold); i++ {
+			assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+				root.SetInteger(fmt.Sprintf("k%d", i), i)
+				return nil
+			}))
+		}
+		assert.NoError(t, c1.Sync(ctx))
+		d1Lamport := d1.InternalDocument().Lamport()
+
+		// 02. c2 attaches with opt-out. The attach response's pull path
+		// crosses the threshold, so the server returns a snapshot. With
+		// the current behavior the response's VV is nil and c2's lamport
+		// fails to catch up.
+		d2 := document.New(docKey)
+		assert.NoError(t, c2.Attach(ctx, d2, client.WithDisableGC()))
+
+		d2Lamport := d2.InternalDocument().Lamport()
+		t.Logf("d1.lamport=%d  d2.lamport after opt-out snapshot pull=%d",
+			d1Lamport, d2Lamport)
+
+		assert.GreaterOrEqual(t, d2Lamport, d1Lamport,
+			"opt-out client must catch up to the server's lamport via the "+
+				"snapshot response; got %d, server is at %d",
+			d2Lamport, d1Lamport)
 	})
 }


### PR DESCRIPTION
## Summary

Follow-up to #1822. Two issues with the disable_gc opt-out for high-fan-out Counter workloads were left behind:

1. **Per-Change VV still accumulates on opt-out clients.** `InternalDocument.ApplyChanges` calls `SyncClocks` unconditionally, which merges every incoming change's VV into the local doc VV. After one fanout round across N actors, every opt-out client emits Changes carrying an O(N)-sized VV — exactly the per-actor overhead the opt-out was supposed to remove. Fixed by adding `change.ID.SyncLamport` (lamport advance only) and routing `ApplyChanges` through it when the document is opted out. The flag is set on `InternalDocument` via a new `SetDisableGC`, which `Client.Attach` now calls before the first `ApplyChangePack`.

2. **Snapshot responses lose lamport info on opt-out.** `pullPack` was nilling `resPack.VersionVector` even when the response carried a snapshot. `applySnapshot` derives the catch-up lamport from that VV, so feeding it nil meant opt-out clients' lamport only advanced by 1 after a snapshot pull, leaving them emitting Changes with stale ticks. Fixed by sending a single-entry VV `{client_actor: max_lamport}` on opt-out snapshot responses — keeps wire size at one entry, lets `SetClocks` catch lamport up correctly, and preserves the size-1 VV invariant on the client.

## Test plan

- [x] `make lint` clean
- [x] `go test ./...` — full unit suite green
- [x] `go test -tags integration ./test/integration/` — full integration suite green (58s)
- [x] New unit regressions in `pkg/document/disable_gc_test.go`:
  - `TestDisableGCKeepsChangeVVAtSizeOne` — 5 actors × 3 fanout rounds, every Change.VV stays at size 1
  - `TestDisableGCStillAdvancesLamport` — lamport still progresses on remote change apply
  - `TestDisableGCSnapshotPullCatchesUpLamport` — single-entry VV from server is enough to catch up
- [x] New integration regressions in `test/integration/disable_gc_test.go`:
  - "opt-out clients keep per-Change VV at size 1 under multi-actor fanout" — end-to-end VV size check across SDK + server
  - "opt-out client picks up server lamport when attach returns a snapshot" — writes past `SnapshotThreshold` then attaches opt-out, asserts lamport catches up

## Notes

JS SDK has the symmetric per-Change VV accumulation bug (PR #1265 mirrors only the wire contract). A follow-up PR on `yorkie-js-sdk` covers that side. The snapshot fix in this PR is server-side and benefits JS clients automatically once merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure DisableGC opt-out is applied immediately on attach so remote changes follow opt-out rules.
  * Preserve lamport progression while keeping per-document version vectors size‑1 for opt-out documents during pulls and sync.
  * Store empty version vectors for snapshots when no opt-in client exists to avoid accumulating per-actor entries.

* **Tests**
  * Added regression and integration tests covering DisableGC attach, snapshot-pull, and multi-actor convergence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yorkie-team/yorkie/pull/1826?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->