### PR TITLE
Register GC pairs for pieces split off tombstoned nodes

### DIFF
--- a/pkg/document/crdt/gc.go
+++ b/pkg/document/crdt/gc.go
@@ -26,6 +26,15 @@ import (
 type GCPair struct {
 	Parent GCParent
 	Child  GCChild
+
+	// GCOnlySize is set for a child whose size was never counted in
+	// docSize.Live: a piece born removed by splitting an already-tombstoned
+	// node. Its value is the net-new size the split created. When set,
+	// RegisterGCPair adds this to docSize.GC and AdjustDiffForGCPair leaves
+	// docSize.Live untouched, instead of the usual live->gc move. Purge
+	// subtracts the child's full size from GC; across the split's original
+	// node and its born-dead pieces these telescope back to zero.
+	GCOnlySize *resource.DataSize
 }
 
 // GCParent is an interface for the parent of the garbage collection target.

--- a/pkg/document/crdt/rga_tree_split.go
+++ b/pkg/document/crdt/rga_tree_split.go
@@ -321,6 +321,13 @@ type RGATreeSplit[V RGATreeSplitValue] struct {
 	initialHead *RGATreeSplitNode[V]
 	treeByIndex *splay.Tree[*RGATreeSplitNode[V]]
 	treeByID    *llrb.Tree[*RGATreeSplitNodeID, *RGATreeSplitNode[V]]
+
+	// pendingGCPairs buffers GC pairs for nodes that were created
+	// already-tombstoned by splitting a removed node. Such pieces inherit
+	// removedAt without ever passing through Remove(), so they would
+	// otherwise never be registered for GC. edit, Text.Style and
+	// Text.RemoveStyle drain this buffer into the GC pairs they return.
+	pendingGCPairs []GCPair
 }
 
 // NewRGATreeSplit creates a new instance of RGATreeSplit.
@@ -441,7 +448,32 @@ func (s *RGATreeSplit[V]) splitNode(
 	diff.Add(node.DataSize(), splitNode.DataSize())
 	diff.Sub(prevSize)
 
+	// NOTE: A piece split off an already-tombstoned node inherits
+	// removedAt without going through Remove(), so no GC pair is created
+	// for it in the normal deletion path. Buffer one here so it can be
+	// purged; otherwise it stays in the list forever. The piece was never
+	// live, so the net-new size the split created goes straight to
+	// docSize.GC when the pair is registered; return a zero diff to the
+	// caller (which accounts diffs to docSize.Live).
+	if splitNode.removedAt != nil {
+		gcSize := diff
+		s.pendingGCPairs = append(s.pendingGCPairs, GCPair{
+			Parent:     s,
+			Child:      splitNode,
+			GCOnlySize: &gcSize,
+		})
+		return splitNode, resource.DataSize{}, nil
+	}
+
 	return splitNode, diff, nil
+}
+
+// drainPendingGCPairs returns the GC pairs buffered for born-tombstoned
+// split pieces and clears the buffer.
+func (s *RGATreeSplit[V]) drainPendingGCPairs() []GCPair {
+	pairs := s.pendingGCPairs
+	s.pendingGCPairs = nil
+	return pairs
 }
 
 // InsertAfter inserts the given node after the given previous node.
@@ -541,6 +573,8 @@ func (s *RGATreeSplit[V]) edit(
 			Child:  removedNode,
 		})
 	}
+
+	pairs = append(pairs, s.drainPendingGCPairs()...)
 
 	return caretPos, pairs, diff, nil
 }

