### PR TITLE
Adopt testing/synctest for deterministic timing tests

### DIFF
--- a/.github/workflows/base-docker-publish.yml
+++ b/.github/workflows/base-docker-publish.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go 1.25
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: 1.25
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: Set up Go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -116,7 +116,7 @@ jobs:
 
     steps:
       - name: Set up Go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -326,7 +326,7 @@ jobs:
 
     steps:
       - name: Set up Go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -369,7 +369,7 @@ jobs:
 
     steps:
       - name: Set up Go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,8 @@ There are multiple types of tests. The location of the test code varies with typ
 - Integration: These tests cover interactions of package components or interactions between Yorkie packages and some other non-Yorkie system resource (eg: MongoDB).
 - Benchmark: These confirm that the performance of the implemented function.
 
+When a unit test needs to observe a timer, ticker, debounce window, or backoff, use a [`testing/synctest`](https://pkg.go.dev/testing/synctest) bubble (`synctest.Test`) instead of sleeping real wall-clock time. Inside the bubble, `time.Sleep` advances a fake clock instantly and `synctest.Wait` deterministically replaces "sleep a little to let goroutines catch up", which keeps tests fast and free of load-dependent flakes. See `pkg/limit/limiter_test.go` for examples.
+
 ### Code Coverage
 
 We are using [Codecov](https://about.codecov.io) for analyzing PR's code coverage. If you want to check the coverage of your code in local browser, you can run the command below.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Thanks for contributing!
 
 Below are needed for developing and building Yorkie.
 
-- [Go](https://golang.org) (version 1.18+)
+- [Go](https://golang.org) (version 1.25+)
 - [Protobuf Compiler](https://github.com/protocolbuffers/protobuf/releases) (version 3.4.0+)
 - [Docker](https://www.docker.com/)
 

--- a/pkg/limit/limiter_test.go
+++ b/pkg/limit/limiter_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -63,173 +64,182 @@ func TestThrottlerBehavior(t *testing.T) {
 		expireInterval  = 10 * time.Millisecond
 		throttleWindow  = 100 * time.Millisecond
 		debouncingTime  = 100 * time.Millisecond
-		executeTime     = 5 * time.Millisecond
-		waitingTime     = expireInterval + throttleWindow + debouncingTime + executeTime
+		waitingTime     = expireInterval + throttleWindow + debouncingTime
 	)
 
 	// Test case: "e1" -> e1 occurs
 	t.Run("e1", func(t *testing.T) {
-		lim := limit.NewLimiter[string](expireBatchSize, expireInterval, throttleWindow, debouncingTime)
-		o := &occurs{}
+		synctest.Test(t, func(t *testing.T) {
+			lim := limit.NewLimiter[string](expireBatchSize, expireInterval, throttleWindow, debouncingTime)
+			o := &occurs{}
 
-		e1 := func() { o.add(1) }
-		if lim.Allow("key", e1) {
-			e1()
-		}
-		// Immediately after execution, the callback should have been invoked.
-		assert.Equal(t, 1, o.get(0))
-		// After waiting, no additional invocation should occur.
-		time.Sleep(waitingTime)
-		assert.Equal(t, 1, o.len())
-		lim.Close()
+			e1 := func() { o.add(1) }
+			if lim.Allow("key", e1) {
+				e1()
+			}
+			// Immediately after execution, the callback should have been invoked.
+			assert.Equal(t, 1, o.get(0))
+			// After waiting, no additional invocation should occur.
+			time.Sleep(waitingTime)
+			assert.Equal(t, 1, o.len())
+			lim.Close()
+		})
 	})
 
 	// Test case: "e1 e2" -> e1 then e2 occurs
 	t.Run("e1 e2", func(t *testing.T) {
-		lim := limit.NewLimiter[string](expireBatchSize, expireInterval, throttleWindow, debouncingTime)
-		o := &occurs{}
+		synctest.Test(t, func(t *testing.T) {
+			lim := limit.NewLimiter[string](expireBatchSize, expireInterval, throttleWindow, debouncingTime)
+			o := &occurs{}
 
-		e1 := func() { o.add(1) }
-		if lim.Allow("key", e1) {
-			e1()
-		}
-		// First callback is executed directly.
-		assert.Equal(t, 1, o.get(0))
+			e1 := func() { o.add(1) }
+			if lim.Allow("key", e1) {
+				e1()
+			}
+			// First callback is executed directly.
+			assert.Equal(t, 1, o.get(0))
 
-		e2 := func() { o.add(2) }
-		if lim.Allow("key", e2) {
-			e2()
-		}
+			e2 := func() { o.add(2) }
+			if lim.Allow("key", e2) {
+				e2()
+			}
 
-		// At this point, only the immediate callback should have occurred.
-		assert.Equal(t, 1, o.len())
-		time.Sleep(waitingTime)
+			// At this point, only the immediate callback should have occurred.
+			assert.Equal(t, 1, o.len())
+			time.Sleep(waitingTime)
 
-		// After waiting, the deferred callback should be executed.
-		assert.Equal(t, 2, o.len())
-		assert.Equal(t, 2, o.get(1))
-		lim.Close()
+			// After waiting, the deferred callback should be executed.
+			assert.Equal(t, 2, o.len())
+			assert.Equal(t, 2, o.get(1))
+			lim.Close()
+		})
 	})
 
 	// Test case: "e1 e2 e3" -> e1 immediately and e3 deferred
 	t.Run("e1 e2 e3", func(t *testing.T) {
-		lim := limit.NewLimiter[string](expireBatchSize, expireInterval, throttleWindow, debouncingTime)
-		o := &occurs{}
+		synctest.Test(t, func(t *testing.T) {
+			lim := limit.NewLimiter[string](expireBatchSize, expireInterval, throttleWindow, debouncingTime)
+			o := &occurs{}
 
-		e1 := func() { o.add(1) }
-		if lim.Allow("key", e1) {
-			e1()
-		}
-		// First callback is executed immediately.
-		assert.Equal(t, 1, o.get(0))
+			e1 := func() { o.add(1) }
+			if lim.Allow("key", e1) {
+				e1()
+			}
+			// First callback is executed immediately.
+			assert.Equal(t, 1, o.get(0))
 
-		e2 := func() { o.add(2) }
-		if lim.Allow("key", e2) {
-			e2()
-		}
-		e3 := func() { o.add(3) }
-		if lim.Allow("key", e3) {
-			e3()
-		}
+			e2 := func() { o.add(2) }
+			if lim.Allow("key", e2) {
+				e2()
+			}
+			e3 := func() { o.add(3) }
+			if lim.Allow("key", e3) {
+				e3()
+			}
 
-		// Only the immediate callback should have been executed so far.
-		assert.Equal(t, 1, o.len())
-		time.Sleep(waitingTime)
+			// Only the immediate callback should have been executed so far.
+			assert.Equal(t, 1, o.len())
+			time.Sleep(waitingTime)
 
-		// After waiting, the latest callback (e3) is executed.
-		assert.Equal(t, 2, o.len())
-		assert.Equal(t, 3, o.get(1))
-		lim.Close()
+			// After waiting, the latest callback (e3) is executed.
+			assert.Equal(t, 2, o.len())
+			assert.Equal(t, 3, o.get(1))
+			lim.Close()
+		})
 	})
 
 	// Test case: "/ e1 e2 e3 / e4" -> e1 immediately then e4 immediately when allowed
 	t.Run("/ e1 e2 e3 / e4", func(t *testing.T) {
-		lim := limit.NewLimiter[string](expireBatchSize, expireInterval, throttleWindow, debouncingTime)
-		o := &occurs{}
+		synctest.Test(t, func(t *testing.T) {
+			lim := limit.NewLimiter[string](expireBatchSize, expireInterval, throttleWindow, debouncingTime)
+			o := &occurs{}
 
-		e1 := func() { o.add(1) }
-		if lim.Allow("key", e1) {
-			e1()
-		}
-		// Immediate execution for the first callback.
-		assert.Equal(t, 1, o.get(0))
+			e1 := func() { o.add(1) }
+			if lim.Allow("key", e1) {
+				e1()
+			}
+			// Immediate execution for the first callback.
+			assert.Equal(t, 1, o.get(0))
 
-		e2 := func() { o.add(2) }
-		if lim.Allow("key", e2) {
-			e2()
-		}
-		e3 := func() { o.add(3) }
-		if lim.Allow("key", e3) {
-			e3()
-		}
+			e2 := func() { o.add(2) }
+			if lim.Allow("key", e2) {
+				e2()
+			}
+			e3 := func() { o.add(3) }
+			if lim.Allow("key", e3) {
+				e3()
+			}
 
-		// Still, only the immediate callback should have been executed.
-		assert.Equal(t, 1, o.len())
+			// Still, only the immediate callback should have been executed.
+			assert.Equal(t, 1, o.len())
 
-		// Wait for part of the throttle window; deferred callbacks are not yet flushed.
-		time.Sleep(throttleWindow + debouncingTime/2)
-		assert.Equal(t, 1, o.len())
+			// Wait for part of the throttle window; deferred callbacks are not yet flushed.
+			time.Sleep(throttleWindow + debouncingTime/2)
+			assert.Equal(t, 1, o.len())
 
-		e4 := func() { o.add(4) }
-		if lim.Allow("key", e4) {
-			e4()
-		}
+			e4 := func() { o.add(4) }
+			if lim.Allow("key", e4) {
+				e4()
+			}
 
-		// The new callback should now be executed immediately.
-		assert.Equal(t, 2, o.len())
-		assert.Equal(t, 4, o.get(1))
-		time.Sleep(waitingTime)
-		// No further callbacks should be executed after waiting.
-		assert.Equal(t, 2, o.len())
-		lim.Close()
+			// The new callback should now be executed immediately.
+			assert.Equal(t, 2, o.len())
+			assert.Equal(t, 4, o.get(1))
+			time.Sleep(waitingTime)
+			// No further callbacks should be executed after waiting.
+			assert.Equal(t, 2, o.len())
+			lim.Close()
+		})
 	})
 
 	// Test case: "/ e1 e2 e3 / e4 e5" -> e1, then e4 immediately, then e5 deferred
 	t.Run("/ e1 e2 e3 / e4 e5", func(t *testing.T) {
-		lim := limit.NewLimiter[string](expireBatchSize, expireInterval, throttleWindow, debouncingTime)
-		o := &occurs{}
+		synctest.Test(t, func(t *testing.T) {
+			lim := limit.NewLimiter[string](expireBatchSize, expireInterval, throttleWindow, debouncingTime)
+			o := &occurs{}
 
-		// e1 occurs directly.
-		e1 := func() { o.add(1) }
-		if lim.Allow("key", e1) {
-			e1()
-		}
-		assert.Equal(t, 1, o.get(0))
+			// e1 occurs directly.
+			e1 := func() { o.add(1) }
+			if lim.Allow("key", e1) {
+				e1()
+			}
+			assert.Equal(t, 1, o.get(0))
 
-		// e2 is saved.
-		e2 := func() { o.add(2) }
-		if lim.Allow("key", e2) {
-			e2()
-		}
-		// e3 replaces e2.
-		e3 := func() { o.add(3) }
-		if lim.Allow("key", e3) {
-			e3()
-		}
-		assert.Equal(t, 1, o.len())
-		time.Sleep(throttleWindow + debouncingTime/2)
-		assert.Equal(t, 1, o.len())
+			// e2 is saved.
+			e2 := func() { o.add(2) }
+			if lim.Allow("key", e2) {
+				e2()
+			}
+			// e3 replaces e2.
+			e3 := func() { o.add(3) }
+			if lim.Allow("key", e3) {
+				e3()
+			}
+			assert.Equal(t, 1, o.len())
+			time.Sleep(throttleWindow + debouncingTime/2)
+			assert.Equal(t, 1, o.len())
 
-		// Before flushing e3, e4 occurs so e3 is skipped.
-		e4 := func() { o.add(4) }
-		if lim.Allow("key", e4) {
-			e4()
-		}
-		assert.Equal(t, 2, o.len())
-		assert.Equal(t, 4, o.get(1))
+			// Before flushing e3, e4 occurs so e3 is skipped.
+			e4 := func() { o.add(4) }
+			if lim.Allow("key", e4) {
+				e4()
+			}
+			assert.Equal(t, 2, o.len())
+			assert.Equal(t, 4, o.get(1))
 
-		// e5 meets limit so it is saved.
-		e5 := func() { o.add(5) }
-		if lim.Allow("key", e5) {
-			e5()
-		}
-		assert.Equal(t, 2, o.len())
+			// e5 meets limit so it is saved.
+			e5 := func() { o.add(5) }
+			if lim.Allow("key", e5) {
+				e5()
+			}
+			assert.Equal(t, 2, o.len())
 
-		// And flushed when it expires.
-		time.Sleep(waitingTime)
-		assert.Equal(t, 3, o.len())
-		assert.Equal(t, 5, o.get(2))
-		lim.Close()
+			// And flushed when it expires.
+			time.Sleep(waitingTime)
+			assert.Equal(t, 3, o.len())
+			assert.Equal(t, 5, o.get(2))
+			lim.Close()
+		})
 	})
 }
 
@@ -240,102 +250,110 @@ func TestConcurrentExecution(t *testing.T) {
 		expireInterval  = 10 * time.Millisecond
 		throttleWindow  = 100 * time.Millisecond
 		debouncingTime  = 100 * time.Millisecond
-		executeTime     = 5 * time.Millisecond
-		waitingTime     = expireInterval + throttleWindow + debouncingTime + executeTime
+		waitingTime     = expireInterval + throttleWindow + debouncingTime
 		numExecute      = 1000
 	)
 
 	t.Run("Multiple Synchronous Calls with Trailing Debounce", func(t *testing.T) {
-		lim := limit.NewLimiter[string](expireBatchSize, expireInterval, throttleWindow, debouncingTime)
-		o := occurs{}
-		callback := func() { o.add(1) }
+		synctest.Test(t, func(t *testing.T) {
+			lim := limit.NewLimiter[string](expireBatchSize, expireInterval, throttleWindow, debouncingTime)
+			o := occurs{}
+			callback := func() { o.add(1) }
 
-		for range numExecute {
-			if lim.Allow("key", callback) {
-				callback()
-			}
-		}
-		assert.Equal(t, 1, o.len())
-
-		time.Sleep(waitingTime)
-		assert.Equal(t, 2, o.len())
-		lim.Close()
-		assert.Equal(t, 2, o.len())
-	})
-
-	t.Run("Concurrent Calls: Single Immediate and Trailing Execution", func(t *testing.T) {
-		lim := limit.NewLimiter[string](expireBatchSize, expireInterval, throttleWindow, debouncingTime)
-		o := occurs{}
-		callback := func() { o.add(1) }
-
-		wg := sync.WaitGroup{}
-		for range numExecute {
-			wg.Go(func() {
-				if lim.Allow("key", callback) {
-					callback()
-				}
-			})
-		}
-		wg.Wait()
-		assert.Equal(t, 1, o.len())
-
-		time.Sleep(waitingTime)
-		assert.Equal(t, 2, o.len())
-		lim.Close()
-		assert.Equal(t, 2, o.len())
-	})
-
-	t.Run("Concurrent Calls with Different Keys", func(t *testing.T) {
-		lim := limit.NewLimiter[int](expireBatchSize, expireInterval, throttleWindow, debouncingTime)
-		o := occurs{
-			array: make([]int, 0, numExecute*2),
-		}
-		callback := func() { o.add(1) }
-
-		wg := sync.WaitGroup{}
-		for i := range numExecute {
-			wg.Go(func() {
-				if lim.Allow(i, callback) {
-					callback()
-				}
-			})
-		}
-		wg.Wait()
-
-		time.Sleep(waitingTime)
-		assert.Equal(t, numExecute, o.len())
-		lim.Close()
-		assert.Equal(t, numExecute, o.len())
-	})
-
-	t.Run("Continuous Event Stream Throttling", func(t *testing.T) {
-		const (
-			numWindows = 3 // Number of throttle windows.
-		)
-
-		lim := limit.NewLimiter[string](expireBatchSize, expireInterval, throttleWindow, debouncingTime)
-
-		o := occurs{
-			array: make([]int, 0, numWindows+1),
-		}
-
-		// Continuously trigger events until the simulation ends.
-		for i := range numWindows {
-			callback := func() { o.add(i) }
 			for range numExecute {
 				if lim.Allow("key", callback) {
 					callback()
 				}
 			}
-			time.Sleep(throttleWindow)
-		}
-		assert.Equal(t, numWindows, o.len())
-		time.Sleep(waitingTime)
-		assert.Equal(t, numWindows+1, o.len())
+			assert.Equal(t, 1, o.len())
 
-		for i := range numWindows {
-			assert.Equal(t, i, o.get(i))
-		}
+			time.Sleep(waitingTime)
+			assert.Equal(t, 2, o.len())
+			lim.Close()
+			assert.Equal(t, 2, o.len())
+		})
+	})
+
+	t.Run("Concurrent Calls: Single Immediate and Trailing Execution", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			lim := limit.NewLimiter[string](expireBatchSize, expireInterval, throttleWindow, debouncingTime)
+			o := occurs{}
+			callback := func() { o.add(1) }
+
+			wg := sync.WaitGroup{}
+			for range numExecute {
+				wg.Go(func() {
+					if lim.Allow("key", callback) {
+						callback()
+					}
+				})
+			}
+			wg.Wait()
+			assert.Equal(t, 1, o.len())
+
+			time.Sleep(waitingTime)
+			assert.Equal(t, 2, o.len())
+			lim.Close()
+			assert.Equal(t, 2, o.len())
+		})
+	})
+
+	t.Run("Concurrent Calls with Different Keys", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			lim := limit.NewLimiter[int](expireBatchSize, expireInterval, throttleWindow, debouncingTime)
+			o := occurs{
+				array: make([]int, 0, numExecute*2),
+			}
+			callback := func() { o.add(1) }
+
+			wg := sync.WaitGroup{}
+			for i := range numExecute {
+				wg.Go(func() {
+					if lim.Allow(i, callback) {
+						callback()
+					}
+				})
+			}
+			wg.Wait()
+
+			time.Sleep(waitingTime)
+			assert.Equal(t, numExecute, o.len())
+			lim.Close()
+			assert.Equal(t, numExecute, o.len())
+		})
+	})
+
+	t.Run("Continuous Event Stream Throttling", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			const (
+				numWindows = 3 // Number of throttle windows.
+			)
+
+			lim := limit.NewLimiter[string](expireBatchSize, expireInterval, throttleWindow, debouncingTime)
+
+			o := occurs{
+				array: make([]int, 0, numWindows+1),
+			}
+
+			// Continuously trigger events until the simulation ends.
+			for i := range numWindows {
+				callback := func() { o.add(i) }
+				for range numExecute {
+					if lim.Allow("key", callback) {
+						callback()
+					}
+				}
+				time.Sleep(throttleWindow)
+			}
+			assert.Equal(t, numWindows, o.len())
+			time.Sleep(waitingTime)
+			assert.Equal(t, numWindows+1, o.len())
+
+			for i := range numWindows {
+				assert.Equal(t, i, o.get(i))
+			}
+			lim.Close()
+		})
 	})
 }
 
