### PR TITLE
Set updated_at on project creation

### DIFF
--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -544,6 +544,7 @@ func (c *Client) CreateProjectInfo(
 		"public_key":                      info.PublicKey,
 		"secret_key":                      info.SecretKey,
 		"created_at":                      info.CreatedAt,
+		"updated_at":                      info.UpdatedAt,
 	})
 	if err != nil {
 		if mongo.IsDuplicateKeyError(err) {

--- a/server/backend/database/project_info.go
+++ b/server/backend/database/project_info.go
@@ -165,6 +165,7 @@ type ProjectInfo struct {
 
 // NewProjectInfo creates a new ProjectInfo of the given name.
 func NewProjectInfo(name string, owner types.ID) *ProjectInfo {
+	now := time.Now()
 	return &ProjectInfo{
 		Name:                        name,
 		Owner:                       owner,
@@ -187,7 +188,8 @@ func NewProjectInfo(name string, owner types.ID) *ProjectInfo {
 		AutoRevisionEnabled:         true,
 		PublicKey:                   shortuuid.New(),
 		SecretKey:                   shortuuid.New(),
-		CreatedAt:                   time.Now(),
+		CreatedAt:                   now,
+		UpdatedAt:                   now,
 	}
 }
 

--- a/server/backend/database/testcases/testcases.go
+++ b/server/backend/database/testcases/testcases.go
@@ -1289,6 +1289,12 @@ func RunUpdateProjectInfoTest(t *testing.T, db database.Database) {
 		assert.Equal(t, database.DefaultChannelSessionTTL.String(), info.ChannelSessionTTL)
 		assert.Equal(t, database.DefaultSnapshotThreshold, info.SnapshotThreshold)
 		assert.Equal(t, database.DefaultSnapshotInterval, info.SnapshotInterval)
+		assert.False(t, info.UpdatedAt.IsZero())
+		assert.Equal(t, info.CreatedAt, info.UpdatedAt)
+
+		createdInfo, err := db.FindProjectInfoByID(ctx, info.ID)
+		assert.NoError(t, err)
+		assert.False(t, createdInfo.UpdatedAt.IsZero())
 		_, err = db.CreateProjectInfo(ctx, existName, dummyOwnerID)
 		assert.NoError(t, err)
 

--- a/server/backend/database/testcases/testcases.go
+++ b/server/backend/database/testcases/testcases.go
@@ -1294,7 +1294,7 @@ func RunUpdateProjectInfoTest(t *testing.T, db database.Database) {
 
 		createdInfo, err := db.FindProjectInfoByID(ctx, info.ID)
 		assert.NoError(t, err)
-		assert.False(t, createdInfo.UpdatedAt.IsZero())
+		assert.Equal(t, createdInfo.CreatedAt, createdInfo.UpdatedAt)
 		_, err = db.CreateProjectInfo(ctx, existName, dummyOwnerID)
 		assert.NoError(t, err)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When a project is created, `updated_at` was never initialized and stayed at the Go zero value (`0001-01-01T00:00:00Z`) until the project was first updated via `UpdateProjectInfo`. Admin API responses exposed this bogus timestamp for freshly created projects.

There were two separate causes:

1. `NewProjectInfo` (`server/backend/database/project_info.go`) only set `CreatedAt`.
2. The MongoDB insert in `CreateProjectInfo` (`server/backend/database/mongo/client.go`) omitted the `updated_at` key entirely, so the field was never persisted even if the constructor set it.

This PR initializes `CreatedAt` and `UpdatedAt` from the same timestamp so they are equal on creation (matching the existing doc-info convention), and adds the missing `updated_at` key to the MongoDB insert document.

**Which issue(s) this PR fixes**:

Fixes #1848

**Special notes for your reviewer**:

- The memory backend stores the whole struct, so it only needs the constructor fix; MongoDB needs the additional insert key.
- The shared test suite (`RunUpdateProjectInfoTest`) now asserts `UpdatedAt` is non-zero right after creation, **including after re-fetching via `FindProjectInfoByID`** — the re-fetch assertion is what actually catches the missing MongoDB key. I verified it fails when the MongoDB insert fix is reverted.
- No migration is needed: existing rows keep their current value until the next update, same as before.

**Does this PR introduce a user-facing change?**:

```release-note
Set updated_at when a project is created
```

**Additional documentation**:

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Project records now reliably include an update timestamp when they’re first created.
  * Newly created projects set both creation and update timestamps to the same initial value.
  * Saved records preserve consistent timestamp values after reloading.
* **Tests**
  * Expanded update-project timestamp assertions to verify values are present and persist correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