--- a/pkg/document/crdt/rga_tree_split.go
+++ b/pkg/document/crdt/rga_tree_split.go
@@ -540,6 +540,7 @@ func (s *RGATreeSplit[V]) edit(
 
 	fromLeft, fromRight, diffFrom, err := s.findNodeWithSplit(from, editedAt)
 	if err != nil {
+		diff.Add(diffTo)
 		return nil, s.drainPendingGCPairs(), diff, err
 	}
 

--- a/pkg/document/crdt/rga_tree_split.go
+++ b/pkg/document/crdt/rga_tree_split.go
@@ -535,12 +535,12 @@ func (s *RGATreeSplit[V]) edit(
 	// 01. Split nodes with from and to
 	toLeft, toRight, diffTo, err := s.findNodeWithSplit(to, editedAt)
 	if err != nil {
-		return nil, nil, diff, err
+		return nil, s.drainPendingGCPairs(), diff, err
 	}
 
 	fromLeft, fromRight, diffFrom, err := s.findNodeWithSplit(from, editedAt)
 	if err != nil {
-		return nil, nil, diff, err
+		return nil, s.drainPendingGCPairs(), diff, err
 	}
 
 	diff.Add(diffTo, diffFrom)

--- a/pkg/document/crdt/root.go
+++ b/pkg/document/crdt/root.go
@@ -234,8 +234,14 @@ func (r *Root) RegisterGCPair(pair GCPair) {
 	// NOTE(hackerwins): If the child is already registered, it means that the
 	// child should be removed from the cache.
 	if p, ok := r.gcNodePairMap[pair.Child.IDString()]; ok {
-		size := p.Child.DataSize()
-		r.docSize.GC.Sub(size)
+		// Subtract exactly what registration added: GCOnlySize for a
+		// born-dead split piece (only its net-new size was added to GC),
+		// the full child size otherwise.
+		if p.GCOnlySize != nil {
+			r.docSize.GC.Sub(*p.GCOnlySize)
+		} else {
+			r.docSize.GC.Sub(p.Child.DataSize())
+		}
 
 		delete(r.gcNodePairMap, p.Child.IDString())
 		return

--- a/pkg/document/crdt/root.go
+++ b/pkg/document/crdt/root.go
@@ -243,6 +243,14 @@ func (r *Root) RegisterGCPair(pair GCPair) {
 
 	r.gcNodePairMap[pair.Child.IDString()] = pair
 
+	// NOTE: A born-removed split piece was never counted in docSize.Live,
+	// so only its net-new size is added to GC (Live is left untouched by
+	// AdjustDiffForGCPair below).
+	if pair.GCOnlySize != nil {
+		r.docSize.GC.Add(*pair.GCOnlySize)
+		return
+	}
+
 	size := pair.Child.DataSize()
 	r.docSize.GC.Add(size)
 }
@@ -254,6 +262,12 @@ func (r *Root) Acc(diff resource.DataSize) {
 
 // AdjustDiffForGCPair adjusts the given diff for the given GCPair.
 func (r *Root) AdjustDiffForGCPair(diff *resource.DataSize, pair GCPair) {
+	// NOTE: A born-removed split piece was never in docSize.Live, so there
+	// is nothing to subtract from Live for it.
+	if pair.GCOnlySize != nil {
+		return
+	}
+
 	size := pair.Child.DataSize()
 	diff.Sub(size)
 

--- a/pkg/document/crdt/text.go
+++ b/pkg/document/crdt/text.go
@@ -354,11 +354,11 @@ func (t *Text) Style(
 	// 01. Split nodes with from and to
 	_, toRight, diffTo, err := t.rgaTreeSplit.findNodeWithSplit(to, executedAt)
 	if err != nil {
-		return nil, diff, err
+		return t.rgaTreeSplit.drainPendingGCPairs(), diff, err
 	}
 	_, fromRight, diffFrom, err := t.rgaTreeSplit.findNodeWithSplit(from, executedAt)
 	if err != nil {
-		return nil, diff, err
+		return t.rgaTreeSplit.drainPendingGCPairs(), diff, err
 	}
 
 	diff.Add(diffTo, diffFrom)
@@ -425,11 +425,11 @@ func (t *Text) RemoveStyle(
 	// 01. Split nodes with from and to
 	_, toRight, diffTo, err := t.rgaTreeSplit.findNodeWithSplit(to, executedAt)
 	if err != nil {
-		return nil, diff, err
+		return t.rgaTreeSplit.drainPendingGCPairs(), diff, err
 	}
 	_, fromRight, diffFrom, err := t.rgaTreeSplit.findNodeWithSplit(from, executedAt)
 	if err != nil {
-		return nil, diff, err
+		return t.rgaTreeSplit.drainPendingGCPairs(), diff, err
 	}
 
 	diff.Add(diffTo, diffFrom)

--- a/pkg/document/crdt/text.go
+++ b/pkg/document/crdt/text.go
@@ -358,6 +358,7 @@ func (t *Text) Style(
 	}
 	_, fromRight, diffFrom, err := t.rgaTreeSplit.findNodeWithSplit(from, executedAt)
 	if err != nil {
+		diff.Add(diffTo)
 		return t.rgaTreeSplit.drainPendingGCPairs(), diff, err
 	}
 
@@ -429,6 +430,7 @@ func (t *Text) RemoveStyle(
 	}
 	_, fromRight, diffFrom, err := t.rgaTreeSplit.findNodeWithSplit(from, executedAt)
 	if err != nil {
+		diff.Add(diffTo)
 		return t.rgaTreeSplit.drainPendingGCPairs(), diff, err
 	}
 

--- a/pkg/document/crdt/text.go
+++ b/pkg/document/crdt/text.go
@@ -407,6 +407,8 @@ func (t *Text) Style(
 		}
 	}
 
+	pairs = append(pairs, t.rgaTreeSplit.drainPendingGCPairs()...)
+
 	return pairs, diff, nil
 }
 
@@ -473,6 +475,8 @@ func (t *Text) RemoveStyle(
 			}
 		}
 	}
+
+	pairs = append(pairs, t.rgaTreeSplit.drainPendingGCPairs()...)
 
 	return pairs, diff, nil
 }

--- a/pkg/document/crdt/text_test.go
+++ b/pkg/document/crdt/text_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yorkie-team/yorkie/pkg/document/crdt"
 	"github.com/yorkie-team/yorkie/test/helper"
@@ -87,5 +88,39 @@ func TestText(t *testing.T) {
 			`[{"attrs":{"b":"1"},"val":"H"},{"val":"ello "},{"val":"Yorkie"}]`,
 			text.Marshal(),
 		)
+	})
+
+	t.Run("returns a born-tombstoned split's GC pair even when the other split errors", func(t *testing.T) {
+		root := helper.TestRoot()
+		ctx := helper.TextChangeContext(root)
+		text := crdt.NewText(crdt.NewRGATreeSplit(crdt.InitialTextNode()), ctx.IssueTimeTicket())
+
+		fromPos, toPos, _ := text.CreateRange(0, 0)
+		_, _, _, err := text.Edit(fromPos, toPos, "hello world", nil, ctx.IssueTimeTicket(), nil)
+		assert.NoError(t, err)
+
+		// Tombstone "llo wo" (index 2..8), leaving "he" and "rld" live.
+		fromPos, toPos, _ = text.CreateRange(2, 8)
+		_, _, _, err = text.Edit(fromPos, toPos, "", nil, ctx.IssueTimeTicket(), nil)
+		assert.NoError(t, err)
+
+		var tombstoned *crdt.RGATreeSplitNode[*crdt.TextValue]
+		for _, n := range text.Nodes() {
+			if n.RemovedAt() != nil {
+				tombstoned = n
+				break
+			}
+		}
+		require.NotNil(t, tombstoned)
+
+		// `to` lands inside the already-tombstoned node, so splitting it
+		// buffers a born-dead GC pair for the split-off piece. `from` is a
+		// position that cannot be found, so the second split call fails.
+		toPos = crdt.NewRGATreeSplitNodePos(tombstoned.ID(), 3)
+		fromPos = crdt.NewRGATreeSplitNodePos(crdt.NewRGATreeSplitNodeID(ctx.IssueTimeTicket(), 0), 0)
+
+		_, pairs, _, err := text.Edit(fromPos, toPos, "", nil, ctx.IssueTimeTicket(), nil)
+		assert.Error(t, err)
+		assert.Len(t, pairs, 1, "the pair buffered by splitting `to` must still be returned on the `from` error path")
 	})
 }