@@ -364,84 +382,70 @@ func TestBatchExpiration(t *testing.T) {
 	}
 
 	t.Run("Process Expire Batch", func(t *testing.T) {
-		lim := limit.NewLimiter[string](expireBatchSize, expireInterval, throttleWindow, debouncingTime)
-		o := occurs{
-			array: make([]int, 0, totalKeys*2),
-		}
-
-		// Channel to track callback completions
-		completionChan := make(chan struct{}, totalKeys*2)
-		callback := createCallbackWithTracking(&o, completionChan)
-
-		// For each key: first call executes immediately, second call schedules a debounced callback.
-		for i := range totalKeys {
-			key := fmt.Sprintf("key-%d", i)
-			// Immediate execution.
-			if lim.Allow(key, callback) {
-				callback()
+		synctest.Test(t, func(t *testing.T) {
+			lim := limit.NewLimiter[string](expireBatchSize, expireInterval, throttleWindow, debouncingTime)
+			o := occurs{
+				array: make([]int, 0, totalKeys*2),
 			}
-			// Queue the debounced callback.
-			lim.Allow(key, callback)
-		}
 
-		assert.Equal(t, totalKeys, o.len())
+			// Channel to track callback completions
+			completionChan := make(chan struct{}, totalKeys*2)
+			callback := createCallbackWithTracking(&o, completionChan)
 
-		// Wait for immediate callbacks to be processed
-		for i := 0; i < totalKeys; i++ {
-			select {
-			case <-completionChan:
-			case <-time.After(100 * time.Millisecond):
-				t.Fatalf("Timeout waiting for immediate callback %d", i)
+			// For each key: first call executes immediately, second call schedules a debounced callback.
+			for i := range totalKeys {
+				key := fmt.Sprintf("key-%d", i)
+				// Immediate execution.
+				if lim.Allow(key, callback) {
+					callback()
+				}
+				// Queue the debounced callback.
+				lim.Allow(key, callback)
 			}
-		}
 
-		// Wait for all debounced callbacks to complete.
-		// NOTE: We don't assert intermediate per-batch counts because the ticker
-		// and test assertions can race — a subsequent batch may fire before the
-		// test checks o.len(), leading to flaky intermediate counts.
-		for i := range expireBatchSize * batchNum {
-			select {
-			case <-completionChan:
-			case <-time.After(expireInterval * 2):
-				t.Fatalf("Timeout waiting for debounced callback %d", i+1)
+			assert.Equal(t, totalKeys, o.len())
+
+			// Wait for immediate callbacks to be processed
+			for range totalKeys {
+				<-completionChan
 			}
-		}
 
-		assert.Equal(t, totalKeys+expireBatchSize*batchNum, o.len())
-		lim.Close()
-		assert.Equal(t, totalKeys+expireBatchSize*batchNum, o.len())
+			// Wait for all debounced callbacks to complete.
+			// NOTE: We don't assert intermediate per-batch counts because the ticker
+			// and test assertions can race — a subsequent batch may fire before the
+			// test checks o.len(), leading to flaky intermediate counts.
+			for range expireBatchSize * batchNum {
+				<-completionChan
+			}
+
+			assert.Equal(t, totalKeys+expireBatchSize*batchNum, o.len())
+			lim.Close()
+			assert.Equal(t, totalKeys+expireBatchSize*batchNum, o.len())
+		})
 	})
 
 	t.Run("Force Close Expired", func(t *testing.T) {
-		lim := limit.NewLimiter[string](expireBatchSize, expireInterval, throttleWindow, debouncingTime)
-		o := occurs{
-			array: make([]int, 0, totalKeys*2),
-		}
-		callback := func() { o.add(1) }
-
-		for i := range totalKeys {
-			key := fmt.Sprintf("key-%d", i)
-			// Immediate execution.
-			if lim.Allow(key, callback) {
-				callback()
+		synctest.Test(t, func(t *testing.T) {
+			lim := limit.NewLimiter[string](expireBatchSize, expireInterval, throttleWindow, debouncingTime)
+			o := occurs{
+				array: make([]int, 0, totalKeys*2),
 			}
-			// Queue the debounced callback.
-			lim.Allow(key, callback)
-		}
+			callback := func() { o.add(1) }
 
-		assert.Equal(t, totalKeys, o.len())
+			for i := range totalKeys {
+				key := fmt.Sprintf("key-%d", i)
+				// Immediate execution.
+				if lim.Allow(key, callback) {
+					callback()
+				}
+				// Queue the debounced callback.
+				lim.Allow(key, callback)
+			}
 
-		done := make(chan struct{})
-		go func() {
+			assert.Equal(t, totalKeys, o.len())
+
 			lim.Close()
-			done <- struct{}{}
-		}()
-		select {
-		case <-done:
 			assert.Equal(t, totalKeys+expireBatchSize*batchNum, o.len())
-		case <-time.After(expireInterval):
-			assert.Equal(t, totalKeys+expireBatchSize*batchNum, o.len())
-			assert.Fail(t, "close timeout")
-		}
+		})
 	})
 }

--- a/server/backend/pubsub/batch_publisher_test.go
+++ b/server/backend/pubsub/batch_publisher_test.go
@@ -18,6 +18,7 @@ package pubsub
 
 import (
 	"testing"
+	"testing/synctest"
 	gotime "time"
 
 	"github.com/stretchr/testify/assert"
@@ -29,32 +30,38 @@ func TestBatchPublisherReapsDeadSubscriptions(t *testing.T) {
 	actor, err := time.ActorIDFromBytes([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
 	assert.NoError(t, err)
 
-	subs := NewSubscriptions(
-		"test",
-		func(s *Subscriptions[int]) *BatchPublisher[int] {
-			return NewBatchPublisher(s, 50*gotime.Millisecond, BatchPublisherConfig[int]{})
-		},
-	)
-	defer subs.Close()
+	synctest.Test(t, func(t *testing.T) {
+		const window = 50 * gotime.Millisecond
+		subs := NewSubscriptions(
+			"test",
+			func(s *Subscriptions[int]) *BatchPublisher[int] {
+				return NewBatchPublisher(s, window, BatchPublisherConfig[int]{})
+			},
+		)
+		defer subs.Close()
 
-	sub := NewSubscription[int](actor, 1)
-	sub.maxFailures = 2
-	subs.Set(sub)
-	assert.Equal(t, 1, subs.Len())
+		sub := NewSubscription[int](actor, 1)
+		sub.maxFailures = 2
+		subs.Set(sub)
+		assert.Equal(t, 1, subs.Len())
 
-	// Saturate the subscription's buffer so subsequent sends time out.
-	assert.True(t, sub.Publish(1))
+		// Saturate the subscription's buffer so subsequent sends time out.
+		assert.True(t, sub.Publish(1))
 
-	// Enqueue events through the publisher so its publish loop sees them.
-	for i := range 4 {
-		subs.Publish(i)
-	}
+		// Enqueue events through the publisher so its publish loop sees them.
+		for i := range 4 {
+			subs.Publish(i)
+		}
 
-	// Each failing send blocks for publishTimeout. With maxFailures=2 and
-	// buffer-full state, the second send marks the sub dead. We wait long
-	// enough for the publish loop to reach the dead branch and reap.
-	assert.Eventually(t, func() bool {
-		return sub.IsDead() && subs.Len() == 0
-	}, 3*gotime.Second, 50*gotime.Millisecond,
-		"subscription should self-prune and be reaped by BatchPublisher")
+		// Each failing send blocks for publishTimeout. With maxFailures=2 and
+		// buffer-full state, the second send marks the sub dead and the publish
+		// loop reaps it once the fake clock passes the window plus two timeouts.
+		gotime.Sleep(window + 2*publishTimeout)
+		synctest.Wait()
+
+		assert.True(t, sub.IsDead(),
+			"subscription should self-prune after consecutive publish failures")
+		assert.Equal(t, 0, subs.Len(),
+			"dead subscription should be reaped by BatchPublisher")
+	})
 }

--- a/server/rpc/admin_server_unit_test.go
+++ b/server/rpc/admin_server_unit_test.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -148,179 +149,187 @@ func TestMakeChannelSessionCountCacheKey(t *testing.T) {
 
 func TestSemaphoreFanOutPattern(t *testing.T) {
 	t.Run("semaphore limits concurrent operations", func(t *testing.T) {
-		const maxConcurrent = 3
-		const totalGroups = 10
-		sem := semaphore.NewWeighted(int64(maxConcurrent))
-		ctx := context.Background()
+		synctest.Test(t, func(t *testing.T) {
+			const maxConcurrent = 3
+			const totalGroups = 10
+			sem := semaphore.NewWeighted(int64(maxConcurrent))
+			ctx := context.Background()
 
-		var peakConcurrency atomic.Int32
-		var currentConcurrency atomic.Int32
+			var peakConcurrency atomic.Int32
+			var currentConcurrency atomic.Int32
 
-		type groupResult struct {
-			value int
-			err   error
-		}
-		resultCh := make(chan groupResult, totalGroups)
+			type groupResult struct {
+				value int
+				err   error
+			}
+			resultCh := make(chan groupResult, totalGroups)
 
-		var wg sync.WaitGroup
-		for i := range totalGroups {
-			wg.Go(func() {
-				if err := sem.Acquire(ctx, 1); err != nil {
-					resultCh <- groupResult{err: err}
-					return
-				}
-				defer sem.Release(1)
-
-				current := currentConcurrency.Add(1)
-				for {
-					old := peakConcurrency.Load()
-					if current <= old || peakConcurrency.CompareAndSwap(old, current) {
-						break
+			var wg sync.WaitGroup
+			for i := range totalGroups {
+				wg.Go(func() {
+					if err := sem.Acquire(ctx, 1); err != nil {
+						resultCh <- groupResult{err: err}
+						return
 					}
-				}
+					defer sem.Release(1)
 
-				time.Sleep(10 * time.Millisecond)
-				currentConcurrency.Add(-1)
+					current := currentConcurrency.Add(1)
+					for {
+						old := peakConcurrency.Load()
+						if current <= old || peakConcurrency.CompareAndSwap(old, current) {
+							break
+						}
+					}
 
-				resultCh <- groupResult{value: i}
-			})
-		}
+					time.Sleep(10 * time.Millisecond)
+					currentConcurrency.Add(-1)
 
-		go func() { wg.Wait(); close(resultCh) }()
+					resultCh <- groupResult{value: i}
+				})
+			}
 
-		var results []int
-		for res := range resultCh {
-			assert.NoError(t, res.err)
-			results = append(results, res.value)
-		}
+			go func() { wg.Wait(); close(resultCh) }()
 
-		assert.Len(t, results, totalGroups)
-		assert.LessOrEqual(t, int(peakConcurrency.Load()), maxConcurrent)
+			var results []int
+			for res := range resultCh {
+				assert.NoError(t, res.err)
+				results = append(results, res.value)
+			}
+
+			assert.Len(t, results, totalGroups)
+			assert.LessOrEqual(t, int(peakConcurrency.Load()), maxConcurrent)
+		})
 	})
 
 	t.Run("context cancellation unblocks semaphore acquire", func(t *testing.T) {
-		sem := semaphore.NewWeighted(1)
-		ctx, cancel := context.WithCancel(context.Background())
+		synctest.Test(t, func(t *testing.T) {
+			sem := semaphore.NewWeighted(1)
+			ctx, cancel := context.WithCancel(context.Background())
 
-		type groupResult struct {
-			id  int
-			err error
-		}
-		resultCh := make(chan groupResult, 5)
-
-		// Hold the semaphore to block subsequent goroutines.
-		err := sem.Acquire(ctx, 1)
-		assert.NoError(t, err)
-
-		var wg sync.WaitGroup
-		for i := range 5 {
-			wg.Go(func() {
-				if err := sem.Acquire(ctx, 1); err != nil {
-					resultCh <- groupResult{id: i, err: err}
-					return
-				}
-				defer sem.Release(1)
-				resultCh <- groupResult{id: i}
-			})
-		}
-
-		// Give goroutines time to block on Acquire.
-		time.Sleep(50 * time.Millisecond)
-
-		// Cancel the context — all blocked goroutines should unblock with error.
-		cancel()
-
-		go func() { wg.Wait(); close(resultCh) }()
-
-		var errCount int
-		for res := range resultCh {
-			if res.err != nil {
-				errCount++
-				assert.ErrorIs(t, res.err, context.Canceled)
+			type groupResult struct {
+				id  int
+				err error
 			}
-		}
-		assert.Equal(t, 5, errCount)
+			resultCh := make(chan groupResult, 5)
 
-		sem.Release(1)
+			// Hold the semaphore to block subsequent goroutines.
+			err := sem.Acquire(ctx, 1)
+			assert.NoError(t, err)
+
+			var wg sync.WaitGroup
+			for i := range 5 {
+				wg.Go(func() {
+					if err := sem.Acquire(ctx, 1); err != nil {
+						resultCh <- groupResult{id: i, err: err}
+						return
+					}
+					defer sem.Release(1)
+					resultCh <- groupResult{id: i}
+				})
+			}
+
+			// Wait until all goroutines are durably blocked on Acquire.
+			synctest.Wait()
+
+			// Cancel the context — all blocked goroutines should unblock with error.
+			cancel()
+
+			go func() { wg.Wait(); close(resultCh) }()
+
+			var errCount int
+			for res := range resultCh {
+				if res.err != nil {
+					errCount++
+					assert.ErrorIs(t, res.err, context.Canceled)
+				}
+			}
+			assert.Equal(t, 5, errCount)
+
+			sem.Release(1)
+		})
 	})
 
 	t.Run("context deadline unblocks semaphore acquire", func(t *testing.T) {
-		sem := semaphore.NewWeighted(1)
-		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-		defer cancel()
+		synctest.Test(t, func(t *testing.T) {
+			sem := semaphore.NewWeighted(1)
+			ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+			defer cancel()
 
-		// Hold the semaphore with a non-cancellable context.
-		err := sem.Acquire(context.Background(), 1)
-		assert.NoError(t, err)
+			// Hold the semaphore with a non-cancellable context.
+			err := sem.Acquire(context.Background(), 1)
+			assert.NoError(t, err)
 
-		type groupResult struct {
-			err error
-		}
-		resultCh := make(chan groupResult, 3)
+			type groupResult struct {
+				err error
+			}
+			resultCh := make(chan groupResult, 3)
 
-		var wg sync.WaitGroup
-		for range 3 {
-			wg.Go(func() {
-				if err := sem.Acquire(ctx, 1); err != nil {
-					resultCh <- groupResult{err: err}
-					return
-				}
-				defer sem.Release(1)
-				resultCh <- groupResult{}
-			})
-		}
+			var wg sync.WaitGroup
+			for range 3 {
+				wg.Go(func() {
+					if err := sem.Acquire(ctx, 1); err != nil {
+						resultCh <- groupResult{err: err}
+						return
+					}
+					defer sem.Release(1)
+					resultCh <- groupResult{}
+				})
+			}
 
-		go func() { wg.Wait(); close(resultCh) }()
+			go func() { wg.Wait(); close(resultCh) }()
 
-		for res := range resultCh {
-			assert.Error(t, res.err)
-			assert.ErrorIs(t, res.err, context.DeadlineExceeded)
-		}
+			for res := range resultCh {
+				assert.Error(t, res.err)
+				assert.ErrorIs(t, res.err, context.DeadlineExceeded)
+			}
 
-		sem.Release(1)
+			sem.Release(1)
+		})
 	})
 
 	t.Run("all goroutines complete even on context cancellation", func(t *testing.T) {
-		const totalGroups = 20
-		sem := semaphore.NewWeighted(2)
-		ctx, cancel := context.WithCancel(context.Background())
+		synctest.Test(t, func(t *testing.T) {
+			const totalGroups = 20
+			sem := semaphore.NewWeighted(2)
+			ctx, cancel := context.WithCancel(context.Background())
 
-		var completedCount atomic.Int32
+			var completedCount atomic.Int32
 
-		type groupResult struct {
-			err error
-		}
-		resultCh := make(chan groupResult, totalGroups)
+			type groupResult struct {
+				err error
+			}
+			resultCh := make(chan groupResult, totalGroups)
 
-		var wg sync.WaitGroup
-		for range totalGroups {
-			wg.Go(func() {
-				defer completedCount.Add(1)
+			var wg sync.WaitGroup
+			for range totalGroups {
+				wg.Go(func() {
+					defer completedCount.Add(1)
 
-				if err := sem.Acquire(ctx, 1); err != nil {
-					resultCh <- groupResult{err: err}
-					return
-				}
-				defer sem.Release(1)
+					if err := sem.Acquire(ctx, 1); err != nil {
+						resultCh <- groupResult{err: err}
+						return
+					}
+					defer sem.Release(1)
 
-				time.Sleep(5 * time.Millisecond)
-				resultCh <- groupResult{}
-			})
-		}
+					time.Sleep(5 * time.Millisecond)
+					resultCh <- groupResult{}
+				})
+			}
 
-		// Cancel early while some goroutines are still running.
-		time.Sleep(15 * time.Millisecond)
-		cancel()
+			// Cancel early while some goroutines are still running.
+			time.Sleep(15 * time.Millisecond)
+			cancel()
 
-		go func() { wg.Wait(); close(resultCh) }()
+			go func() { wg.Wait(); close(resultCh) }()
 
-		var collected int
-		for range resultCh {
-			collected++
-		}
+			var collected int
+			for range resultCh {
+				collected++
+			}
 
-		assert.Equal(t, totalGroups, collected)
-		assert.Equal(t, int32(totalGroups), completedCount.Load())
+			assert.Equal(t, totalGroups, collected)
+			assert.Equal(t, int32(totalGroups), completedCount.Load())
+		})
 	})
 
 	t.Run("fan-out fan-in collects all results and tracks first error", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Several unit tests relied on real wall-clock time — generous `time.Sleep` pacing to let goroutines catch up, `assert.Eventually` polling, and `time.After` timeout guards. These burn seconds of test time and are inherently flaky under CI load.

This PR adopts Go 1.25's `testing/synctest` following the three steps in the issue:

1. **Toolchain bump** — `go.mod` to `go 1.25.0`, plus `GO_VERSION` in `ci.yml`, `base-docker-publish.yml`, and the `Dockerfile` builder image.
2. **Test migration** (first scope: pure in-process packages only):
   - `pkg/limit`: all 11 timing subtests now run in synctest bubbles — package test time drops **3.2s → 0.5s (~7x)**. Also fixes a goroutine leak in `Continuous Event Stream Throttling` (missing `lim.Close()`).
   - `server/rpc` (`TestSemaphoreFanOutPattern`): the "sleep 50ms and hope goroutines are parked" pacing is replaced with `synctest.Wait()`, making the cancellation/deadline cases deterministic.
   - `server/backend/pubsub` (`TestBatchPublisherReapsDeadSubscriptions`): `assert.Eventually(3s, 50ms)` replaced with exact fake-clock instants (ticker at t=window, dead at t=window+2×publishTimeout).
3. **Regression guard** — a short note in `CONTRIBUTING.md` (Testing section) directing new timer-observing tests to `synctest`.

One correction to the issue example: the experimental `synctest.Run` did not survive to Go 1.25 — the stable API is `synctest.Test(t, func(*testing.T))` + `synctest.Wait()`, which is what this PR uses.

**Which issue(s) this PR fixes**:

Fixes #1859

**Special notes for your reviewer**:

- All migrated tests pass with `-race -count=5` (no flakes) locally on go1.25.1.
- Behavior-neutral: no production code changes; assertions and test intent are preserved.
- Deliberately excluded from this first scope: `server/backend/channel` and `server/backend/membership` (their tests block on the in-memory DB's mutexes, which are not durably-blocking in a bubble and need more careful treatment — planned as a follow-up), and `pkg/webhook`/`cluster` (real network I/O, not bubble-compatible).
- Overlaps with #1860 on the Go 1.25 toolchain bump — whichever lands second just rebases the version bump away.

**Does this PR introduce a user-facing change?**:

```release-note
Bump minimum Go version to 1.25
```

**Additional documentation**:

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **CI and Build**
  - Updated automated build and test workflows to use the latest Go setup action.

- **Documentation**
  - Raised the documented minimum supported Go version to 1.25+.
  - Added guidance for writing deterministic timer/concurrency tests using controlled fake clocks.

- **Tests**
  - Improved test reliability for throttling, batching expiration, pub/sub reaping, and semaphore fan-out by replacing real-time waits/timeouts with deterministic synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
