### PR TITLE
Attribute cross-package coverage with -coverpkg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
         run: docker compose -f build/docker/docker-compose.yml up --build -d
 
       - name: Test
-        run: go test -tags integration -race -coverprofile=coverage.txt -covermode=atomic -v ./...
+        run: go test -tags integration -race -coverpkg=./... -coverprofile=coverage.txt -covermode=atomic -v ./...
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ lint: ## runs the golang-ci lint, checks for lint violations
 
 coverage: ## runs coverage tests
 	go clean -testcache
-	go test -tags integration -race -coverprofile=coverage.txt -covermode=atomic ./...
+	go test -tags integration -race -coverpkg=./... -coverprofile=coverage.txt -covermode=atomic ./...
 	go tool cover -html=coverage.txt
 	rm -f coverage.txt
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
`go test -coverprofile ./...` records only statements executed by each package's own tests, so code exercised across package boundaries by the integration suite (RPC handlers, CRDT core) was never attributed and showed 0% despite being run.

Add `-coverpkg=./...` to the CI coverage step and the make coverage target so coverage reflects what the integration tests actually execute. This keeps a single Codecov report and leaves the README badge and codecov.yml untouched, so existing badge and report URLs remain unchanged.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [ ] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [ ] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the coverage test command to include integration-tagged tests.
  * CI test command was refreshed with no change to the effective test options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->