--- a/pkg/document/crdt/text_test.go
+++ b/pkg/document/crdt/text_test.go
@@ -123,4 +123,25 @@ func TestText(t *testing.T) {
 		assert.Error(t, err)
 		assert.Len(t, pairs, 1, "the pair buffered by splitting `to` must still be returned on the `from` error path")
 	})
+
+	t.Run("returns the live diff from splitting `to` even when the other split errors", func(t *testing.T) {
+		root := helper.TestRoot()
+		ctx := helper.TextChangeContext(root)
+		text := crdt.NewText(crdt.NewRGATreeSplit(crdt.InitialTextNode()), ctx.IssueTimeTicket())
+
+		fromPos, toPos, _ := text.CreateRange(0, 0)
+		_, _, _, err := text.Edit(fromPos, toPos, "hello world", nil, ctx.IssueTimeTicket(), nil)
+		assert.NoError(t, err)
+
+		// `to` lands in the middle of the live "hello world" node, so
+		// splitting it produces a non-zero metadata diff for the new node
+		// it mutates the list into. `from` is a position that cannot be
+		// found, so the second split call fails.
+		_, toPos, _ = text.CreateRange(3, 3)
+		fromPos = crdt.NewRGATreeSplitNodePos(crdt.NewRGATreeSplitNodeID(ctx.IssueTimeTicket(), 0), 0)
+
+		_, _, diff, err := text.Edit(fromPos, toPos, "", nil, ctx.IssueTimeTicket(), nil)
+		assert.Error(t, err)
+		assert.Positive(t, diff.Meta, "the diff from splitting `to` must still be returned on the `from` error path")
+	})
 }

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -1068,6 +1068,7 @@ func (t *Tree) Edit(
 	}
 	toParent, toLeft, diffTo, err := t.FindTreeNodesWithSplitText(to, editedAt)
 	if err != nil {
+		diff.Add(diffFrom)
 		return t.drainPendingGCPairs(), diff, err
 	}
 
@@ -1112,7 +1113,7 @@ func (t *Tree) Edit(
 		editedAt, versionVector,
 	)
 	if err != nil {
-		return t.drainPendingGCPairs(), resource.DataSize{}, err
+		return t.drainPendingGCPairs(), diff, err
 	}
 
 	// Phase 5: Delete — tombstone the collected nodes.
