### PR TITLE
Force-add result files in CI store steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,8 +309,7 @@ jobs:
             git remote add origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           fi
 
-          git add bench_result.txt
-          git add commit_hash.txt
+          git add -f bench_result.txt commit_hash.txt
           TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
           git diff --staged --quiet || git commit -m "Update benchmark results at $TIMESTAMP"
           git checkout -B yorkie-ci-benchmark
@@ -515,9 +514,7 @@ jobs:
             git remote add origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           fi
 
-          git add load_summary.json
-          git add output.txt
-          git add commit_hash.txt
+          git add -f load_summary.json output.txt commit_hash.txt
           TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
           git diff --staged --quiet || git commit -m "Update load results at $TIMESTAMP"
           git checkout -B yorkie-ci-load


### PR DESCRIPTION
## Summary

The `Store load result` / `Store benchmark result` steps check out a data branch (`yorkie-ci-load` / `yorkie-ci-benchmark`) and `git add` the result files into it. If that branch carries a `.gitignore` matching a result file (the repo `.gitignore` ignores `output.txt`), `git add output.txt` stages nothing and exits 1, failing the step under `bash -e`.

This is what broke main-push CI: the data branch was overwritten with a full repo snapshot (carrying `.gitignore`), so `git add output.txt` started failing. Using `git add -f` makes the store steps robust to whatever the data branch contains.

## Test plan

- Next main-push CI runs the `load-test`/`bench` jobs; the Store steps stage result files via `git add -f` and push to the data branches without erroring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow artifact handling for improved consistency in storing test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->