### PR TITLE
Add fuzz coverage for counter value decoding

### DIFF
--- a/pkg/document/crdt/counter.go
+++ b/pkg/document/crdt/counter.go
@@ -50,9 +50,15 @@ const (
 func CounterValueFromBytes(counterType CounterType, value []byte) (interface{}, error) {
 	switch counterType {
 	case IntegerCnt, IntegerDedupCnt:
+		if len(value) < 4 {
+			return nil, fmt.Errorf("invalid counter integer payload: got %d bytes, want 4", len(value))
+		}
 		val := int32(binary.LittleEndian.Uint32(value))
 		return int(val), nil
 	case LongCnt:
+		if len(value) < 8 {
+			return nil, fmt.Errorf("invalid counter long payload: got %d bytes, want 8", len(value))
+		}
 		return int64(binary.LittleEndian.Uint64(value)), nil
 	default:
 		return nil, ErrUnsupportedType

--- a/test/fuzz/fuzz_test.go
+++ b/test/fuzz/fuzz_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/yorkie-team/yorkie/api/converter"
 	api "github.com/yorkie-team/yorkie/api/yorkie/v1"
+	"github.com/yorkie-team/yorkie/pkg/document/crdt"
 )
 
 func FuzzFromChangePack(f *testing.F) {
@@ -39,6 +40,17 @@ func FuzzFromChangePack(f *testing.F) {
 			return
 		}
 		_, _ = converter.FromChangePack(pbPack)
+	})
+}
+
+func FuzzCounterValueFromBytes(f *testing.F) {
+	f.Add(byte(crdt.IntegerCnt), []byte{0, 0, 0, 0})
+	f.Add(byte(crdt.LongCnt), []byte{0, 0, 0, 0, 0, 0, 0, 0})
+	f.Add(byte(crdt.IntegerDedupCnt), []byte{0, 0, 0, 0})
+
+	f.Fuzz(func(t *testing.T, rawCounterType byte, value []byte) {
+		counterType := crdt.CounterType(rawCounterType % byte(crdt.IntegerDedupCnt+1))
+		_, _ = crdt.CounterValueFromBytes(counterType, value)
 	})
 }
 

--- a/test/fuzz/testdata/fuzz/FuzzCounterValueFromBytes/a1ecfd3b8981f3dc
+++ b/test/fuzz/testdata/fuzz/FuzzCounterValueFromBytes/a1ecfd3b8981f3dc
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x01')
+[]byte("0")

--- a/test/fuzz/testdata/fuzz/FuzzCounterValueFromBytes/short_integer_dedup_payload
+++ b/test/fuzz/testdata/fuzz/FuzzCounterValueFromBytes/short_integer_dedup_payload
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x02')
+[]byte("000")

--- a/test/fuzz/testdata/fuzz/FuzzCounterValueFromBytes/short_integer_payload
+++ b/test/fuzz/testdata/fuzz/FuzzCounterValueFromBytes/short_integer_payload
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x00')
+[]byte("000")

--- a/test/fuzz/testdata/fuzz/FuzzCounterValueFromBytes/short_long_payload
+++ b/test/fuzz/testdata/fuzz/FuzzCounterValueFromBytes/short_long_payload
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x01')
+[]byte("0000000")


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds fuzz coverage for `crdt.CounterValueFromBytes` and includes regression corpus for malformed counter payloads that previously caused panics during decoding.

Before adding the broader fuzz infrastructure, I am continuing to split the locally discovered fuzz issues by target. This PR is intentionally scoped to the `FuzzCounterValueFromBytes` target so the test coverage, failing corpus, and corresponding fix can be reviewed together.

The fix checks counter payload lengths before decoding `IntegerCnt`, `IntegerDedupCnt`, and `LongCnt` values, and returns errors instead of panicking on malformed input.

**Which issue(s) this PR fixes**:

Refs #1858

**Special notes for your reviewer**:

This PR is scoped to `FuzzCounterValueFromBytes` only. Other fuzz targets and CI/nightly fuzz workflow changes will be split into follow-up PRs.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation**:

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for counter payloads that are shorter than the required size.
  * Returns clear errors instead of attempting to decode incomplete counter data.

* **Tests**
  * Added fuzz testing for counter value decoding.
  * Added coverage for truncated integer, long, and deduplicated counter payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->