@@ -1129,7 +1130,7 @@ func (t *Tree) Edit(
 	if err := t.mergeNodes(
 		fromParent, toBeMovedToFromParents, toBeMergedNodes, editedAt,
 	); err != nil {
-		return append(pairs, t.drainPendingGCPairs()...), resource.DataSize{}, err
+		return append(pairs, t.drainPendingGCPairs()...), diff, err
 	}
 
 	// §6.2: Propagate deletes to children moved by prior merges.
@@ -1140,7 +1141,7 @@ func (t *Tree) Edit(
 
 	// Phase 7: Split — split element nodes for the given splitLevel.
 	if err := t.split(fromParent, fromLeft, splitLevel, editedAt, issueTimeTicket, versionVector); err != nil {
-		return append(pairs, t.drainPendingGCPairs()...), resource.DataSize{}, err
+		return append(pairs, t.drainPendingGCPairs()...), diff, err
 	}
 
 	// Phase 8: Insert — insert the given node at the given position.
@@ -1151,12 +1152,12 @@ func (t *Tree) Edit(
 			if leftInChildren == fromParent {
 				err := fromParent.InsertAt(content, 0)
 				if err != nil {
-					return append(pairs, t.drainPendingGCPairs()...), resource.DataSize{}, err
+					return append(pairs, t.drainPendingGCPairs()...), diff, err
 				}
 			} else {
 				err := fromParent.InsertAfter(content, leftInChildren)
 				if err != nil {
-					return append(pairs, t.drainPendingGCPairs()...), resource.DataSize{}, err
+					return append(pairs, t.drainPendingGCPairs()...), diff, err
 				}
 			}
 
@@ -1614,6 +1615,7 @@ func (t *Tree) Style(
 	}
 	toParent, toLeft, diffTo, err := t.FindTreeNodesWithSplitText(to, editedAt)
 	if err != nil {
+		diff.Add(diffFrom)
 		return t.drainPendingGCPairs(), diff, err
 	}
 
@@ -1697,7 +1699,7 @@ func (t *Tree) Style(
 			}
 		}
 	}); err != nil {
-		return append(pairs, t.drainPendingGCPairs()...), resource.DataSize{}, err
+		return append(pairs, t.drainPendingGCPairs()...), diff, err
 	}
 
 	pairs = append(pairs, t.drainPendingGCPairs()...)
@@ -1721,6 +1723,7 @@ func (t *Tree) RemoveStyle(
 	}
 	toParent, toLeft, diffTo, err := t.FindTreeNodesWithSplitText(to, editedAt)
 	if err != nil {
+		diff.Add(diffFrom)
 		return t.drainPendingGCPairs(), diff, err
 	}
 
@@ -1798,7 +1801,7 @@ func (t *Tree) RemoveStyle(
 			}
 		}
 	}); err != nil {
-		return append(pairs, t.drainPendingGCPairs()...), resource.DataSize{}, err
+		return append(pairs, t.drainPendingGCPairs()...), diff, err
 	}
 
 	pairs = append(pairs, t.drainPendingGCPairs()...)

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -350,9 +350,34 @@ func (n *TreeNode) Split(
 		}
 		n.InsNextID = split.id
 		tree.NodeMapByID.Put(split.id, split)
+
+		// NOTE: A piece split off an already-tombstoned node inherits
+		// removedAt without going through remove(), so no GC pair is
+		// created for it in the normal deletion path. Buffer one here so
+		// it can be purged; otherwise it stays in the tree forever. The
+		// piece was never live, so the net-new size the split created goes
+		// straight to docSize.GC when the pair is registered; return a zero
+		// diff to the caller (which accounts diffs to docSize.Live).
+		if split.removedAt != nil {
+			gcSize := diff
+			tree.pendingGCPairs = append(tree.pendingGCPairs, GCPair{
+				Parent:     tree,
+				Child:      split,
+				GCOnlySize: &gcSize,
+			})
+			return resource.DataSize{}, nil
+		}
 	}
 
 	return diff, nil
+}
+
+// drainPendingGCPairs returns the GC pairs buffered for born-tombstoned
+// split pieces and clears the buffer.
+func (t *Tree) drainPendingGCPairs() []GCPair {
+	pairs := t.pendingGCPairs
+	t.pendingGCPairs = nil
+	return pairs
 }
 
 // SplitText splits the text node at the given offset.
@@ -719,6 +744,13 @@ type Tree struct {
 	createdAt *time.Ticket
 	movedAt   *time.Ticket
 	removedAt *time.Ticket
+
+	// pendingGCPairs buffers GC pairs for nodes that were created
+	// already-tombstoned by splitting a removed node. Such pieces inherit
+	// removedAt without ever passing through remove(), so they would
+	// otherwise never be registered for GC. Edit, Style and RemoveStyle
+	// drain this buffer into the GC pairs they return.
+	pendingGCPairs []GCPair
 }
 
 // NewTree creates a new instance of Tree.
@@ -1146,6 +1178,8 @@ func (t *Tree) Edit(
 			})
 		}
 	}
+
+	pairs = append(pairs, t.drainPendingGCPairs()...)
 
 	return pairs, diff, nil
 }
@@ -1666,6 +1700,8 @@ func (t *Tree) Style(
 		return nil, resource.DataSize{}, err
 	}
 
