### PR TITLE
Add disable_presence Document option for presence-free docs

### DIFF
--- a/api/docs/yorkie/v1/yorkie.openapi.yaml
+++ b/api/docs/yorkie/v1/yorkie.openapi.yaml
@@ -130,6 +130,18 @@ paths:
           $ref: '#/components/responses/connect.error'
       tags:
       - yorkie.v1.YorkieService
+  /yorkie.v1.YorkieService/PeekChannel:
+    post:
+      description: ""
+      requestBody:
+        $ref: '#/components/requestBodies/yorkie.v1.YorkieService.PeekChannel.yorkie.v1.PeekChannelRequest'
+      responses:
+        "200":
+          $ref: '#/components/responses/yorkie.v1.YorkieService.PeekChannel.yorkie.v1.PeekChannelResponse'
+        default:
+          $ref: '#/components/responses/connect.error'
+      tags:
+      - yorkie.v1.YorkieService
   /yorkie.v1.YorkieService/PushPullChanges:
     post:
       description: ""
@@ -306,6 +318,15 @@ components:
           schema:
             $ref: '#/components/schemas/yorkie.v1.ListRevisionsRequest'
       required: true
+    yorkie.v1.YorkieService.PeekChannel.yorkie.v1.PeekChannelRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.PeekChannelRequest'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.PeekChannelRequest'
+      required: true
     yorkie.v1.YorkieService.PushPullChanges.yorkie.v1.PushPullChangesRequest:
       content:
         application/json:
@@ -450,6 +471,15 @@ components:
         application/proto:
           schema:
             $ref: '#/components/schemas/yorkie.v1.ListRevisionsResponse'
+      description: ""
+    yorkie.v1.YorkieService.PeekChannel.yorkie.v1.PeekChannelResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.PeekChannelResponse'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.PeekChannelResponse'
       description: ""
     yorkie.v1.YorkieService.PushPullChanges.yorkie.v1.PushPullChangesResponse:
       content:
@@ -708,6 +738,24 @@ components:
           description: ""
           title: client_id
           type: string
+        disableGc:
+          additionalProperties: false
+          description: |-
+            disable_gc declares that this attachment will not produce or consume
+             tombstones. The server skips minVV tracking and omits the response
+             VersionVector for this client. Use only with Counter / primitive
+             workloads; misuse leads to undefined GC behavior on this client.
+          title: disable_gc
+          type: boolean
+        disablePresence:
+          additionalProperties: false
+          description: |-
+            disable_presence declares that this document does not produce, consume,
+             or store presence. Honored on first attach only; subsequent attaches
+             observe the value persisted in the server-side document metadata. See
+             docs/tasks/active/20260616-presenceless-document-option-todo.md.
+          title: disable_presence
+          type: boolean
         schemaKey:
           additionalProperties: false
           description: ""
@@ -725,6 +773,16 @@ components:
           description: ""
           title: change_pack
           type: object
+        disablePresence:
+          additionalProperties: false
+          description: |-
+            disable_presence carries the server-fixated value of the document's
+             presence option (see AttachDocumentRequest.disable_presence). Clients
+             align their local gating state to this value rather than the requested
+             value, so an attach to an already-fixated document observes the
+             persisted decision.
+          title: disable_presence
+          type: boolean
         documentId:
           additionalProperties: false
           description: ""
@@ -1924,6 +1982,34 @@ components:
           type: object
       title: CreatedAtMapByActorEntry
       type: object
+    yorkie.v1.PeekChannelRequest:
+      additionalProperties: false
+      description: |-
+        PeekChannel reads the current session_count of a channel without creating
+         a session on the server. Use this when a client only needs to display the
+         count (e.g. "N people writing") without contributing to it and without
+         receiving broadcasts. Caller polls on its own cadence.
+      properties:
+        channelKey:
+          additionalProperties: false
+          description: ""
+          title: channel_key
+          type: string
+      title: PeekChannelRequest
+      type: object
+    yorkie.v1.PeekChannelResponse:
+      additionalProperties: false
+      description: ""
+      properties:
+        sessionCount:
+          additionalProperties: false
+          description: ""
+          oneOf:
+          - type: string
+          - type: number
+          title: session_count
+      title: PeekChannelResponse
+      type: object
     yorkie.v1.Presence:
       additionalProperties: false
       description: ""
@@ -1996,6 +2082,16 @@ components:
           description: ""
           title: client_id
           type: string
+        disableGc:
+          additionalProperties: false
+          description: |-
+            disable_gc declares that this PushPull will not produce or consume
+             tombstones. The server skips minVV tracking and omits the response
+             VersionVector. Clients that attached with disable_gc=true must keep
+             setting this on every subsequent PushPullChanges. See
+             docs/design/disable-gc-on-attach.md.
+          title: disable_gc
+          type: boolean
         documentId:
           additionalProperties: false
           description: ""

