### PR TITLE
Gate MongoDB-dependent tests behind the integration build tag

### DIFF
--- a/server/authz/authorization_test.go
+++ b/server/authz/authorization_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 /*
  * Copyright 2026 The Yorkie Authors. All rights reserved.
  *

--- a/server/backend/database/mongo/client_test.go
+++ b/server/backend/database/mongo/client_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 /*
  * Copyright 2021 The Yorkie Authors. All rights reserved.
  *

--- a/server/packs/pushpull_test.go
+++ b/server/packs/pushpull_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 /*
  * Copyright 2024 The Yorkie Authors. All rights reserved.
  *

--- a/server/rpc/server_test.go
+++ b/server/rpc/server_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 /*
  * Copyright 2021 The Yorkie Authors. All rights reserved.
  *

--- a/test/integration/clusternodes_test.go
+++ b/test/integration/clusternodes_test.go
@@ -1,4 +1,4 @@
-package integration
+//go:build integration
 
 /*
  * Copyright 2025 The Yorkie Authors. All rights reserved.
@@ -15,6 +15,8 @@ package integration
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package integration
 
 import (
 	"context"

--- a/test/integration/project_cache_test.go
+++ b/test/integration/project_cache_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 /*
  * Copyright 2025 The Yorkie Authors. All rights reserved.
  *


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Adds the missing `//go:build integration` constraint to six test files that
dial a real MongoDB (`mongodb://localhost:27017`) but had no build tag:

- `server/backend/database/mongo/client_test.go`
- `server/authz/authorization_test.go`
- `server/packs/pushpull_test.go`
- `server/rpc/server_test.go`
- `test/integration/clusternodes_test.go`
- `test/integration/project_cache_test.go`

Without the tag, these files always compiled and ran, so plain
`go test ./...` (documented as DB-free in `CONTRIBUTING.md`'s Unit vs.
Integration testing section) failed whenever no local MongoDB was
reachable. This brings them in line with the rest of the integration
suite (e.g. `test/integration/counter_test.go`), which is only compiled
via `make test` (`-tags integration`).

No behavior change for `make test` / `make coverage`, which already pass
`-tags integration` and therefore already compiled and ran these files.

**Which issue(s) this PR fixes**:

Fixes #1877

**Special notes for your reviewer**:

Verified `go build ./...`, `go vet ./...`, and `go vet -tags integration ./...`
all succeed, and ran both suites end-to-end:
- `go test ./...` with MongoDB stopped: all packages pass, no DB dial attempts.
- `go test -tags integration -race ./...` with MongoDB up (via
  `docker compose -f build/docker/docker-compose.yml up -d`): all packages
  pass, including the six touched files.

Also had to reorder the `package integration` clause in
`clusternodes_test.go` (it previously sat before the license header),
since a `//go:build` line must precede the package clause.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation**:

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Integration tests are now run only when explicitly enabled with the `integration` build tag.
  * Standard test runs are less likely to include tests requiring external services or environments.
  * No test behavior or assertions were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->