+	pairs = append(pairs, t.drainPendingGCPairs()...)
+
 	return pairs, diff, nil
 }
 
@@ -1764,6 +1800,8 @@ func (t *Tree) RemoveStyle(
 	}); err != nil {
 		return nil, resource.DataSize{}, err
 	}
+
+	pairs = append(pairs, t.drainPendingGCPairs()...)
 
 	return pairs, diff, nil
 }

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -1059,15 +1059,16 @@ func (t *Tree) Edit(
 	versionVector time.VersionVector,
 ) ([]GCPair, resource.DataSize, error) {
 	var diff resource.DataSize
+	var pairs []GCPair
 
 	// Phase 1: Position Resolution — resolve CRDTTreePos to tree nodes.
 	fromParent, fromLeft, diffFrom, err := t.FindTreeNodesWithSplitText(from, editedAt)
 	if err != nil {
-		return nil, diff, err
+		return t.drainPendingGCPairs(), diff, err
 	}
 	toParent, toLeft, diffTo, err := t.FindTreeNodesWithSplitText(to, editedAt)
 	if err != nil {
-		return nil, diff, err
+		return t.drainPendingGCPairs(), diff, err
 	}
 
 	diff.Add(diffFrom, diffTo)
@@ -1111,11 +1112,10 @@ func (t *Tree) Edit(
 		editedAt, versionVector,
 	)
 	if err != nil {
-		return nil, resource.DataSize{}, err
+		return t.drainPendingGCPairs(), resource.DataSize{}, err
 	}
 
 	// Phase 5: Delete — tombstone the collected nodes.
-	var pairs []GCPair
 	for _, node := range toBeRemoveds {
 		if node.remove(editedAt) {
 			pairs = append(pairs, GCPair{
@@ -1129,7 +1129,7 @@ func (t *Tree) Edit(
 	if err := t.mergeNodes(
 		fromParent, toBeMovedToFromParents, toBeMergedNodes, editedAt,
 	); err != nil {
-		return nil, resource.DataSize{}, err
+		return append(pairs, t.drainPendingGCPairs()...), resource.DataSize{}, err
 	}
 
 	// §6.2: Propagate deletes to children moved by prior merges.
@@ -1140,7 +1140,7 @@ func (t *Tree) Edit(
 
 	// Phase 7: Split — split element nodes for the given splitLevel.
 	if err := t.split(fromParent, fromLeft, splitLevel, editedAt, issueTimeTicket, versionVector); err != nil {
-		return nil, resource.DataSize{}, err
+		return append(pairs, t.drainPendingGCPairs()...), resource.DataSize{}, err
 	}
 
 	// Phase 8: Insert — insert the given node at the given position.
@@ -1151,12 +1151,12 @@ func (t *Tree) Edit(
 			if leftInChildren == fromParent {
 				err := fromParent.InsertAt(content, 0)
 				if err != nil {
-					return nil, resource.DataSize{}, err
+					return append(pairs, t.drainPendingGCPairs()...), resource.DataSize{}, err
 				}
 			} else {
 				err := fromParent.InsertAfter(content, leftInChildren)
 				if err != nil {
-					return nil, resource.DataSize{}, err
+					return append(pairs, t.drainPendingGCPairs()...), resource.DataSize{}, err
 				}
 			}
 
@@ -1610,11 +1610,11 @@ func (t *Tree) Style(
 
 	fromParent, fromLeft, diffFrom, err := t.FindTreeNodesWithSplitText(from, editedAt)
 	if err != nil {
-		return nil, diff, err
+		return t.drainPendingGCPairs(), diff, err
 	}
 	toParent, toLeft, diffTo, err := t.FindTreeNodesWithSplitText(to, editedAt)
 	if err != nil {
-		return nil, diff, err
+		return t.drainPendingGCPairs(), diff, err
 	}
 
 	diff.Add(diffFrom, diffTo)
@@ -1697,7 +1697,7 @@ func (t *Tree) Style(
 			}
 		}
 	}); err != nil {
-		return nil, resource.DataSize{}, err
+		return append(pairs, t.drainPendingGCPairs()...), resource.DataSize{}, err
 	}
 
 	pairs = append(pairs, t.drainPendingGCPairs()...)
@@ -1717,11 +1717,11 @@ func (t *Tree) RemoveStyle(
 
 	fromParent, fromLeft, diffFrom, err := t.FindTreeNodesWithSplitText(from, editedAt)
 	if err != nil {
-		return nil, diff, err
+		return t.drainPendingGCPairs(), diff, err
 	}
 	toParent, toLeft, diffTo, err := t.FindTreeNodesWithSplitText(to, editedAt)
 	if err != nil {
-		return nil, diff, err
+		return t.drainPendingGCPairs(), diff, err
 	}
 
 	diff.Add(diffFrom, diffTo)
@@ -1798,7 +1798,7 @@ func (t *Tree) RemoveStyle(
 			}
 		}
 	}); err != nil {
-		return nil, resource.DataSize{}, err
+		return append(pairs, t.drainPendingGCPairs()...), resource.DataSize{}, err
 	}
 
 	pairs = append(pairs, t.drainPendingGCPairs()...)

--- a/pkg/document/gc_split_leak_test.go
+++ b/pkg/document/gc_split_leak_test.go
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2025 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package document_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yorkie-team/yorkie/pkg/document"
+	"github.com/yorkie-team/yorkie/pkg/document/change"
+	"github.com/yorkie-team/yorkie/pkg/document/json"
+	"github.com/yorkie-team/yorkie/pkg/document/presence"
+	"github.com/yorkie-team/yorkie/pkg/document/resource"
+	"github.com/yorkie-team/yorkie/pkg/document/time"
+	"github.com/yorkie-team/yorkie/test/helper"
+)
+
+// crossSync exchanges pending local changes between two in-process documents,
+// mimicking a server round-trip without serialization. Delivery uses a neutral
+// checkpoint (clientSeq 0) so the receiver's own pending local changes are not
+// dropped, and an empty version vector so GC stays out of the exchange (GC is
+// asserted separately below). Each sender then self-acks exactly the delivered
+// changes so the next crossSync does not re-send them.
+func crossSync(t *testing.T, d1, d2 *document.Document) {
+	p1 := d1.CreateChangePack()
+	p2 := d2.CreateChangePack()
+
+	require.NoError(t, d2.ApplyChangePack(change.NewPack(
+		p1.DocumentKey, change.NewCheckpoint(0, 0), p1.Changes, time.InitialVersionVector, nil,
+	)))
+	require.NoError(t, d1.ApplyChangePack(change.NewPack(
+		p2.DocumentKey, change.NewCheckpoint(0, 0), p2.Changes, time.InitialVersionVector, nil,
+	)))
+
+	ack := func(p *change.Pack) *change.Pack {
+		var lastSeq uint32
+		if len(p.Changes) > 0 {
+			lastSeq = p.Changes[len(p.Changes)-1].ClientSeq()
+		}
+		return change.NewPack(
+			p.DocumentKey, change.NewCheckpoint(0, lastSeq), nil, time.InitialVersionVector, nil,
+		)
+	}
+	require.NoError(t, d1.ApplyChangePack(ack(p1)))
+	require.NoError(t, d2.ApplyChangePack(ack(p2)))
+}
+
+func newReplicas(t *testing.T) (*document.Document, *document.Document, time.ActorID, time.ActorID) {
+	a1, err := time.ActorIDFromHex("000000000000000000000001")
+	require.NoError(t, err)
+	a2, err := time.ActorIDFromHex("000000000000000000000002")
+	require.NoError(t, err)
+
+	d1 := document.New("test-doc")
+	d2 := document.New("test-doc")
+	d1.SetActor(a1)
+	d2.SetActor(a2)
+	return d1, d2, a1, a2
+}
+
+// TestTreeTombstoneSplitGC reproduces a GC leak where pieces split off an
+// already-tombstoned tree node inherit removedAt without passing through
+// remove(), so they never register a GC pair and can never be purged.
+func TestTreeTombstoneSplitGC(t *testing.T) {
+	t.Run("purges the same nodes on both replicas when a tombstone is split remotely", func(t *testing.T) {
+		d1, d2, a1, a2 := newReplicas(t)
+
+		require.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewTree("t", json.TreeNode{
+				Type: "doc",
+				Children: []json.TreeNode{{
+					Type:     "p",
+					Children: []json.TreeNode{{Type: "text", Value: "hello"}},
+				}},
+			})
+			return nil
+		}))
+		crossSync(t, d1, d2)
+
+		// Concurrent: d1 deletes "el" (splits the text live, at d1);
+		// d2 deletes the whole <p> (tombstones it unsplit, at d2).
+		// When d1's delete arrives at d2, it must split d2's tombstone,
+		// creating born-dead pieces that never get GC pairs.
+		require.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetTree("t").Edit(2, 4, nil, 0)
+			return nil
+		}))
+		require.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetTree("t").Edit(0, 7, nil, 0)
+			return nil
+		}))
+		crossSync(t, d1, d2)
+
+		assert.Equal(t, "<doc></doc>", d1.Root().GetTree("t").ToXML())
+		assert.Equal(t, d1.Root().GetTree("t").ToXML(), d2.Root().GetTree("t").ToXML())
+
+		// Same full vector, same logical tombstones -> purge counts must match.
+		// Before the fix the replica whose tombstone was split leaked the
+		// born-dead pieces and purged fewer nodes than its peer.
+		purged1 := d1.GarbageCollect(helper.MaxVersionVector(a1, a2))
+		purged2 := d2.GarbageCollect(helper.MaxVersionVector(a1, a2))
+		assert.Equal(t, purged1, purged2, "asymmetric purge: d1=%d d2=%d", purged1, purged2)
+
+		assert.Equal(t, 0, d1.GarbageLen())
+		assert.Equal(t, 0, d2.GarbageLen())
+
+		// docSize must stay symmetric and gc must drain to zero on both.
+		assert.Equal(t, d1.DocSize(), d2.DocSize())
+		assert.Equal(t, resource.DataSize{}, d1.DocSize().GC)
+	})
+}
+
+// TestTextTombstoneSplitGC reproduces the same class of leak in the Text CRDT:
+// RGATreeSplitNode.split() copies removedAt into the new piece, so pieces split
+// off an already-tombstoned text node are born removed and miss GC registration.
+func TestTextTombstoneSplitGC(t *testing.T) {
+	t.Run("purges pieces split off a tombstoned text node", func(t *testing.T) {
+		d1, d2, a1, a2 := newReplicas(t)
+
+		require.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.SetNewText("k").Edit(0, 0, "abcdef")
+			return nil
+		}))
+		crossSync(t, d1, d2)
+
+		// d1 tombstones the whole node; d2 concurrently deletes a middle slice.
+		// When d2's delete arrives at d1, it splits d1's tombstone; the piece
+		// after the deleted range is born dead and used to get no GC pair.
+		require.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("k").Edit(0, 6, "")
+			return nil
+		}))
+		require.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+			root.GetText("k").Edit(2, 4, "")
+			return nil
+		}))
+		crossSync(t, d1, d2)
+
+		assert.Equal(t, "", d1.Root().GetText("k").String())
+		assert.Equal(t, "", d2.Root().GetText("k").String())
+
+		purged1 := d1.GarbageCollect(helper.MaxVersionVector(a1, a2))
+		purged2 := d2.GarbageCollect(helper.MaxVersionVector(a1, a2))
+		assert.Equal(t, purged1, purged2, "asymmetric purge: d1=%d d2=%d", purged1, purged2)
+
+		assert.Equal(t, 0, d1.GarbageLen())
+		assert.Equal(t, 0, d2.GarbageLen())
+
+		assert.Equal(t, d1.DocSize(), d2.DocSize())
+		assert.Equal(t, resource.DataSize{}, d1.DocSize().GC)
+	})
+}