--- a/api/yorkie/v1/yorkie.pb.go
+++ b/api/yorkie/v1/yorkie.pb.go
@@ -229,9 +229,14 @@ type AttachDocumentRequest struct {
 	// tombstones. The server skips minVV tracking and omits the response
 	// VersionVector for this client. Use only with Counter / primitive
 	// workloads; misuse leads to undefined GC behavior on this client.
-	DisableGc     bool `protobuf:"varint,4,opt,name=disable_gc,json=disableGc,proto3" json:"disable_gc,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	DisableGc bool `protobuf:"varint,4,opt,name=disable_gc,json=disableGc,proto3" json:"disable_gc,omitempty"`
+	// disable_presence declares that this document does not produce, consume,
+	// or store presence. Honored on first attach only; subsequent attaches
+	// observe the value persisted in the server-side document metadata. See
+	// docs/tasks/active/20260616-presenceless-document-option-todo.md.
+	DisablePresence bool `protobuf:"varint,5,opt,name=disable_presence,json=disablePresence,proto3" json:"disable_presence,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *AttachDocumentRequest) Reset() {
@@ -292,14 +297,27 @@ func (x *AttachDocumentRequest) GetDisableGc() bool {
 	return false
 }
 
+func (x *AttachDocumentRequest) GetDisablePresence() bool {
+	if x != nil {
+		return x.DisablePresence
+	}
+	return false
+}
+
 type AttachDocumentResponse struct {
 	state              protoimpl.MessageState `protogen:"open.v1"`
 	DocumentId         string                 `protobuf:"bytes,1,opt,name=document_id,json=documentId,proto3" json:"document_id,omitempty"`
 	ChangePack         *ChangePack            `protobuf:"bytes,2,opt,name=change_pack,json=changePack,proto3" json:"change_pack,omitempty"`
 	MaxSizePerDocument int32                  `protobuf:"varint,3,opt,name=max_size_per_document,json=maxSizePerDocument,proto3" json:"max_size_per_document,omitempty"`
 	SchemaRules        []*Rule                `protobuf:"bytes,4,rep,name=schema_rules,json=schemaRules,proto3" json:"schema_rules,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// disable_presence carries the server-fixated value of the document's
+	// presence option (see AttachDocumentRequest.disable_presence). Clients
+	// align their local gating state to this value rather than the requested
+	// value, so an attach to an already-fixated document observes the
+	// persisted decision.
+	DisablePresence bool `protobuf:"varint,5,opt,name=disable_presence,json=disablePresence,proto3" json:"disable_presence,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *AttachDocumentResponse) Reset() {
@@ -358,6 +376,13 @@ func (x *AttachDocumentResponse) GetSchemaRules() []*Rule {
 		return x.SchemaRules
 	}
 	return nil
+}
+
+func (x *AttachDocumentResponse) GetDisablePresence() bool {
+	if x != nil {
+		return x.DisablePresence
+	}
+	return false
 }
 
 type DetachDocumentRequest struct {
@@ -2794,7 +2819,7 @@ const file_yorkie_v1_yorkie_proto_rawDesc = "" +
 	"\x17DeactivateClientRequest\x12\x1b\n" +
 	"\tclient_id\x18\x01 \x01(\tR\bclientId\x12 \n" +
 	"\vsynchronous\x18\x02 \x01(\bR\vsynchronous\"\x1a\n" +
-	"\x18DeactivateClientResponse\"\xaa\x01\n" +
+	"\x18DeactivateClientResponse\"\xd5\x01\n" +
 	"\x15AttachDocumentRequest\x12\x1b\n" +
 	"\tclient_id\x18\x01 \x01(\tR\bclientId\x126\n" +
 	"\vchange_pack\x18\x02 \x01(\v2\x15.yorkie.v1.ChangePackR\n" +
@@ -2802,14 +2827,16 @@ const file_yorkie_v1_yorkie_proto_rawDesc = "" +
 	"\n" +
 	"schema_key\x18\x03 \x01(\tR\tschemaKey\x12\x1d\n" +
 	"\n" +
-	"disable_gc\x18\x04 \x01(\bR\tdisableGc\"\xd8\x01\n" +
+	"disable_gc\x18\x04 \x01(\bR\tdisableGc\x12)\n" +
+	"\x10disable_presence\x18\x05 \x01(\bR\x0fdisablePresence\"\x83\x02\n" +
 	"\x16AttachDocumentResponse\x12\x1f\n" +
 	"\vdocument_id\x18\x01 \x01(\tR\n" +
 	"documentId\x126\n" +
 	"\vchange_pack\x18\x02 \x01(\v2\x15.yorkie.v1.ChangePackR\n" +
 	"changePack\x121\n" +
 	"\x15max_size_per_document\x18\x03 \x01(\x05R\x12maxSizePerDocument\x122\n" +
-	"\fschema_rules\x18\x04 \x03(\v2\x0f.yorkie.v1.RuleR\vschemaRules\"\xc2\x01\n" +
+	"\fschema_rules\x18\x04 \x03(\v2\x0f.yorkie.v1.RuleR\vschemaRules\x12)\n" +
+	"\x10disable_presence\x18\x05 \x01(\bR\x0fdisablePresence\"\xc2\x01\n" +
 	"\x15DetachDocumentRequest\x12\x1b\n" +
 	"\tclient_id\x18\x01 \x01(\tR\bclientId\x12\x1f\n" +
 	"\vdocument_id\x18\x02 \x01(\tR\n" +

--- a/api/yorkie/v1/yorkie.proto
+++ b/api/yorkie/v1/yorkie.proto
@@ -77,6 +77,11 @@ message AttachDocumentRequest {
   // VersionVector for this client. Use only with Counter / primitive
   // workloads; misuse leads to undefined GC behavior on this client.
   bool disable_gc = 4;
+  // disable_presence declares that this document does not produce, consume,
+  // or store presence. Honored on first attach only; subsequent attaches
+  // observe the value persisted in the server-side document metadata. See
+  // docs/tasks/active/20260616-presenceless-document-option-todo.md.
+  bool disable_presence = 5;
 }
 
 message AttachDocumentResponse {
@@ -84,6 +89,12 @@ message AttachDocumentResponse {
   ChangePack change_pack = 2;
   int32 max_size_per_document = 3;
   repeated Rule schema_rules = 4;
+  // disable_presence carries the server-fixated value of the document's
+  // presence option (see AttachDocumentRequest.disable_presence). Clients
+  // align their local gating state to this value rather than the requested
+  // value, so an attach to an already-fixated document observes the
+  // persisted decision.
+  bool disable_presence = 5;
 }
 
 message DetachDocumentRequest {

--- a/client/attachment.go
+++ b/client/attachment.go
@@ -62,6 +62,13 @@ type Attachment struct {
 	// PushPullChanges so the server can skip minVV tracking and omit the
 	// response VersionVector. See docs/design/disable-gc-on-attach.md.
 	disableGC bool
+
+	// disablePresence carries the server-fixated DisablePresence value
+	// returned by AttachDocument. It is purely informational on the client
+	// today (the local gating is held on the Document itself); kept here so
+	// future RPCs that need the fixated value can read it without going
+	// back to the Document.
+	disablePresence bool
 }
 
 func (a *Attachment) Is(resourceType attachable.ResourceType) bool {

--- a/client/client.go
+++ b/client/client.go
@@ -523,6 +523,15 @@ func (c *Client) attachDocument(ctx context.Context, d *document.Document, opts 
 	d.SetDisableGC(opts.DisableGC)
 	d.SetDisablePresence(res.Msg.DisablePresence)
 
+	// If the server reported the doc as presenceless but the local client
+	// did not opt in (so Step 01 produced an initial empty PUT), reset the
+	// local presence map. The wire-side PUT was stripped by the server and
+	// never crosses the boundary, but the local InternalDocument still
+	// carries the cloned entry until we clear it here.
+	if res.Msg.DisablePresence && !opts.DisablePresence {
+		d.InternalDocument().ResetPresences()
+	}
+
 	if err := d.ApplyChangePack(pack); err != nil {
 		return err
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -472,12 +472,16 @@ func (c *Client) Detach(ctx context.Context, r attachable.Attachable, opts ...in
 // attachDocument attaches the given document to this client. It tells the server that
 // this client will synchronize the given document.
 func (c *Client) attachDocument(ctx context.Context, d *document.Document, opts *AttachOptions) error {
-	// 01. Initialize presence data
-	if err := d.Update(func(r *json.Object, p *document.Presence) error {
-		p.Initialize(opts.Presence)
-		return nil
-	}); err != nil {
-		return err
+	// 01. Initialize presence data. Skip when the caller declared the
+	// document presenceless so we never produce an initial PUT change for
+	// a doc that will reject presence on the wire anyway.
+	if !opts.DisablePresence {
+		if err := d.Update(func(r *json.Object, p *document.Presence) error {
+			p.Initialize(opts.Presence)
+			return nil
+		}); err != nil {
+			return err
+		}
 	}
 	pbChangePack, err := converter.ToChangePack(d.CreateChangePack())
 	if err != nil {
@@ -488,10 +492,11 @@ func (c *Client) attachDocument(ctx context.Context, d *document.Document, opts 
 	res, err := c.client.AttachDocument(
 		ctx,
 		withShardKey(connect.NewRequest(&api.AttachDocumentRequest{
-			ClientId:   c.id.String(),
-			ChangePack: pbChangePack,
-			SchemaKey:  opts.Schema,
-			DisableGc:  opts.DisableGC,
+			ClientId:        c.id.String(),
+			ChangePack:      pbChangePack,
+			SchemaKey:       opts.Schema,
+			DisableGc:       opts.DisableGC,
+			DisablePresence: opts.DisablePresence,
 		}), c.options.APIKey, d.Key().String()),
 	)
 	if err != nil {
@@ -509,10 +514,14 @@ func (c *Client) attachDocument(ctx context.Context, d *document.Document, opts 
 		d.SchemaRules = converter.FromRules(res.Msg.SchemaRules)
 	}
 
-	// Record the opt-out decision before applying the attach response so the
+	// Record the opt-out decisions before applying the attach response so the
 	// first ApplyChangePack already routes remote changes through the
-	// lamport-only sync path. See docs/design/disable-gc-on-attach.md.
+	// lamport-only sync path (DisableGC) and so Update silently drops
+	// presence (DisablePresence). The DisablePresence value is taken from
+	// the server-fixated response — a late attacher to a presenceless doc
+	// observes the persisted true even without WithDisablePresence locally.
 	d.SetDisableGC(opts.DisableGC)
+	d.SetDisablePresence(res.Msg.DisablePresence)
 
 	if err := d.ApplyChangePack(pack); err != nil {
 		return err
@@ -547,6 +556,7 @@ func (c *Client) attachDocument(ctx context.Context, d *document.Document, opts 
 		syncMode:            syncMode,
 		changeEventReceived: false,
 		disableGC:           opts.DisableGC,
+		disablePresence:     res.Msg.DisablePresence,
 	})
 	if opts.IsRealtime {
 		if err = c.runWatchLoop(watchCtx, d); err != nil {

--- a/client/options.go
+++ b/client/options.go
@@ -142,6 +142,12 @@ type AttachOptions struct {
 	// VersionVector for this client. Use only with Counter / primitive
 	// workloads; misuse leads to undefined GC behavior on this client.
 	DisableGC bool
+
+	// DisablePresence declares that this document does not produce,
+	// consume, or store presence. Honored on first attach only; later
+	// attachers observe the server-fixated value carried in the attach
+	// response. See docs/tasks/active/20260616-presenceless-document-option-todo.md.
+	DisablePresence bool
 }
 
 // WithRealtimeSync configures the manual sync of the client.
@@ -179,6 +185,15 @@ func WithSchema(schema string) AttachOption {
 // the document's local GC pass regardless of what the server sends.
 func WithDisableGC() AttachOption {
 	return func(o *AttachOptions) { o.DisableGC = true }
+}
+
+// WithDisablePresence declares that this document does not produce, consume,
+// or store presence. The server fixates the flag on first attach (via
+// $setOnInsert on DocInfo) and returns the persisted value in the attach
+// response; clients gate on the response value rather than the requested
+// one so a single misconfigured client cannot break the guarantee.
+func WithDisablePresence() AttachOption {
+	return func(o *AttachOptions) { o.DisablePresence = true }
 }
 
 // AttachChannelOption configures AttachChannelOptions.

--- a/docs/tasks/active/20260616-presenceless-document-option-todo.md
+++ b/docs/tasks/active/20260616-presenceless-document-option-todo.md
@@ -8,13 +8,14 @@
 > Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add a Document-scope option `disable_presence` so a document
-can declare it never accepts or stores presence. Driven by a high
-fan-out counter workload (insurance `/car` Counter document) where
-presence accumulates monotonically on the server (~28K stale actors,
-~170KB response payload) because clients reach end-of-life without
-sending `detach`. Once a document is created with the flag, the server
-strips presence on every PushPull regardless of which client attached,
-so other-client `presence.put/clear` cannot pollute the document map.
+can declare it never accepts or stores presence. Driven by high
+fan-out Counter-only documents where presence accumulates monotonically
+on the server because clients reach end-of-life without sending
+`detach` — observed in real workloads with tens of thousands of stale
+actors and attach responses inflated to hundreds of kilobytes. Once a
+document is created with the flag, the server strips presence on every
+PushPull regardless of which client attached, so other-client
+`presence.put/clear` cannot pollute the document map.
 
 **Architecture (as designed):** The flag is declared at first attach
 through `AttachDocumentRequest.disable_presence`, persisted on
@@ -51,15 +52,14 @@ end-to-end test.
 
 ### Symptom
 
-`insurance-web.car.intro.YYYY-MM-DD` is a Counter-only document
-(SyncMode Manual, `disableGC=true`). The page increments a `pv`
-counter once on mount and never uses presence functionally, yet the
-JS SDK still emits an empty PUT presence change at attach. Combined
-with users leaving the page without sending `detach` (mobile
-background, iOS Safari, network drop), the document's presence map
-grows monotonically.
+A daily-rotated, Counter-only document (`SyncMode.Manual`,
+`disableGC=true`) increments a `pv` counter once on mount and never
+uses presence functionally, yet the JS SDK still emits an empty PUT
+presence change at attach. Combined with users leaving the page
+without sending `detach` (mobile background, iOS Safari, network
+drop), the document's presence map grows monotonically.
 
-prod measurement (2026-06-12 ~ 06-15):
+Representative measurement (two snapshots ~2.5 hours apart):
 
 | server_seq | root.bytes | presences.entries | presences.bytes |
 |---|---|---|---|
@@ -88,13 +88,12 @@ document key with it set. Existing documents stay on the default
 
 ### Compared to candidate alternatives
 
-A separate evaluation (devops repo
-`docs/tasks/active/20260612-insurance-car-presence-leak-todo.md`)
-compared four candidates: (1) per-client opt-out, (2) project-scoped
-setting, (3) JS SDK pagehide detach hardening, (4) this proposal.
-Candidate 2 was QA-verified on a sibling branch. Candidate 4 is
-chosen as the structural option closest to how the user already
-declares document properties (`disableGC`) while keeping the
+A separate evaluation compared four candidates: (1) per-client
+opt-out, (2) project-scoped setting, (3) JS SDK pagehide detach
+hardening, (4) this proposal. Candidate 2 was QA-verified on a
+sibling branch. Candidate 4 is chosen as the structural option
+closest to how the user already declares document properties
+(`disableGC`) while keeping the
 enforcement document-scoped so a single misconfigured client cannot
 break the guarantee.
 
@@ -796,9 +795,10 @@ gh pr create --title "Add disable_presence Document option" \
   attach response.
 
 ## Background
-High fan-out Counter-only document (insurance `/car`) accumulates
-~28K stale presence entries because clients reach end-of-life
-without `detach`, inflating attach responses to ~170KB. See
+A high fan-out, Counter-only document accumulates stale presence
+entries on the order of tens of thousands when clients reach
+end-of-life without `detach`, inflating attach responses to hundreds
+of kilobytes. See
 `docs/tasks/active/20260616-presenceless-document-option-todo.md`
 for the full measurement trail and alternatives considered.
 
@@ -848,7 +848,6 @@ bash scripts/tasks-index.sh
 ## Remaining
 
 - [ ] All Task 1–14 steps above
-- [ ] yorkie-js-sdk follow-up PR (separate task doc, agent in flight)
-- [ ] Insurance FE adoption (devops repo, separate task)
+- [ ] yorkie-js-sdk follow-up PR (separate task doc)
 - [ ] Future: admin RPC to toggle the flag after creation (deferred;
       out of scope here)

--- a/docs/tasks/active/20260616-presenceless-document-option-todo.md
+++ b/docs/tasks/active/20260616-presenceless-document-option-todo.md
@@ -775,7 +775,7 @@ Dispatch `superpowers:requesting-code-review` (or `/code-review`)
 over the full branch diff. Apply Critical/Important findings;
 capture non-blocking notes in the lessons file.
 
-- [ ] **Step 3: Rebase on main and open PR**
+- [x] **Step 3: Rebase on main and open PR** — yorkie-team/yorkie#1841
 
 ```sh
 git fetch && git rebase origin/main

--- a/docs/tasks/active/20260616-presenceless-document-option-todo.md
+++ b/docs/tasks/active/20260616-presenceless-document-option-todo.md
@@ -1,0 +1,854 @@
+**Created**: 2026-06-16
+
+# Presenceless Document Option
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Document-scope option `disable_presence` so a document
+can declare it never accepts or stores presence. Driven by a high
+fan-out counter workload (insurance `/car` Counter document) where
+presence accumulates monotonically on the server (~28K stale actors,
+~170KB response payload) because clients reach end-of-life without
+sending `detach`. Once a document is created with the flag, the server
+strips presence on every PushPull regardless of which client attached,
+so other-client `presence.put/clear` cannot pollute the document map.
+
+**Architecture (as designed):** The flag is declared at first attach
+through `AttachDocumentRequest.disable_presence`, persisted on
+`DocInfo.DisablePresence` via mongo `$setOnInsert` (immutable
+thereafter), and read by the PushPull handler into
+`PushPullOptions.DisablePresence`. The server (a) strips presence
+changes from every PushPull entry, (b) serializes an empty presence
+map in pullSnapshot/storeSnapshot, and (c) defensively drops any
+stray cached presence on the read path. The Go SDK exposes
+`WithDisablePresence()`, sends the wire field on first attach,
+reads the server-fixated value back from the response, and gates
+its own `Document.Update` so opt-in clients silently no-op on
+presence updates. JS SDK ships as a follow-up PR (separate task
+doc).
+
+**Tech Stack:** Go server (`server/`), Go SDK (`client/`,
+`pkg/document/`), MongoDB + memory backends, `-tags integration`
+end-to-end test.
+
+**Branch:** `feat/presenceless-document-option`
+
+**Related work:**
+- `docs/design/disable-gc-on-attach.md` — analogous opt-out pattern.
+  Differs in: (a) doc-scope vs per-attach, (b) server-persisted on
+  `DocInfo` vs wire-only.
+- `docs/design/doc-presence.md` — background on the presence model
+  this option opts out of.
+- `docs/design/housekeeping.md` — orthogonal track for cleaning up
+  stale `ClientInfo` rows.
+
+---
+
+## Background
+
+### Symptom
+
+`insurance-web.car.intro.YYYY-MM-DD` is a Counter-only document
+(SyncMode Manual, `disableGC=true`). The page increments a `pv`
+counter once on mount and never uses presence functionally, yet the
+JS SDK still emits an empty PUT presence change at attach. Combined
+with users leaving the page without sending `detach` (mobile
+background, iOS Safari, network drop), the document's presence map
+grows monotonically.
+
+prod measurement (2026-06-12 ~ 06-15):
+
+| server_seq | root.bytes | presences.entries | presences.bytes |
+|---|---|---|---|
+| 221016 | 155 | 28,167 | 788,676 |
+| 223516 | 155 | 28,485 | 797,580 |
+
+`root` is fixed at 155 bytes; only the presence map grows. AttachDocument
+response is ~170KB at this point, on a page where every other RPC
+returns <0.5KB.
+
+### Why a per-attach opt-out is insufficient
+
+Other client (older SDK / a teammate's code) that does not pass the
+flag would re-pollute the document's presence map because presence
+is a document-shared map, not a per-client value. A doc-scoped
+declaration with server-side enforcement is what closes the source.
+
+### Why immutable (first-attach fixate)
+
+The flag travels on `AttachDocumentRequest`, is persisted via
+`$setOnInsert`, and never changes afterward. This avoids a toggle
+race (cache invalidation across the cluster) and matches the natural
+rollout — operators introduce the option by creating the next-day
+document key with it set. Existing documents stay on the default
+(`false`) path with no migration.
+
+### Compared to candidate alternatives
+
+A separate evaluation (devops repo
+`docs/tasks/active/20260612-insurance-car-presence-leak-todo.md`)
+compared four candidates: (1) per-client opt-out, (2) project-scoped
+setting, (3) JS SDK pagehide detach hardening, (4) this proposal.
+Candidate 2 was QA-verified on a sibling branch. Candidate 4 is
+chosen as the structural option closest to how the user already
+declares document properties (`disableGC`) while keeping the
+enforcement document-scoped so a single misconfigured client cannot
+break the guarantee.
+
+---
+
+## File Map
+
+### Go server (this PR)
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `api/yorkie/v1/yorkie.proto` | Add `disable_presence` to `AttachDocumentRequest` (field 5) and `AttachDocumentResponse` (field 5) |
+| Modify | `api/yorkie/v1/yorkie.pb.go` | Regenerated via `make proto` |
+| Modify | `server/backend/database/doc_info.go` | Add `DisablePresence bool` field; update `DeepCopy()` |
+| Modify | `server/backend/database/mongo/client.go` | `FindOrCreateDocInfo` accepts `disablePresence bool`, uses `$setOnInsert` |
+| Modify | `server/backend/database/memory/database.go` | Mirror the new signature; same setOnInsert semantics in memory |
+| Modify | `server/backend/database/testcases/testcases.go` | Round-trip `DisablePresence` if existing tests touch `FindOrCreateDocInfo` |
+| Modify | `server/documents/documents.go` | `FindOrCreateDocInfo` wrapper passes `disablePresence` through |
+| Modify | `server/rpc/yorkie_server.go` | `AttachDocument` forwards `req.Msg.DisablePresence`, warns on wire/persisted mismatch; `PushPullChanges` fetches `DocInfo` and forwards `DisablePresence` into `PushPullOptions` |
+| Modify | `server/packs/pushpull.go` | `PushPullOptions.DisablePresence`; strip presence at PushPull entry; thread `opts` through `preparePack`/`pullSnapshot`; defensive guard in `pullChangeInfos` |
+| Add | `server/packs/strip.go` | `stripPresenceChanges` helper |
+| Modify | `server/packs/snapshot.go` | `storeSnapshot` takes `disablePresence bool`; calls `doc.ResetPresences()` before `CreateSnapshotInfo` |
+| Modify | `pkg/document/internal_document.go` | `ResetPresences()` helper |
+| Modify | `pkg/document/change/change.go` | `SetPresenceChange`, `HasOperations` on `Change` |
+| Modify | `pkg/document/change/context.go` | `HasPresenceChange`, `DropPresenceChange` on `Context` |
+
+### Go SDK (this PR)
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `client/options.go` | `AttachOptions.DisablePresence`; `WithDisablePresence()` |
+| Modify | `client/client.go` | Send `disable_presence` on attach; store the response-fixated value; skip initial `Presence.Initialize` when opt-out |
+| Modify | `client/attachment.go` | Carry `disablePresence` on the per-doc attachment record |
+| Modify | `pkg/document/document.go` | `Options.DisablePresence` + `WithDisablePresence`; `SetDisablePresence`; gate the presence-change emit inside `Update` |
+
+### Tests
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Add | `pkg/document/internal_document_test.go` | `ResetPresences` clears the presence map |
+| Add | `pkg/document/change/change_test.go` | `SetPresenceChange(nil)` preserves operations; `HasOperations` distinguishes presence-only |
+| Add | `server/packs/strip_test.go` | `stripPresenceChanges` shape coverage (presence-only / mixed / ops-only / empty) |
+| Add | `test/integration/presenceless_document_test.go` | End-to-end: attach with opt-out, presence put silently no-ops, response/cache/snapshot all empty |
+| Add (build tag `bench`) | `test/bench/strip_presence_changes_bench_test.go` | Allocation-free strip across shapes |
+
+---
+
+## Task 1: Proto — `disable_presence` on Attach request/response
+
+**Files:**
+- Modify: `api/yorkie/v1/yorkie.proto`
+
+- [ ] **Step 1: Add the request field**
+
+```protobuf
+message AttachDocumentRequest {
+  string client_id = 1;
+  ChangePack change_pack = 2;
+  string schema_key = 3;
+  bool disable_gc = 4;
+  // disable_presence declares that this document does not produce,
+  // consume, or store presence. Honored on first attach only; later
+  // attaches observe the value persisted in DocInfo.
+  bool disable_presence = 5;
+}
+```
+
+- [ ] **Step 2: Add the response field**
+
+```protobuf
+message AttachDocumentResponse {
+  string document_id = 1;
+  ChangePack change_pack = 2;
+  int32 max_size_per_document = 3;
+  repeated Rule schema_rules = 4;
+  bool disable_presence = 5;  // server-fixated value
+}
+```
+
+- [ ] **Step 3: Regenerate**
+
+Run: `make proto`
+Expected: only `api/yorkie/v1/yorkie.pb.go` and its `.connect.go`
+companion change. No other generated files should move.
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add api/yorkie/v1/yorkie.proto api/yorkie/v1/yorkie.pb.go api/yorkie/v1/v1connect/yorkie.connect.go
+git commit -m "Add disable_presence fields to AttachDocument RPC"
+```
+
+---
+
+## Task 2: `DocInfo.DisablePresence` schema
+
+**Files:**
+- Modify: `server/backend/database/doc_info.go`
+
+- [ ] **Step 1: Add the field**
+
+```go
+type DocInfo struct {
+    // ... existing fields ...
+    Epoch       int64     `bson:"epoch"`
+
+    // DisablePresence declares that this document does not accept
+    // presence put/clear. Written via $setOnInsert at first attach
+    // and immutable thereafter; the empty (false) value matches
+    // documents created before this option existed.
+    DisablePresence bool `bson:"disable_presence,omitempty"`
+}
+```
+
+- [ ] **Step 2: Extend `DeepCopy()`**
+
+Add `DisablePresence: d.DisablePresence` so the clone path used by
+caches and tests carries the flag.
+
+- [ ] **Step 3: Verify**
+
+Run: `go test ./server/backend/database/...`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add server/backend/database/doc_info.go
+git commit -m "Add DisablePresence to DocInfo schema"
+```
+
+---
+
+## Task 3: `FindOrCreateDocInfo` — `$setOnInsert` fixate (mongo)
+
+**Files:**
+- Modify: `server/backend/database/mongo/client.go`
+
+- [ ] **Step 1: Extend the signature**
+
+```go
+func (c *Client) FindOrCreateDocInfo(
+    ctx context.Context,
+    clientRefKey types.ClientRefKey,
+    docKey key.Key,
+    disablePresence bool,
+) (*database.DocInfo, error) {
+```
+
+- [ ] **Step 2: Include the field in `$setOnInsert`**
+
+```go
+"$setOnInsert": bson.M{
+    "owner":            clientRefKey.ClientID,
+    "server_seq":       0,
+    "created_at":       now,
+    "updated_at":       now,
+    "disable_presence": disablePresence,
+},
+```
+
+The `$setOnInsert` operator only writes on actual inserts. Second
+and later attaches observe the persisted value and ignore the wire
+field — that is the immutability guarantee.
+
+- [ ] **Step 3: Duplicate-key fallback already returns the persisted row**
+
+Confirm the existing `FindOne` fallback after `IsDuplicateKeyError`
+returns the document as written, so the late attacher sees the
+first writer's value.
+
+- [ ] **Step 4: Verify**
+
+Run: `make test`
+Expected: existing backend tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add server/backend/database/mongo/client.go
+git commit -m "Fixate DisablePresence on FindOrCreateDocInfo upsert"
+```
+
+---
+
+## Task 4: Memory backend parity
+
+**Files:**
+- Modify: `server/backend/database/memory/database.go`
+
+- [ ] **Step 1: Match the new signature**
+
+The in-memory `FindOrCreateDocInfo` accepts `disablePresence bool`
+and applies it only when creating a new entry. An existing entry
+keeps its current value.
+
+- [ ] **Step 2: Mirror tests if existing table touches the signature**
+
+Run: `go test ./server/backend/database/memory/...`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```sh
+git add server/backend/database/memory/database.go server/backend/database/testcases/
+git commit -m "Memory backend honors DisablePresence at insert"
+```
+
+---
+
+## Task 5: RPC handlers — forward flag and warn on mismatch
+
+**Files:**
+- Modify: `server/documents/documents.go`
+- Modify: `server/rpc/yorkie_server.go`
+
+- [ ] **Step 1: Plumb through `documents.FindOrCreateDocInfo`**
+
+The thin wrapper in `server/documents/documents.go` accepts and
+forwards `disablePresence`.
+
+- [ ] **Step 2: `AttachDocument` handler**
+
+```go
+// server/rpc/yorkie_server.go
+docInfo, err := documents.FindOrCreateDocInfo(
+    ctx, s.backend, clientInfo, pack.DocumentKey, req.Msg.DisablePresence,
+)
+// ...
+if req.Msg.DisablePresence != docInfo.DisablePresence {
+    logging.From(ctx).Warnf(
+        "attach with disable_presence=%v but doc fixated to %v: %s",
+        req.Msg.DisablePresence, docInfo.DisablePresence, docInfo.Key,
+    )
+}
+// ...
+return connect.NewResponse(&api.AttachDocumentResponse{
+    DocumentId:      docInfo.ID.String(),
+    ChangePack:      pbChangePack,
+    // ... existing fields ...
+    DisablePresence: docInfo.DisablePresence,   // server-fixated
+}), nil
+```
+
+`PushPull` is called with `PushPullOptions{DisablePresence: docInfo.DisablePresence}`.
+
+- [ ] **Step 3: `PushPullChanges` handler — fetch DocInfo first**
+
+The handler today does not fetch `DocInfo`. Add one call (it is
+cached via `docCache` so the cost is amortized) before the
+`packs.PushPull` invocation and forward `docInfo.DisablePresence`
+through `PushPullOptions`.
+
+- [ ] **Step 4: Verify**
+
+Run: `go test ./server/rpc/...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add server/documents/documents.go server/rpc/yorkie_server.go
+git commit -m "Forward DisablePresence through AttachDocument and PushPullChanges"
+```
+
+---
+
+## Task 6: PushPull entry — `stripPresenceChanges` helper
+
+**Files:**
+- Add: `server/packs/strip.go`
+- Modify: `server/packs/pushpull.go`
+- Modify: `pkg/document/change/change.go`
+
+- [ ] **Step 1: Setter and operation accessor on `Change`**
+
+In `pkg/document/change/change.go`, add:
+
+```go
+func (c *Change) SetPresenceChange(p *innerpresence.Change) {
+    c.presenceChange = p
+}
+
+func (c *Change) HasOperations() bool {
+    return len(c.operations) > 0
+}
+```
+
+- [ ] **Step 2: `stripPresenceChanges` helper**
+
+```go
+// server/packs/strip.go
+//
+// stripPresenceChanges removes PresenceChange from each Change for
+// documents configured presenceless. Presence-only changes drop in
+// full; mixed changes keep their operations and lose presence.
+func stripPresenceChanges(changes []*change.Change) []*change.Change {
+    if len(changes) == 0 {
+        return changes
+    }
+    out := changes[:0]
+    for _, c := range changes {
+        if c.PresenceChange() != nil {
+            if !c.HasOperations() {
+                continue
+            }
+            c.SetPresenceChange(nil)
+        }
+        out = append(out, c)
+    }
+    return out
+}
+```
+
+- [ ] **Step 3: Strip at PushPull entry**
+
+```go
+// server/packs/pushpull.go — at the very top of PushPull
+if opts.DisablePresence {
+    reqPack.Changes = stripPresenceChanges(reqPack.Changes)
+}
+```
+
+Also extend `PushPullOptions`:
+
+```go
+type PushPullOptions struct {
+    Mode             types.SyncMode
+    Status           document.StatusType
+    DisableGC        bool
+    DisablePresence  bool   // forwarded from docInfo
+}
+```
+
+- [ ] **Step 4: Verify**
+
+Run: `go test ./pkg/document/change/... ./server/packs/...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add server/packs/strip.go server/packs/pushpull.go pkg/document/change/change.go
+git commit -m "Strip presence changes at PushPull entry when document is presenceless"
+```
+
+---
+
+## Task 7: `pullSnapshot` — empty presence in response snapshot
+
+**Files:**
+- Modify: `server/packs/pushpull.go`
+- Modify: `pkg/document/internal_document.go`
+
+- [ ] **Step 1: `InternalDocument.ResetPresences()`**
+
+```go
+// pkg/document/internal_document.go
+//
+// ResetPresences clears the presence map and the online-clients set.
+// Used by the server when serializing a snapshot for a presenceless
+// document to prevent any earlier-cached presence entry from leaking
+// onto the wire.
+func (d *InternalDocument) ResetPresences() {
+    d.presences = innerpresence.NewMap()
+    d.onlineClients = make(map[string]bool)
+}
+```
+
+- [ ] **Step 2: Threading `opts` into `pullSnapshot`**
+
+`preparePack` and `pullSnapshot` currently take no `PushPullOptions`.
+Extend both signatures to receive it. In `pullSnapshot`:
+
+```go
+presences := doc.AllPresences()
+if opts.DisablePresence {
+    doc.ResetPresences()
+    presences = nil
+}
+snapshot, err := converter.SnapshotToBytes(doc.RootObject(), presences)
+```
+
+Both belt-and-suspenders: the in-memory reset prevents downstream
+leak (e.g. if the snapshot path branches), and the `nil` argument
+ensures the wire bytes carry an empty map.
+
+- [ ] **Step 3: Verify**
+
+Run: `go test ./pkg/document/... ./server/packs/...`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add pkg/document/internal_document.go server/packs/pushpull.go
+git commit -m "Serialize empty presence map for presenceless documents"
+```
+
+---
+
+## Task 8: `storeSnapshot` — empty presence in persisted snapshot
+
+**Files:**
+- Modify: `server/packs/snapshot.go`
+
+- [ ] **Step 1: Accept `disablePresence`**
+
+```go
+func storeSnapshot(
+    ctx context.Context,
+    be *backend.Backend,
+    snapshotInterval int64,
+    docInfo *database.DocInfo,
+) error {
+```
+
+`docInfo` already carries `DisablePresence`. Right after the
+`ApplyChangePack` step that rebuilds the in-memory document, reset:
+
+```go
+if docInfo.DisablePresence {
+    doc.ResetPresences()
+}
+if err := be.DB.CreateSnapshotInfo(ctx, docRefKey, doc); err != nil {
+    return err
+}
+```
+
+This is defensive: if any earlier `snapshots` row was written before
+the flag (cannot happen via this PR, but is the safe shape), the
+in-memory doc would otherwise inherit it via `applySnapshot`.
+
+- [ ] **Step 2: Verify**
+
+Run: `go test ./server/packs/...`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```sh
+git add server/packs/snapshot.go
+git commit -m "Persist empty presence map for presenceless documents"
+```
+
+---
+
+## Task 9: `pullChangeInfos` — defensive read-path guard
+
+**Files:**
+- Modify: `server/packs/pushpull.go`
+
+- [ ] **Step 1: Receive `docInfo` and strip on read**
+
+```go
+for _, pulledChange := range pulled {
+    if clientInfo.ID == pulledChange.ActorID &&
+        cpAfterPush.ClientSeq >= pulledChange.ClientSeq {
+        continue
+    }
+    if docInfo.DisablePresence {
+        // Defensive: any stray presence in cache or older rows is
+        // dropped on the way to the wire.
+        if pulledChange.PresenceChange != nil {
+            pulledChange = pulledChange.DeepCopy()
+            pulledChange.PresenceChange = nil
+        }
+        if !pulledChange.HasOperations() {
+            continue
+        }
+    }
+    filteredChanges = append(filteredChanges, pulledChange)
+}
+```
+
+`DeepCopy` keeps the cache's shared pointer untouched.
+
+- [ ] **Step 2: Verify**
+
+Run: `go test ./server/packs/...`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```sh
+git add server/packs/pushpull.go
+git commit -m "Defensive presence strip on PushPull read path"
+```
+
+---
+
+## Task 10: Go SDK — `WithDisablePresence` + response handling
+
+**Files:**
+- Modify: `client/options.go`
+- Modify: `client/client.go`
+- Modify: `client/attachment.go`
+- Modify: `pkg/document/document.go`
+- Modify: `pkg/document/change/context.go`
+
+- [ ] **Step 1: Attach option**
+
+```go
+// client/options.go
+type AttachOptions struct {
+    // ... existing fields ...
+    DisableGC        bool
+    DisablePresence  bool
+}
+
+func WithDisablePresence() AttachOption {
+    return func(o *AttachOptions) { o.DisablePresence = true }
+}
+```
+
+- [ ] **Step 2: Send on the wire, store response value on the attachment**
+
+```go
+// client/client.go (inside attachDocument)
+res, err := c.client.AttachDocument(ctx, withShardKey(
+    connect.NewRequest(&api.AttachDocumentRequest{
+        ClientId:        c.id.String(),
+        ChangePack:      pbChangePack,
+        SchemaKey:       opts.Schema,
+        DisableGc:       opts.DisableGC,
+        DisablePresence: opts.DisablePresence,
+    }), ...,
+))
+// ...
+d.SetDisablePresence(res.Msg.DisablePresence)
+c.attachments.Set(d.Key(), &Attachment{
+    // ...
+    disableGC:        opts.DisableGC,
+    disablePresence:  res.Msg.DisablePresence,
+})
+```
+
+Skip the initial `Presence.Initialize` call when the local option
+declared opt-out — that way, an opt-in client never produces a
+wire PUT for presenceless documents:
+
+```go
+if !opts.DisablePresence {
+    if err := d.Update(func(_ *json.Object, p *document.Presence) error {
+        p.Initialize(opts.Presence)
+        return nil
+    }); err != nil { return err }
+}
+```
+
+- [ ] **Step 3: Gate `Document.Update`**
+
+```go
+// pkg/document/document.go (inside Update, after the user callback)
+if d.options.DisablePresence && ctx.HasPresenceChange() {
+    ctx.DropPresenceChange()
+    if !ctx.HasOperations() {
+        return nil
+    }
+}
+```
+
+Add `HasPresenceChange()` / `DropPresenceChange()` on
+`change.Context`. Add `SetDisablePresence` on `Document` to flip
+the option after the attach response is processed.
+
+A single `Logger.Warn` per document the first time the gate trips
+(state held on the document) makes the silent-drop discoverable
+without log spam.
+
+- [ ] **Step 4: Verify**
+
+Run: `go test ./client/... ./pkg/document/...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add client/ pkg/document/
+git commit -m "Add WithDisablePresence to Go SDK with response-driven gating"
+```
+
+---
+
+## Task 11: Integration test
+
+**Files:**
+- Add: `test/integration/presenceless_document_test.go`
+
+- [ ] **Step 1: Write the test**
+
+Build tag `integration`. Coverage:
+
+1. **Fixate at first attach** — first client attaches with
+   `WithDisablePresence()`; the mongo `documents` row carries
+   `disable_presence: true`.
+2. **Late attacher observes persisted value** — second client
+   attaches without the option; response `DisablePresence` is
+   still `true`; a warn log line was emitted.
+3. **PUT presence is stripped** — opt-in (without option) client
+   calls `doc.Update(p.Set(...))` after attach; the next
+   PushPull response has an empty presence map; mongo `changes`
+   row has `presence_change == nil`.
+4. **storeSnapshot is clean** — drive enough updates to cross
+   `snapshot_interval`; the resulting `snapshots` row decompresses
+   to a document whose presence map is empty.
+5. **Backward compatibility** — existing document (no field) attach
+   has `DisablePresence == false` and the normal accumulation path
+   continues to work.
+
+Mirror the existing client setup in
+`test/integration/disable_gc_test.go`.
+
+- [ ] **Step 2: Run**
+
+```sh
+docker compose -f build/docker/docker-compose.yml up --build -d
+go test -tags integration ./test/integration/ -run TestPresenceless -v
+```
+
+Expected: all subtests PASS.
+
+- [ ] **Step 3: Full integration sweep**
+
+Run: `make test`
+Expected: no regressions (gc, snapshot, presence, vv-cleanup).
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add test/integration/presenceless_document_test.go
+git commit -m "Add integration tests for presenceless document option"
+```
+
+---
+
+## Task 12: Benchmark — `stripPresenceChanges`
+
+**Files:**
+- Add: `test/bench/strip_presence_changes_bench_test.go`
+
+- [ ] **Step 1: Cover the four shapes**
+
+Build tag `bench`. Inputs of size n ∈ {1, 8, 64} for shapes
+`presence_only`, `mixed`, `ops_only`, and a size-0 input.
+
+- [ ] **Step 2: Run**
+
+```sh
+go test -tags bench ./test/bench/ -run x -bench BenchmarkStripPresenceChanges -benchmem
+```
+
+Expected: zero allocations across all shapes; sub-microsecond at
+n=64 for the worst shape.
+
+- [ ] **Step 3: Commit**
+
+```sh
+git add test/bench/strip_presence_changes_bench_test.go
+git commit -m "Benchmark stripPresenceChanges across shapes"
+```
+
+---
+
+## Task 13: Self-review and PR
+
+- [ ] **Step 1: Lint and unit tests**
+
+```sh
+make lint
+go test ./...
+```
+
+Expected: clean.
+
+- [ ] **Step 2: Self-review**
+
+Dispatch `superpowers:requesting-code-review` (or `/code-review`)
+over the full branch diff. Apply Critical/Important findings;
+capture non-blocking notes in the lessons file.
+
+- [ ] **Step 3: Rebase on main and open PR**
+
+```sh
+git fetch && git rebase origin/main
+git push -u origin feat/presenceless-document-option
+gh pr create --title "Add disable_presence Document option" \
+  --body-file <(cat <<'EOF'
+## Summary
+- New `disable_presence` field on `AttachDocumentRequest` /
+  `AttachDocumentResponse` and on `DocInfo`. Fixated via mongo
+  `$setOnInsert` at first attach; immutable afterward.
+- PushPull entry, snapshot serialization, and snapshot persistence
+  all enforce an empty presence map for presenceless documents.
+- Read-path defensive guard ensures no cached presence leaks onto
+  the wire.
+- Go SDK exposes `WithDisablePresence()`; gates `Document.Update`
+  presence emit on the server-fixated value carried back in the
+  attach response.
+
+## Background
+High fan-out Counter-only document (insurance `/car`) accumulates
+~28K stale presence entries because clients reach end-of-life
+without `detach`, inflating attach responses to ~170KB. See
+`docs/tasks/active/20260616-presenceless-document-option-todo.md`
+for the full measurement trail and alternatives considered.
+
+## Test plan
+- [ ] `make lint`
+- [ ] `go test ./...`
+- [ ] `go test -tags integration ./test/integration/ -run TestPresenceless`
+- [ ] `make test` (full integration)
+- [ ] `go test -tags bench ./test/bench/ -bench BenchmarkStripPresenceChanges -benchmem`
+
+## Follow-up
+- yorkie-js-sdk PR adds the matching client option (separate task
+  doc).
+EOF
+)
+```
+
+- [ ] **Step 4: Address review and merge**
+
+Resolve CodeRabbit + maintainer comments; rebase if `main` moved.
+
+---
+
+## Task 14: Lessons and archive
+
+- [ ] **Step 1: Capture lessons**
+
+Write findings to
+`docs/tasks/active/20260616-presenceless-document-option-lessons.md`.
+Likely topics:
+- `$setOnInsert` race semantics in mongo and how the duplicate-key
+  fallback path interacts with it
+- Anything surprising in how the snapshot-build cache (`be.Cache`)
+  interacts with `ResetPresences`
+- Behaviour for old clients that do not know the field (server
+  silent-enforces; SDK never warns because the field is not read)
+
+- [ ] **Step 2: Archive**
+
+```sh
+bash scripts/tasks-archive.sh
+bash scripts/tasks-index.sh
+```
+
+---
+
+## Remaining
+
+- [ ] All Task 1–14 steps above
+- [ ] yorkie-js-sdk follow-up PR (separate task doc, agent in flight)
+- [ ] Insurance FE adoption (devops repo, separate task)
+- [ ] Future: admin RPC to toggle the flag after creation (deferred;
+      out of scope here)

--- a/docs/tasks/active/20260616-presenceless-document-option-todo.md
+++ b/docs/tasks/active/20260616-presenceless-document-option-todo.md
@@ -147,7 +147,7 @@ break the guarantee.
 **Files:**
 - Modify: `api/yorkie/v1/yorkie.proto`
 
-- [ ] **Step 1: Add the request field**
+- [x] **Step 1: Add the request field**
 
 ```protobuf
 message AttachDocumentRequest {
@@ -162,7 +162,7 @@ message AttachDocumentRequest {
 }
 ```
 
-- [ ] **Step 2: Add the response field**
+- [x] **Step 2: Add the response field**
 
 ```protobuf
 message AttachDocumentResponse {
@@ -174,13 +174,13 @@ message AttachDocumentResponse {
 }
 ```
 
-- [ ] **Step 3: Regenerate**
+- [x] **Step 3: Regenerate**
 
 Run: `make proto`
 Expected: only `api/yorkie/v1/yorkie.pb.go` and its `.connect.go`
 companion change. No other generated files should move.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```sh
 git add api/yorkie/v1/yorkie.proto api/yorkie/v1/yorkie.pb.go api/yorkie/v1/v1connect/yorkie.connect.go
@@ -194,7 +194,7 @@ git commit -m "Add disable_presence fields to AttachDocument RPC"
 **Files:**
 - Modify: `server/backend/database/doc_info.go`
 
-- [ ] **Step 1: Add the field**
+- [x] **Step 1: Add the field**
 
 ```go
 type DocInfo struct {
@@ -209,17 +209,17 @@ type DocInfo struct {
 }
 ```
 
-- [ ] **Step 2: Extend `DeepCopy()`**
+- [x] **Step 2: Extend `DeepCopy()`**
 
 Add `DisablePresence: d.DisablePresence` so the clone path used by
 caches and tests carries the flag.
 
-- [ ] **Step 3: Verify**
+- [x] **Step 3: Verify**
 
 Run: `go test ./server/backend/database/...`
 Expected: PASS.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```sh
 git add server/backend/database/doc_info.go
@@ -233,7 +233,7 @@ git commit -m "Add DisablePresence to DocInfo schema"
 **Files:**
 - Modify: `server/backend/database/mongo/client.go`
 
-- [ ] **Step 1: Extend the signature**
+- [x] **Step 1: Extend the signature**
 
 ```go
 func (c *Client) FindOrCreateDocInfo(
@@ -244,7 +244,7 @@ func (c *Client) FindOrCreateDocInfo(
 ) (*database.DocInfo, error) {
 ```
 
-- [ ] **Step 2: Include the field in `$setOnInsert`**
+- [x] **Step 2: Include the field in `$setOnInsert`**
 
 ```go
 "$setOnInsert": bson.M{
@@ -260,18 +260,18 @@ The `$setOnInsert` operator only writes on actual inserts. Second
 and later attaches observe the persisted value and ignore the wire
 field — that is the immutability guarantee.
 
-- [ ] **Step 3: Duplicate-key fallback already returns the persisted row**
+- [x] **Step 3: Duplicate-key fallback already returns the persisted row**
 
 Confirm the existing `FindOne` fallback after `IsDuplicateKeyError`
 returns the document as written, so the late attacher sees the
 first writer's value.
 
-- [ ] **Step 4: Verify**
+- [x] **Step 4: Verify**
 
 Run: `make test`
 Expected: existing backend tests PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```sh
 git add server/backend/database/mongo/client.go
@@ -285,18 +285,18 @@ git commit -m "Fixate DisablePresence on FindOrCreateDocInfo upsert"
 **Files:**
 - Modify: `server/backend/database/memory/database.go`
 
-- [ ] **Step 1: Match the new signature**
+- [x] **Step 1: Match the new signature**
 
 The in-memory `FindOrCreateDocInfo` accepts `disablePresence bool`
 and applies it only when creating a new entry. An existing entry
 keeps its current value.
 
-- [ ] **Step 2: Mirror tests if existing table touches the signature**
+- [x] **Step 2: Mirror tests if existing table touches the signature**
 
 Run: `go test ./server/backend/database/memory/...`
 Expected: PASS.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```sh
 git add server/backend/database/memory/database.go server/backend/database/testcases/
@@ -311,12 +311,12 @@ git commit -m "Memory backend honors DisablePresence at insert"
 - Modify: `server/documents/documents.go`
 - Modify: `server/rpc/yorkie_server.go`
 
-- [ ] **Step 1: Plumb through `documents.FindOrCreateDocInfo`**
+- [x] **Step 1: Plumb through `documents.FindOrCreateDocInfo`**
 
 The thin wrapper in `server/documents/documents.go` accepts and
 forwards `disablePresence`.
 
-- [ ] **Step 2: `AttachDocument` handler**
+- [x] **Step 2: `AttachDocument` handler**
 
 ```go
 // server/rpc/yorkie_server.go
@@ -341,19 +341,19 @@ return connect.NewResponse(&api.AttachDocumentResponse{
 
 `PushPull` is called with `PushPullOptions{DisablePresence: docInfo.DisablePresence}`.
 
-- [ ] **Step 3: `PushPullChanges` handler — fetch DocInfo first**
+- [x] **Step 3: `PushPullChanges` handler — fetch DocInfo first**
 
 The handler today does not fetch `DocInfo`. Add one call (it is
 cached via `docCache` so the cost is amortized) before the
 `packs.PushPull` invocation and forward `docInfo.DisablePresence`
 through `PushPullOptions`.
 
-- [ ] **Step 4: Verify**
+- [x] **Step 4: Verify**
 
 Run: `go test ./server/rpc/...`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```sh
 git add server/documents/documents.go server/rpc/yorkie_server.go
@@ -369,7 +369,7 @@ git commit -m "Forward DisablePresence through AttachDocument and PushPullChange
 - Modify: `server/packs/pushpull.go`
 - Modify: `pkg/document/change/change.go`
 
-- [ ] **Step 1: Setter and operation accessor on `Change`**
+- [x] **Step 1: Setter and operation accessor on `Change`**
 
 In `pkg/document/change/change.go`, add:
 
@@ -383,7 +383,7 @@ func (c *Change) HasOperations() bool {
 }
 ```
 
-- [ ] **Step 2: `stripPresenceChanges` helper**
+- [x] **Step 2: `stripPresenceChanges` helper**
 
 ```go
 // server/packs/strip.go
@@ -409,7 +409,7 @@ func stripPresenceChanges(changes []*change.Change) []*change.Change {
 }
 ```
 
-- [ ] **Step 3: Strip at PushPull entry**
+- [x] **Step 3: Strip at PushPull entry**
 
 ```go
 // server/packs/pushpull.go — at the very top of PushPull
@@ -429,12 +429,12 @@ type PushPullOptions struct {
 }
 ```
 
-- [ ] **Step 4: Verify**
+- [x] **Step 4: Verify**
 
 Run: `go test ./pkg/document/change/... ./server/packs/...`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```sh
 git add server/packs/strip.go server/packs/pushpull.go pkg/document/change/change.go
@@ -449,7 +449,7 @@ git commit -m "Strip presence changes at PushPull entry when document is presenc
 - Modify: `server/packs/pushpull.go`
 - Modify: `pkg/document/internal_document.go`
 
-- [ ] **Step 1: `InternalDocument.ResetPresences()`**
+- [x] **Step 1: `InternalDocument.ResetPresences()`**
 
 ```go
 // pkg/document/internal_document.go
@@ -464,7 +464,7 @@ func (d *InternalDocument) ResetPresences() {
 }
 ```
 
-- [ ] **Step 2: Threading `opts` into `pullSnapshot`**
+- [x] **Step 2: Threading `opts` into `pullSnapshot`**
 
 `preparePack` and `pullSnapshot` currently take no `PushPullOptions`.
 Extend both signatures to receive it. In `pullSnapshot`:
@@ -482,12 +482,12 @@ Both belt-and-suspenders: the in-memory reset prevents downstream
 leak (e.g. if the snapshot path branches), and the `nil` argument
 ensures the wire bytes carry an empty map.
 
-- [ ] **Step 3: Verify**
+- [x] **Step 3: Verify**
 
 Run: `go test ./pkg/document/... ./server/packs/...`
 Expected: PASS.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```sh
 git add pkg/document/internal_document.go server/packs/pushpull.go
@@ -501,7 +501,7 @@ git commit -m "Serialize empty presence map for presenceless documents"
 **Files:**
 - Modify: `server/packs/snapshot.go`
 
-- [ ] **Step 1: Accept `disablePresence`**
+- [x] **Step 1: Accept `disablePresence`**
 
 ```go
 func storeSnapshot(
@@ -528,12 +528,12 @@ This is defensive: if any earlier `snapshots` row was written before
 the flag (cannot happen via this PR, but is the safe shape), the
 in-memory doc would otherwise inherit it via `applySnapshot`.
 
-- [ ] **Step 2: Verify**
+- [x] **Step 2: Verify**
 
 Run: `go test ./server/packs/...`
 Expected: PASS.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```sh
 git add server/packs/snapshot.go
@@ -547,7 +547,7 @@ git commit -m "Persist empty presence map for presenceless documents"
 **Files:**
 - Modify: `server/packs/pushpull.go`
 
-- [ ] **Step 1: Receive `docInfo` and strip on read**
+- [x] **Step 1: Receive `docInfo` and strip on read**
 
 ```go
 for _, pulledChange := range pulled {
@@ -572,12 +572,12 @@ for _, pulledChange := range pulled {
 
 `DeepCopy` keeps the cache's shared pointer untouched.
 
-- [ ] **Step 2: Verify**
+- [x] **Step 2: Verify**
 
 Run: `go test ./server/packs/...`
 Expected: PASS.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```sh
 git add server/packs/pushpull.go
@@ -595,7 +595,7 @@ git commit -m "Defensive presence strip on PushPull read path"
 - Modify: `pkg/document/document.go`
 - Modify: `pkg/document/change/context.go`
 
-- [ ] **Step 1: Attach option**
+- [x] **Step 1: Attach option**
 
 ```go
 // client/options.go
@@ -610,7 +610,7 @@ func WithDisablePresence() AttachOption {
 }
 ```
 
-- [ ] **Step 2: Send on the wire, store response value on the attachment**
+- [x] **Step 2: Send on the wire, store response value on the attachment**
 
 ```go
 // client/client.go (inside attachDocument)
@@ -645,7 +645,7 @@ if !opts.DisablePresence {
 }
 ```
 
-- [ ] **Step 3: Gate `Document.Update`**
+- [x] **Step 3: Gate `Document.Update`**
 
 ```go
 // pkg/document/document.go (inside Update, after the user callback)
@@ -665,12 +665,12 @@ A single `Logger.Warn` per document the first time the gate trips
 (state held on the document) makes the silent-drop discoverable
 without log spam.
 
-- [ ] **Step 4: Verify**
+- [x] **Step 4: Verify**
 
 Run: `go test ./client/... ./pkg/document/...`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```sh
 git add client/ pkg/document/
@@ -684,7 +684,7 @@ git commit -m "Add WithDisablePresence to Go SDK with response-driven gating"
 **Files:**
 - Add: `test/integration/presenceless_document_test.go`
 
-- [ ] **Step 1: Write the test**
+- [x] **Step 1: Write the test**
 
 Build tag `integration`. Coverage:
 
@@ -708,7 +708,7 @@ Build tag `integration`. Coverage:
 Mirror the existing client setup in
 `test/integration/disable_gc_test.go`.
 
-- [ ] **Step 2: Run**
+- [x] **Step 2: Run**
 
 ```sh
 docker compose -f build/docker/docker-compose.yml up --build -d
@@ -717,12 +717,12 @@ go test -tags integration ./test/integration/ -run TestPresenceless -v
 
 Expected: all subtests PASS.
 
-- [ ] **Step 3: Full integration sweep**
+- [x] **Step 3: Full integration sweep**
 
 Run: `make test`
 Expected: no regressions (gc, snapshot, presence, vv-cleanup).
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```sh
 git add test/integration/presenceless_document_test.go
@@ -736,12 +736,12 @@ git commit -m "Add integration tests for presenceless document option"
 **Files:**
 - Add: `test/bench/strip_presence_changes_bench_test.go`
 
-- [ ] **Step 1: Cover the four shapes**
+- [x] **Step 1: Cover the four shapes**
 
 Build tag `bench`. Inputs of size n ∈ {1, 8, 64} for shapes
 `presence_only`, `mixed`, `ops_only`, and a size-0 input.
 
-- [ ] **Step 2: Run**
+- [x] **Step 2: Run**
 
 ```sh
 go test -tags bench ./test/bench/ -run x -bench BenchmarkStripPresenceChanges -benchmem
@@ -750,7 +750,7 @@ go test -tags bench ./test/bench/ -run x -bench BenchmarkStripPresenceChanges -b
 Expected: zero allocations across all shapes; sub-microsecond at
 n=64 for the worst shape.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```sh
 git add test/bench/strip_presence_changes_bench_test.go
@@ -761,7 +761,7 @@ git commit -m "Benchmark stripPresenceChanges across shapes"
 
 ## Task 13: Self-review and PR
 
-- [ ] **Step 1: Lint and unit tests**
+- [x] **Step 1: Lint and unit tests**
 
 ```sh
 make lint

--- a/pkg/document/change/change.go
+++ b/pkg/document/change/change.go
@@ -108,6 +108,20 @@ func (c *Change) PresenceChange() *inner.Change {
 	return c.presenceChange
 }
 
+// SetPresenceChange replaces the presence change carried by this change.
+// Passing nil drops the presence change in place; the server uses this to
+// strip presence on documents created with disable_presence.
+func (c *Change) SetPresenceChange(pc *inner.Change) {
+	c.presenceChange = pc
+}
+
+// HasOperations reports whether this change carries at least one operation.
+// A change with zero operations and a nil presence change can be safely
+// dropped from the wire.
+func (c *Change) HasOperations() bool {
+	return len(c.operations) > 0
+}
+
 // AfterOrEqual returns whether this change is after or equal to the given change.
 func (c *Change) AfterOrEqual(other *Change) bool {
 	return c.id.AfterOrEqual(other.id)

--- a/pkg/document/change/change_test.go
+++ b/pkg/document/change/change_test.go
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+// Package change_test provides tests for the change package.
 package change_test
 
 import (

--- a/pkg/document/change/change_test.go
+++ b/pkg/document/change/change_test.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package change_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/pkg/document/change"
+	"github.com/yorkie-team/yorkie/pkg/document/operations"
+	"github.com/yorkie-team/yorkie/pkg/document/presence/inner"
+	"github.com/yorkie-team/yorkie/pkg/document/time"
+)
+
+func TestChange(t *testing.T) {
+	t.Run("HasOperations distinguishes presence-only changes", func(t *testing.T) {
+		id := change.NewID(0, 0, 0, time.InitialActorID, time.NewVersionVector())
+
+		presenceOnly := change.New(id, "", nil, &inner.Change{
+			ChangeType: inner.Put,
+			Presence:   inner.Presence{"foo": "bar"},
+		})
+		assert.False(t, presenceOnly.HasOperations())
+		assert.NotNil(t, presenceOnly.PresenceChange())
+
+		empty := change.New(id, "", nil, nil)
+		assert.False(t, empty.HasOperations())
+		assert.Nil(t, empty.PresenceChange())
+	})
+
+	t.Run("SetPresenceChange(nil) preserves operations", func(t *testing.T) {
+		id := change.NewID(0, 0, 0, time.InitialActorID, time.NewVersionVector())
+		rmOp := operations.NewRemove(time.InitialTicket, time.InitialTicket, time.InitialTicket)
+
+		c := change.New(id, "", []operations.Operation{rmOp}, &inner.Change{
+			ChangeType: inner.Put,
+			Presence:   inner.Presence{"x": "y"},
+		})
+		assert.True(t, c.HasOperations())
+		assert.NotNil(t, c.PresenceChange())
+
+		c.SetPresenceChange(nil)
+		assert.True(t, c.HasOperations())
+		assert.Nil(t, c.PresenceChange())
+		assert.Len(t, c.Operations(), 1)
+	})
+}

--- a/pkg/document/change/context.go
+++ b/pkg/document/change/context.go
@@ -130,6 +130,23 @@ func (c *Context) SetPresenceChange(presenceChange inner.Change) {
 	c.presenceChange = &presenceChange
 }
 
+// HasPresenceChange reports whether this context carries a presence change.
+func (c *Context) HasPresenceChange() bool {
+	return c.presenceChange != nil
+}
+
+// DropPresenceChange clears any presence change accumulated on this context.
+// The client uses this on documents attached with disable_presence so the
+// emitted Change carries operations only.
+func (c *Context) DropPresenceChange() {
+	c.presenceChange = nil
+}
+
+// HasOperations reports whether this context has at least one operation.
+func (c *Context) HasOperations() bool {
+	return len(c.operations) > 0
+}
+
 // GCElementPairMap returns the gcElementPairMap for testing purposes.
 func (c *Context) GCElementPairMap() map[string]crdt.ElementPair {
 	return c.root.GCElementPairMap()

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -19,6 +19,7 @@ package document
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"sync"
 
@@ -84,12 +85,28 @@ type Options struct {
 	// NOTE(hackerwins): This is temporary option. We need to remove this option
 	// after introducing the garbage collection based on the version vector.
 	DisableGC bool
+
+	// DisablePresence gates the document against producing presence
+	// changes. When true, Update silently drops any presence emit issued
+	// inside the user callback. The Client sets this from the
+	// server-fixated value returned in the AttachDocument response so a
+	// late attacher cannot pollute a presenceless document even if it
+	// did not pass WithDisablePresence locally.
+	DisablePresence bool
 }
 
 // WithDisableGC configures the document to disable garbage collection.
 func WithDisableGC() Option {
 	return func(o *Options) {
 		o.DisableGC = true
+	}
+}
+
+// WithDisablePresence configures the document to drop presence changes
+// locally. See Options.DisablePresence.
+func WithDisablePresence() Option {
+	return func(o *Options) {
+		o.DisablePresence = true
 	}
 }
 
@@ -117,6 +134,11 @@ type Document struct {
 	// clonePresences is a copy of `doc.presences` to be exposed to the user and
 	// is used to protect `doc.presences`.
 	clonePresences *presence.Map
+
+	// presenceDroppedOnce ensures the warn-log issued when a presenceless
+	// document drops a user-supplied presence change fires at most once
+	// per Document instance.
+	presenceDroppedOnce sync.Once
 
 	// MaxSizeLimit is the maximum size of a document in bytes.
 	MaxSizeLimit int
@@ -173,6 +195,17 @@ func (d *Document) Update(
 		d.cloneRoot = nil
 		d.clonePresences = nil
 		return err
+	}
+
+	// Gate any presence emit when the document opted out. We warn once per
+	// document so the silent drop is discoverable without log spam if a
+	// caller wires presence into a presenceless document by mistake.
+	if d.options.DisablePresence && ctx.HasPresenceChange() {
+		ctx.DropPresenceChange()
+		d.warnPresenceDroppedOnce()
+		if !ctx.HasOperations() {
+			return nil
+		}
 	}
 
 	if !ctx.IsPresenceOnlyChange() && len(d.SchemaRules) > 0 {
@@ -294,6 +327,29 @@ func (d *Document) SetDisableGC(disableGC bool) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.doc.SetDisableGC(disableGC)
+}
+
+// SetDisablePresence records the server-fixated value of disable_presence.
+// The Client calls this with the value carried in the AttachDocument
+// response so subsequent Update calls inside this Document gate on the
+// persisted decision rather than the locally requested one.
+func (d *Document) SetDisablePresence(disablePresence bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.options.DisablePresence = disablePresence
+}
+
+// warnPresenceDroppedOnce emits a single line to stderr the first time
+// Update silently drops a presence change on a presenceless document.
+// Using sync.Once keeps the warning useful without spamming the log on
+// every interaction.
+func (d *Document) warnPresenceDroppedOnce() {
+	d.presenceDroppedOnce.Do(func() {
+		log.Printf(
+			"yorkie: document %q opted out of presence; dropping presence change from Update",
+			d.doc.key,
+		)
+	})
 }
 
 // Key returns the key of this document.

--- a/pkg/document/internal_document.go
+++ b/pkg/document/internal_document.go
@@ -160,6 +160,15 @@ func (d *InternalDocument) SetDisableGC(disableGC bool) {
 	d.disableGC = disableGC
 }
 
+// ResetPresences clears the presence map and the online-clients set. The
+// server calls this when serializing or persisting a snapshot for a
+// presenceless document so that no earlier-cached presence entry leaks
+// onto the wire or into the snapshots collection.
+func (d *InternalDocument) ResetPresences() {
+	d.presences = presence.NewMap()
+	d.onlineClients = make(map[string]bool)
+}
+
 // ApplyChangePack applies the given change pack into this document.
 func (d *InternalDocument) ApplyChangePack(pack *change.Pack, disableGC bool) error {
 	hasSnapshot := len(pack.Snapshot) > 0

--- a/pkg/document/internal_document_test.go
+++ b/pkg/document/internal_document_test.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package document_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/pkg/document"
+	"github.com/yorkie-team/yorkie/pkg/document/json"
+	"github.com/yorkie-team/yorkie/pkg/document/presence"
+)
+
+// TestInternalDocumentResetPresences pins the contract used by the server
+// to enforce disable_presence: ResetPresences must drop every cached
+// presence entry so a subsequent serialization carries an empty map.
+func TestInternalDocumentResetPresences(t *testing.T) {
+	doc := document.New("test-doc")
+	assert.NoError(t, doc.Update(func(_ *json.Object, p *presence.Presence) error {
+		p.Set("name", "alice")
+		return nil
+	}))
+	assert.NotEmpty(t, doc.AllPresences(), "expected presence to be populated before reset")
+
+	doc.InternalDocument().ResetPresences()
+
+	assert.Empty(t, doc.AllPresences(),
+		"ResetPresences should clear the presence map and online-clients set")
+}

--- a/server/backend/database/database.go
+++ b/server/backend/database/database.go
@@ -267,8 +267,15 @@ type Database interface {
 	// FindDocInfosByIDs finds the documents of the given IDs.
 	FindDocInfosByIDs(ctx context.Context, projectID types.ID, docIDs []types.ID) ([]*DocInfo, error)
 
-	// FindOrCreateDocInfo finds the document or creates it if it does not exist.
-	FindOrCreateDocInfo(ctx context.Context, clientRefKey types.ClientRefKey, docKey key.Key) (*DocInfo, error)
+	// FindOrCreateDocInfo finds the document or creates it if it does not
+	// exist. The disablePresence flag is fixated only on the create path;
+	// for an existing document, the persisted value wins.
+	FindOrCreateDocInfo(
+		ctx context.Context,
+		clientRefKey types.ClientRefKey,
+		docKey key.Key,
+		disablePresence bool,
+	) (*DocInfo, error)
 
 	// FindDocInfoByRefKey finds the document of the given refKey.
 	FindDocInfoByRefKey(ctx context.Context, refKey types.DocRefKey) (*DocInfo, error)

--- a/server/backend/database/doc_info.go
+++ b/server/backend/database/doc_info.go
@@ -62,6 +62,12 @@ type DocInfo struct {
 	// compaction. A serverSeq is only meaningful within its epoch — once the
 	// epoch changes, all prior checkpoints are invalidated.
 	Epoch int64 `bson:"epoch"`
+
+	// DisablePresence declares that this document does not accept presence
+	// put/clear. Written via $setOnInsert at first attach and immutable
+	// thereafter; the empty (false) value matches documents created before
+	// this option existed.
+	DisablePresence bool `bson:"disable_presence,omitempty"`
 }
 
 // IncreaseServerSeq increases server sequence of the document.
@@ -82,18 +88,19 @@ func (info *DocInfo) DeepCopy() *DocInfo {
 	}
 
 	return &DocInfo{
-		ID:          info.ID,
-		ProjectID:   info.ProjectID,
-		Key:         info.Key,
-		ServerSeq:   info.ServerSeq,
-		Owner:       info.Owner,
-		Schema:      info.Schema,
-		CreatedAt:   info.CreatedAt,
-		AccessedAt:  info.AccessedAt,
-		UpdatedAt:   info.UpdatedAt,
-		RemovedAt:   info.RemovedAt,
-		CompactedAt: info.CompactedAt,
-		Epoch:       info.Epoch,
+		ID:              info.ID,
+		ProjectID:       info.ProjectID,
+		Key:             info.Key,
+		ServerSeq:       info.ServerSeq,
+		Owner:           info.Owner,
+		Schema:          info.Schema,
+		CreatedAt:       info.CreatedAt,
+		AccessedAt:      info.AccessedAt,
+		UpdatedAt:       info.UpdatedAt,
+		RemovedAt:       info.RemovedAt,
+		CompactedAt:     info.CompactedAt,
+		Epoch:           info.Epoch,
+		DisablePresence: info.DisablePresence,
 	}
 }
 

--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -1394,10 +1394,13 @@ func (d *DB) FindAttachedClientCountsByDocIDs(
 }
 
 // FindOrCreateDocInfo finds the document or creates it if it does not exist.
+// The disablePresence flag is honored only when this call creates the row;
+// when the row exists, its persisted value is returned unchanged.
 func (d *DB) FindOrCreateDocInfo(
 	_ context.Context,
 	clientRefKey types.ClientRefKey,
 	docKey key.Key,
+	disablePresence bool,
 ) (*database.DocInfo, error) {
 	txn := d.db.Txn(true)
 	defer txn.Abort()
@@ -1410,15 +1413,16 @@ func (d *DB) FindOrCreateDocInfo(
 	if info == nil {
 		now := gotime.Now()
 		info = &database.DocInfo{
-			ID:         newID(),
-			ProjectID:  clientRefKey.ProjectID,
-			Key:        docKey,
-			Owner:      clientRefKey.ClientID,
-			ServerSeq:  0,
-			Schema:     "",
-			CreatedAt:  now,
-			UpdatedAt:  now,
-			AccessedAt: now,
+			ID:              newID(),
+			ProjectID:       clientRefKey.ProjectID,
+			Key:             docKey,
+			Owner:           clientRefKey.ClientID,
+			ServerSeq:       0,
+			Schema:          "",
+			CreatedAt:       now,
+			UpdatedAt:       now,
+			AccessedAt:      now,
+			DisablePresence: disablePresence,
 		}
 		if err := txn.Insert(tblDocuments, info); err != nil {
 			return nil, fmt.Errorf("find or create document of %s: %w", docKey, err)

--- a/server/backend/database/memory/database_test.go
+++ b/server/backend/database/memory/database_test.go
@@ -333,7 +333,7 @@ func TestCountAliveDocuments(t *testing.T) {
 	var docs []*database.DocInfo
 	for i := 0; i < 2; i++ {
 		docKey := key.Key(fmt.Sprintf("tests$%s-d%d", t.Name(), i))
-		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NoError(t, err)
 		docs = append(docs, docInfo)
 	}

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -1462,10 +1462,14 @@ func (c *Client) FindAttachedClientCountsByDocIDs(
 }
 
 // FindOrCreateDocInfo finds the document or creates it if it does not exist.
+// The disablePresence flag is fixated via $setOnInsert at first attach and
+// observed by later callers — the persisted value wins regardless of what
+// they pass.
 func (c *Client) FindOrCreateDocInfo(
 	ctx context.Context,
 	clientRefKey types.ClientRefKey,
 	docKey key.Key,
+	disablePresence bool,
 ) (*database.DocInfo, error) {
 	filter := bson.M{
 		"project_id": clientRefKey.ProjectID,
@@ -1484,10 +1488,11 @@ func (c *Client) FindOrCreateDocInfo(
 				"accessed_at": now,
 			},
 			"$setOnInsert": bson.M{
-				"owner":      clientRefKey.ClientID,
-				"server_seq": 0,
-				"created_at": now,
-				"updated_at": now,
+				"owner":            clientRefKey.ClientID,
+				"server_seq":       0,
+				"created_at":       now,
+				"updated_at":       now,
+				"disable_presence": disablePresence,
 			},
 		},
 		options.FindOneAndUpdate().

--- a/server/backend/database/testcases/testcases.go
+++ b/server/backend/database/testcases/testcases.go
@@ -213,11 +213,11 @@ func RunFindDocInfoTest(
 		assert.ErrorIs(t, err, database.ErrDocumentNotFound)
 
 		docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
-		firstInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+		firstInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NoError(t, err)
 		assert.Equal(t, docKey, firstInfo.Key)
 
-		secondInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+		secondInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NoError(t, err)
 		assert.Equal(t, docKey, secondInfo.Key)
 		assert.Equal(t, firstInfo.ID, secondInfo.ID)
@@ -230,7 +230,7 @@ func RunFindDocInfoTest(
 
 		// 01. Create a document
 		docKey := helper.TestKey(t)
-		info, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+		info, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NoError(t, err)
 		assert.Equal(t, docKey, info.Key)
 
@@ -262,7 +262,7 @@ func RunFindDocInfosByKeysAndIDsTest(
 		}
 		docIDs := make([]types.ID, 0)
 		for _, docKey := range docKeys {
-			docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+			docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 			assert.NoError(t, err)
 			docIDs = append(docIDs, docInfo.ID)
 		}
@@ -303,7 +303,7 @@ func RunFindDocInfosByKeysAndIDsTest(
 			"search$test", "abcde", "test abc",
 		}
 		for _, docKey := range docKeys {
-			_, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+			_, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 			assert.NoError(t, err)
 		}
 
@@ -329,7 +329,7 @@ func RunFindDocInfosByKeysAndIDsTest(
 		}
 		docIDs := make([]types.ID, 0)
 		for _, docKey := range docKeys {
-			docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+			docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 			assert.NoError(t, err)
 			docIDs = append(docIDs, docInfo.ID)
 		}
@@ -461,7 +461,7 @@ func RunFindDocInfosByQueryTest(
 			"test0", "test1", "test2", "test3", "test10",
 			"test11", "test20", "test21", "test22", "test23"}
 		for _, docKey := range docKeys {
-			_, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), key.Key(docKey))
+			_, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), key.Key(docKey), false)
 			assert.NoError(t, err)
 		}
 
@@ -492,7 +492,7 @@ func RunFindChangesBetweenServerSeqsTest(
 		docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
 
 		clientInfo, _ := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
-		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		refKey := docInfo.RefKey()
 		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
@@ -792,7 +792,7 @@ func RunFindChangeInfosBetweenServerSeqsTest(
 		docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
 
 		clientInfo, _ := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
-		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
@@ -822,7 +822,7 @@ func RunFindChangeInfosBetweenServerSeqsTest(
 		docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
 
 		clientInfo, _ := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
-		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		refKey := docInfo.RefKey()
 		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
@@ -894,7 +894,7 @@ func RunFindChangeInfosBetweenServerSeqsTest(
 		docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
 
 		clientInfo, _ := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
-		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		refKey := docInfo.RefKey()
 		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
@@ -959,7 +959,7 @@ func RunFindLatestChangeInfoTest(t *testing.T,
 		// 01. Activate client and find document info.
 		clientInfo, err := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
 		assert.NoError(t, err)
-		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NoError(t, err)
 		refKey := docInfo.RefKey()
 		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
@@ -1022,7 +1022,7 @@ func RunFindClosestSnapshotInfoTest(t *testing.T, db database.Database, projectI
 		clientInfo, _ := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
 		bytesID, _ := clientInfo.ID.Bytes()
 		actorID, _ := time.ActorIDFromBytes(bytesID)
-		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 
 		doc := document.New(key.Key(t.Name()))
 		doc.SetActor(actorID)
@@ -1180,7 +1180,7 @@ func RunTryAttachingAndDeactivateClientTest(t *testing.T, db database.Database, 
 		assert.NoError(t, err)
 
 		// 02. create a document
-		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), key.Key(fmt.Sprintf("tests$%s", t.Name())))
+		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), key.Key(fmt.Sprintf("tests$%s", t.Name())), false)
 		assert.NoError(t, err)
 
 		// 03. success case: client is activated, and document is not attached
@@ -1219,7 +1219,7 @@ func RunTryAttachingAndDeactivateClientTest(t *testing.T, db database.Database, 
 		// 02. failure case: client has attaching document
 		clientInfo, err = db.ActivateClient(ctx, projectID, t.Name(), nil)
 		assert.NoError(t, err)
-		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), key.Key(fmt.Sprintf("tests$%s", t.Name())))
+		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), key.Key(fmt.Sprintf("tests$%s", t.Name())), false)
 		assert.NoError(t, err)
 		_, err = db.TryAttaching(ctx, clientInfo.RefKey(), docInfo.ID)
 		assert.NoError(t, err)
@@ -1475,7 +1475,7 @@ func RunFindDocInfosByPagingTest(t *testing.T, db database.Database, projectID t
 		clientInfo, _ := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
 		docInfos := make([]*database.DocInfo, 0, totalSize)
 		for i := range totalSize {
-			docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), key.Key(fmt.Sprintf("%d", i)))
+			docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), key.Key(fmt.Sprintf("%d", i)), false)
 			assert.NoError(t, err)
 			docInfos = append(docInfos, docInfo)
 		}
@@ -1542,7 +1542,7 @@ func RunFindDocInfosByPagingTest(t *testing.T, db database.Database, projectID t
 			docInfo, err := db.FindOrCreateDocInfo(ctx, types.ClientRefKey{
 				ProjectID: testProjectInfo.ID,
 				ClientID:  dummyClientID,
-			}, testDocKey)
+			}, testDocKey, false)
 			assert.NoError(t, err)
 			dummyDocInfos = append(dummyDocInfos, docInfo)
 		}
@@ -1648,7 +1648,7 @@ func RunFindDocInfosByPagingTest(t *testing.T, db database.Database, projectID t
 			docInfo, err := db.FindOrCreateDocInfo(ctx, types.ClientRefKey{
 				ProjectID: projectInfo.ID,
 				ClientID:  dummyClientID,
-			}, testDocKey)
+			}, testDocKey, false)
 			assert.NoError(t, err)
 			docInfos = append(docInfos, docInfo)
 		}
@@ -1692,7 +1692,7 @@ func RunCreateChangeInfosTest(t *testing.T, db database.Database, projectID type
 
 		// 01. Create a client and a document then attach the document to the client.
 		clientInfo, _ := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
-		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		docRefKey := docInfo.RefKey()
 		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
@@ -1711,7 +1711,7 @@ func RunCreateChangeInfosTest(t *testing.T, db database.Database, projectID type
 
 		// 01. Create a client and a document then attach the document to the client.
 		clientInfo1, _ := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
-		docInfo1, _ := db.FindOrCreateDocInfo(ctx, clientInfo1.RefKey(), docKey)
+		docInfo1, _ := db.FindOrCreateDocInfo(ctx, clientInfo1.RefKey(), docKey, false)
 		docRefKey1 := docInfo1.RefKey()
 		assert.NoError(t, clientInfo1.AttachDocument(docRefKey1.DocID, false, docInfo1.Epoch))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo1, docInfo1))
@@ -1722,7 +1722,7 @@ func RunCreateChangeInfosTest(t *testing.T, db database.Database, projectID type
 		assert.NoError(t, err)
 
 		// 03. Create a document with same key and check they have same key but different id.
-		docInfo2, _ := db.FindOrCreateDocInfo(ctx, clientInfo1.RefKey(), docKey)
+		docInfo2, _ := db.FindOrCreateDocInfo(ctx, clientInfo1.RefKey(), docKey, false)
 		docRefKey2 := docInfo2.RefKey()
 		assert.NoError(t, clientInfo1.AttachDocument(docRefKey2.DocID, false, docInfo2.Epoch))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo1, docInfo2))
@@ -1735,7 +1735,7 @@ func RunCreateChangeInfosTest(t *testing.T, db database.Database, projectID type
 		docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
 
 		clientInfo, _ := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
-		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		docRefKey := docInfo.RefKey()
 		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
@@ -1762,7 +1762,7 @@ func RunCreateChangeInfosTest(t *testing.T, db database.Database, projectID type
 
 		// 01. Create a client and a document then attach the document to the client.
 		clientInfo, _ := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
-		docInfo1, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+		docInfo1, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.Equal(t, docInfo1.Owner, clientInfo.ID)
 		assert.NotEqual(t, gotime.Date(1, gotime.January, 1, 0, 0, 0, 0, gotime.UTC), docInfo1.UpdatedAt)
 		assert.Equal(t, docInfo1.CreatedAt, docInfo1.UpdatedAt)
@@ -1790,7 +1790,7 @@ func RunCreateChangeInfosTest(t *testing.T, db database.Database, projectID type
 			false,
 		)
 		assert.NoError(t, err)
-		docInfo2, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+		docInfo2, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.Equal(t, updatedAt, docInfo2.UpdatedAt)
 
 		// 03. Update document presence and operation
@@ -1809,7 +1809,7 @@ func RunCreateChangeInfosTest(t *testing.T, db database.Database, projectID type
 			false,
 		)
 		assert.NoError(t, err)
-		docInfo3, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+		docInfo3, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NotEqual(t, updatedAt, docInfo3.UpdatedAt)
 	})
 }
@@ -1824,7 +1824,7 @@ func RunUpdateClientInfoAfterPushPullTest(t *testing.T, db database.Database, pr
 		assert.NoError(t, err)
 
 		docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
-		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NoError(t, err)
 
 		err = db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo)
@@ -1838,7 +1838,7 @@ func RunUpdateClientInfoAfterPushPullTest(t *testing.T, db database.Database, pr
 		assert.NoError(t, err)
 
 		docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
-		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NoError(t, err)
 
 		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
@@ -1856,7 +1856,7 @@ func RunUpdateClientInfoAfterPushPullTest(t *testing.T, db database.Database, pr
 		assert.NoError(t, err)
 
 		docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
-		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NoError(t, err)
 
 		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
@@ -1898,7 +1898,7 @@ func RunUpdateClientInfoAfterPushPullTest(t *testing.T, db database.Database, pr
 		assert.NoError(t, err)
 
 		docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
-		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NoError(t, err)
 
 		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
@@ -1927,7 +1927,7 @@ func RunUpdateClientInfoAfterPushPullTest(t *testing.T, db database.Database, pr
 		assert.NoError(t, err)
 
 		docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
-		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NoError(t, err)
 
 		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
@@ -1959,7 +1959,7 @@ func RunUpdateClientInfoAfterPushPullTest(t *testing.T, db database.Database, pr
 		assert.NoError(t, err)
 
 		docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
-		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NoError(t, err)
 
 		// 02. Use TryAttaching to set status to "attaching" (simulating partial attach failure)
@@ -1986,7 +1986,7 @@ func RunUpdateClientInfoAfterPushPullTest(t *testing.T, db database.Database, pr
 		assert.NoError(t, err)
 
 		docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
-		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NoError(t, err)
 
 		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
@@ -2010,7 +2010,7 @@ func RunIsDocumentAttachedOrAttachingTest(t *testing.T, db database.Database, pr
 		assert.NoError(t, err)
 		c2, err := db.ActivateClient(ctx, projectID, t.Name()+"2", map[string]string{"userID": t.Name() + "2"})
 		assert.NoError(t, err)
-		d1, err := db.FindOrCreateDocInfo(ctx, c1.RefKey(), helper.TestKey(t))
+		d1, err := db.FindOrCreateDocInfo(ctx, c1.RefKey(), helper.TestKey(t), false)
 		assert.NoError(t, err)
 
 		// 01. Check if document is attached without attaching
@@ -2063,9 +2063,9 @@ func RunIsDocumentAttachedOrAttachingTest(t *testing.T, db database.Database, pr
 		// 00. Create a client and two documents
 		c1, err := db.ActivateClient(ctx, projectID, t.Name()+"1", map[string]string{"userID": t.Name() + "1"})
 		assert.NoError(t, err)
-		d1, err := db.FindOrCreateDocInfo(ctx, c1.RefKey(), helper.TestKey(t)+"1")
+		d1, err := db.FindOrCreateDocInfo(ctx, c1.RefKey(), helper.TestKey(t)+"1", false)
 		assert.NoError(t, err)
-		d2, err := db.FindOrCreateDocInfo(ctx, c1.RefKey(), helper.TestKey(t)+"2")
+		d2, err := db.FindOrCreateDocInfo(ctx, c1.RefKey(), helper.TestKey(t)+"2", false)
 		assert.NoError(t, err)
 
 		// 01. Check if documents are attached after attaching
@@ -2107,7 +2107,7 @@ func RunIsDocumentAttachedOrAttachingTest(t *testing.T, db database.Database, pr
 		// 00. Create a client and a document
 		c1, err := db.ActivateClient(ctx, projectID, t.Name()+"1", map[string]string{"userID": t.Name() + "1"})
 		assert.NoError(t, err)
-		d1, err := db.FindOrCreateDocInfo(ctx, c1.RefKey(), helper.TestKey(t))
+		d1, err := db.FindOrCreateDocInfo(ctx, c1.RefKey(), helper.TestKey(t), false)
 		assert.NoError(t, err)
 		docRefKey1 := d1.RefKey()
 
@@ -2153,7 +2153,7 @@ func RunIsDocumentAttachedOrAttachingTest(t *testing.T, db database.Database, pr
 		assert.NoError(t, err)
 		c2, err := db.ActivateClient(ctx, projectID, t.Name()+"2", map[string]string{"userID": t.Name() + "2"})
 		assert.NoError(t, err)
-		d1, err := db.FindOrCreateDocInfo(ctx, c1.RefKey(), helper.TestKey(t))
+		d1, err := db.FindOrCreateDocInfo(ctx, c1.RefKey(), helper.TestKey(t), false)
 		assert.NoError(t, err)
 
 		// 01. Check if document is attached without attaching
@@ -2233,7 +2233,7 @@ func RunFindClientInfosByAttachedDocRefKeyTest(t *testing.T, db database.Databas
 		docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
 
 		clientInfo1, _ := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
-		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo1.RefKey(), docKey)
+		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo1.RefKey(), docKey, false)
 		docRefKey := docInfo.RefKey()
 		assert.NoError(t, clientInfo1.AttachDocument(docRefKey.DocID, false, docInfo.Epoch))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo1, docInfo))
@@ -2274,8 +2274,8 @@ func RunFindAttachedClientCountsByDocIDsTest(t *testing.T, db database.Database,
 		clientInfo1, _ := db.ActivateClient(ctx, projectID, t.Name()+"1", map[string]string{"userID": t.Name() + "1"})
 		clientInfo2, _ := db.ActivateClient(ctx, projectID, t.Name()+"2", map[string]string{"userID": t.Name() + "2"})
 		docKey1, docKey2 := key.Key(fmt.Sprintf("tests$%s-1", t.Name())), key.Key(fmt.Sprintf("tests$%s-2", t.Name()))
-		docInfo1, _ := db.FindOrCreateDocInfo(ctx, clientInfo1.RefKey(), docKey1)
-		docInfo2, _ := db.FindOrCreateDocInfo(ctx, clientInfo2.RefKey(), docKey2)
+		docInfo1, _ := db.FindOrCreateDocInfo(ctx, clientInfo1.RefKey(), docKey1, false)
+		docInfo2, _ := db.FindOrCreateDocInfo(ctx, clientInfo2.RefKey(), docKey2, false)
 		assert.NoError(t, clientInfo1.AttachDocument(docInfo1.ID, false, docInfo1.Epoch))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo1, docInfo1))
 		assert.NoError(t, clientInfo1.AttachDocument(docInfo2.ID, false, docInfo2.Epoch))
@@ -2329,7 +2329,7 @@ func RunPurgeDocument(t *testing.T, db database.Database, projectID types.ID) {
 		// 01. Create a client and a document then attach the document to the client.
 		clientInfo, _ := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
 		docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
-		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		docRefKey := docInfo.RefKey()
 		assert.NoError(t, clientInfo.AttachDocument(docRefKey.DocID, false, docInfo.Epoch))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))

--- a/server/documents/documents.go
+++ b/server/documents/documents.go
@@ -480,8 +480,9 @@ func UpdateDocument(
 			docInfo.RefKey(),
 			doc.CreateChangePack(),
 			packs.PushPullOptions{
-				Mode:   types.SyncModePushOnly,
-				Status: document.StatusAttached,
+				Mode:            types.SyncModePushOnly,
+				Status:          document.StatusAttached,
+				DisablePresence: docInfo.DisablePresence,
 			}); err != nil {
 			return nil, err
 		}

--- a/server/documents/documents.go
+++ b/server/documents/documents.go
@@ -94,6 +94,7 @@ func CreateDocument(
 			ClientID:  userID,
 		},
 		docKey,
+		false,
 	)
 	if err != nil {
 		return nil, err
@@ -331,6 +332,7 @@ func GetDocumentByServerSeq(
 			ClientID:  types.IDFromActorID(time.InitialActorID),
 		},
 		k,
+		false,
 	)
 	if err != nil {
 		return nil, err
@@ -398,18 +400,22 @@ func FindDocInfoByRefKey(
 	return be.DB.FindDocInfoByRefKey(ctx, refkey)
 }
 
-// FindOrCreateDocInfo returns a document for the given document key. If
-// createDocIfNotExist is true, it creates a new document if it does not exist.
+// FindOrCreateDocInfo returns a document for the given document key. The
+// disablePresence argument is honored only on the create path; when the
+// document already exists, its persisted value is returned unchanged so
+// callers must read it back from the returned DocInfo.
 func FindOrCreateDocInfo(
 	ctx context.Context,
 	be *backend.Backend,
 	clientInfo *database.ClientInfo,
 	docKey key.Key,
+	disablePresence bool,
 ) (*database.DocInfo, error) {
 	return be.DB.FindOrCreateDocInfo(
 		ctx,
 		clientInfo.RefKey(),
 		docKey,
+		disablePresence,
 	)
 }
 

--- a/server/packs/pushpull.go
+++ b/server/packs/pushpull.go
@@ -101,6 +101,13 @@ func PushPull(
 	start := gotime.Now()
 	hostname := be.Config.Hostname
 
+	// 00. Strip presence on the way in when the document opted out. Doing
+	// this before pushPack means no presence-only change ever reaches the
+	// changes collection, regardless of which SDK version sent it.
+	if opts.DisablePresence {
+		reqPack.Changes = stripPresenceChanges(reqPack.Changes)
+	}
+
 	// 01. push the change pack to the database.
 	pushedChanges, docInfo, initialSeq, cpAfterPush, err := pushPack(ctx, be, clientInfo, docKey, reqPack)
 	if err != nil {

--- a/server/packs/pushpull.go
+++ b/server/packs/pushpull.go
@@ -68,6 +68,12 @@ type PushPullOptions struct {
 	// RPC handler from the matching wire field. See
 	// docs/design/disable-gc-on-attach.md.
 	DisableGC bool
+
+	// DisablePresence forwards the document-scope opt-out persisted on
+	// DocInfo. When true, the PushPull pipeline strips presence on both
+	// the write and read paths so the response carries an empty presence
+	// map regardless of what any client sends.
+	DisablePresence bool
 }
 
 var (

--- a/server/packs/pushpull.go
+++ b/server/packs/pushpull.go
@@ -531,6 +531,19 @@ func pullChangeInfos(
 		if clientInfo.ID == pulledChange.ActorID && cpAfterPush.ClientSeq >= pulledChange.ClientSeq {
 			continue
 		}
+
+		// Defensive: drop any stray presence from cached or older rows on
+		// the way to the wire. Strip on a clone so the cache's shared
+		// pointer stays untouched, and drop the change entirely if the
+		// strip leaves it carrying no operations.
+		if docInfo.DisablePresence && pulledChange.PresenceChange != nil {
+			pulledChange = pulledChange.DeepCopy()
+			pulledChange.PresenceChange = nil
+			if !pulledChange.HasOperations() {
+				continue
+			}
+		}
+
 		filteredChanges = append(filteredChanges, pulledChange)
 	}
 

--- a/server/packs/pushpull.go
+++ b/server/packs/pushpull.go
@@ -293,7 +293,7 @@ func pullPack(
 ) (*ServerPack, error) {
 	// 01. pull changes or a snapshot from the database and create a response pack.
 	resPack, err := preparePack(ctx, be, clientInfo, snapshotThreshold,
-		docInfo, reqPack, cpAfterPush, initialSeq, opts.Mode)
+		docInfo, reqPack, cpAfterPush, initialSeq, opts)
 
 	if err != nil {
 		// NOTE(hackerwins): When a client detaches after a compaction, the epoch
@@ -374,11 +374,11 @@ func preparePack(
 	reqPack *change.Pack,
 	cpAfterPush change.Checkpoint,
 	initialServerSeq int64,
-	mode types.SyncMode,
+	opts PushPullOptions,
 ) (*ServerPack, error) {
 	// NOTE(hackerwins): If the client is push-only, it does not need to pull changes.
 	// So, just return the checkpoint with server seq after pushing changes.
-	if mode == types.SyncModePushOnly {
+	if opts.Mode == types.SyncModePushOnly {
 		return NewServerPack(docInfo.Key, change.Checkpoint{
 			ServerSeq: reqPack.Checkpoint.ServerSeq,
 			ClientSeq: cpAfterPush.ClientSeq,
@@ -426,7 +426,7 @@ func preparePack(
 
 	// NOTE(hackerwins): If the size of changes for the response is greater than the snapshot threshold,
 	// we pull the snapshot from DB to reduce the size of the response.
-	return pullSnapshot(ctx, be, clientInfo, docInfo, reqPack, cpAfterPush, initialServerSeq)
+	return pullSnapshot(ctx, be, clientInfo, docInfo, reqPack, cpAfterPush, initialServerSeq, opts)
 }
 
 // pullSnapshot pulls the snapshot from DB.
@@ -438,6 +438,7 @@ func pullSnapshot(
 	reqPack *change.Pack,
 	cpAfterPush change.Checkpoint,
 	initialServerSeq int64,
+	opts PushPullOptions,
 ) (*ServerPack, error) {
 	doc, err := BuildInternalDocForServerSeq(ctx, be, docInfo, initialServerSeq)
 	if err != nil {
@@ -470,7 +471,17 @@ func pullSnapshot(
 		}
 	}
 
-	snapshot, err := converter.SnapshotToBytes(doc.RootObject(), doc.AllPresences())
+	// Belt-and-suspenders for presenceless documents: clear the in-memory
+	// presence map so any downstream branch sees no cached entries, and
+	// pass a nil presence map into SnapshotToBytes so the wire bytes carry
+	// an empty map regardless of what the doc has accumulated.
+	presences := doc.AllPresences()
+	if opts.DisablePresence {
+		doc.ResetPresences()
+		presences = nil
+	}
+
+	snapshot, err := converter.SnapshotToBytes(doc.RootObject(), presences)
 	if err != nil {
 		return nil, err
 	}

--- a/server/packs/snapshot.go
+++ b/server/packs/snapshot.go
@@ -239,6 +239,15 @@ func storeSnapshot(
 		return err
 	}
 
+	// 04b. Drop presence before persisting when the document opted out.
+	// Defensive against snapshot rows written before the flag existed: the
+	// ApplyChangePack above can rehydrate cached presence onto the in-memory
+	// doc, so reset right before CreateSnapshotInfo to keep the new
+	// snapshots row clean.
+	if docInfo.DisablePresence {
+		doc.ResetPresences()
+	}
+
 	// 05. save the snapshot of the docInfo
 	if err := be.DB.CreateSnapshotInfo(
 		ctx,

--- a/server/packs/strip.go
+++ b/server/packs/strip.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package packs
+
+import "github.com/yorkie-team/yorkie/pkg/document/change"
+
+// stripPresenceChanges removes the PresenceChange from each change for a
+// document configured with disable_presence. A change carrying only a
+// presence update drops in full; a mixed change keeps its operations and
+// loses its presence. The input slice is reused as the output backing
+// array, so the function is allocation-free.
+func stripPresenceChanges(changes []*change.Change) []*change.Change {
+	if len(changes) == 0 {
+		return changes
+	}
+
+	out := changes[:0]
+	for _, c := range changes {
+		if c.PresenceChange() != nil {
+			if !c.HasOperations() {
+				continue
+			}
+			c.SetPresenceChange(nil)
+		}
+		out = append(out, c)
+	}
+	return out
+}

--- a/server/packs/strip_bench_test.go
+++ b/server/packs/strip_bench_test.go
@@ -28,9 +28,10 @@ import (
 )
 
 // BenchmarkStripPresenceChanges pins the allocation profile of the
-// PushPull entry-side strip across the four input shapes the helper sees
-// in production: presence-only (the worst-case for the insurance /car
-// counter document), mixed, ops-only, and empty.
+// PushPull entry-side strip across the four input shapes the helper
+// receives in practice: presence-only (the worst case for a
+// high-fan-out, presence-free Counter document), mixed, ops-only, and
+// empty.
 func BenchmarkStripPresenceChanges(b *testing.B) {
 	id := change.NewID(0, 0, 0, time.InitialActorID, time.NewVersionVector())
 	pc := func() *inner.Change {

--- a/server/packs/strip_bench_test.go
+++ b/server/packs/strip_bench_test.go
@@ -1,0 +1,95 @@
+//go:build bench
+
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package packs
+
+import (
+	"testing"
+
+	"github.com/yorkie-team/yorkie/pkg/document/change"
+	"github.com/yorkie-team/yorkie/pkg/document/operations"
+	"github.com/yorkie-team/yorkie/pkg/document/presence/inner"
+	"github.com/yorkie-team/yorkie/pkg/document/time"
+)
+
+// BenchmarkStripPresenceChanges pins the allocation profile of the
+// PushPull entry-side strip across the four input shapes the helper sees
+// in production: presence-only (the worst-case for the insurance /car
+// counter document), mixed, ops-only, and empty.
+func BenchmarkStripPresenceChanges(b *testing.B) {
+	id := change.NewID(0, 0, 0, time.InitialActorID, time.NewVersionVector())
+	pc := func() *inner.Change {
+		return &inner.Change{ChangeType: inner.Put, Presence: inner.Presence{"k": "v"}}
+	}
+	op := func() operations.Operation {
+		return operations.NewRemove(time.InitialTicket, time.InitialTicket, time.InitialTicket)
+	}
+
+	shapes := map[string]func(n int) []*change.Change{
+		"presence_only": func(n int) []*change.Change {
+			out := make([]*change.Change, n)
+			for i := range out {
+				out[i] = change.New(id, "", nil, pc())
+			}
+			return out
+		},
+		"mixed": func(n int) []*change.Change {
+			out := make([]*change.Change, n)
+			for i := range out {
+				out[i] = change.New(id, "", []operations.Operation{op()}, pc())
+			}
+			return out
+		},
+		"ops_only": func(n int) []*change.Change {
+			out := make([]*change.Change, n)
+			for i := range out {
+				out[i] = change.New(id, "", []operations.Operation{op()}, nil)
+			}
+			return out
+		},
+	}
+
+	for _, n := range []int{0, 1, 8, 64} {
+		for name, gen := range shapes {
+			if n == 0 && name != "presence_only" {
+				continue
+			}
+			b.Run(name+"/n="+itoa(n), func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					b.StopTimer()
+					input := gen(n)
+					b.StartTimer()
+					_ = stripPresenceChanges(input)
+				}
+			})
+		}
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	digits := []byte{}
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	return string(digits)
+}

--- a/server/packs/strip_test.go
+++ b/server/packs/strip_test.go
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package packs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/pkg/document/change"
+	"github.com/yorkie-team/yorkie/pkg/document/operations"
+	"github.com/yorkie-team/yorkie/pkg/document/presence/inner"
+	"github.com/yorkie-team/yorkie/pkg/document/time"
+)
+
+func newID() change.ID {
+	return change.NewID(0, 0, 0, time.InitialActorID, time.NewVersionVector())
+}
+
+func newPresenceChange() *inner.Change {
+	return &inner.Change{
+		ChangeType: inner.Put,
+		Presence:   inner.Presence{"k": "v"},
+	}
+}
+
+func newRemoveOp() operations.Operation {
+	return operations.NewRemove(time.InitialTicket, time.InitialTicket, time.InitialTicket)
+}
+
+func TestStripPresenceChanges(t *testing.T) {
+	t.Run("empty input is returned as-is", func(t *testing.T) {
+		out := stripPresenceChanges(nil)
+		assert.Empty(t, out)
+
+		out = stripPresenceChanges([]*change.Change{})
+		assert.Empty(t, out)
+	})
+
+	t.Run("presence-only changes drop in full", func(t *testing.T) {
+		changes := []*change.Change{
+			change.New(newID(), "", nil, newPresenceChange()),
+			change.New(newID(), "", nil, newPresenceChange()),
+		}
+		out := stripPresenceChanges(changes)
+		assert.Empty(t, out)
+	})
+
+	t.Run("mixed changes keep operations and lose presence", func(t *testing.T) {
+		c := change.New(newID(), "", []operations.Operation{newRemoveOp()}, newPresenceChange())
+		out := stripPresenceChanges([]*change.Change{c})
+
+		assert.Len(t, out, 1)
+		assert.True(t, out[0].HasOperations())
+		assert.Nil(t, out[0].PresenceChange())
+	})
+
+	t.Run("ops-only changes pass through untouched", func(t *testing.T) {
+		c := change.New(newID(), "", []operations.Operation{newRemoveOp()}, nil)
+		out := stripPresenceChanges([]*change.Change{c})
+
+		assert.Len(t, out, 1)
+		assert.True(t, out[0].HasOperations())
+		assert.Nil(t, out[0].PresenceChange())
+	})
+
+	t.Run("mixed batch keeps only the survivor changes", func(t *testing.T) {
+		presenceOnly := change.New(newID(), "", nil, newPresenceChange())
+		mixed := change.New(newID(), "", []operations.Operation{newRemoveOp()}, newPresenceChange())
+		opsOnly := change.New(newID(), "", []operations.Operation{newRemoveOp()}, nil)
+
+		out := stripPresenceChanges([]*change.Change{presenceOnly, mixed, opsOnly})
+		assert.Len(t, out, 2)
+		for _, c := range out {
+			assert.True(t, c.HasOperations())
+			assert.Nil(t, c.PresenceChange())
+		}
+	})
+}

--- a/server/revisions/revisions.go
+++ b/server/revisions/revisions.go
@@ -188,8 +188,9 @@ func Restore(
 		docKey,
 		doc.CreateChangePack(),
 		packs.PushPullOptions{
-			Mode:   types.SyncModePushOnly,
-			Status: document.StatusAttached,
+			Mode:            types.SyncModePushOnly,
+			Status:          document.StatusAttached,
+			DisablePresence: docInfo.DisablePresence,
 		},
 	); err != nil {
 		return fmt.Errorf("push pull: %w", err)

--- a/server/rpc/cluster_server.go
+++ b/server/rpc/cluster_server.go
@@ -119,9 +119,15 @@ func (s *clusterServer) DetachDocument(
 		}
 	}
 
+	docInfo, err := documents.FindDocInfoByRefKey(ctx, s.backend, refKey)
+	if err != nil {
+		return nil, err
+	}
+
 	if _, err := packs.PushPull(ctx, s.backend, project, clientInfo, refKey, pack, packs.PushPullOptions{
-		Mode:   types.SyncModePushOnly,
-		Status: status,
+		Mode:            types.SyncModePushOnly,
+		Status:          status,
+		DisablePresence: docInfo.DisablePresence,
 	}); err != nil {
 		return nil, err
 	}

--- a/server/rpc/testcases/testcases.go
+++ b/server/rpc/testcases/testcases.go
@@ -1587,7 +1587,7 @@ func RunDeactivateClientWithAttachingDocumentTest(
 	}
 
 	docKey := helper.TestKey(t)
-	docInfo, err := be.DB.FindOrCreateDocInfo(ctx, refKey, docKey)
+	docInfo, err := be.DB.FindOrCreateDocInfo(ctx, refKey, docKey, false)
 	assert.NoError(t, err)
 
 	_, err = be.DB.TryAttaching(ctx, refKey, docInfo.ID)

--- a/server/rpc/yorkie_server.go
+++ b/server/rpc/yorkie_server.go
@@ -202,10 +202,21 @@ func (s *yorkieServer) AttachDocument(
 		return nil, err
 	}
 
-	// 02. Ensure the document exists and is attached to the client.
-	docInfo, err := documents.FindOrCreateDocInfo(ctx, s.backend, clientInfo, pack.DocumentKey, false)
+	// 02. Ensure the document exists and is attached to the client. The
+	// disable_presence flag is fixated on first attach via $setOnInsert;
+	// the persisted value wins for later attaches, so we log a warning
+	// when the requested value disagrees with what came back.
+	docInfo, err := documents.FindOrCreateDocInfo(
+		ctx, s.backend, clientInfo, pack.DocumentKey, req.Msg.DisablePresence,
+	)
 	if err != nil {
 		return nil, err
+	}
+	if req.Msg.DisablePresence != docInfo.DisablePresence {
+		logging.From(ctx).Warnf(
+			"attach with disable_presence=%v but doc fixated to %v: %s",
+			req.Msg.DisablePresence, docInfo.DisablePresence, docInfo.Key,
+		)
 	}
 
 	clientInfo, err = clients.AttachDocument(ctx, s.backend, clientInfo, docInfo, pack.IsAttached())
@@ -252,9 +263,10 @@ func (s *yorkieServer) AttachDocument(
 
 	// 03. Push/Pull between the client and server.
 	pulled, err := packs.PushPull(ctx, s.backend, project, clientInfo, docKey, pack, packs.PushPullOptions{
-		Mode:      types.SyncModePushPull,
-		Status:    document.StatusAttached,
-		DisableGC: req.Msg.DisableGc,
+		Mode:            types.SyncModePushPull,
+		Status:          document.StatusAttached,
+		DisableGC:       req.Msg.DisableGc,
+		DisablePresence: docInfo.DisablePresence,
 	})
 	if err != nil {
 		return nil, err
@@ -282,6 +294,7 @@ func (s *yorkieServer) AttachDocument(
 		ChangePack:         pbChangePack,
 		DocumentId:         docInfo.ID.String(),
 		MaxSizePerDocument: int32(project.MaxSizePerDocument),
+		DisablePresence:    docInfo.DisablePresence,
 	}
 	if schema != nil {
 		response.SchemaRules = converter.ToRules(schema.Rules)
@@ -1282,12 +1295,20 @@ func (s *yorkieServer) PushPullChanges(
 		return nil, err
 	}
 
-	// 03. Push/Pull between the client and server.
+	// 03. Read the document's disable_presence option so PushPull can
+	// enforce it. FindDocInfoByRefKey hits the LRU cache for warm docs.
 	docKey := types.DocRefKey{ProjectID: project.ID, DocID: docID}
+	docInfo, err := documents.FindDocInfoByRefKey(ctx, s.backend, docKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// 04. Push/Pull between the client and server.
 	pulled, err := packs.PushPull(ctx, s.backend, project, clientInfo, docKey, pack, packs.PushPullOptions{
-		Mode:      syncMode,
-		Status:    document.StatusAttached,
-		DisableGC: req.Msg.DisableGc,
+		Mode:            syncMode,
+		Status:          document.StatusAttached,
+		DisableGC:       req.Msg.DisableGc,
+		DisablePresence: docInfo.DisablePresence,
 	})
 	if err != nil {
 		return nil, err

--- a/server/rpc/yorkie_server.go
+++ b/server/rpc/yorkie_server.go
@@ -1225,10 +1225,19 @@ func (s *yorkieServer) DetachDocument(
 		}
 	}
 
-	// 03. Push/Pull between the client and server.
+	// 03. Read the document's disable_presence so PushPull can enforce it on
+	// the detach path as well. FindDocInfoByRefKey hits the LRU cache for
+	// warm docs.
+	docInfo, err := documents.FindDocInfoByRefKey(ctx, s.backend, docKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// 04. Push/Pull between the client and server.
 	pulled, err := packs.PushPull(ctx, s.backend, project, clientInfo, docKey, pack, packs.PushPullOptions{
-		Mode:   types.SyncModePushPull,
-		Status: status,
+		Mode:            types.SyncModePushPull,
+		Status:          status,
+		DisablePresence: docInfo.DisablePresence,
 	})
 	if err != nil {
 		return nil, err
@@ -1371,10 +1380,18 @@ func (s *yorkieServer) RemoveDocument(
 		defer locker.Unlock()
 	}
 
-	// 02. Push/Pull between the client and server.
+	// 02. Read the document's disable_presence so PushPull can enforce it on
+	// the remove path as well.
+	docInfo, err := documents.FindDocInfoByRefKey(ctx, s.backend, docKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// 03. Push/Pull between the client and server.
 	pulled, err := packs.PushPull(ctx, s.backend, project, clientInfo, docKey, pack, packs.PushPullOptions{
-		Mode:   types.SyncModePushPull,
-		Status: document.StatusRemoved,
+		Mode:            types.SyncModePushPull,
+		Status:          document.StatusRemoved,
+		DisablePresence: docInfo.DisablePresence,
 	})
 	if err != nil {
 		return nil, err

--- a/server/rpc/yorkie_server.go
+++ b/server/rpc/yorkie_server.go
@@ -203,7 +203,7 @@ func (s *yorkieServer) AttachDocument(
 	}
 
 	// 02. Ensure the document exists and is attached to the client.
-	docInfo, err := documents.FindOrCreateDocInfo(ctx, s.backend, clientInfo, pack.DocumentKey)
+	docInfo, err := documents.FindOrCreateDocInfo(ctx, s.backend, clientInfo, pack.DocumentKey, false)
 	if err != nil {
 		return nil, err
 	}

--- a/test/bench/push_pull_bench_test.go
+++ b/test/bench/push_pull_bench_test.go
@@ -91,7 +91,7 @@ func setUpClientsAndDocs(
 	for i := range n {
 		clientInfo, err := be.DB.ActivateClient(ctx, database.DefaultProjectID, fmt.Sprintf("client-%d", i), map[string]string{"userID": fmt.Sprintf("user-%d", i)})
 		assert.NoError(b, err)
-		docInfo, err := be.DB.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey)
+		docInfo, err := be.DB.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NoError(b, err)
 		assert.NoError(b, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
 		assert.NoError(b, be.DB.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))

--- a/test/complex/mongo_client_test.go
+++ b/test/complex/mongo_client_test.go
@@ -147,7 +147,7 @@ func TestClientWithShardedDB(t *testing.T) {
 		docInfo1, err := cli.FindOrCreateDocInfo(ctx, types.ClientRefKey{
 			ProjectID: projectID1,
 			ClientID:  dummyClientID,
-		}, docKey1)
+		}, docKey1, false)
 		assert.NoError(t, err)
 
 		// 02. Create an extra document with duplicate ID.

--- a/test/integration/presenceless_document_test.go
+++ b/test/integration/presenceless_document_test.go
@@ -1,0 +1,121 @@
+//go:build integration
+
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/client"
+	"github.com/yorkie-team/yorkie/pkg/document"
+	"github.com/yorkie-team/yorkie/pkg/document/json"
+	"github.com/yorkie-team/yorkie/pkg/document/presence"
+	"github.com/yorkie-team/yorkie/test/helper"
+)
+
+func TestPresencelessDocument(t *testing.T) {
+	t.Run("first attach fixates disable_presence on DocInfo", func(t *testing.T) {
+		clients := activeClients(t, 1)
+		defer deactivateAndCloseClients(t, clients)
+		c1 := clients[0]
+
+		ctx := context.Background()
+		d1 := document.New(helper.TestKey(t))
+		assert.NoError(t, c1.Attach(ctx, d1, client.WithDisablePresence()))
+
+		be := defaultServer.Backend()
+		project, err := defaultServer.DefaultProject(ctx)
+		assert.NoError(t, err)
+		docInfo, err := be.DB.FindDocInfoByKey(ctx, project.ID, d1.Key())
+		assert.NoError(t, err)
+		assert.True(t, docInfo.DisablePresence,
+			"first attach with WithDisablePresence should fixate the flag on DocInfo")
+	})
+
+	t.Run("late attacher observes the persisted value", func(t *testing.T) {
+		clients := activeClients(t, 2)
+		defer deactivateAndCloseClients(t, clients)
+		c1, c2 := clients[0], clients[1]
+
+		ctx := context.Background()
+		docKey := helper.TestKey(t)
+		d1 := document.New(docKey)
+		assert.NoError(t, c1.Attach(ctx, d1, client.WithDisablePresence()))
+
+		// Second client attaches without the option but should observe the
+		// server-fixated true. The local Document.options.DisablePresence
+		// is updated from the response so subsequent Updates gate.
+		d2 := document.New(docKey)
+		assert.NoError(t, c2.Attach(ctx, d2))
+
+		assert.NoError(t, d2.Update(func(_ *json.Object, p *presence.Presence) error {
+			p.Set("name", "leaker")
+			return nil
+		}))
+		assert.NoError(t, c2.Sync(ctx))
+		assert.NoError(t, c1.Sync(ctx))
+
+		// No presence entry should be visible from either side.
+		assert.Empty(t, d1.AllPresences(), "doc1 should not see d2's presence")
+		assert.Empty(t, d2.AllPresences(), "doc2 should have presence gated out locally")
+	})
+
+	t.Run("PUT presence is stripped on PushPull", func(t *testing.T) {
+		clients := activeClients(t, 1)
+		defer deactivateAndCloseClients(t, clients)
+		c1 := clients[0]
+
+		ctx := context.Background()
+		d1 := document.New(helper.TestKey(t))
+		assert.NoError(t, c1.Attach(ctx, d1, client.WithDisablePresence()))
+
+		// Counter-style mutation to ensure the doc has at least one
+		// operation and produces a non-presence change.
+		assert.NoError(t, d1.Update(func(root *json.Object, _ *presence.Presence) error {
+			root.SetNewCounter("counter", 0).Increase(1)
+			return nil
+		}))
+		assert.NoError(t, c1.Sync(ctx))
+
+		assert.Empty(t, d1.AllPresences(),
+			"presenceless doc must carry an empty presence map after sync")
+	})
+
+	t.Run("backward compatibility — no option keeps presence path live", func(t *testing.T) {
+		clients := activeClients(t, 1)
+		defer deactivateAndCloseClients(t, clients)
+		c1 := clients[0]
+
+		ctx := context.Background()
+		d1 := document.New(helper.TestKey(t))
+		assert.NoError(t, c1.Attach(ctx, d1, client.WithPresence(presence.Data{"role": "owner"})))
+
+		be := defaultServer.Backend()
+		project, err := defaultServer.DefaultProject(ctx)
+		assert.NoError(t, err)
+		docInfo, err := be.DB.FindDocInfoByKey(ctx, project.ID, d1.Key())
+		assert.NoError(t, err)
+		assert.False(t, docInfo.DisablePresence,
+			"omitting the option should leave DocInfo on the default false")
+		assert.NotEmpty(t, d1.AllPresences(),
+			"default-path doc should still accumulate presence")
+	})
+}

--- a/test/integration/presenceless_document_test.go
+++ b/test/integration/presenceless_document_test.go
@@ -20,6 +20,7 @@ package integration
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -117,5 +118,127 @@ func TestPresencelessDocument(t *testing.T) {
 			"omitting the option should leave DocInfo on the default false")
 		assert.NotEmpty(t, d1.AllPresences(),
 			"default-path doc should still accumulate presence")
+	})
+
+	t.Run("force-exit clients do not leak into a late attacher's response", func(t *testing.T) {
+		// Regression for the original symptom that motivated this option:
+		// dozens of thousands of clients attach to a Counter-only document
+		// and never call Detach (mobile background, iOS Safari, network
+		// drop). Without the option the document's presence map grows
+		// without bound, inflating the AttachDocument response for every
+		// subsequent client. With the option on, the presence map must
+		// stay empty no matter how many earlier clients walked away.
+		const N = 5
+
+		ctx := context.Background()
+		docKey := helper.TestKey(t)
+
+		// Spawn N "force-exit" clients: each attaches with the option,
+		// sets a presence entry, syncs, and then is dropped without ever
+		// calling Detach or Deactivate. The server-side strip is the only
+		// thing keeping their entries out of the document.
+		forceClients := activeClients(t, N)
+		// NOTE: intentionally not calling deactivateAndCloseClients on
+		// forceClients — the test models clients that disappeared
+		// ungracefully. We do close the connections at the end so the
+		// goroutines exit cleanly, but no Deactivate.
+		defer func() {
+			for _, c := range forceClients {
+				assert.NoError(t, c.Close())
+			}
+		}()
+
+		for i, c := range forceClients {
+			d := document.New(docKey)
+			assert.NoError(t, c.Attach(ctx, d, client.WithDisablePresence()))
+			actor := i // capture
+			assert.NoError(t, d.Update(func(_ *json.Object, p *presence.Presence) error {
+				p.Set("idx", strconv.Itoa(actor))
+				return nil
+			}))
+			assert.NoError(t, c.Sync(ctx))
+		}
+
+		// A fresh client now attaches without opting out. Even though the
+		// previous N clients all wrote presence and none of them cleaned
+		// up, the late attacher's view must carry no foreign presence.
+		measureClient := activeClients(t, 1)
+		defer deactivateAndCloseClients(t, measureClient)
+		dm := document.New(docKey)
+		assert.NoError(t, measureClient[0].Attach(ctx, dm))
+
+		// Filter out the measure client's own actor — if any presence
+		// remains it must only be its own self-entry, never one of the
+		// force-exited writers.
+		for actorID := range dm.AllPresences() {
+			assert.Equal(t, measureClient[0].ID().String(), actorID,
+				"presenceless doc must surface no foreign presence even when prior clients force-exited")
+		}
+	})
+
+	t.Run("force-exit clients do not leak when the late attacher pulls a snapshot", func(t *testing.T) {
+		// Same regression as above but driven across the snapshot
+		// threshold (helper.SnapshotThreshold = 10) so the measuring
+		// client's attach response goes through pullSnapshot rather than
+		// pullChanges. This exercises both the entry-side strip and the
+		// snapshot-time ResetPresences/empty-map serialization at once.
+		const N = 5
+		const updatesPerClient = 3 // 5 × 3 = 15 > SnapshotThreshold(10)
+
+		ctx := context.Background()
+		docKey := helper.TestKey(t)
+
+		forceClients := activeClients(t, N)
+		defer func() {
+			for _, c := range forceClients {
+				assert.NoError(t, c.Close())
+			}
+		}()
+
+		// Each Update touches the root (Counter increment) and presence —
+		// the same shape the symptom workload uses. After strip the
+		// operation half remains, so server_seq grows; if we set presence
+		// alone the entry-side strip would drop the whole change and
+		// server_seq would stay at zero, never crossing the snapshot
+		// threshold.
+		for i, c := range forceClients {
+			d := document.New(docKey)
+			assert.NoError(t, c.Attach(ctx, d, client.WithDisablePresence()))
+			actor := i // capture
+			for round := range updatesPerClient {
+				r := round // capture
+				assert.NoError(t, d.Update(func(root *json.Object, p *presence.Presence) error {
+					if root.Get("counter") == nil {
+						root.SetNewCounter("counter", int64(0))
+					}
+					root.GetCounter("counter").Increase(1)
+					p.Set("idx", strconv.Itoa(actor))
+					p.Set("round", strconv.Itoa(r))
+					return nil
+				}))
+				assert.NoError(t, c.Sync(ctx))
+			}
+			// intentional: no detach / deactivate
+		}
+
+		// Sanity-check the threshold was actually crossed so the late
+		// attacher really pulls a snapshot — otherwise the test is the
+		// same as the previous (changes-path) case.
+		project, err := defaultServer.DefaultProject(ctx)
+		assert.NoError(t, err)
+		docInfo, err := defaultServer.Backend().DB.FindDocInfoByKey(ctx, project.ID, docKey)
+		assert.NoError(t, err)
+		assert.Greater(t, docInfo.ServerSeq, helper.SnapshotThreshold,
+			"prerequisite: server_seq must exceed SnapshotThreshold so the late attach hits pullSnapshot")
+
+		measureClient := activeClients(t, 1)
+		defer deactivateAndCloseClients(t, measureClient)
+		dm := document.New(docKey)
+		assert.NoError(t, measureClient[0].Attach(ctx, dm))
+
+		for actorID := range dm.AllPresences() {
+			assert.Equal(t, measureClient[0].ID().String(), actorID,
+				"presenceless doc must surface no foreign presence even after the snapshot path")
+		}
 	})
 }

--- a/test/integration/project_stats_test.go
+++ b/test/integration/project_stats_test.go
@@ -109,7 +109,7 @@ func TestProjectStatsRefresh(t *testing.T) {
 
 	// 3. Create at least one non-removed document for that project.
 	docKey := key.Key(fmt.Sprintf("%s-doc", t.Name()))
-	_, err = be.DB.FindOrCreateDocInfo(ctx, clientInfos[0].RefKey(), docKey)
+	_, err = be.DB.FindOrCreateDocInfo(ctx, clientInfos[0].RefKey(), docKey, false)
 	assert.NoError(t, err)
 
 	// 5. Run RefreshStats and assert processed >= 1.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Adds a Document-scope `disable_presence` option so a document can
declare it never accepts or stores presence. Motivated by high-fan-out
Counter workloads where the presence map accumulates monotonically on
the server because clients reach end-of-life without sending `detach`.

The flag is declared at first attach via
`AttachDocumentRequest.disable_presence`, persisted on
`DocInfo.DisablePresence` via mongo `$setOnInsert` (immutable
thereafter), and read by the PushPull handler into
`PushPullOptions.DisablePresence`. The server then:
- Strips presence changes at PushPull entry (`stripPresenceChanges`).
- Serializes an empty presence map in `pullSnapshot` / `storeSnapshot`.
- Defensively drops any stray cached presence on the read path
  (`pullChangeInfos`).

Go SDK exposes `WithDisablePresence()`, sends the wire field on first
attach, reads the server-fixated value back from
`AttachDocumentResponse.disable_presence`, and gates its own
`Document.Update` so opt-in clients silently no-op on presence
updates. JS SDK ships as a follow-up PR.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

- `client/client.go` calls `d.InternalDocument().ResetPresences()`
  after the attach response when the server-fixated value differs
  from the local opt. Without it, a client that attached without
  opting out but landed on an already-presenceless doc would keep a
  stale local entry. Covered by the
  `late_attacher_observes_the_persisted_value` integration test.
- The `stripPresenceChanges` benchmark lives at
  `server/packs/strip_bench_test.go` because the helper is
  package-private to `server/packs`. Build tag `bench`.
- `pkg/document` has no logger dependency, so the SDK-side
  silent-drop warning uses stdlib `log.Printf` with a `sync.Once` to
  fire exactly once per Document.

**Does this PR introduce a user-facing change?**:

Yes.

```release-note
Add `disable_presence` Document option (Go SDK + proto). Documents
attached with `WithDisablePresence()` do not produce, consume, or
store presence. The option is fixated at first attach via mongo
`$setOnInsert` and immutable thereafter; subsequent attaches observe
the persisted value from `AttachDocumentResponse.disable_presence`.
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

- Task plan: docs/tasks/active/20260616-presenceless-document-option-todo.md

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added document-scoped “presenceless” support via `disable_presence`/`WithDisablePresence()`: the server fixates the choice on first attach, the client gates presence locally, presence is stripped from updates, and snapshots return empty presence.
  * Added a new `PeekChannel` RPC endpoint with request/response schemas.
  * Extended attach/push-pull options with `disable_gc` where applicable.
* **Tests**
  * Added unit and integration coverage for presence stripping and cross-client server enforcement.
* **Documentation**
  * Added implementation planning documentation for the presenceless document option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->