### PR TITLE
Prevent panic when splitLevel walks past the tree root

### DIFF
--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -1462,6 +1462,10 @@ func (t *Tree) split(
 			}
 		}
 
+		if parent.Index.Parent == nil {
+			break
+		}
+
 		var err error
 		offset := 0
 		if left != parent {

--- a/test/integration/tree_test.go
+++ b/test/integration/tree_test.go
@@ -20,6 +20,7 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -4481,6 +4482,57 @@ func TestTree(t *testing.T) {
 
 		syncClientsThenAssertEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
 		assert.Equal(t, "<root><p>ab</p><p>ced</p></root>", d1.Root().GetTree("t").ToXML())
+	})
+
+	t.Run("can edit with splitLevel walking past root does not panic", func(t *testing.T) {
+		ctx := context.Background()
+		txt := func(v string) *json.TreeNode { return &json.TreeNode{Type: "text", Value: v} }
+
+		seeds := []struct {
+			name   string
+			tree   json.TreeNode
+			length int
+		}{
+			// <doc><p>x</p></doc>
+			{"shallow", json.TreeNode{Type: "doc", Children: []json.TreeNode{
+				{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "x"}}},
+			}}, 3},
+			// <doc><p>x</p><p>y</p></doc>
+			{"twoP", json.TreeNode{Type: "doc", Children: []json.TreeNode{
+				{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "x"}}},
+				{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "y"}}},
+			}}, 6},
+			// <doc><p><b>x</b></p></doc>
+			{"deep", json.TreeNode{Type: "doc", Children: []json.TreeNode{
+				{Type: "p", Children: []json.TreeNode{
+					{Type: "b", Children: []json.TreeNode{{Type: "text", Value: "x"}}},
+				}},
+			}}, 5},
+			// <doc><p></p></doc>
+			{"emptyP", json.TreeNode{Type: "doc", Children: []json.TreeNode{
+				{Type: "p", Children: []json.TreeNode{}},
+			}}, 2},
+		}
+
+		for _, seed := range seeds {
+			for pos := range seed.length + 1 {
+				for _, sl := range []int{1, 2} {
+					name := fmt.Sprintf("%s/pos=%d/sl=%d", seed.name, pos, sl)
+					t.Run(name, func(t *testing.T) {
+						d := document.New(helper.TestKey(t))
+						assert.NoError(t, c1.Attach(ctx, d))
+						assert.NoError(t, d.Update(func(root *json.Object, _ *presence.Presence) error {
+							root.SetNewTree("t", seed.tree)
+							return nil
+						}))
+						assert.NoError(t, d.Update(func(root *json.Object, _ *presence.Presence) error {
+							root.GetTree("t").Edit(pos, pos, txt("a"), sl)
+							return nil
+						}))
+					})
+				}
+			}
+		}
 	})
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Tree.split walked up to the root and split it, dereferencing the root's nil parent. Stop the walk once the node to split has no parent.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #1865 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

**Checklist**:

- [X] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [X] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when editing at or beyond the document’s root boundary.
  * Improved stability for edits involving deeply nested or split tree structures.

* **Tests**
  * Added regression coverage for multiple tree shapes, edit positions, and split levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->