--- a/pkg/document/operations/edit.go
+++ b/pkg/document/operations/edit.go
@@ -70,13 +70,12 @@ func (e *Edit) Execute(root *crdt.Root, versionVector time.VersionVector) error 
 	switch obj := parent.(type) {
 	case *crdt.Text:
 		_, pairs, diff, err := obj.Edit(e.from, e.to, e.content, e.attributes, e.executedAt, versionVector)
-		if err != nil {
-			return err
-		}
-
 		for _, pair := range pairs {
 			root.RegisterGCPair(pair)
 			root.AdjustDiffForGCPair(&diff, pair)
+		}
+		if err != nil {
+			return err
 		}
 
 		root.Acc(diff)

--- a/pkg/document/operations/edit.go
+++ b/pkg/document/operations/edit.go
@@ -74,11 +74,10 @@ func (e *Edit) Execute(root *crdt.Root, versionVector time.VersionVector) error 
 			root.RegisterGCPair(pair)
 			root.AdjustDiffForGCPair(&diff, pair)
 		}
+		root.Acc(diff)
 		if err != nil {
 			return err
 		}
-
-		root.Acc(diff)
 
 	default:
 		return ErrNotApplicableDataType

--- a/pkg/document/operations/style.go
+++ b/pkg/document/operations/style.go
@@ -100,11 +100,10 @@ func (e *Style) Execute(root *crdt.Root, versionVector time.VersionVector) error
 		root.RegisterGCPair(pair)
 		root.AdjustDiffForGCPair(&diff, pair)
 	}
