### PR TITLE
Parallelize per-candidate Deactivate within a cycle

### DIFF
--- a/cmd/yorkie/server.go
+++ b/cmd/yorkie/server.go
@@ -345,6 +345,12 @@ func init() {
 		"candidates limit for a single housekeeping run",
 	)
 	cmd.Flags().IntVar(
+		&conf.Housekeeping.DeactivateConcurrency,
+		"housekeeping-deactivate-concurrency",
+		server.DefaultHousekeepingDeactivateConcurrency,
+		"max concurrent client deactivations within a single housekeeping cycle (0 or 1 = sequential)",
+	)
+	cmd.Flags().IntVar(
 		&conf.Housekeeping.CompactionMinChanges,
 		"housekeeping-compaction-min-changes",
 		server.DefaultHousekeepingCompactionMinChanges,

--- a/docs/design/housekeeping.md
+++ b/docs/design/housekeeping.md
@@ -52,8 +52,12 @@ Housekeeping:
   # Interval between housekeeping runs (default: 30s)
   Interval: "30s"
 
-  # Maximum number of candidates to be returned in a single query (default: 500)
-  CandidatesLimit: 500
+  # Maximum number of candidates to be returned in a single query (default: 2000)
+  CandidatesLimit: 2000
+
+  # Maximum number of concurrent client deactivations within a single cycle.
+  # Values <= 1 fall back to sequential execution (default: 8)
+  DeactivateConcurrency: 8
 
   # Minimum number of changes required to compact a document (default: 1000)
   CompactionMinChanges: 1000
@@ -80,9 +84,19 @@ This approach is essential because:
 // Pseudocode for client deactivation
 for each project {
     candidates = FindInactiveClients(project, threshold: "24h")
+
+    // Dispatch per-candidate deactivations across up to
+    // DeactivateConcurrency goroutines within the cycle.
+    // Concurrency <= 1 falls back to sequential execution.
+    sem = NewWeighted(DeactivateConcurrency)
     for each candidate {
-        DeactivateClient(candidate)
+        sem.Acquire()
+        go {
+            defer sem.Release()
+            DeactivateClient(candidate)
+        }
     }
+    wait for all in-flight deactivations
 }
 ```
 
@@ -126,6 +140,7 @@ for each project {
 
 - **Interval**: Runs every 30 seconds by default
 - **Concurrency Control**: Uses distributed locking to prevent multiple instances from running simultaneously
+- **Parallel Deactivation**: Within a single cycle, up to `DeactivateConcurrency` client deactivations run in parallel (default: 8); values <= 1 fall back to sequential execution
 - **Project Cycling**: Processes projects in a round-robin fashion to distribute load
 - **Batching**: Limits candidates per project to prevent overwhelming the system
 
@@ -169,6 +184,7 @@ For detailed information about the garbage collection algorithm, refer to:
 Housekeeping:
   Interval: "10s"
   CandidatesLimit: 10
+  DeactivateConcurrency: 8
   CompactionMinChanges: 100
 ```
 
@@ -178,6 +194,7 @@ Housekeeping:
 Housekeeping:
   Interval: "1m"
   CandidatesLimit: 1000
+  DeactivateConcurrency: 8
   CompactionMinChanges: 5000
 ```
 

--- a/server/backend/housekeeping/config.go
+++ b/server/backend/housekeeping/config.go
@@ -31,6 +31,11 @@ type Config struct {
 	// CandidatesLimit is the maximum number of candidates to be returned in a single query.
 	CandidatesLimit int `yaml:"CandidatesLimit"`
 
+	// DeactivateConcurrency is the maximum number of concurrent client
+	// deactivations within a single housekeeping cycle. Values <= 1 fall
+	// back to sequential execution (legacy behavior).
+	DeactivateConcurrency int `yaml:"DeactivateConcurrency"`
+
 	// CompactionMinChanges is the minimum number of changes to compact a document.
 	CompactionMinChanges int `yaml:"CompactionMinChanges"`
 
@@ -53,6 +58,13 @@ func (c *Config) Validate() error {
 		return fmt.Errorf(
 			`invalid argument %d for "--housekeeping-candidates-limit" flag`,
 			c.CandidatesLimit,
+		)
+	}
+
+	if c.DeactivateConcurrency < 0 {
+		return fmt.Errorf(
+			`invalid argument %d for "--housekeeping-deactivate-concurrency" flag: must be >= 0`,
+			c.DeactivateConcurrency,
 		)
 	}
 

--- a/server/backend/housekeeping/config_test.go
+++ b/server/backend/housekeeping/config_test.go
@@ -44,6 +44,17 @@ func TestConfig(t *testing.T) {
 		conf3 := validConf
 		conf3.CompactionMinChanges = 0
 		assert.Error(t, conf3.Validate())
+
+		// A negative DeactivateConcurrency must be rejected. This guards the
+		// check against being masked by an ensure-default coercion upstream.
+		conf4 := validConf
+		conf4.DeactivateConcurrency = -1
+		assert.Error(t, conf4.Validate())
+
+		// Zero is a valid sequential opt-in and must pass validation.
+		conf5 := validConf
+		conf5.DeactivateConcurrency = 0
+		assert.NoError(t, conf5.Validate())
 	})
 
 	t.Run("parse test", func(t *testing.T) {

--- a/server/backend/housekeeping/housekeeping.go
+++ b/server/backend/housekeeping/housekeeping.go
@@ -59,6 +59,13 @@ func (h *Housekeeping) RegisterTask(
 	if _, err := h.scheduler.NewJob(
 		gocron.DurationJob(interval),
 		gocron.NewTask(func() {
+			// TODO(raararaara): Wire a cancellable context here so Stop() can
+			// signal in-flight tasks on shutdown. Today this is
+			// context.Background(), so the deactivation dispatch cannot stop
+			// mid-cycle on a termination signal. Wiring it must also restore
+			// per-candidate in-flight protection (context.WithoutCancel in
+			// deactivateCandidates) and audit compaction / project-stats,
+			// which share this task path, for cancel-safety.
 			ctx := context.Background()
 
 			if !h.membership.IsLeader() {

--- a/server/clients/housekeeping.go
+++ b/server/clients/housekeeping.go
@@ -18,7 +18,11 @@ package clients
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 	"time"
+
+	"golang.org/x/sync/semaphore"
 
 	"github.com/yorkie-team/yorkie/api/types"
 	"github.com/yorkie-team/yorkie/server/backend"
@@ -38,10 +42,23 @@ type CandidatePair struct {
 
 // DeactivateInactives deactivates clients that have not been active for a
 // long time using direct client iteration.
+//
+// When concurrency > 1, per-candidate Deactivate calls are dispatched across
+// at most `concurrency` goroutines. Each Deactivate is independent (its own
+// DB read + cluster RPC fan-out + atomic DB update), so the parallelism
+// shortens per-cycle wallclock without changing per-candidate semantics.
+// The atomic $expr guard on DeactivateClient continues to reject candidates
+// that became non-trivial between the snapshot and the update.
+//
+// Note: this changes per-cycle wallclock, not throughput cap. The cycle
+// rate (Interval) and batch size (CandidatesLimit) still determine
+// throughput; concurrency only frees the per-cycle duration gate so the
+// operator can lower Interval or raise CandidatesLimit safely.
 func DeactivateInactives(
 	ctx context.Context,
 	be *backend.Backend,
 	candidatesLimit int,
+	concurrency int,
 	lastClientID types.ID,
 ) (types.ID, int, int, error) {
 	locker, ok := be.Lockers.LockerWithTryLock(deactivationKey)
@@ -65,16 +82,78 @@ func DeactivateInactives(
 		return database.ZeroID, 0, 0, nil
 	}
 
-	deactivatedCount := 0
-	for _, candidate := range candidates {
-		if _, err := Deactivate(ctx, be, candidate.Project, candidate.Client.RefKey()); err != nil {
-			logging.From(ctx).Warnf("failed to deactivate client %s: %v", candidate.Client.ID, err)
-			continue
-		}
-		deactivatedCount++
-	}
+	deactivatedCount := deactivateCandidates(ctx, be, candidates, concurrency)
 
 	return lastID, len(candidates), deactivatedCount, nil
+}
+
+// deactivateCandidates dispatches per-candidate Deactivate calls against the
+// real backend. Splits sequential vs parallel by `concurrency` and delegates
+// the actual dispatch / counting to dispatchDeactivate so the scheduling
+// logic stays unit-testable independent of the backend.
+func deactivateCandidates(
+	ctx context.Context,
+	be *backend.Backend,
+	candidates []CandidatePair,
+	concurrency int,
+) int {
+	return dispatchDeactivate(ctx, candidates, concurrency, func(c CandidatePair) error {
+		_, err := Deactivate(ctx, be, c.Project, c.Client.RefKey())
+		return err
+	})
+}
+
+// dispatchDeactivate runs `deactivate` for each candidate. With concurrency
+// <= 1, runs sequentially (legacy behavior). With concurrency > 1, runs up
+// to `concurrency` calls in parallel using a weighted semaphore. Errors are
+// logged and skipped — only successes increment the returned count.
+//
+// Pulled out as a separate function so the dispatch behavior (sequential vs
+// parallel, count correctness, error skipping) can be unit-tested without a
+// full backend.
+func dispatchDeactivate(
+	ctx context.Context,
+	candidates []CandidatePair,
+	concurrency int,
+	deactivate func(CandidatePair) error,
+) int {
+	if concurrency <= 1 {
+		count := 0
+		for _, c := range candidates {
+			if err := deactivate(c); err != nil {
+				logging.From(ctx).Warnf("failed to deactivate client %s: %v", c.Client.ID, err)
+				continue
+			}
+			count++
+		}
+		return count
+	}
+
+	sem := semaphore.NewWeighted(int64(concurrency))
+	var deactivated atomic.Int32
+	var wg sync.WaitGroup
+
+	for _, candidate := range candidates {
+		if err := sem.Acquire(ctx, 1); err != nil {
+			// Context cancelled mid-cycle. Stop dispatching; in-flight
+			// goroutines will finish on their own.
+			logging.From(ctx).Warnf("acquire deactivate slot: %v", err)
+			break
+		}
+		wg.Add(1)
+		go func(c CandidatePair) {
+			defer wg.Done()
+			defer sem.Release(1)
+			if err := deactivate(c); err != nil {
+				logging.From(ctx).Warnf("failed to deactivate client %s: %v", c.Client.ID, err)
+				return
+			}
+			deactivated.Add(1)
+		}(candidate)
+	}
+	wg.Wait()
+
+	return int(deactivated.Load())
 }
 
 // FindDeactivateCandidates finds candidates to deactivate using cache for projects.

--- a/server/clients/housekeeping.go
+++ b/server/clients/housekeeping.go
@@ -91,14 +91,27 @@ func DeactivateInactives(
 // real backend. Splits sequential vs parallel by `concurrency` and delegates
 // the actual dispatch / counting to dispatchDeactivate so the scheduling
 // logic stays unit-testable independent of the backend.
+//
+// In-flight Deactivate() calls run on a workCtx detached from the parent
+// via context.WithoutCancel. Parent ctx cancellation (typically a shutdown
+// signal) still stops dispatching new candidates (sem.Acquire fails fast
+// in dispatchDeactivate), but already-launched per-candidate operations
+// finish through DetachDocument + DeactivateClient instead of aborting
+// mid-flight and leaving the client in a partial state
+// (some docs detached, client still activated) that would only be
+// reconsidered a full ClientDeactivateThreshold later.
+// The Kubernetes pod terminationGracePeriodSeconds (default 30s) bounds
+// how long wg.Wait can block during shutdown; per-candidate cluster RPC
+// calls are separately bounded by the cluster rpcTimeout.
 func deactivateCandidates(
 	ctx context.Context,
 	be *backend.Backend,
 	candidates []CandidatePair,
 	concurrency int,
 ) int {
+	workCtx := context.WithoutCancel(ctx)
 	return dispatchDeactivate(ctx, candidates, concurrency, func(c CandidatePair) error {
-		_, err := Deactivate(ctx, be, c.Project, c.Client.RefKey())
+		_, err := Deactivate(workCtx, be, c.Project, c.Client.RefKey())
 		return err
 	})
 }

--- a/server/clients/housekeeping.go
+++ b/server/clients/housekeeping.go
@@ -91,27 +91,14 @@ func DeactivateInactives(
 // real backend. Splits sequential vs parallel by `concurrency` and delegates
 // the actual dispatch / counting to dispatchDeactivate so the scheduling
 // logic stays unit-testable independent of the backend.
-//
-// In-flight Deactivate() calls run on a workCtx detached from the parent
-// via context.WithoutCancel. Parent ctx cancellation (typically a shutdown
-// signal) still stops dispatching new candidates (sem.Acquire fails fast
-// in dispatchDeactivate), but already-launched per-candidate operations
-// finish through DetachDocument + DeactivateClient instead of aborting
-// mid-flight and leaving the client in a partial state
-// (some docs detached, client still activated) that would only be
-// reconsidered a full ClientDeactivateThreshold later.
-// The Kubernetes pod terminationGracePeriodSeconds (default 30s) bounds
-// how long wg.Wait can block during shutdown; per-candidate cluster RPC
-// calls are separately bounded by the cluster rpcTimeout.
 func deactivateCandidates(
 	ctx context.Context,
 	be *backend.Backend,
 	candidates []CandidatePair,
 	concurrency int,
 ) int {
-	workCtx := context.WithoutCancel(ctx)
 	return dispatchDeactivate(ctx, candidates, concurrency, func(c CandidatePair) error {
-		_, err := Deactivate(workCtx, be, c.Project, c.Client.RefKey())
+		_, err := Deactivate(ctx, be, c.Project, c.Client.RefKey())
 		return err
 	})
 }
@@ -151,8 +138,8 @@ func dispatchDeactivate(
 
 	for _, candidate := range candidates {
 		if err := sem.Acquire(ctx, 1); err != nil {
-			// Context cancelled mid-cycle. Stop dispatching; in-flight
-			// goroutines will finish on their own.
+			// ctx error (e.g. cancellation): stop acquiring new slots.
+			// Already-launched goroutines drain via wg.Wait below.
 			logging.From(ctx).Warnf("acquire deactivate slot: %v", err)
 			break
 		}

--- a/server/clients/housekeeping.go
+++ b/server/clients/housekeeping.go
@@ -120,6 +120,9 @@ func dispatchDeactivate(
 	if concurrency <= 1 {
 		count := 0
 		for _, c := range candidates {
+			if ctx.Err() != nil {
+				break
+			}
 			if err := deactivate(c); err != nil {
 				logging.From(ctx).Warnf("failed to deactivate client %s: %v", c.Client.ID, err)
 				continue

--- a/server/clients/housekeeping_test.go
+++ b/server/clients/housekeeping_test.go
@@ -132,21 +132,25 @@ func TestDispatchDeactivate_ConcurrencyBoundedBySemaphore(t *testing.T) {
 }
 
 func TestDispatchDeactivate_ContextCancelStops(t *testing.T) {
-	candidates := makeCandidates(50)
-	cancelCtx, cancel := context.WithCancel(testCtx())
-	cancel()
-	ctx := cancelCtx
+	for _, concurrency := range []int{1, 4} {
+		t.Run(fmt.Sprintf("concurrency=%d", concurrency), func(t *testing.T) {
+			candidates := makeCandidates(50)
+			cancelCtx, cancel := context.WithCancel(testCtx())
+			cancel()
 
-	var calls atomic.Int32
-	count := dispatchDeactivate(ctx, candidates, 4, func(_ CandidatePair) error {
-		calls.Add(1)
-		return nil
-	})
+			var calls atomic.Int32
+			count := dispatchDeactivate(cancelCtx, candidates, concurrency, func(_ CandidatePair) error {
+				calls.Add(1)
+				return nil
+			})
 
-	// On a cancelled context, the semaphore.Acquire fails for the first
-	// candidate, so dispatch breaks out before any goroutine runs.
-	assert.Equal(t, 0, count)
-	assert.Equal(t, int32(0), calls.Load())
+			// Both the sequential and parallel branches must short-circuit on
+			// a cancelled context. Sequential branch checks ctx.Err() at the
+			// loop head; parallel branch fails semaphore.Acquire immediately.
+			assert.Equal(t, 0, count)
+			assert.Equal(t, int32(0), calls.Load())
+		})
+	}
 }
 
 func TestDispatchDeactivate_NoCandidates(t *testing.T) {

--- a/server/clients/housekeeping_test.go
+++ b/server/clients/housekeeping_test.go
@@ -28,7 +28,9 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/yorkie-team/yorkie/api/types"
+	"github.com/yorkie-team/yorkie/server/backend"
 	"github.com/yorkie-team/yorkie/server/backend/database"
+	yorkiesync "github.com/yorkie-team/yorkie/server/backend/sync"
 	"github.com/yorkie-team/yorkie/server/logging"
 )
 
@@ -163,4 +165,39 @@ func TestDispatchDeactivate_NoCandidates(t *testing.T) {
 			assert.Equal(t, 0, count)
 		})
 	}
+}
+
+// TestDeactivateInactives_SkipsWhenLockHeld verifies the concurrent-cycle
+// contract: when a prior housekeeping tick is still holding the deactivation
+// lock, an overlapping tick observes the busy lock via TryLock and returns
+// immediately without touching the database. The cursor is preserved (the
+// caller-supplied lastClientID is returned unchanged) and no candidates are
+// processed.
+//
+// Distinguishing the skip path from the empty-candidates path: the skip
+// branch returns `lastClientID` (input), while the empty-candidates branch
+// returns `database.ZeroID`.
+func TestDeactivateInactives_SkipsWhenLockHeld(t *testing.T) {
+	be := &backend.Backend{
+		Lockers: yorkiesync.New(),
+	}
+	inputLastID := types.ID("aaaaaaaaaaaaaaaaaaaaaaaa")
+
+	// Simulate an in-flight prior cycle by pre-acquiring the same lock.
+	holder, acquired := be.Lockers.LockerWithTryLock(deactivationKey)
+	if !acquired {
+		t.Fatalf("expected to acquire deactivation lock initially")
+	}
+	defer holder.Unlock()
+
+	outLastID, candidatesCount, processedCount, err := DeactivateInactives(
+		testCtx(), be, 500, 8, inputLastID,
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, inputLastID, outLastID,
+		"skip path must return the input lastClientID (cursor unchanged); "+
+			"empty-candidates path would have returned database.ZeroID")
+	assert.Equal(t, 0, candidatesCount)
+	assert.Equal(t, 0, processedCount)
 }

--- a/server/clients/housekeeping_test.go
+++ b/server/clients/housekeeping_test.go
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package clients
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/api/types"
+	"github.com/yorkie-team/yorkie/server/backend/database"
+	"github.com/yorkie-team/yorkie/server/logging"
+)
+
+// testCtx returns a context with the default logger bound. dispatchDeactivate
+// uses logging.From(ctx) on error paths; without a bound logger the default
+// is nil and the call panics.
+func testCtx() context.Context {
+	return logging.With(context.Background(), logging.DefaultLogger())
+}
+
+func makeCandidates(n int) []CandidatePair {
+	pairs := make([]CandidatePair, n)
+	for i := 0; i < n; i++ {
+		pairs[i] = CandidatePair{
+			Project: &types.Project{ID: types.ID("project")},
+			Client: &database.ClientInfo{
+				ID:        types.ID(fmt.Sprintf("%024d", i+1)),
+				ProjectID: types.ID("project"),
+			},
+		}
+	}
+	return pairs
+}
+
+func TestDispatchDeactivate_SequentialCountsSuccesses(t *testing.T) {
+	candidates := makeCandidates(10)
+	var calls atomic.Int32
+
+	count := dispatchDeactivate(testCtx(), candidates, 1, func(_ CandidatePair) error {
+		calls.Add(1)
+		return nil
+	})
+
+	assert.Equal(t, 10, count)
+	assert.Equal(t, int32(10), calls.Load())
+}
+
+func TestDispatchDeactivate_ParallelCountsSuccesses(t *testing.T) {
+	candidates := makeCandidates(100)
+	var calls atomic.Int32
+
+	count := dispatchDeactivate(testCtx(), candidates, 16, func(_ CandidatePair) error {
+		calls.Add(1)
+		return nil
+	})
+
+	assert.Equal(t, 100, count)
+	assert.Equal(t, int32(100), calls.Load())
+}
+
+func TestDispatchDeactivate_SkipsErrorsAndContinues(t *testing.T) {
+	candidates := makeCandidates(10)
+	wantErr := errors.New("simulated deactivate failure")
+
+	for _, concurrency := range []int{1, 4} {
+		t.Run(fmt.Sprintf("concurrency=%d", concurrency), func(t *testing.T) {
+			var calls atomic.Int32
+			count := dispatchDeactivate(testCtx(), candidates, concurrency, func(c CandidatePair) error {
+				calls.Add(1)
+				// fail every odd-indexed candidate
+				if c.Client.ID[len(c.Client.ID)-1]%2 == 1 {
+					return wantErr
+				}
+				return nil
+			})
+
+			assert.Equal(t, int32(len(candidates)), calls.Load(), "every candidate should be attempted")
+			// half succeed (indices 1,3,5,... → ID last char '1','3',... → odd → fail; so even ones succeed)
+			assert.Less(t, count, len(candidates))
+			assert.Greater(t, count, 0)
+		})
+	}
+}
+
+func TestDispatchDeactivate_ConcurrencyBoundedBySemaphore(t *testing.T) {
+	const total = 200
+	const concurrency = 8
+
+	candidates := makeCandidates(total)
+	var inflight atomic.Int32
+	var maxInflight atomic.Int32
+	var mu sync.Mutex
+
+	dispatchDeactivate(testCtx(), candidates, concurrency, func(_ CandidatePair) error {
+		cur := inflight.Add(1)
+		// track max observed in-flight
+		mu.Lock()
+		if cur > maxInflight.Load() {
+			maxInflight.Store(cur)
+		}
+		mu.Unlock()
+		// hold the slot briefly so we see actual concurrency
+		time.Sleep(2 * time.Millisecond)
+		inflight.Add(-1)
+		return nil
+	})
+
+	got := maxInflight.Load()
+	assert.LessOrEqual(t, got, int32(concurrency), "max in-flight must not exceed concurrency")
+	assert.Greater(t, got, int32(1), "with parallel dispatch we expect >1 in-flight at some point")
+}
+
+func TestDispatchDeactivate_ContextCancelStops(t *testing.T) {
+	candidates := makeCandidates(50)
+	cancelCtx, cancel := context.WithCancel(testCtx())
+	cancel()
+	ctx := cancelCtx
+
+	var calls atomic.Int32
+	count := dispatchDeactivate(ctx, candidates, 4, func(_ CandidatePair) error {
+		calls.Add(1)
+		return nil
+	})
+
+	// On a cancelled context, the semaphore.Acquire fails for the first
+	// candidate, so dispatch breaks out before any goroutine runs.
+	assert.Equal(t, 0, count)
+	assert.Equal(t, int32(0), calls.Load())
+}
+
+func TestDispatchDeactivate_NoCandidates(t *testing.T) {
+	for _, concurrency := range []int{0, 1, 16} {
+		t.Run(fmt.Sprintf("concurrency=%d", concurrency), func(t *testing.T) {
+			count := dispatchDeactivate(testCtx(), nil, concurrency, func(_ CandidatePair) error {
+				t.Fatal("should not be called")
+				return nil
+			})
+			assert.Equal(t, 0, count)
+		})
+	}
+}

--- a/server/config.go
+++ b/server/config.go
@@ -43,10 +43,11 @@ const (
 	DefaultMembershipLeaseDuration   = 15 * time.Second
 	DefaultMembershipRenewalInterval = 5 * time.Second
 
-	DefaultHousekeepingInterval             = 30 * time.Second
-	DefaultHousekeepingCandidatesLimit      = 500
-	DefaultHousekeepingCompactionMinChanges = 1000
-	DefaultProjectStatsRefreshInterval      = 5 * time.Minute
+	DefaultHousekeepingInterval              = 30 * time.Second
+	DefaultHousekeepingCandidatesLimit       = 500
+	DefaultHousekeepingDeactivateConcurrency = 16
+	DefaultHousekeepingCompactionMinChanges  = 1000
+	DefaultProjectStatsRefreshInterval       = 5 * time.Minute
 
 	DefaultMongoConnectionURI                = "mongodb://localhost:27017"
 	DefaultMongoConnectionTimeout            = 5 * time.Second
@@ -235,6 +236,9 @@ func (c *Config) ensureHouseKeepingDefaultValue() {
 	if c.Housekeeping.CandidatesLimit == 0 {
 		c.Housekeeping.CandidatesLimit = DefaultHousekeepingCandidatesLimit
 	}
+	if c.Housekeeping.DeactivateConcurrency == 0 {
+		c.Housekeeping.DeactivateConcurrency = DefaultHousekeepingDeactivateConcurrency
+	}
 	if c.Housekeeping.CompactionMinChanges == 0 {
 		c.Housekeeping.CompactionMinChanges = DefaultHousekeepingCompactionMinChanges
 	}
@@ -394,6 +398,7 @@ func newConfig(port int, profilingPort int) *Config {
 		Housekeeping: &housekeeping.Config{
 			Interval:                    DefaultHousekeepingInterval.String(),
 			CandidatesLimit:             DefaultHousekeepingCandidatesLimit,
+			DeactivateConcurrency:       DefaultHousekeepingDeactivateConcurrency,
 			CompactionMinChanges:        DefaultHousekeepingCompactionMinChanges,
 			ProjectStatsRefreshInterval: DefaultProjectStatsRefreshInterval.String(),
 		},

--- a/server/config.go
+++ b/server/config.go
@@ -236,9 +236,11 @@ func (c *Config) ensureHouseKeepingDefaultValue() {
 	if c.Housekeeping.CandidatesLimit == 0 {
 		c.Housekeeping.CandidatesLimit = DefaultHousekeepingCandidatesLimit
 	}
-	if c.Housekeeping.DeactivateConcurrency < 0 {
-		c.Housekeeping.DeactivateConcurrency = DefaultHousekeepingDeactivateConcurrency
-	}
+	// DeactivateConcurrency intentionally has no ensure-coercion here.
+	// newConfig() pre-seeds the default before YAML unmarshal, so an omitted
+	// field already resolves to the default; an explicit 0 is preserved as a
+	// sequential opt-in (dispatch falls back to sequential when <= 1), and a
+	// negative value is left for Validate() to reject.
 	if c.Housekeeping.CompactionMinChanges == 0 {
 		c.Housekeeping.CompactionMinChanges = DefaultHousekeepingCompactionMinChanges
 	}

--- a/server/config.go
+++ b/server/config.go
@@ -236,7 +236,7 @@ func (c *Config) ensureHouseKeepingDefaultValue() {
 	if c.Housekeeping.CandidatesLimit == 0 {
 		c.Housekeeping.CandidatesLimit = DefaultHousekeepingCandidatesLimit
 	}
-	if c.Housekeeping.DeactivateConcurrency == 0 {
+	if c.Housekeeping.DeactivateConcurrency < 0 {
 		c.Housekeeping.DeactivateConcurrency = DefaultHousekeepingDeactivateConcurrency
 	}
 	if c.Housekeeping.CompactionMinChanges == 0 {

--- a/server/config.go
+++ b/server/config.go
@@ -44,8 +44,8 @@ const (
 	DefaultMembershipRenewalInterval = 5 * time.Second
 
 	DefaultHousekeepingInterval              = 30 * time.Second
-	DefaultHousekeepingCandidatesLimit       = 500
-	DefaultHousekeepingDeactivateConcurrency = 16
+	DefaultHousekeepingCandidatesLimit       = 2000
+	DefaultHousekeepingDeactivateConcurrency = 8
 	DefaultHousekeepingCompactionMinChanges  = 1000
 	DefaultProjectStatsRefreshInterval       = 5 * time.Minute
 

--- a/server/config.sample.yml
+++ b/server/config.sample.yml
@@ -56,13 +56,13 @@ Housekeeping:
   # Interval is the time between housekeeping runs (default: 30s).
   Interval: "30s"
 
-  # CandidatesLimit is the maximum number of candidates to be returned in a single query (default: 500).
-  CandidatesLimit: 500
+  # CandidatesLimit is the maximum number of candidates to be returned in a single query (default: 2000).
+  CandidatesLimit: 2000
 
   # DeactivateConcurrency is the max number of concurrent per-candidate
-  # Deactivate calls within a single housekeeping cycle (default: 16).
+  # Deactivate calls within a single housekeeping cycle (default: 8).
   # Set to 0 or 1 to fall back to sequential execution.
-  DeactivateConcurrency: 16
+  DeactivateConcurrency: 8
 
   # CompactionMinChanges is minimum number of changes to compact a document. (default: 1000).
   CompactionMinChanges: 1000

--- a/server/config.sample.yml
+++ b/server/config.sample.yml
@@ -59,6 +59,11 @@ Housekeeping:
   # CandidatesLimit is the maximum number of candidates to be returned in a single query (default: 500).
   CandidatesLimit: 500
 
+  # DeactivateConcurrency is the max number of concurrent per-candidate
+  # Deactivate calls within a single housekeeping cycle (default: 16).
+  # Set to 0 or 1 to fall back to sequential execution.
+  DeactivateConcurrency: 16
+
   # CompactionMinChanges is minimum number of changes to compact a document. (default: 1000).
   CompactionMinChanges: 1000
 

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -50,6 +50,7 @@ func assertDefaultConfig(t *testing.T, conf *server.Config) {
 
 	assertDurationEqual(t, server.DefaultHousekeepingInterval, conf.Housekeeping.Interval)
 	assert.Equal(t, server.DefaultHousekeepingCandidatesLimit, conf.Housekeeping.CandidatesLimit)
+	assert.Equal(t, server.DefaultHousekeepingDeactivateConcurrency, conf.Housekeeping.DeactivateConcurrency)
 	assert.Equal(t, server.DefaultHousekeepingCompactionMinChanges, conf.Housekeeping.CompactionMinChanges)
 
 	assertDurationEqual(t, server.DefaultAdminTokenDuration, conf.Backend.AdminTokenDuration)
@@ -117,5 +118,23 @@ func TestNewConfigFromFile(t *testing.T) {
 		conf, err := server.NewConfigFromFile(filePath)
 		assert.NoError(t, err)
 		assertDefaultConfig(t, conf)
+	})
+
+	t.Run("explicit zero DeactivateConcurrency preserved (sequential opt-in)", func(t *testing.T) {
+		filePath := "config.zero-concurrency.yml"
+		file, err := os.Create(filePath)
+		assert.NoError(t, err)
+		_, err = file.WriteString("Housekeeping:\n  DeactivateConcurrency: 0\n")
+		assert.NoError(t, err)
+		defer func() {
+			assert.NoError(t, file.Close())
+			assert.NoError(t, os.Remove(filePath))
+		}()
+
+		conf, err := server.NewConfigFromFile(filePath)
+		assert.NoError(t, err)
+		// Explicit 0 must survive ensureDefaultValue so the documented
+		// "0 or 1 → sequential fallback" rollback works.
+		assert.Equal(t, 0, conf.Housekeeping.DeactivateConcurrency)
 	})
 }

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -137,4 +137,23 @@ func TestNewConfigFromFile(t *testing.T) {
 		// "0 or 1 → sequential fallback" rollback works.
 		assert.Equal(t, 0, conf.Housekeeping.DeactivateConcurrency)
 	})
+
+	t.Run("negative DeactivateConcurrency survives ensure for Validate to reject", func(t *testing.T) {
+		filePath := "config.negative-concurrency.yml"
+		file, err := os.Create(filePath)
+		assert.NoError(t, err)
+		_, err = file.WriteString("Housekeeping:\n  DeactivateConcurrency: -5\n")
+		assert.NoError(t, err)
+		defer func() {
+			assert.NoError(t, file.Close())
+			assert.NoError(t, os.Remove(filePath))
+		}()
+
+		conf, err := server.NewConfigFromFile(filePath)
+		assert.NoError(t, err)
+		// ensureDefaultValue must not coerce a negative value away, otherwise
+		// the Validate() guard below would be dead code.
+		assert.Equal(t, -5, conf.Housekeeping.DeactivateConcurrency)
+		assert.Error(t, conf.Housekeeping.Validate())
+	})
 }

--- a/server/server.go
+++ b/server/server.go
@@ -212,6 +212,15 @@ func (r *Yorkie) RegisterHousekeepingTasks(be *backend.Backend) error {
 	compactionState := &housekeepingState{lastID: database.ZeroID}
 	statsState := &housekeepingState{lastID: database.ZeroID}
 
+	// Log deactivation task config at registration so operators can grep for
+	// "HSKP: deactivation registered" and verify concurrency mode (parallel
+	// vs sequential fallback) without waiting for the first cycle.
+	deactivateConcurrency := be.Housekeeping.Config.DeactivateConcurrency
+	logging.DefaultLogger().Infof(
+		"HSKP: deactivation registered — interval=%s candidates_limit=%d concurrency=%d",
+		interval, be.Housekeeping.Config.CandidatesLimit, deactivateConcurrency,
+	)
+
 	if err = be.Housekeeping.RegisterTask(interval, func(ctx context.Context) error {
 		deactivateState.Lock()
 		currentLastID := deactivateState.lastID
@@ -224,7 +233,7 @@ func (r *Yorkie) RegisterHousekeepingTasks(be *backend.Backend) error {
 			ctx,
 			be,
 			be.Housekeeping.Config.CandidatesLimit,
-			be.Housekeeping.Config.DeactivateConcurrency,
+			deactivateConcurrency,
 			currentLastID,
 		)
 		if err != nil {
@@ -242,13 +251,14 @@ func (r *Yorkie) RegisterHousekeepingTasks(be *backend.Backend) error {
 
 		if processedCount > 0 {
 			logging.From(ctx).Infof(
-				"HSKP: deactivation #%d %s candidates %d/%d deactivated %d/%d %s",
+				"HSKP: deactivation #%d %s candidates %d/%d deactivated %d/%d cc=%d %s",
 				deactivateState.term,
 				currentLastID,
 				candidatesCount,
 				deactivateState.totalCandidates,
 				processedCount,
 				deactivateState.totalProcessed,
+				deactivateConcurrency,
 				time.Since(start),
 			)
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -224,6 +224,7 @@ func (r *Yorkie) RegisterHousekeepingTasks(be *backend.Backend) error {
 			ctx,
 			be,
 			be.Housekeeping.Config.CandidatesLimit,
+			be.Housekeeping.Config.DeactivateConcurrency,
 			currentLastID,
 		)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Dispatches per-candidate `Deactivate` calls across a bounded worker pool
(default 8) via a weighted semaphore instead of processing them
sequentially. Adds `Housekeeping.DeactivateConcurrency` and bumps the
default `CandidatesLimit` from 500 to 2000, raising the per-cycle cap
from `~17/s` to `~66/s`.

Each `Deactivate` operates on an independent `ClientRefKey` — its own
mongo read, its own optional cluster RPC fan-out, its own atomic
`$expr`-guarded update — so sequential dispatch is an implementation
choice, not a correctness requirement. Concurrent writes on distinct
`_id`s scale linearly under WiredTiger document-level locking; the
leader pod's CPU sits idle waiting on mongo I/O otherwise. The cluster
RPC path already fans out concurrently via `Backend.FanOut` — this
applies the same pattern to housekeeping.

Concurrency 8 balances the Go mongo driver's default max pool size
(100/host) against per-cycle wallclock reduction. Setting
`--housekeeping-deactivate-concurrency=1` restores the sequential loop;
`--housekeeping-candidates-limit=500` restores the previous batch size.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Alternatives considered:

| Alternative | Why not |
|---|---|
| Bulk `UpdateMany` for trivial candidates | Only covers the no-attached-docs subset; non-trivial candidates still need per-candidate cluster RPC fan-out. Orthogonal — can be layered later. |
| Cursor sharding into N ranges | Larger change with separate cursor state and range-filtered queries. Same net effect on throughput as bumping `CandidatesLimit`. |
| Reusing `Backend.FanOut` | Shaped around `map[K]V` with a server-wide cluster-RPC semaphore. Housekeeping dispatch has different bounds and benefits from its own knob. |

Observability: a registration-time log line lists `interval`,
`candidates_limit`, and `concurrency` so operators can verify the
dispatch mode without waiting for the first cycle. Each per-cycle
HSKP log now includes `cc=<N>` so sequential fallback is grep-able.

Rollback: `--housekeeping-deactivate-concurrency=1` restores the exact
sequential dispatch loop, and `--housekeeping-candidates-limit=500`
restores the previous batch size — both without a rebuild.

**Does this PR introduce a user-facing change?**:

Yes.

```release-note
Housekeeping now dispatches per-candidate `Deactivate` calls across a
bounded worker pool. Introduces `--housekeeping-deactivate-concurrency`
(yaml: `Housekeeping.DeactivateConcurrency`, default 8). Bumps the
default `Housekeeping.CandidatesLimit` from 500 to 2000. Setting
`--housekeeping-deactivate-concurrency=0` or `1` falls back to the
exact sequential loop for legacy behavior.
```

**Additional documentation**:

```docs
```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [ ] Didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `Housekeeping.DeactivateConcurrency` and a CLI flag to cap the maximum concurrent client deactivations per housekeeping cycle (with `0`/`1` enabling sequential behavior).
  * Increased the default housekeeping candidate limit (500 → 2000) and introduced a default deactivation concurrency value (8).
* **Documentation**
  * Updated the sample configuration to include `DeactivateConcurrency`.
  * Startup/registration logs now include housekeeping interval, candidates limit, and deactivation concurrency.
* **Bug Fixes**
  * Negative concurrency values are now rejected; explicitly configured values (including `0`) are preserved.
* **Tests**
  * Added/extended tests for sequential vs parallel behavior, concurrency limits, cancellation behavior, and context handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->