### PR TITLE
Fix dead sync package link in pub-sub design doc

### DIFF
--- a/docs/design/pub-sub.md
+++ b/docs/design/pub-sub.md
@@ -41,7 +41,7 @@ In brief, when the client sends a WatchDocument request, it establishes a stream
 
 ### How does it work?
 
-We are using the [PubSub pattern](https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern) for handling event delivery targets. For more details, you can check out the [sync package](https://github.com/yorkie-team/yorkie/blob/main/server/backend/sync/pubsub.go) that we're working on.
+We are using the [PubSub pattern](https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern) for handling event delivery targets. For more details, you can check out the [pubsub package](https://github.com/yorkie-team/yorkie/blob/main/server/backend/pubsub/pubsub.go) that we're working on.
 
 ![pub-sub pattern vs observer pattern](media/pubsub-pattern.png)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The `sync package` link in `docs/design/pub-sub.md` points to `server/backend/sync/pubsub.go`, which returns 404. The file was moved to `server/backend/pubsub/pubsub.go` in #1136 (Simplify Coordinator by Refactoring to Locker and PubSub). Update the link to the new path.

**Which issue(s) this PR fixes**:

Fixes #

**Checklist**:

- [X] Added relevant tests or not required
- [X] Addressed and resolved all CodeRabbit review comments
- [X] Didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the pub-sub design documentation to reference the current implementation location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->