### PR TITLE
Remove stale ActorID cache-priming comment in pubsub

### DIFF
--- a/server/backend/pubsub/pubsub.go
+++ b/server/backend/pubsub/pubsub.go
@@ -150,10 +150,6 @@ func (m *PubSub) Publish(
 	publisherID time.ActorID,
 	event events.DocEvent,
 ) {
-	// NOTE(hackerwins): String() triggers the cache of ActorID to avoid
-	// race condition of concurrent access to the cache.
-	_ = event.Actor.String()
-
 	docKey := event.Key
 
 	if logging.Enabled(zap.DebugLevel) {


### PR DESCRIPTION
**What this PR does / why we need it**:
`Publish()` had a comment and a no-op `event.Actor.String()` call explaining
that it primes ActorID's internal string cache to avoid a race on concurrent
access. That cache was removed when ActorID was refactored into a plain
`[12]byte` value type in #1234, so the call has been a no-op ever since —
it computes and discards a string with no side effect. Removing it as dead
code.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note

```

**Additional documentation**:

```docs

```

**Checklist**:

- [X] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [X] Didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event publishing reliability by removing unnecessary actor data access that could cause concurrency-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->