+	root.Acc(diff)
 	if err != nil {
 		return err
 	}
-
-	root.Acc(diff)
 
 	return nil
 }

--- a/pkg/document/operations/style.go
+++ b/pkg/document/operations/style.go
@@ -92,19 +92,16 @@ func (e *Style) Execute(root *crdt.Root, versionVector time.VersionVector) error
 	var err error
 	if len(e.attributesToRemove) > 0 {
 		pairs, diff, err = obj.RemoveStyle(e.from, e.to, e.attributesToRemove, e.executedAt, versionVector)
-		if err != nil {
-			return err
-		}
 	} else {
 		pairs, diff, err = obj.Style(e.from, e.to, e.attributes, e.executedAt, versionVector)
-		if err != nil {
-			return err
-		}
 	}
 
 	for _, pair := range pairs {
 		root.RegisterGCPair(pair)
 		root.AdjustDiffForGCPair(&diff, pair)
+	}
+	if err != nil {
+		return err
 	}
 
 	root.Acc(diff)

--- a/pkg/document/operations/tree_edit.go
+++ b/pkg/document/operations/tree_edit.go
@@ -116,11 +116,10 @@ func (e *TreeEdit) Execute(root *crdt.Root, versionVector time.VersionVector) er
 			root.RegisterGCPair(pair)
 			root.AdjustDiffForGCPair(&diff, pair)
 		}
