### PR TITLE
docs: add note about adding GOPATH/bin to PATH after make tools

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,13 @@ make tools
 make build		# executable: ./bin/yorkie
 ```
 
+> [!NOTE]
+> `make tools` installs binaries into `$(go env GOPATH)/bin`. Make sure that directory is in your `PATH` so the installed tools (e.g. `golangci-lint`) are accessible:
+> ```sh
+> export PATH=$PATH:$(go env GOPATH)/bin
+> # Add this line to your shell rc file (~/.zshrc, ~/.bashrc, etc.) to make it permanent.
+> ```
+
 You can set testing environment via Docker Compose. It is needed because integration tests require local applications like MongoDB.
 
 ```sh


### PR DESCRIPTION
**What this PR does / why we need it**:

New contributors following `CONTRIBUTING.md` step-by-step encounter a confusing failure when running `make lint` right after `make tools`:

```sh
$ make lint
golangci-lint run --timeout 2m ./...
make: golangci-lint: No such file or directory
make: *** [lint] Error 1
```

`make tools` installs binaries via `go install` into `$(go env GOPATH)/bin`, but that directory is not always in `PATH`. This PR adds a NOTE callout after the `make tools` code block to explain the prerequisite.

**Which issue(s) this PR fixes**:

Fixes #1876

**Special notes for your reviewer**:

Documentation-only change. No code is modified.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation**:

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added setup guidance explaining where development tools are installed.
  * Included instructions for adding the tools directory to the system `PATH`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->