### PR TITLE
Expose housekeeping flags in yorkie-cluster chart

### DIFF
--- a/build/charts/yorkie-cluster/templates/yorkie/deployment.yaml
+++ b/build/charts/yorkie-cluster/templates/yorkie/deployment.yaml
@@ -167,6 +167,28 @@ spec:
           "--starrocks-dsn",
           "{{ .Values.yorkie.args.starrocksDSN }}",
           {{- end }}
+          {{- with .Values.yorkie.housekeeping }}
+          {{- if hasKey . "interval" }}
+          "--housekeeping-interval",
+          "{{ .interval }}",
+          {{- end }}
+          {{- if hasKey . "candidatesLimit" }}
+          "--housekeeping-candidates-limit",
+          "{{ .candidatesLimit }}",
+          {{- end }}
+          {{- if hasKey . "deactivateConcurrency" }}
+          "--housekeeping-deactivate-concurrency",
+          "{{ .deactivateConcurrency }}",
+          {{- end }}
+          {{- if hasKey . "compactionMinChanges" }}
+          "--housekeeping-compaction-min-changes",
+          "{{ .compactionMinChanges }}",
+          {{- end }}
+          {{- if hasKey . "projectStatsRefreshInterval" }}
+          "--housekeeping-project-stats-refresh-interval",
+          "{{ .projectStatsRefreshInterval }}",
+          {{- end }}
+          {{- end }}
         ]
         ports:
           - containerPort: {{ .Values.yorkie.ports.rpcPort }}

--- a/build/charts/yorkie-cluster/values.yaml
+++ b/build/charts/yorkie-cluster/values.yaml
@@ -30,6 +30,15 @@ yorkie:
   mongoMonitoringEnabled: false
   mongoMonitoringSlowQueryThreshold: "100ms"
 
+  # Housekeeping tunables. Leave any field empty (default) to fall back to
+  # the yorkie binary's built-in default. See --help output for each flag.
+  housekeeping:
+    # interval: "30s"
+    # candidatesLimit: 2000
+    # deactivateConcurrency: 8
+    # compactionMinChanges: 1000
+    # projectStatsRefreshInterval: "5m"
+
   resources: {}
 
 # Configuration for istio ingress gateway


### PR DESCRIPTION
**What this PR does / why we need it**:

The yorkie binary already accepts `--housekeeping-interval`,
`--housekeeping-candidates-limit`, `--housekeeping-deactivate-concurrency`,
`--housekeeping-compaction-min-changes` and
`--housekeeping-project-stats-refresh-interval`, but `deployment.yaml` in
the `yorkie-cluster` chart did not pass any of them through to the
container. Operators using the chart had no path to tune housekeeping
short of building a custom image or mounting a config file.

- `values.yaml` gains a commented-out `yorkie.housekeeping` block
  listing tunable fields.
- `deployment.yaml` conditionally appends each flag when the field is
  set. `hasKey` is used (rather than a truthiness check) so an explicit
  `0` — the documented sequential-fallback value for
  `deactivateConcurrency` — is passed through rather than treated as
  "unset".
- No field is populated by default. The binary's own defaults apply
  when the block is left empty.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Independent of PR #1849 (housekeeping worker pool). This PR only touches
the chart — no Go code changes. Base is `main`, so it can be reviewed
and merged separately.

Verified with `helm lint` and `helm template`:
- Default (no override): no `--housekeeping-*` flags in rendered args
- With `--set yorkie.housekeeping.deactivateConcurrency=0`: renders
  `"--housekeeping-deactivate-concurrency", "0"` (confirming `hasKey`
  path admits explicit zero)
- With multiple overrides: all set fields rendered as flag/value pairs

**Does this PR introduce a user-facing change?**:

Yes.

```release-note
The `yorkie-cluster` Helm chart now exposes the housekeeping tunables
(`interval`, `candidatesLimit`, `deactivateConcurrency`,
`compactionMinChanges`, `projectStatsRefreshInterval`) via a new
`yorkie.housekeeping` values block. Fields left unset fall back to the
yorkie binary's built-in defaults; `deactivateConcurrency: 0`
(sequential fallback) is passed through explicitly via `hasKey`.
```

**Additional documentation**:

```docs
```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [ ] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional housekeeping settings to Yorkie’s deployment configuration.
  * You can now set housekeeping-related runtime flags through chart values, including interval, candidate limits, concurrency, compaction thresholds, and project stats refresh timing.
  * Updated the default values file with examples and guidance for these new options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->