### PR TITLE
Self-prune leaked Subscription via consecutive Publish failures

### DIFF
--- a/docs/design/pub-sub.md
+++ b/docs/design/pub-sub.md
@@ -187,4 +187,30 @@ func (s *yorkieServer) WatchDocument(
 
 ### Risks and Mitigation
 
-Currently, Subscription instances are managed in memory.
+Subscription instances are managed in memory on the pod that owns the
+stream. Two concrete risks follow from this.
+
+**1. Subscription leak when the stream never terminates cleanly.**
+The only cleanup path tied to a `Subscription` is the WatchDocument
+stream handler's `defer s.backend.PubSub.Unsubscribe(...)`. If the
+stream context never reaches `Done()` — half-closed TCP, dropped
+HTTP/2 stream, a client that crashes without an explicit close — the
+entry survives in `Subscriptions.internalMap` indefinitely. The
+`BatchPublisher` then emits a `Publish to %s timeout or closed` log
+line every cycle for the stale subscriber.
+
+*Mitigation:* `Subscription[E]` counts consecutive `Publish` failures
+(timeout on the events channel or an already-closed channel). Once
+the counter reaches `defaultMaxConsecutivePublishFailures`, the
+subscription marks itself dead and closes its events channel. The
+`BatchPublisher.publish()` loop calls `Subscription.IsDead()` at the
+top of each iteration, skips dead entries, and reaps them via
+`Subscriptions.Delete(id)` after the loop. Stream-lifecycle cleanup
+remains the primary path; self-prune is a fallback for the dead-stream
+case.
+
+**2. In-memory state is per-pod.** A leaked subscription on pod X
+cannot be reaped by anything running on pod Y. The self-prune
+mitigation runs locally on the pod that owns the stale subscription,
+which is sufficient for log-volume and CPU costs but does not provide
+cluster-wide subscription introspection.

--- a/docs/tasks/active/20260609-subscription-self-prune-todo.md
+++ b/docs/tasks/active/20260609-subscription-self-prune-todo.md
@@ -271,7 +271,11 @@ t.Run("stale subscription is reaped by batch publisher", func(t *testing.T) {
 
     // Never drain sub.Events(); fill the buffer (size 1 for DocSubscription)
     // and emit publishes until the publisher reaps it.
-    docEvent := events.DocEvent{Type: events.DocChanged, Actor: idB, Key: refKey}
+    docEvent := events.DocEvent{
+        Type:      events.DocChanged,
+        Publisher: idB,
+        DocRefKey: refKey,
+    }
     // Each publish() cycle attempts to send up to len(events) items; the
     // default threshold is 100 consecutive failures. Emit enough events
     // to cross that bar within a reasonable timeout.

--- a/docs/tasks/active/20260609-subscription-self-prune-todo.md
+++ b/docs/tasks/active/20260609-subscription-self-prune-todo.md
@@ -1,0 +1,444 @@
+**Created**: 2026-06-09
+
+# Self-Prune Stale Document Subscriptions
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reclaim leaked document `Subscription[E]` entries that survive when the owning WatchDocument stream never invokes its `defer` cleanup (half-closed TCP, hung client, dropped HTTP/2 stream). Today the only path that removes a subscription from `Subscriptions.internalMap` is the stream handler's `defer s.backend.PubSub.Unsubscribe(...)`. When that trigger never fires, `BatchPublisher.publish()` keeps emitting `"Publish to %s timeout or closed"` for the dead subscriber every cycle indefinitely.
+
+**Architecture:** Track consecutive `Publish` failures inside `Subscription[E]`. When the counter crosses a per-subscription threshold, the subscription closes its events channel and marks itself dead. `BatchPublisher.publish()` checks `IsDead()` before delivering to a subscriber, skips dead entries, and calls `Subscriptions.Delete(id)` for them after the event loop. Stream-lifecycle cleanup via the handler's `defer` remains the primary cleanup path; self-prune is a safety net for the dead-stream case.
+
+**Tech Stack:** Go, internal `package pubsub` unit tests, `-tags integration` test
+
+**Spec:** `docs/design/pub-sub.md` — extend the "Risks and Mitigation" section.
+
+---
+
+## Background
+
+A document subscription has two end-of-life conditions today:
+
+1. The WatchDocument streaming RPC handler exits and runs `defer
+   s.backend.PubSub.Unsubscribe(ctx, docKey, sub)` (`server/rpc/yorkie_server.go`).
+2. Nothing else.
+
+When the stream context never fires `Done()` (the client's TCP went away
+but the server's HTTP/2 layer did not detect it, the client crashed
+mid-stream, etc.), `Subscriptions.internalMap` keeps the entry alive
+forever. Every `BatchPublisher.publish()` tick then iterates over the
+dead entry and emits a log line at INFO level, with no path to
+reclamation.
+
+Operations evidence (qa cluster, 2026-06-09): a deactivated client whose
+DB record shows `status: deactivated, documents[doc].status: detached,
+attached_docs: []` from five days ago is still being targeted by
+publishes on at least one pod, producing the bulk of the daily log
+volume.
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `server/backend/pubsub/subscription.go` | Add `failureCount`/`maxFailures` fields, self-prune in `Publish`, `IsDead` accessor |
+| Modify | `server/backend/pubsub/batch_publisher.go` | Skip dead subs in iteration, reap via `Subscriptions.Delete` after the loop |
+| Add | `server/backend/pubsub/subscription_test.go` | Internal-package unit tests for self-prune behavior |
+| Modify | `server/backend/pubsub/pubsub_test.go` | External-package test asserting `Subscriptions.Len()` shrinks after dead-sub publishes |
+| Add | `test/integration/subscription_leak_test.go` | Integration test: stuck WatchDocument stream is reaped within a bounded number of publish cycles |
+| Modify | `docs/design/pub-sub.md` | Expand "Risks and Mitigation" with the leak description and self-prune mitigation |
+
+---
+
+### Task 1: Failing Internal Unit Tests
+
+**Files:**
+- Add: `server/backend/pubsub/subscription_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `server/backend/pubsub/subscription_test.go` in `package pubsub`
+(internal) so the new fields are reachable. Three subtests:
+
+```go
+package pubsub
+
+import (
+    "testing"
+    gotime "time"
+
+    "github.com/stretchr/testify/assert"
+
+    "github.com/yorkie-team/yorkie/pkg/document/time"
+)
+
+func TestSubscription_SelfPrune(t *testing.T) {
+    actor, err := time.ActorIDFromBytes([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
+    assert.NoError(t, err)
+
+    t.Run("publish success resets failure count", func(t *testing.T) {
+        sub := NewSubscription[int](actor, 1)
+        sub.maxFailures = 3
+
+        // Fill the buffer once.
+        assert.True(t, sub.Publish(1))
+        // Next Publish blocks for publishTimeout then fails.
+        assert.False(t, sub.Publish(2))
+        // Drain to free the buffer.
+        <-sub.Events()
+        // Successful publish must reset the counter.
+        assert.True(t, sub.Publish(3))
+        assert.False(t, sub.IsDead())
+    })
+
+    t.Run("dead after consecutive failures", func(t *testing.T) {
+        sub := NewSubscription[int](actor, 1)
+        sub.maxFailures = 3
+
+        assert.True(t, sub.Publish(1)) // buffer full
+        for range sub.maxFailures {
+            assert.False(t, sub.Publish(99))
+        }
+        assert.True(t, sub.IsDead())
+    })
+
+    t.Run("dead publish short-circuits without waiting timeout", func(t *testing.T) {
+        sub := NewSubscription[int](actor, 1)
+        sub.Close()
+
+        start := gotime.Now()
+        assert.False(t, sub.Publish(42))
+        assert.Less(t, gotime.Since(start), publishTimeout/2)
+    })
+}
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+Run: `go test ./server/backend/pubsub/ -run TestSubscription_SelfPrune -v -count=1`
+
+Expected: compile error (fields not yet declared).
+
+---
+
+### Task 2: Implement Self-Prune in Subscription
+
+**Files:**
+- Modify: `server/backend/pubsub/subscription.go`
+
+- [ ] **Step 1: Add fields and constructor wiring**
+
+Add to the constants block:
+
+```go
+// defaultMaxConsecutivePublishFailures is the threshold of consecutive
+// Publish failures (timeout or already-closed channel) after which a
+// Subscription marks itself dead and lets the BatchPublisher reap it.
+// Set conservatively so transient slow consumers are not pruned, while
+// keeping leaked subscriptions from accumulating indefinitely.
+defaultMaxConsecutivePublishFailures = 100
+```
+
+Add fields to `Subscription[E]`:
+
+```go
+failureCount int
+maxFailures  int
+```
+
+Initialize `maxFailures` in `NewSubscription`:
+
+```go
+maxFailures: defaultMaxConsecutivePublishFailures,
+```
+
+- [ ] **Step 2: Update Publish to count and self-close**
+
+Modify `Subscription[E].Publish`:
+
+```go
+func (s *Subscription[E]) Publish(event E) bool {
+    s.mu.Lock()
+    defer s.mu.Unlock()
+
+    if s.closed {
+        return false
+    }
+
+    select {
+    case s.events <- event:
+        s.failureCount = 0
+        return true
+    case <-gotime.After(publishTimeout):
+        s.failureCount++
+        if s.failureCount >= s.maxFailures {
+            s.closed = true
+            close(s.events)
+        }
+        return false
+    }
+}
+```
+
+- [ ] **Step 3: Add IsDead accessor**
+
+```go
+// IsDead reports whether this Subscription has been closed, either
+// explicitly via Close or by self-prune after too many consecutive
+// Publish failures. The BatchPublisher uses this to skip and reap
+// stale subscriptions.
+func (s *Subscription[E]) IsDead() bool {
+    s.mu.Lock()
+    defer s.mu.Unlock()
+    return s.closed
+}
+```
+
+- [ ] **Step 4: Re-run unit tests**
+
+Run: `go test ./server/backend/pubsub/ -run TestSubscription_SelfPrune -v -count=1`
+
+Expected: PASS.
+
+---
+
+### Task 3: Reap Dead Subscriptions in BatchPublisher
+
+**Files:**
+- Modify: `server/backend/pubsub/batch_publisher.go`
+
+- [ ] **Step 1: Skip dead subs during publish**
+
+Replace the inner loop in `publish()` with:
+
+```go
+var deadIDs []string
+for _, sub := range bp.subs.Values() {
+    if sub.IsDead() {
+        deadIDs = append(deadIDs, sub.ID())
+        continue
+    }
+    for _, event := range events {
+        if bp.filter != nil && bp.filter(sub.Subscriber(), event) {
+            continue
+        }
+        if ok := sub.Publish(event); !ok {
+            bp.logger.Infof(
+                "Publish to %s timeout or closed",
+                sub.Subscriber(),
+            )
+            if sub.IsDead() {
+                deadIDs = append(deadIDs, sub.ID())
+                break
+            }
+        }
+    }
+}
+for _, id := range deadIDs {
+    bp.subs.Delete(id)
+}
+```
+
+- [ ] **Step 2: Confirm Close() idempotency holds**
+
+`Subscriptions.Delete` runs `sub.Close()` inside the cmap callback.
+`Subscription.Close` already guards with `if !s.closed`, so a sub that
+self-pruned earlier is safe to double-close. No code change needed
+here — just confirm by re-reading lines 70-78 of `subscription.go`.
+
+---
+
+### Task 4: External-Package Reap Test
+
+**Files:**
+- Modify: `server/backend/pubsub/pubsub_test.go`
+
+- [ ] **Step 1: Add a subtest**
+
+Inside the existing `TestPubSub` block, append:
+
+```go
+t.Run("stale subscription is reaped by batch publisher", func(t *testing.T) {
+    pubSub := pubsub.New()
+    refKey := types.DocRefKey{
+        ProjectID: types.ID("000000000000000000000000"),
+        DocID:     types.ID("000000000000000000000000"),
+    }
+
+    ctx := context.Background()
+    sub, _, err := pubSub.Subscribe(ctx, idA, refKey, 0)
+    assert.NoError(t, err)
+
+    // Never drain sub.Events(); fill the buffer (size 1 for DocSubscription)
+    // and emit publishes until the publisher reaps it.
+    docEvent := events.DocEvent{Type: events.DocChanged, Actor: idB, Key: refKey}
+    // Each publish() cycle attempts to send up to len(events) items; the
+    // default threshold is 100 consecutive failures. Emit enough events
+    // to cross that bar within a reasonable timeout.
+    deadline := gotime.Now().Add(30 * gotime.Second)
+    for gotime.Now().Before(deadline) {
+        pubSub.Publish(ctx, idB, docEvent)
+        if sub.IsDead() {
+            break
+        }
+        gotime.Sleep(50 * gotime.Millisecond)
+    }
+    assert.True(t, sub.IsDead(), "subscription should be marked dead after repeated full-buffer publishes")
+
+    // Allow one publisher cycle (window 100ms) to reap.
+    gotime.Sleep(300 * gotime.Millisecond)
+    assert.Equal(t, 0, len(pubSub.ClientIDs(refKey)),
+        "BatchPublisher should remove the dead subscription from Subscriptions")
+})
+```
+
+> Note: `Subscription.IsDead` is exported, so this external test can reference it.
+
+- [ ] **Step 2: Run**
+
+Run: `go test ./server/backend/pubsub/ -v -count=1`
+
+Expected: all PASS (existing + new subtest).
+
+---
+
+### Task 5: Integration Test for Stuck Stream
+
+**Files:**
+- Add: `test/integration/subscription_leak_test.go`
+
+- [ ] **Step 1: Write the test**
+
+Use the existing helpers in `test/integration/` (see other tests for the
+pattern of starting a `defaultServer` and creating clients). Set up:
+
+- Client A: attaches doc, calls Watch, but instead of consuming stream
+  events, blocks (`<-make(chan struct{})`) on the receive goroutine to
+  simulate a stuck consumer that never reads.
+- Client B: attaches the same doc and pushes enough updates to fill A's
+  subscription buffer and cross `maxFailures` over time.
+- Assertion: within `~maxFailures * publishTimeout` plus a slack
+  multiplier, the server's `Subscriptions` for that doc contains only
+  client B (or 0 entries) — check via an admin endpoint or by reading
+  `pubSub.ClientIDs(docKey)` against the backend instance the test
+  controls.
+
+If the test harness does not expose the in-process `pubSub` directly,
+fall back to asserting that the log line `Publish to %s timeout or
+closed` stops emitting for client A's ActorID within the bounded
+window. The first form is preferred since it asserts the structural
+invariant rather than a log side-effect.
+
+- [ ] **Step 2: Run**
+
+Run: `go test -tags integration ./test/integration/ -run TestSubscriptionLeak -v -count=1`
+
+Expected: PASS.
+
+---
+
+### Task 6: Update Design Doc
+
+**Files:**
+- Modify: `docs/design/pub-sub.md`
+
+- [ ] **Step 1: Expand "Risks and Mitigation"**
+
+The current text reads only: *"Currently, Subscription instances are
+managed in memory."*
+
+Replace with a fuller treatment that names two risks and their
+mitigations:
+
+1. **Subscription leak on dead streams.** The handler-`defer` cleanup
+   path requires the WatchDocument stream to terminate. Half-closed TCP
+   or dropped HTTP/2 streams skip that path, leaving subscriptions
+   resident.
+   *Mitigation:* `Subscription[E]` tracks consecutive `Publish` failures.
+   After `defaultMaxConsecutivePublishFailures`, the subscription closes
+   itself; `BatchPublisher.publish()` skips and removes it on the next
+   cycle.
+2. **In-memory only.** State is per-pod. A client whose stream lands on
+   pod X cannot have its subscription reaped from pod Y. The self-prune
+   mitigation runs locally on each pod where the dead subscription was
+   created — sufficient for the leak case, but does not provide
+   cluster-wide subscription introspection.
+
+Also add a short paragraph below the existing "How does it work?"
+section noting the prune path:
+
+> When `Subscription.Publish` returns false repeatedly, the subscription
+> marks itself dead via `IsDead`. On its next iteration, the
+> `BatchPublisher` skips the entry and calls `Subscriptions.Delete`,
+> returning the slot to `subscriptionsMap`.
+
+---
+
+### Task 7: Lint and Full Test
+
+- [ ] **Step 1: Lint**
+
+Run: `make lint`
+
+Expected: no errors.
+
+- [ ] **Step 2: Unit tests**
+
+Run: `go test ./...`
+
+Expected: all PASS.
+
+- [ ] **Step 3: Integration tests (MongoDB required)**
+
+Bring up the integration environment per `CLAUDE.md`:
+
+```sh
+docker compose -f build/docker/docker-compose.yml up --build -d
+```
+
+Run: `make test`
+
+Expected: all PASS, including the new `TestSubscriptionLeak`.
+
+---
+
+### Task 8: Commit Sequence and PR
+
+- [ ] **Step 1: Commit pieces separately**
+
+```bash
+git add server/backend/pubsub/subscription_test.go
+git commit -m "Add failing self-prune tests for stale Subscription"
+
+git add server/backend/pubsub/subscription.go
+git commit -m "Mark Subscription dead after consecutive Publish failures"
+
+git add server/backend/pubsub/batch_publisher.go server/backend/pubsub/pubsub_test.go
+git commit -m "Reap dead Subscriptions from BatchPublisher iteration"
+
+git add test/integration/subscription_leak_test.go
+git commit -m "Add integration test for stuck-stream subscription cleanup"
+
+git add docs/design/pub-sub.md
+git commit -m "Document subscription leak risk and self-prune mitigation"
+
+git add docs/tasks/active/20260609-subscription-self-prune-todo.md \
+        docs/tasks/active/README.md
+git commit -m "Record subscription self-prune task"
+```
+
+Each subject must be ≤ 70 chars; body lines ≤ 80; line 2 blank
+(commit-msg validator enforces this).
+
+- [ ] **Step 2: Rebase against latest main**
+
+```bash
+git fetch origin main
+git rebase origin/main
+```
+
+- [ ] **Step 3: Push and open PR**
+
+`gh` is wired to GHE in this environment, so use the GitHub REST API
+directly with a `github.com`-scoped token. Title ≤ 70 chars; body =
+Summary + Test plan.

--- a/server/backend/pubsub/batch_publisher.go
+++ b/server/backend/pubsub/batch_publisher.go
@@ -121,21 +121,16 @@ func (bp *BatchPublisher[E]) processLoop() {
 func (bp *BatchPublisher[E]) publish() {
 	bp.mutex.Lock()
 
-	if len(bp.events) == 0 {
-		bp.mutex.Unlock()
-		return
-	}
-
 	events := bp.events
 	bp.events = nil
 
-	if bp.onPublish != nil {
+	if len(events) > 0 && bp.onPublish != nil {
 		bp.onPublish()
 	}
 
 	bp.mutex.Unlock()
 
-	if logging.Enabled(zap.DebugLevel) {
+	if len(events) > 0 && logging.Enabled(zap.DebugLevel) {
 		bp.logger.Infof(
 			"Publishing batch of %d events for %s",
 			len(events),
@@ -143,7 +138,14 @@ func (bp *BatchPublisher[E]) publish() {
 		)
 	}
 
+	// Iterate even when the batch is empty so dead subscriptions
+	// (self-pruned after consecutive Publish failures) are reaped.
+	var deadIDs []string
 	for _, sub := range bp.subs.Values() {
+		if sub.IsDead() {
+			deadIDs = append(deadIDs, sub.ID())
+			continue
+		}
 		for _, event := range events {
 			if bp.filter != nil && bp.filter(sub.Subscriber(), event) {
 				continue
@@ -154,8 +156,15 @@ func (bp *BatchPublisher[E]) publish() {
 					"Publish to %s timeout or closed",
 					sub.Subscriber(),
 				)
+				if sub.IsDead() {
+					deadIDs = append(deadIDs, sub.ID())
+					break
+				}
 			}
 		}
+	}
+	for _, id := range deadIDs {
+		bp.subs.Delete(id)
 	}
 }
 

--- a/server/backend/pubsub/batch_publisher_test.go
+++ b/server/backend/pubsub/batch_publisher_test.go
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pubsub
+
+import (
+	"testing"
+	gotime "time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/pkg/document/time"
+)
+
+func TestBatchPublisherReapsDeadSubscriptions(t *testing.T) {
+	actor, err := time.ActorIDFromBytes([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
+	assert.NoError(t, err)
+
+	subs := NewSubscriptions(
+		"test",
+		func(s *Subscriptions[int]) *BatchPublisher[int] {
+			return NewBatchPublisher(s, 50*gotime.Millisecond, BatchPublisherConfig[int]{})
+		},
+	)
+	defer subs.Close()
+
+	sub := NewSubscription[int](actor, 1)
+	sub.maxFailures = 2
+	subs.Set(sub)
+	assert.Equal(t, 1, subs.Len())
+
+	// Saturate the subscription's buffer so subsequent sends time out.
+	assert.True(t, sub.Publish(1))
+
+	// Enqueue events through the publisher so its publish loop sees them.
+	for i := range 4 {
+		subs.Publish(i)
+	}
+
+	// Each failing send blocks for publishTimeout. With maxFailures=2 and
+	// buffer-full state, the second send marks the sub dead. We wait long
+	// enough for the publish loop to reach the dead branch and reap.
+	assert.Eventually(t, func() bool {
+		return sub.IsDead() && subs.Len() == 0
+	}, 3*gotime.Second, 50*gotime.Millisecond,
+		"subscription should self-prune and be reaped by BatchPublisher")
+}

--- a/server/backend/pubsub/subscription.go
+++ b/server/backend/pubsub/subscription.go
@@ -40,17 +40,33 @@ const (
 //
 // Declared as var (not const) so tests can shorten it via
 // SetDefaultMaxConsecutivePublishFailures; production code keeps the
-// default.
-var defaultMaxConsecutivePublishFailures = 100
+// default. Access is guarded by defaultMaxFailuresMu so the setter and
+// the reader in NewSubscription stay race-free.
+var (
+	defaultMaxFailuresMu                 sync.RWMutex
+	defaultMaxConsecutivePublishFailures = 100
+)
 
 // SetDefaultMaxConsecutivePublishFailures overrides the default failure
 // threshold for newly created Subscriptions. Intended for tests only;
 // production code should rely on the package default. Callers should
-// restore the previous value with defer.
+// restore the previous value with defer. Panics on n < 1 since a
+// non-positive threshold would prune every subscription on first send.
 func SetDefaultMaxConsecutivePublishFailures(n int) (previous int) {
+	if n < 1 {
+		panic("pubsub: max consecutive publish failures must be >= 1")
+	}
+	defaultMaxFailuresMu.Lock()
+	defer defaultMaxFailuresMu.Unlock()
 	previous = defaultMaxConsecutivePublishFailures
 	defaultMaxConsecutivePublishFailures = n
 	return previous
+}
+
+func currentDefaultMaxFailures() int {
+	defaultMaxFailuresMu.RLock()
+	defer defaultMaxFailuresMu.RUnlock()
+	return defaultMaxConsecutivePublishFailures
 }
 
 // Subscription represents a subscription of a subscriber to events of type E.
@@ -71,7 +87,7 @@ func NewSubscription[E any](subscriber time.ActorID, bufSize int) *Subscription[
 		subscriber:  subscriber,
 		events:      make(chan E, bufSize),
 		closed:      false,
-		maxFailures: defaultMaxConsecutivePublishFailures,
+		maxFailures: currentDefaultMaxFailures(),
 	}
 }
 

--- a/server/backend/pubsub/subscription.go
+++ b/server/backend/pubsub/subscription.go
@@ -32,22 +32,46 @@ const (
 	publishTimeout = 100 * gotime.Millisecond
 )
 
+// defaultMaxConsecutivePublishFailures is the threshold of consecutive
+// Publish failures (timeout or already-closed channel) after which a
+// Subscription marks itself dead and lets the BatchPublisher reap it.
+// Set conservatively so transient slow consumers are not pruned, while
+// keeping leaked subscriptions from accumulating indefinitely.
+//
+// Declared as var (not const) so tests can shorten it via
+// SetDefaultMaxConsecutivePublishFailures; production code keeps the
+// default.
+var defaultMaxConsecutivePublishFailures = 100
+
+// SetDefaultMaxConsecutivePublishFailures overrides the default failure
+// threshold for newly created Subscriptions. Intended for tests only;
+// production code should rely on the package default. Callers should
+// restore the previous value with defer.
+func SetDefaultMaxConsecutivePublishFailures(n int) (previous int) {
+	previous = defaultMaxConsecutivePublishFailures
+	defaultMaxConsecutivePublishFailures = n
+	return previous
+}
+
 // Subscription represents a subscription of a subscriber to events of type E.
 type Subscription[E any] struct {
-	id         string
-	subscriber time.ActorID
-	mu         sync.Mutex
-	closed     bool
-	events     chan E
+	id           string
+	subscriber   time.ActorID
+	mu           sync.Mutex
+	closed       bool
+	failureCount int
+	maxFailures  int
+	events       chan E
 }
 
 // NewSubscription creates a new instance of Subscription with the given buffer size.
 func NewSubscription[E any](subscriber time.ActorID, bufSize int) *Subscription[E] {
 	return &Subscription[E]{
-		id:         xid.New().String(),
-		subscriber: subscriber,
-		events:     make(chan E, bufSize),
-		closed:     false,
+		id:          xid.New().String(),
+		subscriber:  subscriber,
+		events:      make(chan E, bufSize),
+		closed:      false,
+		maxFailures: defaultMaxConsecutivePublishFailures,
 	}
 }
 
@@ -78,6 +102,12 @@ func (s *Subscription[E]) Close() {
 }
 
 // Publish publishes the given event to the subscriber.
+//
+// On a successful send the internal failure counter is reset. On timeout
+// or an already-closed channel the counter increments; once it reaches
+// maxFailures the subscription closes itself so the BatchPublisher can
+// reap it on the next iteration. This is the only fallback path when
+// the owning stream handler never invokes Unsubscribe.
 func (s *Subscription[E]) Publish(event E) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -89,11 +119,26 @@ func (s *Subscription[E]) Publish(event E) bool {
 	// NOTE(hackerwins): When a subscription is being closed by a subscriber,
 	// the subscriber may not receive messages.
 	select {
-	case s.Events() <- event:
+	case s.events <- event:
+		s.failureCount = 0
 		return true
 	case <-gotime.After(publishTimeout):
+		s.failureCount++
+		if s.failureCount >= s.maxFailures {
+			s.closed = true
+			close(s.events)
+		}
 		return false
 	}
+}
+
+// IsDead reports whether this Subscription has been closed, either
+// explicitly via Close or by self-prune after too many consecutive
+// Publish failures.
+func (s *Subscription[E]) IsDead() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closed
 }
 
 // Subscriptions is a collection of Subscription[E] with an associated BatchPublisher.

--- a/server/backend/pubsub/subscription_test.go
+++ b/server/backend/pubsub/subscription_test.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pubsub
+
+import (
+	"testing"
+	gotime "time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/pkg/document/time"
+)
+
+func TestSubscriptionSelfPrune(t *testing.T) {
+	actor, err := time.ActorIDFromBytes([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
+	assert.NoError(t, err)
+
+	t.Run("publish success resets failure count", func(t *testing.T) {
+		sub := NewSubscription[int](actor, 1)
+		sub.maxFailures = 3
+
+		assert.True(t, sub.Publish(1))
+		assert.False(t, sub.Publish(2)) // buffer full, timeout, failureCount=1
+
+		<-sub.Events() // drain
+		assert.True(t, sub.Publish(3))
+		assert.False(t, sub.IsDead())
+	})
+
+	t.Run("dead after consecutive failures", func(t *testing.T) {
+		sub := NewSubscription[int](actor, 1)
+		sub.maxFailures = 3
+
+		assert.True(t, sub.Publish(1))
+		for range sub.maxFailures {
+			assert.False(t, sub.Publish(99))
+		}
+		assert.True(t, sub.IsDead())
+	})
+
+	t.Run("dead publish short-circuits without waiting timeout", func(t *testing.T) {
+		sub := NewSubscription[int](actor, 1)
+		sub.Close()
+
+		start := gotime.Now()
+		assert.False(t, sub.Publish(42))
+		assert.Less(t, gotime.Since(start), publishTimeout/2)
+	})
+}

--- a/server/backend/pubsub/subscription_test.go
+++ b/server/backend/pubsub/subscription_test.go
@@ -38,6 +38,12 @@ func TestSubscriptionSelfPrune(t *testing.T) {
 
 		<-sub.Events() // drain
 		assert.True(t, sub.Publish(3))
+
+		// Without the reset, failureCount would already be 1 and these
+		// two further failures would push it to 3 (== maxFailures), so
+		// IsDead() must remain false only if the success cleared it.
+		assert.False(t, sub.Publish(4))
+		assert.False(t, sub.Publish(5))
 		assert.False(t, sub.IsDead())
 	})
 
@@ -56,8 +62,12 @@ func TestSubscriptionSelfPrune(t *testing.T) {
 		sub := NewSubscription[int](actor, 1)
 		sub.Close()
 
+		// A dead Publish must short-circuit instead of waiting the full
+		// publishTimeout. Bound against publishTimeout itself (not half)
+		// to tolerate scheduler jitter on slow CI runners while still
+		// proving short-circuit semantics.
 		start := gotime.Now()
 		assert.False(t, sub.Publish(42))
-		assert.Less(t, gotime.Since(start), publishTimeout/2)
+		assert.Less(t, gotime.Since(start), publishTimeout)
 	})
 }

--- a/test/integration/subscription_leak_test.go
+++ b/test/integration/subscription_leak_test.go
@@ -16,6 +16,9 @@
  * limitations under the License.
  */
 
+// Package integration contains end-to-end tests exercising the Yorkie
+// server against a real MongoDB instance. Files are gated by the
+// `integration` build tag and run via `make test`.
 package integration
 
 import (

--- a/test/integration/subscription_leak_test.go
+++ b/test/integration/subscription_leak_test.go
@@ -1,0 +1,109 @@
+//go:build integration
+
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	gotime "time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/api/types"
+	"github.com/yorkie-team/yorkie/pkg/document"
+	"github.com/yorkie-team/yorkie/pkg/document/json"
+	"github.com/yorkie-team/yorkie/pkg/document/presence"
+	"github.com/yorkie-team/yorkie/pkg/document/time"
+	"github.com/yorkie-team/yorkie/server/backend/pubsub"
+	"github.com/yorkie-team/yorkie/test/helper"
+)
+
+// TestSubscriptionLeakSelfPrune exercises the dead-stream path that the
+// stream handler's defer cannot reach. A subscription is created via
+// PubSub.Subscribe and its events channel is never drained, simulating a
+// WatchDocument handler whose stream stayed blocked (half-closed TCP,
+// hung client). With the failure threshold shortened, the BatchPublisher
+// must self-prune and remove the entry from the document's subscription
+// map.
+//
+// The full WatchStream + stuck client flow ends up exercising the same
+// pubsub path, but adds HTTP/2 flow-control buffering that lets the
+// handler drain events for hundreds of cycles before the buffer fills.
+// Bypassing the stream keeps the test deterministic.
+func TestSubscriptionLeakSelfPrune(t *testing.T) {
+	previous := pubsub.SetDefaultMaxConsecutivePublishFailures(3)
+	defer pubsub.SetDefaultMaxConsecutivePublishFailures(previous)
+
+	ctx := context.Background()
+
+	clients := activeClients(t, 1)
+	defer deactivateAndCloseClients(t, clients)
+	c1 := clients[0]
+
+	docKey := helper.TestKey(t)
+	d1 := document.New(docKey)
+	assert.NoError(t, c1.Attach(ctx, d1))
+
+	be := defaultServer.Backend()
+	project, err := defaultServer.DefaultProject(ctx)
+	assert.NoError(t, err)
+	docInfo, err := be.DB.FindDocInfoByKey(ctx, project.ID, docKey)
+	assert.NoError(t, err)
+	refKey := types.DocRefKey{ProjectID: project.ID, DocID: docInfo.ID}
+
+	// Subscribe directly so the events channel never drains.
+	stuckActor, err := time.ActorIDFromBytes(
+		[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 99},
+	)
+	assert.NoError(t, err)
+	sub, _, err := be.PubSub.Subscribe(ctx, stuckActor, refKey, 0)
+	assert.NoError(t, err)
+	_ = sub
+
+	assert.True(t, hasSubscriber(be.PubSub.ClientIDs(refKey), stuckActor),
+		"stuck actor should be registered before publishes")
+
+	// Drive several DocChanged publishes spread over multiple publish
+	// cycles (window = 100ms) so the BatchPublisher accumulates failures
+	// against the stuck subscription's full buffer rather than batching
+	// them into a single cycle that hits the OnEnqueue dedup cap.
+	for i := range 10 {
+		assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetString("k", fmt.Sprintf("v-%d", i))
+			return nil
+		}))
+		assert.NoError(t, c1.Sync(ctx))
+		gotime.Sleep(120 * gotime.Millisecond)
+	}
+
+	assert.Eventually(t, func() bool {
+		return !hasSubscriber(be.PubSub.ClientIDs(refKey), stuckActor)
+	}, 5*gotime.Second, 50*gotime.Millisecond,
+		"stuck subscription should be reaped after maxFailures publish failures")
+}
+
+func hasSubscriber(ids []time.ActorID, target time.ActorID) bool {
+	for _, id := range ids {
+		if id.Compare(target) == 0 {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Adds a self-prune fallback so `Subscription` entries are reclaimed
when their owning WatchDocument stream never delivers a clean
termination signal (half-closed TCP, hung client). A `Subscription`
counts consecutive `Publish` failures and self-closes once
`maxFailures` is reached; the `BatchPublisher` reaps dead entries on
the next cycle. Stream-lifecycle cleanup via the handler's `defer`
remains the primary path. The leak surfaces as log volume — one
`Publish to ... timeout or closed` line per dead sub per publish
window — and as publish-loop latency for live subs sharing the
publisher, not as memory pressure.

**Which issue(s) this PR fixes**:

Fixes #

<!-- No issue filed; downstream-reported leak. -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

Additional documentation:

- Design: pub-sub Risks and Mitigation: docs/design/pub-sub.md
- Task plan: docs/tasks/active/20260609-subscription-self-prune-todo.md

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic self-pruning of stuck/abandoned subscriptions so pub/sub entries are detected and removed locally, preventing indefinite memory buildup and noisy retries.

* **Documentation**
  * Expanded design notes detailing risks, the self-prune mitigation, and its limitation to the owning pod (no cluster-wide reaping).

* **Tests**
  * Added unit and integration tests validating failure-counting, self-prune behavior, and cleanup of stuck consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->