+		root.Acc(diff)
 		if err != nil {
 			return err
 		}
-
-		root.Acc(diff)
 
 	default:
 		return ErrNotApplicableDataType

--- a/pkg/document/operations/tree_edit.go
+++ b/pkg/document/operations/tree_edit.go
@@ -112,13 +112,12 @@ func (e *TreeEdit) Execute(root *crdt.Root, versionVector time.VersionVector) er
 			}(),
 			versionVector,
 		)
-		if err != nil {
-			return err
-		}
-
 		for _, pair := range pairs {
 			root.RegisterGCPair(pair)
 			root.AdjustDiffForGCPair(&diff, pair)
+		}
+		if err != nil {
+			return err
 		}
 
 		root.Acc(diff)

--- a/pkg/document/operations/tree_style.go
+++ b/pkg/document/operations/tree_style.go
@@ -100,11 +100,10 @@ func (e *TreeStyle) Execute(root *crdt.Root, versionVector time.VersionVector) e
 		root.RegisterGCPair(pair)
 		root.AdjustDiffForGCPair(&diff, pair)
 	}
+	root.Acc(diff)
 	if err != nil {
 		return err
 	}
-
-	root.Acc(diff)
 
 	return nil
 }

--- a/pkg/document/operations/tree_style.go
+++ b/pkg/document/operations/tree_style.go
@@ -92,19 +92,16 @@ func (e *TreeStyle) Execute(root *crdt.Root, versionVector time.VersionVector) e
 	var err error
 	if len(e.attributes) > 0 {
 		pairs, diff, err = obj.Style(e.from, e.to, e.attributes, e.executedAt, versionVector)
-		if err != nil {
-			return err
-		}
 	} else {
 		pairs, diff, err = obj.RemoveStyle(e.from, e.to, e.attributesToRemove, e.executedAt, versionVector)
-		if err != nil {
-			return err
-		}
 	}
 
 	for _, pair := range pairs {
 		root.RegisterGCPair(pair)
 		root.AdjustDiffForGCPair(&diff, pair)
+	}
+	if err != nil {
+		return err
 	}
 
 	root.Acc(diff)


### PR DESCRIPTION
#### What this PR does / why we need it?

Fixes a garbage-collection leak around **tombstone splits**, the Go-server counterpart of the same fix in yorkie-js-sdk.

When a node is split, the new piece is cloned from the original — including `removedAt` (`SplitText`/`SplitElement` and `RGATreeSplitNode.split` all copy it). So a piece split off an already-tombstoned node is *born dead* without ever passing through `remove()`. GC pairs are only created on the live→dead transition, so no pair is ever registered for these pieces: they linger in the tree / RGA list forever, invisible to `GarbageLen()`, and a replica that splits a tombstone purges asymmetrically from one that split the node while it was still live.

The fix buffers a GC pair on the `Tree` / `RGATreeSplit` whenever a split produces a born-removed piece, and drains the buffer into the pairs returned by `Edit`/`Style`/`RemoveStyle` so operations register them with the root as usual. Covers both text and element splits (shared split path).

It also accounts `docSize` correctly. `RegisterGCPair` normally moves a child's size `Live`→`GC`, but a born-dead piece was never in `Live`, so the usual move drives `docSize.Live` negative and leaves `GC` residue after a full GC (measured: the split replica ended `Live.Data -8`, `GC.Data 8` vs `0/0` on its peer). `GCPair` gains an optional `GCOnlySize` holding the net-new size the split created; when set, `RegisterGCPair` adds it to `GC` and `AdjustDiffForGCPair` leaves `Live` untouched. Across the split's original node and its born-dead pieces the GC contributions telescope back to zero.

Unlike the JS SDK, Go already handles two related cases: `Tree.GCPairs` traverses tombstones (so the snapshot-load path was fine), and `RGATreeSplitNode.Remove` returns `false` on an LWW tombstone overwrite (so there is no toggle-unregistration bug). Those parts of the JS fix are not needed here.

#### Which issue(s) this PR fixes?

Fixes #1873


#### Does this PR introduce a user-facing change?

```release-note
Fix a garbage-collection leak where pieces split off a tombstoned Tree or Text node were never purged.
```

### Checklist
- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed garbage-collection accounting for split pieces that were already tombstoned, including correct GC-only sizing and diff handling.
  * Ensured pending GC pairs are drained and propagated consistently for tree/text styling and split flows, including when operations return errors.
  * Reordered edit/style/remove-style execution so GC pair registration and diff application occur before error propagation.
* **Tests**
  * Added regression tests for concurrent tombstone + split GC behavior with replica synchronization (tree and text), verifying convergence and empty garbage state.
  * Added text edit error-path tests to confirm GC pairs are still returned and metadata diffs are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->