### PR TITLE
Remove unused Bitnami Helm repo from chart-release workflow

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -31,7 +31,6 @@ jobs:
         run: |
           helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
           helm repo add grafana https://grafana.github.io/helm-charts
-          helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add starrocks https://starrocks.github.io/starrocks-kubernetes-operator
           helm repo add percona https://percona.github.io/percona-helm-charts/
           helm repo update


### PR DESCRIPTION
## Summary

- The `Release Charts` workflow on `main` is failing because `helm repo add bitnami https://charts.bitnami.com/bitnami` hangs for 2 minutes and then times out (`context deadline exceeded`). See [run 27701130921](https://github.com/yorkie-team/yorkie/actions/runs/27701130921/job/81937538856).
- Broadcom sunset the public Bitnami Helm catalog: `charts.bitnami.com/bitnami` now 302-redirects to `repo.broadcom.com/bitnami-files/` with a 27 MB `index.yaml`, which exceeds Helm's default 2-minute client timeout from GitHub Actions runners.
- The entry is no longer used. `build/charts/yorkie-analytics` pulls Kafka via OCI (`oci://registry-1.docker.io/bitnamicharts`), and the remaining `bitnami/*` references in the charts are container images. The leftover line dates back to #1594, which replaced the Bitnami MongoDB chart with the Percona Operator.

## Test plan

- [ ] Wait for the `Release Charts` workflow to run on `main` after merge and confirm the `Add dependency chart repos` step succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed bitnami Helm chart repository from the release workflow. Other configured repositories (Prometheus Community, Grafana, StarRocks, Percona) continue to be added during chart releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->