### PR TITLE
docs: add identity-preserving restore (GC-recreate) to undo-redo remaining options

### DIFF
--- a/docs/design/undo-redo.md
+++ b/docs/design/undo-redo.md
@@ -558,6 +558,7 @@ it creates new nodes independent of GC state.
 |----------|------|------|
 | Node-ID overlap detection | Extend undo op with removed node IDs; reconciliation compares node sets instead of index ranges. Content re-insert preserved (GC-safe). | Significant change to operation model and reconciliation logic. |
 | Reconciliation content trimming | Case 3: when undo fully contained by remote delete, clear content. | Only handles full containment; partial overlap (Cases 5-6) can't predict future undo intent. |
+| Identity-preserving restore (GC-recreate) | Undo un-tombstones surviving nodes and recreates purged nodes under their original IDs. GC-safe: carried values make restore independent of tombstone survival, extending Approach B past its multi-client GC failure. | Significant change to operation model on the scale of Approach B. Re-injecting nodes with past `createdAt` needs a convergence proof against the GC contract. |
 | Accept as known limitation | Document the issue; focus on other improvements. | Overlapping undo is uncommon in practice; users can work around. |
 
 ### Analysis: Tree Redo Divergence (resolved)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Adds the identity-preserving restore approach to the Remaining Options table in undo-redo.md. The approach extends Approach B (selective un-tombstone) past its multi-client GC failure: the reverse op carries (createdAt, offset-range, content) spans, so purged nodes are recreated under their original IDs instead of resurrected in place. Overlapping undos then deduplicate by construction (idempotent restore).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new undo/redo option to the design notes, describing an identity-preserving restore approach for surviving and removed items.
  * Clarified the tradeoffs of this option, including GC safety and the need for convergence validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->