### PR TITLE
Identity-preserving restore for Tree undo/redo

### DIFF
--- a/api/converter/converter_tree_restore_test.go
+++ b/api/converter/converter_tree_restore_test.go
@@ -17,6 +17,7 @@
 package converter_test
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -153,12 +154,14 @@ func TestTreeRestoreSpanRejectsNilCreatedAt(t *testing.T) {
 	build := func() []*api.Operation {
 		op := operations.NewRestoreTreeEdit(seed, pos, pos, executedAt,
 			[]*crdt.TreeRestoreSpan{{
-				ID:       crdt.NewTreeNodeID(seed, 2),
-				NodeType: "text",
-				IsText:   true,
-				Length:   1,
-				Value:    "x",
-				ParentID: crdt.NewTreeNodeID(seed, 0),
+				ID:             crdt.NewTreeNodeID(seed, 2),
+				NodeType:       "text",
+				IsText:         true,
+				Length:         1,
+				Value:          "x",
+				ParentID:       crdt.NewTreeNodeID(seed, 0),
+				LeftSiblingID:  crdt.NewTreeNodeID(seed, 1),
+				RightSiblingID: crdt.NewTreeNodeID(seed, 3),
 			}}, crdt.RestoreModeRestore, nil)
 		pbOps, err := converter.ToOperations([]operations.Operation{op})
 		assert.NoError(t, err)
@@ -178,4 +181,68 @@ func TestTreeRestoreSpanRejectsNilCreatedAt(t *testing.T) {
 		_, err := converter.FromOperations(pbOps)
 		assert.Error(t, err)
 	})
+
+	t.Run("nil left sibling created_at", func(t *testing.T) {
+		pbOps := build()
+		pbOps[0].GetTreeEdit().RestoreSpans[0].LeftSiblingId.CreatedAt = nil
+		_, err := converter.FromOperations(pbOps)
+		assert.Error(t, err)
+	})
+
+	t.Run("nil right sibling created_at", func(t *testing.T) {
+		pbOps := build()
+		pbOps[0].GetTreeEdit().RestoreSpans[0].RightSiblingId.CreatedAt = nil
+		_, err := converter.FromOperations(pbOps)
+		assert.Error(t, err)
+	})
+}
+
+// TestTreeRestoreSpanRejectsBadTextLength guards the recreate slicing path: a
+// text span whose Length does not match its Value (in UTF-16 code units) would
+// slice out of bounds when a purged range is rebuilt, so it is rejected on read.
+func TestTreeRestoreSpanRejectsBadTextLength(t *testing.T) {
+	actor, err := time.ActorIDFromHex("000000000000000000000000")
+	assert.NoError(t, err)
+	seed := time.NewTicket(1, 0, actor)
+	executedAt := time.NewTicket(4, 0, actor)
+	pos := crdt.NewTreePos(crdt.NewTreeNodeID(seed, 0), crdt.NewTreeNodeID(seed, 0))
+
+	// Length 3 but "hello" is 5 UTF-16 code units — serialization is in range,
+	// but deserialization must reject the mismatch.
+	op := operations.NewRestoreTreeEdit(seed, pos, pos, executedAt,
+		[]*crdt.TreeRestoreSpan{{
+			ID:       crdt.NewTreeNodeID(seed, 2),
+			NodeType: "text",
+			IsText:   true,
+			Length:   3,
+			Value:    "hello",
+			ParentID: crdt.NewTreeNodeID(seed, 0),
+		}}, crdt.RestoreModeRestore, nil)
+	pbOps, err := converter.ToOperations([]operations.Operation{op})
+	assert.NoError(t, err)
+	_, err = converter.FromOperations(pbOps)
+	assert.Error(t, err)
+}
+
+// TestTreeRestoreSpanRejectsLengthOverflow guards serialization: a Length beyond
+// int32 must error rather than silently wrap to a bogus (possibly negative)
+// wire value (parity with the Text toRestoreSpans bounds check).
+func TestTreeRestoreSpanRejectsLengthOverflow(t *testing.T) {
+	actor, err := time.ActorIDFromHex("000000000000000000000000")
+	assert.NoError(t, err)
+	seed := time.NewTicket(1, 0, actor)
+	executedAt := time.NewTicket(4, 0, actor)
+	pos := crdt.NewTreePos(crdt.NewTreeNodeID(seed, 0), crdt.NewTreeNodeID(seed, 0))
+
+	op := operations.NewRestoreTreeEdit(seed, pos, pos, executedAt,
+		[]*crdt.TreeRestoreSpan{{
+			ID:       crdt.NewTreeNodeID(seed, 2),
+			NodeType: "text",
+			IsText:   true,
+			Length:   math.MaxInt32 + 1,
+			Value:    "x",
+			ParentID: crdt.NewTreeNodeID(seed, 0),
+		}}, crdt.RestoreModeRestore, nil)
+	_, err = converter.ToOperations([]operations.Operation{op})
+	assert.Error(t, err)
 }

--- a/api/converter/converter_tree_restore_test.go
+++ b/api/converter/converter_tree_restore_test.go
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2024 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package converter_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/api/converter"
+	api "github.com/yorkie-team/yorkie/api/yorkie/v1"
+	"github.com/yorkie-team/yorkie/pkg/document/crdt"
+	"github.com/yorkie-team/yorkie/pkg/document/operations"
+	"github.com/yorkie-team/yorkie/pkg/document/time"
+)
+
+// TestTreeRestoreSpanRoundTrip verifies that identity-preserving Tree restore
+// payloads survive the protobuf round-trip on TreeEdit operations, including
+// the tree-specific structure (parent/left/right anchors, per-node attributes).
+func TestTreeRestoreSpanRoundTrip(t *testing.T) {
+	actor, err := time.ActorIDFromHex("000000000000000000000000")
+	assert.NoError(t, err)
+	seed := time.NewTicket(1, 0, actor)
+	executedAt := time.NewTicket(4, 0, actor)
+	pos := crdt.NewTreePos(crdt.NewTreeNodeID(seed, 0), crdt.NewTreeNodeID(seed, 0))
+
+	attrs := crdt.NewRHT()
+	attrs.Set("bold", "true", seed)
+
+	elem := &crdt.TreeRestoreSpan{
+		ID:             crdt.NewTreeNodeID(seed, 2),
+		NodeType:       "p",
+		IsText:         false,
+		Attributes:     attrs,
+		ParentID:       crdt.NewTreeNodeID(seed, 0),
+		LeftSiblingID:  crdt.NewTreeNodeID(seed, 1),
+		RightSiblingID: crdt.NewTreeNodeID(seed, 3),
+	}
+	text := &crdt.TreeRestoreSpan{
+		ID:       crdt.NewTreeNodeID(seed, 5),
+		NodeType: "text",
+		IsText:   true,
+		Length:   5,
+		Value:    "hello",
+		ParentID: crdt.NewTreeNodeID(seed, 2),
+	}
+
+	cases := []struct {
+		name             string
+		mode             crdt.RestoreMode
+		restoreSpans     []*crdt.TreeRestoreSpan
+		retombstoneSpans []*crdt.TreeRestoreSpan
+	}{
+		{
+			name:         "restore element + text spans",
+			mode:         crdt.RestoreModeRestore,
+			restoreSpans: []*crdt.TreeRestoreSpan{elem, text},
+		},
+		{
+			name:             "restore with a retombstone companion set",
+			mode:             crdt.RestoreModeRestore,
+			restoreSpans:     []*crdt.TreeRestoreSpan{elem},
+			retombstoneSpans: []*crdt.TreeRestoreSpan{text},
+		},
+		{
+			name:             "pure-insert reverse carries only retombstone spans",
+			mode:             crdt.RestoreModeRestore,
+			retombstoneSpans: []*crdt.TreeRestoreSpan{elem, text},
+		},
+		{
+			name:             "redo (retombstone direction)",
+			mode:             crdt.RestoreModeRetombstone,
+			restoreSpans:     []*crdt.TreeRestoreSpan{text},
+			retombstoneSpans: []*crdt.TreeRestoreSpan{elem},
+		},
+	}
+
+	assertSpan := func(t *testing.T, want, got *crdt.TreeRestoreSpan) {
+		t.Helper()
+		assert.True(t, want.ID.Equal(got.ID))
+		assert.Equal(t, want.NodeType, got.NodeType)
+		assert.Equal(t, want.IsText, got.IsText)
+		assert.Equal(t, want.Length, got.Length)
+		assert.Equal(t, want.Value, got.Value)
+		if want.ParentID != nil {
+			assert.True(t, want.ParentID.Equal(got.ParentID))
+		}
+		if want.LeftSiblingID != nil {
+			assert.True(t, want.LeftSiblingID.Equal(got.LeftSiblingID))
+		}
+		if want.RightSiblingID != nil {
+			assert.True(t, want.RightSiblingID.Equal(got.RightSiblingID))
+		}
+		if want.Attributes != nil {
+			assert.NotNil(t, got.Attributes)
+			assert.Equal(t, want.Attributes.Marshal(), got.Attributes.Marshal())
+		} else {
+			assert.Nil(t, got.Attributes)
+		}
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			op := operations.NewRestoreTreeEdit(seed, pos, pos, executedAt,
+				tc.restoreSpans, tc.mode, tc.retombstoneSpans)
+
+			pbOps, err := converter.ToOperations([]operations.Operation{op})
+			assert.NoError(t, err)
+			ops, err := converter.FromOperations(pbOps)
+			assert.NoError(t, err)
+			assert.Len(t, ops, 1)
+
+			got, ok := ops[0].(*operations.TreeEdit)
+			assert.True(t, ok)
+			assert.Equal(t, tc.mode, got.RestoreMode())
+			assert.Len(t, got.RestoreSpans(), len(tc.restoreSpans))
+			assert.Len(t, got.RetombstoneSpans(), len(tc.retombstoneSpans))
+			for i := range tc.restoreSpans {
+				assertSpan(t, tc.restoreSpans[i], got.RestoreSpans()[i])
+			}
+			for i := range tc.retombstoneSpans {
+				assertSpan(t, tc.retombstoneSpans[i], got.RetombstoneSpans()[i])
+			}
+		})
+	}
+}
+
+// TestTreeRestoreSpanRejectsNilCreatedAt guards the wire boundary: a span whose
+// id (or parent id) carries no created_at is malformed and must be rejected on
+// deserialization, before it reaches the restore path where a nil identity
+// ticket would panic on the first comparison.
+func TestTreeRestoreSpanRejectsNilCreatedAt(t *testing.T) {
+	actor, err := time.ActorIDFromHex("000000000000000000000000")
+	assert.NoError(t, err)
+	seed := time.NewTicket(1, 0, actor)
+	executedAt := time.NewTicket(4, 0, actor)
+	pos := crdt.NewTreePos(crdt.NewTreeNodeID(seed, 0), crdt.NewTreeNodeID(seed, 0))
+
+	build := func() []*api.Operation {
+		op := operations.NewRestoreTreeEdit(seed, pos, pos, executedAt,
+			[]*crdt.TreeRestoreSpan{{
+				ID:       crdt.NewTreeNodeID(seed, 2),
+				NodeType: "text",
+				IsText:   true,
+				Length:   1,
+				Value:    "x",
+				ParentID: crdt.NewTreeNodeID(seed, 0),
+			}}, crdt.RestoreModeRestore, nil)
+		pbOps, err := converter.ToOperations([]operations.Operation{op})
+		assert.NoError(t, err)
+		return pbOps
+	}
+
+	t.Run("nil span id created_at", func(t *testing.T) {
+		pbOps := build()
+		pbOps[0].GetTreeEdit().RestoreSpans[0].Id.CreatedAt = nil
+		_, err := converter.FromOperations(pbOps)
+		assert.Error(t, err)
+	})
+
+	t.Run("nil parent id created_at", func(t *testing.T) {
+		pbOps := build()
+		pbOps[0].GetTreeEdit().RestoreSpans[0].ParentId.CreatedAt = nil
+		_, err := converter.FromOperations(pbOps)
+		assert.Error(t, err)
+	})
+}

--- a/api/converter/converter_tree_restore_test.go
+++ b/api/converter/converter_tree_restore_test.go
@@ -246,3 +246,53 @@ func TestTreeRestoreSpanRejectsLengthOverflow(t *testing.T) {
 	_, err = converter.ToOperations([]operations.Operation{op})
 	assert.Error(t, err)
 }
+
+// TestTreeRestoreSpanRejectsNilID guards serialization: a span with a nil id
+// is malformed and must be rejected before toTreeNodeID dereferences it.
+func TestTreeRestoreSpanRejectsNilID(t *testing.T) {
+	actor, err := time.ActorIDFromHex("000000000000000000000000")
+	assert.NoError(t, err)
+	seed := time.NewTicket(1, 0, actor)
+	executedAt := time.NewTicket(4, 0, actor)
+	pos := crdt.NewTreePos(crdt.NewTreeNodeID(seed, 0), crdt.NewTreeNodeID(seed, 0))
+
+	op := operations.NewRestoreTreeEdit(seed, pos, pos, executedAt,
+		[]*crdt.TreeRestoreSpan{{
+			ID:       nil,
+			NodeType: "text",
+			IsText:   true,
+			Length:   1,
+			Value:    "x",
+			ParentID: crdt.NewTreeNodeID(seed, 0),
+		}}, crdt.RestoreModeRestore, nil)
+	_, err = converter.ToOperations([]operations.Operation{op})
+	assert.Error(t, err)
+}
+
+// TestTreeRestoreSpanRejectsSpansWithoutMode guards the wire boundary: spans
+// present but the mode unset would silently drop them into an ordinary edit,
+// so deserialization must reject the mismatch.
+func TestTreeRestoreSpanRejectsSpansWithoutMode(t *testing.T) {
+	actor, err := time.ActorIDFromHex("000000000000000000000000")
+	assert.NoError(t, err)
+	seed := time.NewTicket(1, 0, actor)
+	executedAt := time.NewTicket(4, 0, actor)
+	pos := crdt.NewTreePos(crdt.NewTreeNodeID(seed, 0), crdt.NewTreeNodeID(seed, 0))
+
+	op := operations.NewRestoreTreeEdit(seed, pos, pos, executedAt,
+		[]*crdt.TreeRestoreSpan{{
+			ID:       crdt.NewTreeNodeID(seed, 2),
+			NodeType: "text",
+			IsText:   true,
+			Length:   1,
+			Value:    "x",
+			ParentID: crdt.NewTreeNodeID(seed, 0),
+		}}, crdt.RestoreModeRestore, nil)
+	pbOps, err := converter.ToOperations([]operations.Operation{op})
+	assert.NoError(t, err)
+
+	// Blank the mode while keeping the spans: a malformed restore payload.
+	pbOps[0].GetTreeEdit().RestoreMode = api.RestoreMode_RESTORE_MODE_UNSPECIFIED
+	_, err = converter.FromOperations(pbOps)
+	assert.Error(t, err)
+}

--- a/api/converter/converter_tree_restore_test.go
+++ b/api/converter/converter_tree_restore_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Yorkie Authors. All rights reserved.
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/converter/converter_tree_restore_test.go
+++ b/api/converter/converter_tree_restore_test.go
@@ -296,3 +296,65 @@ func TestTreeRestoreSpanRejectsSpansWithoutMode(t *testing.T) {
 	_, err = converter.FromOperations(pbOps)
 	assert.Error(t, err)
 }
+
+// TestTreeRestoreSpanRejectsModeWithoutSpans guards the other direction of the
+// same mismatch. A mode with no spans is worse than a silent no-op: Execute
+// keys the restore path off span presence, so the op falls through to the
+// ordinary edit path and applies from/to as a range DELETION, discarding the
+// contents too. No well-formed client emits this (the JS SDK gates its write
+// path on span length), so it can only arrive from a buggy or hostile peer and
+// must not reach the tree.
+func TestTreeRestoreSpanRejectsModeWithoutSpans(t *testing.T) {
+	actor, err := time.ActorIDFromHex("000000000000000000000000")
+	assert.NoError(t, err)
+	seed := time.NewTicket(1, 0, actor)
+	executedAt := time.NewTicket(4, 0, actor)
+	pos := crdt.NewTreePos(crdt.NewTreeNodeID(seed, 0), crdt.NewTreeNodeID(seed, 0))
+
+	// Serialize an ordinary edit, then set only the mode.
+	op := operations.NewTreeEdit(seed, pos, pos, nil, 0, executedAt)
+	pbOps, err := converter.ToOperations([]operations.Operation{op})
+	assert.NoError(t, err)
+	assert.Empty(t, pbOps[0].GetTreeEdit().RestoreSpans)
+	assert.Empty(t, pbOps[0].GetTreeEdit().RetombstoneSpans)
+
+	for _, mode := range []api.RestoreMode{
+		api.RestoreMode_RESTORE_MODE_RESTORE,
+		api.RestoreMode_RESTORE_MODE_RETOMBSTONE,
+	} {
+		pbOps[0].GetTreeEdit().RestoreMode = mode
+		_, err = converter.FromOperations(pbOps)
+		assert.ErrorIs(t, err, converter.ErrInvalidRestoreSpan, "mode %v with no spans", mode)
+	}
+
+	// An ordinary edit (no mode, no spans) still round-trips.
+	pbOps[0].GetTreeEdit().RestoreMode = api.RestoreMode_RESTORE_MODE_UNSPECIFIED
+	ops, err := converter.FromOperations(pbOps)
+	assert.NoError(t, err)
+	assert.Len(t, ops, 1)
+}
+
+// TestRestoreSpanRejectsModeWithoutSpans is the Text counterpart: the same
+// mismatch reaches Edit.Execute, which also keys off span presence.
+func TestRestoreSpanRejectsModeWithoutSpans(t *testing.T) {
+	actor, err := time.ActorIDFromHex("000000000000000000000000")
+	assert.NoError(t, err)
+	seed := time.NewTicket(1, 0, actor)
+	executedAt := time.NewTicket(4, 0, actor)
+	pos := crdt.NewRGATreeSplitNodePos(crdt.NewRGATreeSplitNodeID(seed, 0), 0)
+
+	op := operations.NewEdit(seed, pos, pos, "", nil, executedAt)
+	pbOps, err := converter.ToOperations([]operations.Operation{op})
+	assert.NoError(t, err)
+	assert.Empty(t, pbOps[0].GetEdit().RestoreSpans)
+	assert.Empty(t, pbOps[0].GetEdit().RetombstoneSpans)
+
+	pbOps[0].GetEdit().RestoreMode = api.RestoreMode_RESTORE_MODE_RESTORE
+	_, err = converter.FromOperations(pbOps)
+	assert.ErrorIs(t, err, converter.ErrInvalidRestoreSpan)
+
+	pbOps[0].GetEdit().RestoreMode = api.RestoreMode_RESTORE_MODE_UNSPECIFIED
+	ops, err := converter.FromOperations(pbOps)
+	assert.NoError(t, err)
+	assert.Len(t, ops, 1)
+}

--- a/api/converter/from_pb.go
+++ b/api/converter/from_pb.go
@@ -1038,6 +1038,16 @@ func fromTreeRestoreSpans(pbSpans []*api.TreeRestoreSpan) ([]*crdt.TreeRestoreSp
 		if id.CreatedAt == nil {
 			return nil, ErrInvalidRestoreSpan
 		}
+		// A text span's Length is the UTF-16 code-unit count of Value; the
+		// recreate path slices Value by [0, Length), so a mismatched (or
+		// negative) Length from crafted input would slice out of bounds.
+		// Reject it here (parity with fromRestoreSpans' Content-length check).
+		if pbSpan.Length < 0 {
+			return nil, ErrInvalidRestoreSpan
+		}
+		if pbSpan.IsText && int(pbSpan.Length) != len(utf16.Encode([]rune(pbSpan.Value))) {
+			return nil, ErrInvalidRestoreSpan
+		}
 		var attrs *crdt.RHT
 		if len(pbSpan.Attributes) > 0 {
 			attrs, err = fromRHT(pbSpan.Attributes)
@@ -1066,10 +1076,16 @@ func fromTreeRestoreSpans(pbSpans []*api.TreeRestoreSpan) ([]*crdt.TreeRestoreSp
 			if span.LeftSiblingID, err = fromTreeNodeID(pbSpan.LeftSiblingId); err != nil {
 				return nil, err
 			}
+			if span.LeftSiblingID.CreatedAt == nil {
+				return nil, ErrInvalidRestoreSpan
+			}
 		}
 		if pbSpan.RightSiblingId != nil {
 			if span.RightSiblingID, err = fromTreeNodeID(pbSpan.RightSiblingId); err != nil {
 				return nil, err
+			}
+			if span.RightSiblingID.CreatedAt == nil {
+				return nil, ErrInvalidRestoreSpan
 			}
 		}
 		spans = append(spans, span)

--- a/api/converter/from_pb.go
+++ b/api/converter/from_pb.go
@@ -725,6 +725,26 @@ func fromTreeEdit(pbTreeEdit *api.Operation_TreeEdit) (*operations.TreeEdit, err
 		return nil, err
 	}
 
+	restoreSpans, err := fromTreeRestoreSpans(pbTreeEdit.RestoreSpans)
+	if err != nil {
+		return nil, err
+	}
+	retombstoneSpans, err := fromTreeRestoreSpans(pbTreeEdit.RetombstoneSpans)
+	if err != nil {
+		return nil, err
+	}
+	if mode := fromRestoreMode(pbTreeEdit.RestoreMode); mode != crdt.RestoreModeNone {
+		return operations.NewRestoreTreeEdit(
+			parentCreatedAt,
+			from,
+			to,
+			executedAt,
+			restoreSpans,
+			mode,
+			retombstoneSpans,
+		), nil
+	}
+
 	return operations.NewTreeEdit(
 		parentCreatedAt,
 		from,
@@ -996,6 +1016,65 @@ func fromTreeNodeID(pbPos *api.TreeNodeID) (*crdt.TreeNodeID, error) {
 		createdAt,
 		int(pbPos.Offset),
 	), nil
+}
+
+// fromTreeRestoreSpans converts Protobuf identity-preserving Tree restore
+// spans to model format. A span addresses content by insertion identity, so a
+// missing id/parent_id created_at is malformed and rejected (parity with the
+// Text restore span read path).
+func fromTreeRestoreSpans(pbSpans []*api.TreeRestoreSpan) ([]*crdt.TreeRestoreSpan, error) {
+	if len(pbSpans) == 0 {
+		return nil, nil
+	}
+	spans := make([]*crdt.TreeRestoreSpan, 0, len(pbSpans))
+	for _, pbSpan := range pbSpans {
+		if pbSpan == nil || pbSpan.Id == nil {
+			return nil, ErrInvalidRestoreSpan
+		}
+		id, err := fromTreeNodeID(pbSpan.Id)
+		if err != nil {
+			return nil, err
+		}
+		if id.CreatedAt == nil {
+			return nil, ErrInvalidRestoreSpan
+		}
+		var attrs *crdt.RHT
+		if len(pbSpan.Attributes) > 0 {
+			attrs, err = fromRHT(pbSpan.Attributes)
+			if err != nil {
+				return nil, err
+			}
+		}
+		span := &crdt.TreeRestoreSpan{
+			ID:         id,
+			NodeType:   pbSpan.NodeType,
+			IsText:     pbSpan.IsText,
+			Length:     int(pbSpan.Length),
+			Value:      pbSpan.Value,
+			Attributes: attrs,
+		}
+		if pbSpan.ParentId != nil {
+			span.ParentID, err = fromTreeNodeID(pbSpan.ParentId)
+			if err != nil {
+				return nil, err
+			}
+			if span.ParentID.CreatedAt == nil {
+				return nil, ErrInvalidRestoreSpan
+			}
+		}
+		if pbSpan.LeftSiblingId != nil {
+			if span.LeftSiblingID, err = fromTreeNodeID(pbSpan.LeftSiblingId); err != nil {
+				return nil, err
+			}
+		}
+		if pbSpan.RightSiblingId != nil {
+			if span.RightSiblingID, err = fromTreeNodeID(pbSpan.RightSiblingId); err != nil {
+				return nil, err
+			}
+		}
+		spans = append(spans, span)
+	}
+	return spans, nil
 }
 
 func fromTimeTicket(pbTicket *api.TimeTicket) (*time.Ticket, error) {

--- a/api/converter/from_pb.go
+++ b/api/converter/from_pb.go
@@ -549,13 +549,19 @@ func fromEdit(pbEdit *api.Operation_Edit) (*operations.Edit, error) {
 	if err != nil {
 		return nil, err
 	}
+	// A restore payload and a restore mode only mean anything together, so
+	// reject either one without the other. Without this, Execute's span-based
+	// guard falls through to the ordinary edit path: spans without a mode are
+	// silently dropped, and a mode without spans applies from/to as a range
+	// DELETION under a "restore" label (also discarding content/attributes).
+	// Neither is something a well-formed client sends.
 	mode := fromRestoreMode(pbEdit.RestoreMode)
-	// Restore payload without a mode (or vice versa) is malformed: the spans
-	// would be silently dropped as an ordinary edit. Reject it.
-	if mode == crdt.RestoreModeNone && (len(restoreSpans) > 0 || len(retombstoneSpans) > 0) {
+	hasMode := mode != crdt.RestoreModeNone
+	hasSpans := len(restoreSpans) > 0 || len(retombstoneSpans) > 0
+	if hasMode != hasSpans {
 		return nil, ErrInvalidRestoreSpan
 	}
-	if mode != crdt.RestoreModeNone {
+	if hasMode {
 		return operations.NewRestoreEdit(
 			parentCreatedAt,
 			from,
@@ -739,13 +745,19 @@ func fromTreeEdit(pbTreeEdit *api.Operation_TreeEdit) (*operations.TreeEdit, err
 	if err != nil {
 		return nil, err
 	}
+	// A restore payload and a restore mode only mean anything together, so
+	// reject either one without the other. Without this, Execute's span-based
+	// guard falls through to the ordinary edit path: spans without a mode are
+	// silently dropped, and a mode without spans applies from/to as a range
+	// DELETION under a "restore" label (also discarding contents/split_level).
+	// Neither is something a well-formed client sends.
 	mode := fromRestoreMode(pbTreeEdit.RestoreMode)
-	// Restore payload without a mode (or vice versa) is malformed: the spans
-	// would be silently dropped as an ordinary edit. Reject it.
-	if mode == crdt.RestoreModeNone && (len(restoreSpans) > 0 || len(retombstoneSpans) > 0) {
+	hasMode := mode != crdt.RestoreModeNone
+	hasSpans := len(restoreSpans) > 0 || len(retombstoneSpans) > 0
+	if hasMode != hasSpans {
 		return nil, ErrInvalidRestoreSpan
 	}
-	if mode != crdt.RestoreModeNone {
+	if hasMode {
 		return operations.NewRestoreTreeEdit(
 			parentCreatedAt,
 			from,

--- a/api/converter/from_pb.go
+++ b/api/converter/from_pb.go
@@ -549,7 +549,13 @@ func fromEdit(pbEdit *api.Operation_Edit) (*operations.Edit, error) {
 	if err != nil {
 		return nil, err
 	}
-	if mode := fromRestoreMode(pbEdit.RestoreMode); mode != crdt.RestoreModeNone {
+	mode := fromRestoreMode(pbEdit.RestoreMode)
+	// Restore payload without a mode (or vice versa) is malformed: the spans
+	// would be silently dropped as an ordinary edit. Reject it.
+	if mode == crdt.RestoreModeNone && (len(restoreSpans) > 0 || len(retombstoneSpans) > 0) {
+		return nil, ErrInvalidRestoreSpan
+	}
+	if mode != crdt.RestoreModeNone {
 		return operations.NewRestoreEdit(
 			parentCreatedAt,
 			from,
@@ -733,7 +739,13 @@ func fromTreeEdit(pbTreeEdit *api.Operation_TreeEdit) (*operations.TreeEdit, err
 	if err != nil {
 		return nil, err
 	}
-	if mode := fromRestoreMode(pbTreeEdit.RestoreMode); mode != crdt.RestoreModeNone {
+	mode := fromRestoreMode(pbTreeEdit.RestoreMode)
+	// Restore payload without a mode (or vice versa) is malformed: the spans
+	// would be silently dropped as an ordinary edit. Reject it.
+	if mode == crdt.RestoreModeNone && (len(restoreSpans) > 0 || len(retombstoneSpans) > 0) {
+		return nil, ErrInvalidRestoreSpan
+	}
+	if mode != crdt.RestoreModeNone {
 		return operations.NewRestoreTreeEdit(
 			parentCreatedAt,
 			from,

--- a/api/converter/to_bytes.go
+++ b/api/converter/to_bytes.go
@@ -18,6 +18,7 @@ package converter
 
 import (
 	"fmt"
+	"math"
 	"reflect"
 
 	"google.golang.org/protobuf/proto"
@@ -364,13 +365,18 @@ func toTreeNodeID(pos *crdt.TreeNodeID) *api.TreeNodeID {
 }
 
 // toTreeRestoreSpans converts identity-preserving Tree restore spans to
-// Protobuf. Optional id fields are emitted only when present.
-func toTreeRestoreSpans(spans []*crdt.TreeRestoreSpan) []*api.TreeRestoreSpan {
+// Protobuf. Optional id fields are emitted only when present. Length is bounds
+// -checked against int32 rather than silently wrapping (parity with
+// toRestoreSpans), so a document large enough to overflow it errors instead.
+func toTreeRestoreSpans(spans []*crdt.TreeRestoreSpan) ([]*api.TreeRestoreSpan, error) {
 	if len(spans) == 0 {
-		return nil
+		return nil, nil
 	}
 	pbSpans := make([]*api.TreeRestoreSpan, 0, len(spans))
 	for _, span := range spans {
+		if span.Length < 0 || span.Length > math.MaxInt32 {
+			return nil, ErrInvalidRestoreSpan
+		}
 		pbSpan := &api.TreeRestoreSpan{
 			Id:         toTreeNodeID(span.ID),
 			NodeType:   span.NodeType,
@@ -390,7 +396,7 @@ func toTreeRestoreSpans(spans []*crdt.TreeRestoreSpan) []*api.TreeRestoreSpan {
 		}
 		pbSpans = append(pbSpans, pbSpan)
 	}
-	return pbSpans
+	return pbSpans, nil
 }
 
 func toTreePos(pos *crdt.TreePos) *api.TreePos {

--- a/api/converter/to_bytes.go
+++ b/api/converter/to_bytes.go
@@ -363,6 +363,36 @@ func toTreeNodeID(pos *crdt.TreeNodeID) *api.TreeNodeID {
 	}
 }
 
+// toTreeRestoreSpans converts identity-preserving Tree restore spans to
+// Protobuf. Optional id fields are emitted only when present.
+func toTreeRestoreSpans(spans []*crdt.TreeRestoreSpan) []*api.TreeRestoreSpan {
+	if len(spans) == 0 {
+		return nil
+	}
+	pbSpans := make([]*api.TreeRestoreSpan, 0, len(spans))
+	for _, span := range spans {
+		pbSpan := &api.TreeRestoreSpan{
+			Id:         toTreeNodeID(span.ID),
+			NodeType:   span.NodeType,
+			IsText:     span.IsText,
+			Length:     int32(span.Length),
+			Value:      span.Value,
+			Attributes: toRHT(span.Attributes),
+		}
+		if span.ParentID != nil {
+			pbSpan.ParentId = toTreeNodeID(span.ParentID)
+		}
+		if span.LeftSiblingID != nil {
+			pbSpan.LeftSiblingId = toTreeNodeID(span.LeftSiblingID)
+		}
+		if span.RightSiblingID != nil {
+			pbSpan.RightSiblingId = toTreeNodeID(span.RightSiblingID)
+		}
+		pbSpans = append(pbSpans, pbSpan)
+	}
+	return pbSpans
+}
+
 func toTreePos(pos *crdt.TreePos) *api.TreePos {
 	return &api.TreePos{
 		ParentId: &api.TreeNodeID{

--- a/api/converter/to_bytes.go
+++ b/api/converter/to_bytes.go
@@ -374,6 +374,9 @@ func toTreeRestoreSpans(spans []*crdt.TreeRestoreSpan) ([]*api.TreeRestoreSpan, 
 	}
 	pbSpans := make([]*api.TreeRestoreSpan, 0, len(spans))
 	for _, span := range spans {
+		if span.ID == nil {
+			return nil, ErrInvalidRestoreSpan
+		}
 		if span.Length < 0 || span.Length > math.MaxInt32 {
 			return nil, ErrInvalidRestoreSpan
 		}

--- a/api/converter/to_pb.go
+++ b/api/converter/to_pb.go
@@ -517,16 +517,20 @@ func toIncrease(increase *operations.Increase) (*api.Operation_Increase_, error)
 }
 
 func toTreeEdit(e *operations.TreeEdit) (*api.Operation_TreeEdit_, error) {
-	return &api.Operation_TreeEdit_{
-		TreeEdit: &api.Operation_TreeEdit{
-			ParentCreatedAt: ToTimeTicket(e.ParentCreatedAt()),
-			From:            toTreePos(e.FromPos()),
-			To:              toTreePos(e.ToPos()),
-			Contents:        ToTreeNodesWhenEdit(e.Contents()),
-			SplitLevel:      int32(e.SplitLevel()),
-			ExecutedAt:      ToTimeTicket(e.ExecutedAt()),
-		},
-	}, nil
+	pbTreeEdit := &api.Operation_TreeEdit{
+		ParentCreatedAt: ToTimeTicket(e.ParentCreatedAt()),
+		From:            toTreePos(e.FromPos()),
+		To:              toTreePos(e.ToPos()),
+		Contents:        ToTreeNodesWhenEdit(e.Contents()),
+		SplitLevel:      int32(e.SplitLevel()),
+		ExecutedAt:      ToTimeTicket(e.ExecutedAt()),
+	}
+	if len(e.RestoreSpans()) > 0 || len(e.RetombstoneSpans()) > 0 {
+		pbTreeEdit.RestoreSpans = toTreeRestoreSpans(e.RestoreSpans())
+		pbTreeEdit.RetombstoneSpans = toTreeRestoreSpans(e.RetombstoneSpans())
+		pbTreeEdit.RestoreMode = toRestoreMode(e.RestoreMode())
+	}
+	return &api.Operation_TreeEdit_{TreeEdit: pbTreeEdit}, nil
 }
 
 func toTreeStyle(style *operations.TreeStyle) (*api.Operation_TreeStyle_, error) {

--- a/api/converter/to_pb.go
+++ b/api/converter/to_pb.go
@@ -526,8 +526,16 @@ func toTreeEdit(e *operations.TreeEdit) (*api.Operation_TreeEdit_, error) {
 		ExecutedAt:      ToTimeTicket(e.ExecutedAt()),
 	}
 	if len(e.RestoreSpans()) > 0 || len(e.RetombstoneSpans()) > 0 {
-		pbTreeEdit.RestoreSpans = toTreeRestoreSpans(e.RestoreSpans())
-		pbTreeEdit.RetombstoneSpans = toTreeRestoreSpans(e.RetombstoneSpans())
+		restoreSpans, err := toTreeRestoreSpans(e.RestoreSpans())
+		if err != nil {
+			return nil, err
+		}
+		retombstoneSpans, err := toTreeRestoreSpans(e.RetombstoneSpans())
+		if err != nil {
+			return nil, err
+		}
+		pbTreeEdit.RestoreSpans = restoreSpans
+		pbTreeEdit.RetombstoneSpans = retombstoneSpans
 		pbTreeEdit.RestoreMode = toRestoreMode(e.RestoreMode())
 	}
 	return &api.Operation_TreeEdit_{TreeEdit: pbTreeEdit}, nil

--- a/api/yorkie/v1/resources.pb.go
+++ b/api/yorkie/v1/resources.pb.go
@@ -325,7 +325,7 @@ func (x ChannelEvent_Type) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ChannelEvent_Type.Descriptor instead.
 func (ChannelEvent_Type) EnumDescriptor() ([]byte, []int) {
-	return file_yorkie_v1_resources_proto_rawDescGZIP(), []int{32, 0}
+	return file_yorkie_v1_resources_proto_rawDescGZIP(), []int{33, 0}
 }
 
 // ///////////////////////////////////////
@@ -2824,6 +2824,123 @@ func (x *RestoreSpan) GetAttributes() map[string]string {
 	return nil
 }
 
+// TreeRestoreSpan carries a tree node run from a single deletion, addressed
+// by TreeNodeID identity, for identity-preserving Tree undo/redo. Unlike the
+// text RestoreSpan (flat offsets), a tree span records the node's structure
+// (type/attrs) and its position anchors, because in a tree id-order is not
+// sibling-order: left_sibling_id and right_sibling_id are redundant external
+// boundary anchors of the deleted run, so restore can reconstruct the run's
+// internal order from the op's own spans and needs only one surviving
+// boundary to place it. value/attributes are a deep copy so a GC-purged node
+// can be recreated.
+type TreeRestoreSpan struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Id             *TreeNodeID            `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	NodeType       string                 `protobuf:"bytes,2,opt,name=node_type,json=nodeType,proto3" json:"node_type,omitempty"`
+	IsText         bool                   `protobuf:"varint,3,opt,name=is_text,json=isText,proto3" json:"is_text,omitempty"`
+	Length         int32                  `protobuf:"varint,4,opt,name=length,proto3" json:"length,omitempty"`
+	Value          string                 `protobuf:"bytes,5,opt,name=value,proto3" json:"value,omitempty"`
+	Attributes     map[string]*NodeAttr   `protobuf:"bytes,6,rep,name=attributes,proto3" json:"attributes,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	ParentId       *TreeNodeID            `protobuf:"bytes,7,opt,name=parent_id,json=parentId,proto3" json:"parent_id,omitempty"`
+	LeftSiblingId  *TreeNodeID            `protobuf:"bytes,8,opt,name=left_sibling_id,json=leftSiblingId,proto3" json:"left_sibling_id,omitempty"`
+	RightSiblingId *TreeNodeID            `protobuf:"bytes,9,opt,name=right_sibling_id,json=rightSiblingId,proto3" json:"right_sibling_id,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *TreeRestoreSpan) Reset() {
+	*x = TreeRestoreSpan{}
+	mi := &file_yorkie_v1_resources_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TreeRestoreSpan) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TreeRestoreSpan) ProtoMessage() {}
+
+func (x *TreeRestoreSpan) ProtoReflect() protoreflect.Message {
+	mi := &file_yorkie_v1_resources_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TreeRestoreSpan.ProtoReflect.Descriptor instead.
+func (*TreeRestoreSpan) Descriptor() ([]byte, []int) {
+	return file_yorkie_v1_resources_proto_rawDescGZIP(), []int{29}
+}
+
+func (x *TreeRestoreSpan) GetId() *TreeNodeID {
+	if x != nil {
+		return x.Id
+	}
+	return nil
+}
+
+func (x *TreeRestoreSpan) GetNodeType() string {
+	if x != nil {
+		return x.NodeType
+	}
+	return ""
+}
+
+func (x *TreeRestoreSpan) GetIsText() bool {
+	if x != nil {
+		return x.IsText
+	}
+	return false
+}
+
+func (x *TreeRestoreSpan) GetLength() int32 {
+	if x != nil {
+		return x.Length
+	}
+	return 0
+}
+
+func (x *TreeRestoreSpan) GetValue() string {
+	if x != nil {
+		return x.Value
+	}
+	return ""
+}
+
+func (x *TreeRestoreSpan) GetAttributes() map[string]*NodeAttr {
+	if x != nil {
+		return x.Attributes
+	}
+	return nil
+}
+
+func (x *TreeRestoreSpan) GetParentId() *TreeNodeID {
+	if x != nil {
+		return x.ParentId
+	}
+	return nil
+}
+
+func (x *TreeRestoreSpan) GetLeftSiblingId() *TreeNodeID {
+	if x != nil {
+		return x.LeftSiblingId
+	}
+	return nil
+}
+
+func (x *TreeRestoreSpan) GetRightSiblingId() *TreeNodeID {
+	if x != nil {
+		return x.RightSiblingId
+	}
+	return nil
+}
+
 type TimeTicket struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Lamport       int64                  `protobuf:"varint,1,opt,name=lamport,proto3" json:"lamport,omitempty"`
@@ -2835,7 +2952,7 @@ type TimeTicket struct {
 
 func (x *TimeTicket) Reset() {
 	*x = TimeTicket{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[29]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2847,7 +2964,7 @@ func (x *TimeTicket) String() string {
 func (*TimeTicket) ProtoMessage() {}
 
 func (x *TimeTicket) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[29]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2860,7 +2977,7 @@ func (x *TimeTicket) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TimeTicket.ProtoReflect.Descriptor instead.
 func (*TimeTicket) Descriptor() ([]byte, []int) {
-	return file_yorkie_v1_resources_proto_rawDescGZIP(), []int{29}
+	return file_yorkie_v1_resources_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *TimeTicket) GetLamport() int64 {
@@ -2894,7 +3011,7 @@ type DocEventBody struct {
 
 func (x *DocEventBody) Reset() {
 	*x = DocEventBody{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[30]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2906,7 +3023,7 @@ func (x *DocEventBody) String() string {
 func (*DocEventBody) ProtoMessage() {}
 
 func (x *DocEventBody) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[30]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2919,7 +3036,7 @@ func (x *DocEventBody) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DocEventBody.ProtoReflect.Descriptor instead.
 func (*DocEventBody) Descriptor() ([]byte, []int) {
-	return file_yorkie_v1_resources_proto_rawDescGZIP(), []int{30}
+	return file_yorkie_v1_resources_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *DocEventBody) GetTopic() string {
@@ -2947,7 +3064,7 @@ type DocEvent struct {
 
 func (x *DocEvent) Reset() {
 	*x = DocEvent{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[31]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2959,7 +3076,7 @@ func (x *DocEvent) String() string {
 func (*DocEvent) ProtoMessage() {}
 
 func (x *DocEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[31]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2972,7 +3089,7 @@ func (x *DocEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DocEvent.ProtoReflect.Descriptor instead.
 func (*DocEvent) Descriptor() ([]byte, []int) {
-	return file_yorkie_v1_resources_proto_rawDescGZIP(), []int{31}
+	return file_yorkie_v1_resources_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *DocEvent) GetType() DocEventType {
@@ -3010,7 +3127,7 @@ type ChannelEvent struct {
 
 func (x *ChannelEvent) Reset() {
 	*x = ChannelEvent{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[32]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3022,7 +3139,7 @@ func (x *ChannelEvent) String() string {
 func (*ChannelEvent) ProtoMessage() {}
 
 func (x *ChannelEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[32]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3035,7 +3152,7 @@ func (x *ChannelEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChannelEvent.ProtoReflect.Descriptor instead.
 func (*ChannelEvent) Descriptor() ([]byte, []int) {
-	return file_yorkie_v1_resources_proto_rawDescGZIP(), []int{32}
+	return file_yorkie_v1_resources_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *ChannelEvent) GetType() ChannelEvent_Type {
@@ -3090,7 +3207,7 @@ type DataSize struct {
 
 func (x *DataSize) Reset() {
 	*x = DataSize{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[33]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3102,7 +3219,7 @@ func (x *DataSize) String() string {
 func (*DataSize) ProtoMessage() {}
 
 func (x *DataSize) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[33]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3115,7 +3232,7 @@ func (x *DataSize) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DataSize.ProtoReflect.Descriptor instead.
 func (*DataSize) Descriptor() ([]byte, []int) {
-	return file_yorkie_v1_resources_proto_rawDescGZIP(), []int{33}
+	return file_yorkie_v1_resources_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *DataSize) GetData() int32 {
@@ -3142,7 +3259,7 @@ type DocSize struct {
 
 func (x *DocSize) Reset() {
 	*x = DocSize{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[34]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3154,7 +3271,7 @@ func (x *DocSize) String() string {
 func (*DocSize) ProtoMessage() {}
 
 func (x *DocSize) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[34]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3167,7 +3284,7 @@ func (x *DocSize) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DocSize.ProtoReflect.Descriptor instead.
 func (*DocSize) Descriptor() ([]byte, []int) {
-	return file_yorkie_v1_resources_proto_rawDescGZIP(), []int{34}
+	return file_yorkie_v1_resources_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *DocSize) GetLive() *DataSize {
@@ -3198,7 +3315,7 @@ type Schema struct {
 
 func (x *Schema) Reset() {
 	*x = Schema{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[35]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3210,7 +3327,7 @@ func (x *Schema) String() string {
 func (*Schema) ProtoMessage() {}
 
 func (x *Schema) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[35]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3223,7 +3340,7 @@ func (x *Schema) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Schema.ProtoReflect.Descriptor instead.
 func (*Schema) Descriptor() ([]byte, []int) {
-	return file_yorkie_v1_resources_proto_rawDescGZIP(), []int{35}
+	return file_yorkie_v1_resources_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *Schema) GetId() string {
@@ -3280,7 +3397,7 @@ type TreeNodeRule struct {
 
 func (x *TreeNodeRule) Reset() {
 	*x = TreeNodeRule{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[36]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3292,7 +3409,7 @@ func (x *TreeNodeRule) String() string {
 func (*TreeNodeRule) ProtoMessage() {}
 
 func (x *TreeNodeRule) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[36]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3305,7 +3422,7 @@ func (x *TreeNodeRule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TreeNodeRule.ProtoReflect.Descriptor instead.
 func (*TreeNodeRule) Descriptor() ([]byte, []int) {
-	return file_yorkie_v1_resources_proto_rawDescGZIP(), []int{36}
+	return file_yorkie_v1_resources_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *TreeNodeRule) GetNodeType() string {
@@ -3347,7 +3464,7 @@ type Rule struct {
 
 func (x *Rule) Reset() {
 	*x = Rule{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[37]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3359,7 +3476,7 @@ func (x *Rule) String() string {
 func (*Rule) ProtoMessage() {}
 
 func (x *Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[37]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3372,7 +3489,7 @@ func (x *Rule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Rule.ProtoReflect.Descriptor instead.
 func (*Rule) Descriptor() ([]byte, []int) {
-	return file_yorkie_v1_resources_proto_rawDescGZIP(), []int{37}
+	return file_yorkie_v1_resources_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *Rule) GetPath() string {
@@ -3409,7 +3526,7 @@ type RevisionSummary struct {
 
 func (x *RevisionSummary) Reset() {
 	*x = RevisionSummary{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[38]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3421,7 +3538,7 @@ func (x *RevisionSummary) String() string {
 func (*RevisionSummary) ProtoMessage() {}
 
 func (x *RevisionSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[38]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3434,7 +3551,7 @@ func (x *RevisionSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevisionSummary.ProtoReflect.Descriptor instead.
 func (*RevisionSummary) Descriptor() ([]byte, []int) {
-	return file_yorkie_v1_resources_proto_rawDescGZIP(), []int{38}
+	return file_yorkie_v1_resources_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *RevisionSummary) GetId() string {
@@ -3484,7 +3601,7 @@ type Operation_Set struct {
 
 func (x *Operation_Set) Reset() {
 	*x = Operation_Set{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[41]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3496,7 +3613,7 @@ func (x *Operation_Set) String() string {
 func (*Operation_Set) ProtoMessage() {}
 
 func (x *Operation_Set) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[41]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3552,7 +3669,7 @@ type Operation_Add struct {
 
 func (x *Operation_Add) Reset() {
 	*x = Operation_Add{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[42]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3564,7 +3681,7 @@ func (x *Operation_Add) String() string {
 func (*Operation_Add) ProtoMessage() {}
 
 func (x *Operation_Add) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[42]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3620,7 +3737,7 @@ type Operation_Move struct {
 
 func (x *Operation_Move) Reset() {
 	*x = Operation_Move{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[43]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3632,7 +3749,7 @@ func (x *Operation_Move) String() string {
 func (*Operation_Move) ProtoMessage() {}
 
 func (x *Operation_Move) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[43]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3687,7 +3804,7 @@ type Operation_Remove struct {
 
 func (x *Operation_Remove) Reset() {
 	*x = Operation_Remove{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[44]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3699,7 +3816,7 @@ func (x *Operation_Remove) String() string {
 func (*Operation_Remove) ProtoMessage() {}
 
 func (x *Operation_Remove) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[44]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3759,7 +3876,7 @@ type Operation_Edit struct {
 
 func (x *Operation_Edit) Reset() {
 	*x = Operation_Edit{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[45]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3771,7 +3888,7 @@ func (x *Operation_Edit) String() string {
 func (*Operation_Edit) ProtoMessage() {}
 
 func (x *Operation_Edit) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[45]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3872,7 +3989,7 @@ type Operation_Style struct {
 
 func (x *Operation_Style) Reset() {
 	*x = Operation_Style{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[46]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3884,7 +4001,7 @@ func (x *Operation_Style) String() string {
 func (*Operation_Style) ProtoMessage() {}
 
 func (x *Operation_Style) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[46]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3961,7 +4078,7 @@ type Operation_Increase struct {
 
 func (x *Operation_Increase) Reset() {
 	*x = Operation_Increase{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[47]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3973,7 +4090,7 @@ func (x *Operation_Increase) String() string {
 func (*Operation_Increase) ProtoMessage() {}
 
 func (x *Operation_Increase) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[47]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4026,13 +4143,16 @@ type Operation_TreeEdit struct {
 	Contents            []*TreeNodes           `protobuf:"bytes,5,rep,name=contents,proto3" json:"contents,omitempty"`
 	SplitLevel          int32                  `protobuf:"varint,7,opt,name=split_level,json=splitLevel,proto3" json:"split_level,omitempty"`
 	ExecutedAt          *TimeTicket            `protobuf:"bytes,6,opt,name=executed_at,json=executedAt,proto3" json:"executed_at,omitempty"`
+	RestoreSpans        []*TreeRestoreSpan     `protobuf:"bytes,8,rep,name=restore_spans,json=restoreSpans,proto3" json:"restore_spans,omitempty"` // identity-preserving undo/redo
+	RestoreMode         RestoreMode            `protobuf:"varint,9,opt,name=restore_mode,json=restoreMode,proto3,enum=yorkie.v1.RestoreMode" json:"restore_mode,omitempty"`
+	RetombstoneSpans    []*TreeRestoreSpan     `protobuf:"bytes,10,rep,name=retombstone_spans,json=retombstoneSpans,proto3" json:"retombstone_spans,omitempty"`
 	unknownFields       protoimpl.UnknownFields
 	sizeCache           protoimpl.SizeCache
 }
 
 func (x *Operation_TreeEdit) Reset() {
 	*x = Operation_TreeEdit{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[48]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4044,7 +4164,7 @@ func (x *Operation_TreeEdit) String() string {
 func (*Operation_TreeEdit) ProtoMessage() {}
 
 func (x *Operation_TreeEdit) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[48]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4109,6 +4229,27 @@ func (x *Operation_TreeEdit) GetExecutedAt() *TimeTicket {
 	return nil
 }
 
+func (x *Operation_TreeEdit) GetRestoreSpans() []*TreeRestoreSpan {
+	if x != nil {
+		return x.RestoreSpans
+	}
+	return nil
+}
+
+func (x *Operation_TreeEdit) GetRestoreMode() RestoreMode {
+	if x != nil {
+		return x.RestoreMode
+	}
+	return RestoreMode_RESTORE_MODE_UNSPECIFIED
+}
+
+func (x *Operation_TreeEdit) GetRetombstoneSpans() []*TreeRestoreSpan {
+	if x != nil {
+		return x.RetombstoneSpans
+	}
+	return nil
+}
+
 type Operation_TreeStyle struct {
 	state               protoimpl.MessageState `protogen:"open.v1"`
 	ParentCreatedAt     *TimeTicket            `protobuf:"bytes,1,opt,name=parent_created_at,json=parentCreatedAt,proto3" json:"parent_created_at,omitempty"`
@@ -4124,7 +4265,7 @@ type Operation_TreeStyle struct {
 
 func (x *Operation_TreeStyle) Reset() {
 	*x = Operation_TreeStyle{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[49]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4136,7 +4277,7 @@ func (x *Operation_TreeStyle) String() string {
 func (*Operation_TreeStyle) ProtoMessage() {}
 
 func (x *Operation_TreeStyle) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[49]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4213,7 +4354,7 @@ type Operation_ArraySet struct {
 
 func (x *Operation_ArraySet) Reset() {
 	*x = Operation_ArraySet{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[50]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4225,7 +4366,7 @@ func (x *Operation_ArraySet) String() string {
 func (*Operation_ArraySet) ProtoMessage() {}
 
 func (x *Operation_ArraySet) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[50]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4281,7 +4422,7 @@ type JSONElement_JSONObject struct {
 
 func (x *JSONElement_JSONObject) Reset() {
 	*x = JSONElement_JSONObject{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[58]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4293,7 +4434,7 @@ func (x *JSONElement_JSONObject) String() string {
 func (*JSONElement_JSONObject) ProtoMessage() {}
 
 func (x *JSONElement_JSONObject) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[58]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4349,7 +4490,7 @@ type JSONElement_JSONArray struct {
 
 func (x *JSONElement_JSONArray) Reset() {
 	*x = JSONElement_JSONArray{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[59]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4361,7 +4502,7 @@ func (x *JSONElement_JSONArray) String() string {
 func (*JSONElement_JSONArray) ProtoMessage() {}
 
 func (x *JSONElement_JSONArray) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[59]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4418,7 +4559,7 @@ type JSONElement_Primitive struct {
 
 func (x *JSONElement_Primitive) Reset() {
 	*x = JSONElement_Primitive{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[60]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4430,7 +4571,7 @@ func (x *JSONElement_Primitive) String() string {
 func (*JSONElement_Primitive) ProtoMessage() {}
 
 func (x *JSONElement_Primitive) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[60]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4493,7 +4634,7 @@ type JSONElement_Text struct {
 
 func (x *JSONElement_Text) Reset() {
 	*x = JSONElement_Text{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[61]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4505,7 +4646,7 @@ func (x *JSONElement_Text) String() string {
 func (*JSONElement_Text) ProtoMessage() {}
 
 func (x *JSONElement_Text) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[61]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4563,7 +4704,7 @@ type JSONElement_Counter struct {
 
 func (x *JSONElement_Counter) Reset() {
 	*x = JSONElement_Counter{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[62]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4575,7 +4716,7 @@ func (x *JSONElement_Counter) String() string {
 func (*JSONElement_Counter) ProtoMessage() {}
 
 func (x *JSONElement_Counter) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[62]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4645,7 +4786,7 @@ type JSONElement_Tree struct {
 
 func (x *JSONElement_Tree) Reset() {
 	*x = JSONElement_Tree{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[63]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4657,7 +4798,7 @@ func (x *JSONElement_Tree) String() string {
 func (*JSONElement_Tree) ProtoMessage() {}
 
 func (x *JSONElement_Tree) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[63]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4710,7 +4851,7 @@ type UpdatableProjectFields_AuthWebhookMethods struct {
 
 func (x *UpdatableProjectFields_AuthWebhookMethods) Reset() {
 	*x = UpdatableProjectFields_AuthWebhookMethods{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[66]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4722,7 +4863,7 @@ func (x *UpdatableProjectFields_AuthWebhookMethods) String() string {
 func (*UpdatableProjectFields_AuthWebhookMethods) ProtoMessage() {}
 
 func (x *UpdatableProjectFields_AuthWebhookMethods) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[66]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4754,7 +4895,7 @@ type UpdatableProjectFields_EventWebhookEvents struct {
 
 func (x *UpdatableProjectFields_EventWebhookEvents) Reset() {
 	*x = UpdatableProjectFields_EventWebhookEvents{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[67]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4766,7 +4907,7 @@ func (x *UpdatableProjectFields_EventWebhookEvents) String() string {
 func (*UpdatableProjectFields_EventWebhookEvents) ProtoMessage() {}
 
 func (x *UpdatableProjectFields_EventWebhookEvents) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[67]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4798,7 +4939,7 @@ type UpdatableProjectFields_AllowedOrigins struct {
 
 func (x *UpdatableProjectFields_AllowedOrigins) Reset() {
 	*x = UpdatableProjectFields_AllowedOrigins{}
-	mi := &file_yorkie_v1_resources_proto_msgTypes[68]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4810,7 +4951,7 @@ func (x *UpdatableProjectFields_AllowedOrigins) String() string {
 func (*UpdatableProjectFields_AllowedOrigins) ProtoMessage() {}
 
 func (x *UpdatableProjectFields_AllowedOrigins) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_resources_proto_msgTypes[68]
+	mi := &file_yorkie_v1_resources_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4875,7 +5016,7 @@ const file_yorkie_v1_resources_proto_rawDesc = "" +
 	"\x06vector\x18\x01 \x03(\v2$.yorkie.v1.VersionVector.VectorEntryR\x06vector\x1a9\n" +
 	"\vVectorEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\x03R\x05value:\x028\x01\"\xa8\"\n" +
+	"\x05value\x18\x02 \x01(\x03R\x05value:\x028\x01\"\xed#\n" +
 	"\tOperation\x12,\n" +
 	"\x03set\x18\x01 \x01(\v2\x18.yorkie.v1.Operation.SetH\x00R\x03set\x12,\n" +
 	"\x03add\x18\x02 \x01(\v2\x18.yorkie.v1.Operation.AddH\x00R\x03add\x12/\n" +
@@ -4957,7 +5098,7 @@ const file_yorkie_v1_resources_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\v2\x1c.yorkie.v1.JSONElementSimpleR\x05value\x126\n" +
 	"\vexecuted_at\x18\x03 \x01(\v2\x15.yorkie.v1.TimeTicketR\n" +
 	"executedAt\x12\x14\n" +
-	"\x05actor\x18\x04 \x01(\tR\x05actor\x1a\xf1\x03\n" +
+	"\x05actor\x18\x04 \x01(\tR\x05actor\x1a\xb6\x05\n" +
 	"\bTreeEdit\x12A\n" +
 	"\x11parent_created_at\x18\x01 \x01(\v2\x15.yorkie.v1.TimeTicketR\x0fparentCreatedAt\x12&\n" +
 	"\x04from\x18\x02 \x01(\v2\x12.yorkie.v1.TreePosR\x04from\x12\"\n" +
@@ -4967,7 +5108,11 @@ const file_yorkie_v1_resources_proto_rawDesc = "" +
 	"\vsplit_level\x18\a \x01(\x05R\n" +
 	"splitLevel\x126\n" +
 	"\vexecuted_at\x18\x06 \x01(\v2\x15.yorkie.v1.TimeTicketR\n" +
-	"executedAt\x1a]\n" +
+	"executedAt\x12?\n" +
+	"\rrestore_spans\x18\b \x03(\v2\x1a.yorkie.v1.TreeRestoreSpanR\frestoreSpans\x129\n" +
+	"\frestore_mode\x18\t \x01(\x0e2\x16.yorkie.v1.RestoreModeR\vrestoreMode\x12G\n" +
+	"\x11retombstone_spans\x18\n" +
+	" \x03(\v2\x1a.yorkie.v1.TreeRestoreSpanR\x10retombstoneSpans\x1a]\n" +
 	"\x18CreatedAtMapByActorEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12+\n" +
 	"\x05value\x18\x02 \x01(\v2\x15.yorkie.v1.TimeTicketR\x05value:\x028\x01\x1a\xe1\x04\n" +
@@ -5262,7 +5407,22 @@ const file_yorkie_v1_resources_proto_rawDesc = "" +
 	"attributes\x1a=\n" +
 	"\x0fAttributesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"_\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xf0\x03\n" +
+	"\x0fTreeRestoreSpan\x12%\n" +
+	"\x02id\x18\x01 \x01(\v2\x15.yorkie.v1.TreeNodeIDR\x02id\x12\x1b\n" +
+	"\tnode_type\x18\x02 \x01(\tR\bnodeType\x12\x17\n" +
+	"\ais_text\x18\x03 \x01(\bR\x06isText\x12\x16\n" +
+	"\x06length\x18\x04 \x01(\x05R\x06length\x12\x14\n" +
+	"\x05value\x18\x05 \x01(\tR\x05value\x12J\n" +
+	"\n" +
+	"attributes\x18\x06 \x03(\v2*.yorkie.v1.TreeRestoreSpan.AttributesEntryR\n" +
+	"attributes\x122\n" +
+	"\tparent_id\x18\a \x01(\v2\x15.yorkie.v1.TreeNodeIDR\bparentId\x12=\n" +
+	"\x0fleft_sibling_id\x18\b \x01(\v2\x15.yorkie.v1.TreeNodeIDR\rleftSiblingId\x12?\n" +
+	"\x10right_sibling_id\x18\t \x01(\v2\x15.yorkie.v1.TreeNodeIDR\x0erightSiblingId\x1aR\n" +
+	"\x0fAttributesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12)\n" +
+	"\x05value\x18\x02 \x01(\v2\x13.yorkie.v1.NodeAttrR\x05value:\x028\x01\"_\n" +
 	"\n" +
 	"TimeTicket\x12\x18\n" +
 	"\alamport\x18\x01 \x01(\x03R\alamport\x12\x1c\n" +
@@ -5358,7 +5518,7 @@ func file_yorkie_v1_resources_proto_rawDescGZIP() []byte {
 }
 
 var file_yorkie_v1_resources_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_yorkie_v1_resources_proto_msgTypes = make([]protoimpl.MessageInfo, 72)
+var file_yorkie_v1_resources_proto_msgTypes = make([]protoimpl.MessageInfo, 74)
 var file_yorkie_v1_resources_proto_goTypes = []any{
 	(RestoreMode)(0),               // 0: yorkie.v1.RestoreMode
 	(ValueType)(0),                 // 1: yorkie.v1.ValueType
@@ -5394,243 +5554,254 @@ var file_yorkie_v1_resources_proto_goTypes = []any{
 	(*Checkpoint)(nil),             // 31: yorkie.v1.Checkpoint
 	(*TextNodePos)(nil),            // 32: yorkie.v1.TextNodePos
 	(*RestoreSpan)(nil),            // 33: yorkie.v1.RestoreSpan
-	(*TimeTicket)(nil),             // 34: yorkie.v1.TimeTicket
-	(*DocEventBody)(nil),           // 35: yorkie.v1.DocEventBody
-	(*DocEvent)(nil),               // 36: yorkie.v1.DocEvent
-	(*ChannelEvent)(nil),           // 37: yorkie.v1.ChannelEvent
-	(*DataSize)(nil),               // 38: yorkie.v1.DataSize
-	(*DocSize)(nil),                // 39: yorkie.v1.DocSize
-	(*Schema)(nil),                 // 40: yorkie.v1.Schema
-	(*TreeNodeRule)(nil),           // 41: yorkie.v1.TreeNodeRule
-	(*Rule)(nil),                   // 42: yorkie.v1.Rule
-	(*RevisionSummary)(nil),        // 43: yorkie.v1.RevisionSummary
-	nil,                            // 44: yorkie.v1.Snapshot.PresencesEntry
-	nil,                            // 45: yorkie.v1.VersionVector.VectorEntry
-	(*Operation_Set)(nil),          // 46: yorkie.v1.Operation.Set
-	(*Operation_Add)(nil),          // 47: yorkie.v1.Operation.Add
-	(*Operation_Move)(nil),         // 48: yorkie.v1.Operation.Move
-	(*Operation_Remove)(nil),       // 49: yorkie.v1.Operation.Remove
-	(*Operation_Edit)(nil),         // 50: yorkie.v1.Operation.Edit
-	(*Operation_Style)(nil),        // 51: yorkie.v1.Operation.Style
-	(*Operation_Increase)(nil),     // 52: yorkie.v1.Operation.Increase
-	(*Operation_TreeEdit)(nil),     // 53: yorkie.v1.Operation.TreeEdit
-	(*Operation_TreeStyle)(nil),    // 54: yorkie.v1.Operation.TreeStyle
-	(*Operation_ArraySet)(nil),     // 55: yorkie.v1.Operation.ArraySet
-	nil,                            // 56: yorkie.v1.Operation.Edit.CreatedAtMapByActorEntry
-	nil,                            // 57: yorkie.v1.Operation.Edit.AttributesEntry
-	nil,                            // 58: yorkie.v1.Operation.Style.AttributesEntry
-	nil,                            // 59: yorkie.v1.Operation.Style.CreatedAtMapByActorEntry
-	nil,                            // 60: yorkie.v1.Operation.TreeEdit.CreatedAtMapByActorEntry
-	nil,                            // 61: yorkie.v1.Operation.TreeStyle.AttributesEntry
-	nil,                            // 62: yorkie.v1.Operation.TreeStyle.CreatedAtMapByActorEntry
-	(*JSONElement_JSONObject)(nil), // 63: yorkie.v1.JSONElement.JSONObject
-	(*JSONElement_JSONArray)(nil),  // 64: yorkie.v1.JSONElement.JSONArray
-	(*JSONElement_Primitive)(nil),  // 65: yorkie.v1.JSONElement.Primitive
-	(*JSONElement_Text)(nil),       // 66: yorkie.v1.JSONElement.Text
-	(*JSONElement_Counter)(nil),    // 67: yorkie.v1.JSONElement.Counter
-	(*JSONElement_Tree)(nil),       // 68: yorkie.v1.JSONElement.Tree
-	nil,                            // 69: yorkie.v1.TextNode.AttributesEntry
-	nil,                            // 70: yorkie.v1.TreeNode.AttributesEntry
-	(*UpdatableProjectFields_AuthWebhookMethods)(nil), // 71: yorkie.v1.UpdatableProjectFields.AuthWebhookMethods
-	(*UpdatableProjectFields_EventWebhookEvents)(nil), // 72: yorkie.v1.UpdatableProjectFields.EventWebhookEvents
-	(*UpdatableProjectFields_AllowedOrigins)(nil),     // 73: yorkie.v1.UpdatableProjectFields.AllowedOrigins
-	nil,                            // 74: yorkie.v1.DocumentSummary.PresencesEntry
-	nil,                            // 75: yorkie.v1.Presence.DataEntry
-	nil,                            // 76: yorkie.v1.RestoreSpan.AttributesEntry
-	(*timestamppb.Timestamp)(nil),  // 77: google.protobuf.Timestamp
-	(*wrapperspb.StringValue)(nil), // 78: google.protobuf.StringValue
-	(*wrapperspb.UInt64Value)(nil), // 79: google.protobuf.UInt64Value
-	(*wrapperspb.Int64Value)(nil),  // 80: google.protobuf.Int64Value
-	(*wrapperspb.Int32Value)(nil),  // 81: google.protobuf.Int32Value
-	(*wrapperspb.BoolValue)(nil),   // 82: google.protobuf.BoolValue
+	(*TreeRestoreSpan)(nil),        // 34: yorkie.v1.TreeRestoreSpan
+	(*TimeTicket)(nil),             // 35: yorkie.v1.TimeTicket
+	(*DocEventBody)(nil),           // 36: yorkie.v1.DocEventBody
+	(*DocEvent)(nil),               // 37: yorkie.v1.DocEvent
+	(*ChannelEvent)(nil),           // 38: yorkie.v1.ChannelEvent
+	(*DataSize)(nil),               // 39: yorkie.v1.DataSize
+	(*DocSize)(nil),                // 40: yorkie.v1.DocSize
+	(*Schema)(nil),                 // 41: yorkie.v1.Schema
+	(*TreeNodeRule)(nil),           // 42: yorkie.v1.TreeNodeRule
+	(*Rule)(nil),                   // 43: yorkie.v1.Rule
+	(*RevisionSummary)(nil),        // 44: yorkie.v1.RevisionSummary
+	nil,                            // 45: yorkie.v1.Snapshot.PresencesEntry
+	nil,                            // 46: yorkie.v1.VersionVector.VectorEntry
+	(*Operation_Set)(nil),          // 47: yorkie.v1.Operation.Set
+	(*Operation_Add)(nil),          // 48: yorkie.v1.Operation.Add
+	(*Operation_Move)(nil),         // 49: yorkie.v1.Operation.Move
+	(*Operation_Remove)(nil),       // 50: yorkie.v1.Operation.Remove
+	(*Operation_Edit)(nil),         // 51: yorkie.v1.Operation.Edit
+	(*Operation_Style)(nil),        // 52: yorkie.v1.Operation.Style
+	(*Operation_Increase)(nil),     // 53: yorkie.v1.Operation.Increase
+	(*Operation_TreeEdit)(nil),     // 54: yorkie.v1.Operation.TreeEdit
+	(*Operation_TreeStyle)(nil),    // 55: yorkie.v1.Operation.TreeStyle
+	(*Operation_ArraySet)(nil),     // 56: yorkie.v1.Operation.ArraySet
+	nil,                            // 57: yorkie.v1.Operation.Edit.CreatedAtMapByActorEntry
+	nil,                            // 58: yorkie.v1.Operation.Edit.AttributesEntry
+	nil,                            // 59: yorkie.v1.Operation.Style.AttributesEntry
+	nil,                            // 60: yorkie.v1.Operation.Style.CreatedAtMapByActorEntry
+	nil,                            // 61: yorkie.v1.Operation.TreeEdit.CreatedAtMapByActorEntry
+	nil,                            // 62: yorkie.v1.Operation.TreeStyle.AttributesEntry
+	nil,                            // 63: yorkie.v1.Operation.TreeStyle.CreatedAtMapByActorEntry
+	(*JSONElement_JSONObject)(nil), // 64: yorkie.v1.JSONElement.JSONObject
+	(*JSONElement_JSONArray)(nil),  // 65: yorkie.v1.JSONElement.JSONArray
+	(*JSONElement_Primitive)(nil),  // 66: yorkie.v1.JSONElement.Primitive
+	(*JSONElement_Text)(nil),       // 67: yorkie.v1.JSONElement.Text
+	(*JSONElement_Counter)(nil),    // 68: yorkie.v1.JSONElement.Counter
+	(*JSONElement_Tree)(nil),       // 69: yorkie.v1.JSONElement.Tree
+	nil,                            // 70: yorkie.v1.TextNode.AttributesEntry
+	nil,                            // 71: yorkie.v1.TreeNode.AttributesEntry
+	(*UpdatableProjectFields_AuthWebhookMethods)(nil), // 72: yorkie.v1.UpdatableProjectFields.AuthWebhookMethods
+	(*UpdatableProjectFields_EventWebhookEvents)(nil), // 73: yorkie.v1.UpdatableProjectFields.EventWebhookEvents
+	(*UpdatableProjectFields_AllowedOrigins)(nil),     // 74: yorkie.v1.UpdatableProjectFields.AllowedOrigins
+	nil,                            // 75: yorkie.v1.DocumentSummary.PresencesEntry
+	nil,                            // 76: yorkie.v1.Presence.DataEntry
+	nil,                            // 77: yorkie.v1.RestoreSpan.AttributesEntry
+	nil,                            // 78: yorkie.v1.TreeRestoreSpan.AttributesEntry
+	(*timestamppb.Timestamp)(nil),  // 79: google.protobuf.Timestamp
+	(*wrapperspb.StringValue)(nil), // 80: google.protobuf.StringValue
+	(*wrapperspb.UInt64Value)(nil), // 81: google.protobuf.UInt64Value
+	(*wrapperspb.Int64Value)(nil),  // 82: google.protobuf.Int64Value
+	(*wrapperspb.Int32Value)(nil),  // 83: google.protobuf.Int32Value
+	(*wrapperspb.BoolValue)(nil),   // 84: google.protobuf.BoolValue
 }
 var file_yorkie_v1_resources_proto_depIdxs = []int32{
 	12,  // 0: yorkie.v1.Snapshot.root:type_name -> yorkie.v1.JSONElement
-	44,  // 1: yorkie.v1.Snapshot.presences:type_name -> yorkie.v1.Snapshot.PresencesEntry
+	45,  // 1: yorkie.v1.Snapshot.presences:type_name -> yorkie.v1.Snapshot.PresencesEntry
 	31,  // 2: yorkie.v1.ChangePack.checkpoint:type_name -> yorkie.v1.Checkpoint
 	7,   // 3: yorkie.v1.ChangePack.changes:type_name -> yorkie.v1.Change
-	34,  // 4: yorkie.v1.ChangePack.min_synced_ticket:type_name -> yorkie.v1.TimeTicket
+	35,  // 4: yorkie.v1.ChangePack.min_synced_ticket:type_name -> yorkie.v1.TimeTicket
 	9,   // 5: yorkie.v1.ChangePack.version_vector:type_name -> yorkie.v1.VersionVector
 	8,   // 6: yorkie.v1.Change.id:type_name -> yorkie.v1.ChangeID
 	10,  // 7: yorkie.v1.Change.operations:type_name -> yorkie.v1.Operation
 	28,  // 8: yorkie.v1.Change.presence_change:type_name -> yorkie.v1.PresenceChange
 	9,   // 9: yorkie.v1.ChangeID.version_vector:type_name -> yorkie.v1.VersionVector
-	45,  // 10: yorkie.v1.VersionVector.vector:type_name -> yorkie.v1.VersionVector.VectorEntry
-	46,  // 11: yorkie.v1.Operation.set:type_name -> yorkie.v1.Operation.Set
-	47,  // 12: yorkie.v1.Operation.add:type_name -> yorkie.v1.Operation.Add
-	48,  // 13: yorkie.v1.Operation.move:type_name -> yorkie.v1.Operation.Move
-	49,  // 14: yorkie.v1.Operation.remove:type_name -> yorkie.v1.Operation.Remove
-	50,  // 15: yorkie.v1.Operation.edit:type_name -> yorkie.v1.Operation.Edit
-	51,  // 16: yorkie.v1.Operation.style:type_name -> yorkie.v1.Operation.Style
-	52,  // 17: yorkie.v1.Operation.increase:type_name -> yorkie.v1.Operation.Increase
-	53,  // 18: yorkie.v1.Operation.tree_edit:type_name -> yorkie.v1.Operation.TreeEdit
-	54,  // 19: yorkie.v1.Operation.tree_style:type_name -> yorkie.v1.Operation.TreeStyle
-	55,  // 20: yorkie.v1.Operation.array_set:type_name -> yorkie.v1.Operation.ArraySet
-	34,  // 21: yorkie.v1.JSONElementSimple.created_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 22: yorkie.v1.JSONElementSimple.moved_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 23: yorkie.v1.JSONElementSimple.removed_at:type_name -> yorkie.v1.TimeTicket
+	46,  // 10: yorkie.v1.VersionVector.vector:type_name -> yorkie.v1.VersionVector.VectorEntry
+	47,  // 11: yorkie.v1.Operation.set:type_name -> yorkie.v1.Operation.Set
+	48,  // 12: yorkie.v1.Operation.add:type_name -> yorkie.v1.Operation.Add
+	49,  // 13: yorkie.v1.Operation.move:type_name -> yorkie.v1.Operation.Move
+	50,  // 14: yorkie.v1.Operation.remove:type_name -> yorkie.v1.Operation.Remove
+	51,  // 15: yorkie.v1.Operation.edit:type_name -> yorkie.v1.Operation.Edit
+	52,  // 16: yorkie.v1.Operation.style:type_name -> yorkie.v1.Operation.Style
+	53,  // 17: yorkie.v1.Operation.increase:type_name -> yorkie.v1.Operation.Increase
+	54,  // 18: yorkie.v1.Operation.tree_edit:type_name -> yorkie.v1.Operation.TreeEdit
+	55,  // 19: yorkie.v1.Operation.tree_style:type_name -> yorkie.v1.Operation.TreeStyle
+	56,  // 20: yorkie.v1.Operation.array_set:type_name -> yorkie.v1.Operation.ArraySet
+	35,  // 21: yorkie.v1.JSONElementSimple.created_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 22: yorkie.v1.JSONElementSimple.moved_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 23: yorkie.v1.JSONElementSimple.removed_at:type_name -> yorkie.v1.TimeTicket
 	1,   // 24: yorkie.v1.JSONElementSimple.type:type_name -> yorkie.v1.ValueType
-	63,  // 25: yorkie.v1.JSONElement.json_object:type_name -> yorkie.v1.JSONElement.JSONObject
-	64,  // 26: yorkie.v1.JSONElement.json_array:type_name -> yorkie.v1.JSONElement.JSONArray
-	65,  // 27: yorkie.v1.JSONElement.primitive:type_name -> yorkie.v1.JSONElement.Primitive
-	66,  // 28: yorkie.v1.JSONElement.text:type_name -> yorkie.v1.JSONElement.Text
-	67,  // 29: yorkie.v1.JSONElement.counter:type_name -> yorkie.v1.JSONElement.Counter
-	68,  // 30: yorkie.v1.JSONElement.tree:type_name -> yorkie.v1.JSONElement.Tree
+	64,  // 25: yorkie.v1.JSONElement.json_object:type_name -> yorkie.v1.JSONElement.JSONObject
+	65,  // 26: yorkie.v1.JSONElement.json_array:type_name -> yorkie.v1.JSONElement.JSONArray
+	66,  // 27: yorkie.v1.JSONElement.primitive:type_name -> yorkie.v1.JSONElement.Primitive
+	67,  // 28: yorkie.v1.JSONElement.text:type_name -> yorkie.v1.JSONElement.Text
+	68,  // 29: yorkie.v1.JSONElement.counter:type_name -> yorkie.v1.JSONElement.Counter
+	69,  // 30: yorkie.v1.JSONElement.tree:type_name -> yorkie.v1.JSONElement.Tree
 	12,  // 31: yorkie.v1.RHTNode.element:type_name -> yorkie.v1.JSONElement
 	14,  // 32: yorkie.v1.RGANode.next:type_name -> yorkie.v1.RGANode
 	12,  // 33: yorkie.v1.RGANode.element:type_name -> yorkie.v1.JSONElement
-	34,  // 34: yorkie.v1.RGANode.position_created_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 35: yorkie.v1.RGANode.position_moved_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 36: yorkie.v1.RGANode.position_removed_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 37: yorkie.v1.NodeAttr.updated_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 34: yorkie.v1.RGANode.position_created_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 35: yorkie.v1.RGANode.position_moved_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 36: yorkie.v1.RGANode.position_removed_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 37: yorkie.v1.NodeAttr.updated_at:type_name -> yorkie.v1.TimeTicket
 	17,  // 38: yorkie.v1.TextNode.id:type_name -> yorkie.v1.TextNodeID
-	34,  // 39: yorkie.v1.TextNode.removed_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 39: yorkie.v1.TextNode.removed_at:type_name -> yorkie.v1.TimeTicket
 	17,  // 40: yorkie.v1.TextNode.ins_prev_id:type_name -> yorkie.v1.TextNodeID
-	69,  // 41: yorkie.v1.TextNode.attributes:type_name -> yorkie.v1.TextNode.AttributesEntry
-	34,  // 42: yorkie.v1.TextNodeID.created_at:type_name -> yorkie.v1.TimeTicket
+	70,  // 41: yorkie.v1.TextNode.attributes:type_name -> yorkie.v1.TextNode.AttributesEntry
+	35,  // 42: yorkie.v1.TextNodeID.created_at:type_name -> yorkie.v1.TimeTicket
 	20,  // 43: yorkie.v1.TreeNode.id:type_name -> yorkie.v1.TreeNodeID
-	34,  // 44: yorkie.v1.TreeNode.removed_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 44: yorkie.v1.TreeNode.removed_at:type_name -> yorkie.v1.TimeTicket
 	20,  // 45: yorkie.v1.TreeNode.ins_prev_id:type_name -> yorkie.v1.TreeNodeID
 	20,  // 46: yorkie.v1.TreeNode.ins_next_id:type_name -> yorkie.v1.TreeNodeID
-	70,  // 47: yorkie.v1.TreeNode.attributes:type_name -> yorkie.v1.TreeNode.AttributesEntry
+	71,  // 47: yorkie.v1.TreeNode.attributes:type_name -> yorkie.v1.TreeNode.AttributesEntry
 	20,  // 48: yorkie.v1.TreeNode.merged_from:type_name -> yorkie.v1.TreeNodeID
-	34,  // 49: yorkie.v1.TreeNode.merged_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 49: yorkie.v1.TreeNode.merged_at:type_name -> yorkie.v1.TimeTicket
 	18,  // 50: yorkie.v1.TreeNodes.content:type_name -> yorkie.v1.TreeNode
-	34,  // 51: yorkie.v1.TreeNodeID.created_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 51: yorkie.v1.TreeNodeID.created_at:type_name -> yorkie.v1.TimeTicket
 	20,  // 52: yorkie.v1.TreePos.parent_id:type_name -> yorkie.v1.TreeNodeID
 	20,  // 53: yorkie.v1.TreePos.left_sibling_id:type_name -> yorkie.v1.TreeNodeID
-	77,  // 54: yorkie.v1.User.created_at:type_name -> google.protobuf.Timestamp
-	77,  // 55: yorkie.v1.Member.invited_at:type_name -> google.protobuf.Timestamp
-	77,  // 56: yorkie.v1.Project.created_at:type_name -> google.protobuf.Timestamp
-	77,  // 57: yorkie.v1.Project.updated_at:type_name -> google.protobuf.Timestamp
-	78,  // 58: yorkie.v1.UpdatableProjectFields.name:type_name -> google.protobuf.StringValue
-	78,  // 59: yorkie.v1.UpdatableProjectFields.auth_webhook_url:type_name -> google.protobuf.StringValue
-	71,  // 60: yorkie.v1.UpdatableProjectFields.auth_webhook_methods:type_name -> yorkie.v1.UpdatableProjectFields.AuthWebhookMethods
-	79,  // 61: yorkie.v1.UpdatableProjectFields.auth_webhook_max_retries:type_name -> google.protobuf.UInt64Value
-	78,  // 62: yorkie.v1.UpdatableProjectFields.auth_webhook_min_wait_interval:type_name -> google.protobuf.StringValue
-	78,  // 63: yorkie.v1.UpdatableProjectFields.auth_webhook_max_wait_interval:type_name -> google.protobuf.StringValue
-	78,  // 64: yorkie.v1.UpdatableProjectFields.auth_webhook_request_timeout:type_name -> google.protobuf.StringValue
-	78,  // 65: yorkie.v1.UpdatableProjectFields.event_webhook_url:type_name -> google.protobuf.StringValue
-	72,  // 66: yorkie.v1.UpdatableProjectFields.event_webhook_events:type_name -> yorkie.v1.UpdatableProjectFields.EventWebhookEvents
-	79,  // 67: yorkie.v1.UpdatableProjectFields.event_webhook_max_retries:type_name -> google.protobuf.UInt64Value
-	78,  // 68: yorkie.v1.UpdatableProjectFields.event_webhook_min_wait_interval:type_name -> google.protobuf.StringValue
-	78,  // 69: yorkie.v1.UpdatableProjectFields.event_webhook_max_wait_interval:type_name -> google.protobuf.StringValue
-	78,  // 70: yorkie.v1.UpdatableProjectFields.event_webhook_request_timeout:type_name -> google.protobuf.StringValue
-	80,  // 71: yorkie.v1.UpdatableProjectFields.snapshot_threshold:type_name -> google.protobuf.Int64Value
-	80,  // 72: yorkie.v1.UpdatableProjectFields.snapshot_interval:type_name -> google.protobuf.Int64Value
-	78,  // 73: yorkie.v1.UpdatableProjectFields.client_deactivate_threshold:type_name -> google.protobuf.StringValue
-	81,  // 74: yorkie.v1.UpdatableProjectFields.max_subscribers_per_document:type_name -> google.protobuf.Int32Value
-	81,  // 75: yorkie.v1.UpdatableProjectFields.max_attachments_per_document:type_name -> google.protobuf.Int32Value
-	81,  // 76: yorkie.v1.UpdatableProjectFields.max_size_per_document:type_name -> google.protobuf.Int32Value
-	82,  // 77: yorkie.v1.UpdatableProjectFields.remove_on_detach:type_name -> google.protobuf.BoolValue
-	82,  // 78: yorkie.v1.UpdatableProjectFields.auto_revision_enabled:type_name -> google.protobuf.BoolValue
-	78,  // 79: yorkie.v1.UpdatableProjectFields.channel_session_ttl:type_name -> google.protobuf.StringValue
-	73,  // 80: yorkie.v1.UpdatableProjectFields.allowed_origins:type_name -> yorkie.v1.UpdatableProjectFields.AllowedOrigins
-	39,  // 81: yorkie.v1.DocumentSummary.document_size:type_name -> yorkie.v1.DocSize
-	74,  // 82: yorkie.v1.DocumentSummary.presences:type_name -> yorkie.v1.DocumentSummary.PresencesEntry
-	77,  // 83: yorkie.v1.DocumentSummary.created_at:type_name -> google.protobuf.Timestamp
-	77,  // 84: yorkie.v1.DocumentSummary.accessed_at:type_name -> google.protobuf.Timestamp
-	77,  // 85: yorkie.v1.DocumentSummary.updated_at:type_name -> google.protobuf.Timestamp
+	79,  // 54: yorkie.v1.User.created_at:type_name -> google.protobuf.Timestamp
+	79,  // 55: yorkie.v1.Member.invited_at:type_name -> google.protobuf.Timestamp
+	79,  // 56: yorkie.v1.Project.created_at:type_name -> google.protobuf.Timestamp
+	79,  // 57: yorkie.v1.Project.updated_at:type_name -> google.protobuf.Timestamp
+	80,  // 58: yorkie.v1.UpdatableProjectFields.name:type_name -> google.protobuf.StringValue
+	80,  // 59: yorkie.v1.UpdatableProjectFields.auth_webhook_url:type_name -> google.protobuf.StringValue
+	72,  // 60: yorkie.v1.UpdatableProjectFields.auth_webhook_methods:type_name -> yorkie.v1.UpdatableProjectFields.AuthWebhookMethods
+	81,  // 61: yorkie.v1.UpdatableProjectFields.auth_webhook_max_retries:type_name -> google.protobuf.UInt64Value
+	80,  // 62: yorkie.v1.UpdatableProjectFields.auth_webhook_min_wait_interval:type_name -> google.protobuf.StringValue
+	80,  // 63: yorkie.v1.UpdatableProjectFields.auth_webhook_max_wait_interval:type_name -> google.protobuf.StringValue
+	80,  // 64: yorkie.v1.UpdatableProjectFields.auth_webhook_request_timeout:type_name -> google.protobuf.StringValue
+	80,  // 65: yorkie.v1.UpdatableProjectFields.event_webhook_url:type_name -> google.protobuf.StringValue
+	73,  // 66: yorkie.v1.UpdatableProjectFields.event_webhook_events:type_name -> yorkie.v1.UpdatableProjectFields.EventWebhookEvents
+	81,  // 67: yorkie.v1.UpdatableProjectFields.event_webhook_max_retries:type_name -> google.protobuf.UInt64Value
+	80,  // 68: yorkie.v1.UpdatableProjectFields.event_webhook_min_wait_interval:type_name -> google.protobuf.StringValue
+	80,  // 69: yorkie.v1.UpdatableProjectFields.event_webhook_max_wait_interval:type_name -> google.protobuf.StringValue
+	80,  // 70: yorkie.v1.UpdatableProjectFields.event_webhook_request_timeout:type_name -> google.protobuf.StringValue
+	82,  // 71: yorkie.v1.UpdatableProjectFields.snapshot_threshold:type_name -> google.protobuf.Int64Value
+	82,  // 72: yorkie.v1.UpdatableProjectFields.snapshot_interval:type_name -> google.protobuf.Int64Value
+	80,  // 73: yorkie.v1.UpdatableProjectFields.client_deactivate_threshold:type_name -> google.protobuf.StringValue
+	83,  // 74: yorkie.v1.UpdatableProjectFields.max_subscribers_per_document:type_name -> google.protobuf.Int32Value
+	83,  // 75: yorkie.v1.UpdatableProjectFields.max_attachments_per_document:type_name -> google.protobuf.Int32Value
+	83,  // 76: yorkie.v1.UpdatableProjectFields.max_size_per_document:type_name -> google.protobuf.Int32Value
+	84,  // 77: yorkie.v1.UpdatableProjectFields.remove_on_detach:type_name -> google.protobuf.BoolValue
+	84,  // 78: yorkie.v1.UpdatableProjectFields.auto_revision_enabled:type_name -> google.protobuf.BoolValue
+	80,  // 79: yorkie.v1.UpdatableProjectFields.channel_session_ttl:type_name -> google.protobuf.StringValue
+	74,  // 80: yorkie.v1.UpdatableProjectFields.allowed_origins:type_name -> yorkie.v1.UpdatableProjectFields.AllowedOrigins
+	40,  // 81: yorkie.v1.DocumentSummary.document_size:type_name -> yorkie.v1.DocSize
+	75,  // 82: yorkie.v1.DocumentSummary.presences:type_name -> yorkie.v1.DocumentSummary.PresencesEntry
+	79,  // 83: yorkie.v1.DocumentSummary.created_at:type_name -> google.protobuf.Timestamp
+	79,  // 84: yorkie.v1.DocumentSummary.accessed_at:type_name -> google.protobuf.Timestamp
+	79,  // 85: yorkie.v1.DocumentSummary.updated_at:type_name -> google.protobuf.Timestamp
 	3,   // 86: yorkie.v1.PresenceChange.type:type_name -> yorkie.v1.PresenceChange.ChangeType
 	29,  // 87: yorkie.v1.PresenceChange.presence:type_name -> yorkie.v1.Presence
-	75,  // 88: yorkie.v1.Presence.data:type_name -> yorkie.v1.Presence.DataEntry
-	34,  // 89: yorkie.v1.TextNodePos.created_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 90: yorkie.v1.RestoreSpan.created_at:type_name -> yorkie.v1.TimeTicket
-	76,  // 91: yorkie.v1.RestoreSpan.attributes:type_name -> yorkie.v1.RestoreSpan.AttributesEntry
-	2,   // 92: yorkie.v1.DocEvent.type:type_name -> yorkie.v1.DocEventType
-	35,  // 93: yorkie.v1.DocEvent.body:type_name -> yorkie.v1.DocEventBody
-	4,   // 94: yorkie.v1.ChannelEvent.type:type_name -> yorkie.v1.ChannelEvent.Type
-	38,  // 95: yorkie.v1.DocSize.live:type_name -> yorkie.v1.DataSize
-	38,  // 96: yorkie.v1.DocSize.gc:type_name -> yorkie.v1.DataSize
-	42,  // 97: yorkie.v1.Schema.rules:type_name -> yorkie.v1.Rule
-	77,  // 98: yorkie.v1.Schema.created_at:type_name -> google.protobuf.Timestamp
-	41,  // 99: yorkie.v1.Rule.tree_nodes:type_name -> yorkie.v1.TreeNodeRule
-	77,  // 100: yorkie.v1.RevisionSummary.created_at:type_name -> google.protobuf.Timestamp
-	29,  // 101: yorkie.v1.Snapshot.PresencesEntry.value:type_name -> yorkie.v1.Presence
-	34,  // 102: yorkie.v1.Operation.Set.parent_created_at:type_name -> yorkie.v1.TimeTicket
-	11,  // 103: yorkie.v1.Operation.Set.value:type_name -> yorkie.v1.JSONElementSimple
-	34,  // 104: yorkie.v1.Operation.Set.executed_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 105: yorkie.v1.Operation.Add.parent_created_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 106: yorkie.v1.Operation.Add.prev_created_at:type_name -> yorkie.v1.TimeTicket
-	11,  // 107: yorkie.v1.Operation.Add.value:type_name -> yorkie.v1.JSONElementSimple
-	34,  // 108: yorkie.v1.Operation.Add.executed_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 109: yorkie.v1.Operation.Move.parent_created_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 110: yorkie.v1.Operation.Move.prev_created_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 111: yorkie.v1.Operation.Move.created_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 112: yorkie.v1.Operation.Move.executed_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 113: yorkie.v1.Operation.Remove.parent_created_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 114: yorkie.v1.Operation.Remove.created_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 115: yorkie.v1.Operation.Remove.executed_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 116: yorkie.v1.Operation.Edit.parent_created_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 117: yorkie.v1.Operation.Edit.from:type_name -> yorkie.v1.TextNodePos
-	32,  // 118: yorkie.v1.Operation.Edit.to:type_name -> yorkie.v1.TextNodePos
-	56,  // 119: yorkie.v1.Operation.Edit.created_at_map_by_actor:type_name -> yorkie.v1.Operation.Edit.CreatedAtMapByActorEntry
-	34,  // 120: yorkie.v1.Operation.Edit.executed_at:type_name -> yorkie.v1.TimeTicket
-	57,  // 121: yorkie.v1.Operation.Edit.attributes:type_name -> yorkie.v1.Operation.Edit.AttributesEntry
-	33,  // 122: yorkie.v1.Operation.Edit.restore_spans:type_name -> yorkie.v1.RestoreSpan
-	0,   // 123: yorkie.v1.Operation.Edit.restore_mode:type_name -> yorkie.v1.RestoreMode
-	33,  // 124: yorkie.v1.Operation.Edit.retombstone_spans:type_name -> yorkie.v1.RestoreSpan
-	34,  // 125: yorkie.v1.Operation.Style.parent_created_at:type_name -> yorkie.v1.TimeTicket
-	32,  // 126: yorkie.v1.Operation.Style.from:type_name -> yorkie.v1.TextNodePos
-	32,  // 127: yorkie.v1.Operation.Style.to:type_name -> yorkie.v1.TextNodePos
-	58,  // 128: yorkie.v1.Operation.Style.attributes:type_name -> yorkie.v1.Operation.Style.AttributesEntry
-	34,  // 129: yorkie.v1.Operation.Style.executed_at:type_name -> yorkie.v1.TimeTicket
-	59,  // 130: yorkie.v1.Operation.Style.created_at_map_by_actor:type_name -> yorkie.v1.Operation.Style.CreatedAtMapByActorEntry
-	34,  // 131: yorkie.v1.Operation.Increase.parent_created_at:type_name -> yorkie.v1.TimeTicket
-	11,  // 132: yorkie.v1.Operation.Increase.value:type_name -> yorkie.v1.JSONElementSimple
-	34,  // 133: yorkie.v1.Operation.Increase.executed_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 134: yorkie.v1.Operation.TreeEdit.parent_created_at:type_name -> yorkie.v1.TimeTicket
-	21,  // 135: yorkie.v1.Operation.TreeEdit.from:type_name -> yorkie.v1.TreePos
-	21,  // 136: yorkie.v1.Operation.TreeEdit.to:type_name -> yorkie.v1.TreePos
-	60,  // 137: yorkie.v1.Operation.TreeEdit.created_at_map_by_actor:type_name -> yorkie.v1.Operation.TreeEdit.CreatedAtMapByActorEntry
-	19,  // 138: yorkie.v1.Operation.TreeEdit.contents:type_name -> yorkie.v1.TreeNodes
-	34,  // 139: yorkie.v1.Operation.TreeEdit.executed_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 140: yorkie.v1.Operation.TreeStyle.parent_created_at:type_name -> yorkie.v1.TimeTicket
-	21,  // 141: yorkie.v1.Operation.TreeStyle.from:type_name -> yorkie.v1.TreePos
-	21,  // 142: yorkie.v1.Operation.TreeStyle.to:type_name -> yorkie.v1.TreePos
-	61,  // 143: yorkie.v1.Operation.TreeStyle.attributes:type_name -> yorkie.v1.Operation.TreeStyle.AttributesEntry
-	34,  // 144: yorkie.v1.Operation.TreeStyle.executed_at:type_name -> yorkie.v1.TimeTicket
-	62,  // 145: yorkie.v1.Operation.TreeStyle.created_at_map_by_actor:type_name -> yorkie.v1.Operation.TreeStyle.CreatedAtMapByActorEntry
-	34,  // 146: yorkie.v1.Operation.ArraySet.parent_created_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 147: yorkie.v1.Operation.ArraySet.created_at:type_name -> yorkie.v1.TimeTicket
-	11,  // 148: yorkie.v1.Operation.ArraySet.value:type_name -> yorkie.v1.JSONElementSimple
-	34,  // 149: yorkie.v1.Operation.ArraySet.executed_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 150: yorkie.v1.Operation.Edit.CreatedAtMapByActorEntry.value:type_name -> yorkie.v1.TimeTicket
-	34,  // 151: yorkie.v1.Operation.Style.CreatedAtMapByActorEntry.value:type_name -> yorkie.v1.TimeTicket
-	34,  // 152: yorkie.v1.Operation.TreeEdit.CreatedAtMapByActorEntry.value:type_name -> yorkie.v1.TimeTicket
-	34,  // 153: yorkie.v1.Operation.TreeStyle.CreatedAtMapByActorEntry.value:type_name -> yorkie.v1.TimeTicket
-	13,  // 154: yorkie.v1.JSONElement.JSONObject.nodes:type_name -> yorkie.v1.RHTNode
-	34,  // 155: yorkie.v1.JSONElement.JSONObject.created_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 156: yorkie.v1.JSONElement.JSONObject.moved_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 157: yorkie.v1.JSONElement.JSONObject.removed_at:type_name -> yorkie.v1.TimeTicket
-	14,  // 158: yorkie.v1.JSONElement.JSONArray.nodes:type_name -> yorkie.v1.RGANode
-	34,  // 159: yorkie.v1.JSONElement.JSONArray.created_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 160: yorkie.v1.JSONElement.JSONArray.moved_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 161: yorkie.v1.JSONElement.JSONArray.removed_at:type_name -> yorkie.v1.TimeTicket
-	1,   // 162: yorkie.v1.JSONElement.Primitive.type:type_name -> yorkie.v1.ValueType
-	34,  // 163: yorkie.v1.JSONElement.Primitive.created_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 164: yorkie.v1.JSONElement.Primitive.moved_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 165: yorkie.v1.JSONElement.Primitive.removed_at:type_name -> yorkie.v1.TimeTicket
-	16,  // 166: yorkie.v1.JSONElement.Text.nodes:type_name -> yorkie.v1.TextNode
-	34,  // 167: yorkie.v1.JSONElement.Text.created_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 168: yorkie.v1.JSONElement.Text.moved_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 169: yorkie.v1.JSONElement.Text.removed_at:type_name -> yorkie.v1.TimeTicket
-	1,   // 170: yorkie.v1.JSONElement.Counter.type:type_name -> yorkie.v1.ValueType
-	34,  // 171: yorkie.v1.JSONElement.Counter.created_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 172: yorkie.v1.JSONElement.Counter.moved_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 173: yorkie.v1.JSONElement.Counter.removed_at:type_name -> yorkie.v1.TimeTicket
-	18,  // 174: yorkie.v1.JSONElement.Tree.nodes:type_name -> yorkie.v1.TreeNode
-	34,  // 175: yorkie.v1.JSONElement.Tree.created_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 176: yorkie.v1.JSONElement.Tree.moved_at:type_name -> yorkie.v1.TimeTicket
-	34,  // 177: yorkie.v1.JSONElement.Tree.removed_at:type_name -> yorkie.v1.TimeTicket
-	15,  // 178: yorkie.v1.TextNode.AttributesEntry.value:type_name -> yorkie.v1.NodeAttr
-	15,  // 179: yorkie.v1.TreeNode.AttributesEntry.value:type_name -> yorkie.v1.NodeAttr
-	29,  // 180: yorkie.v1.DocumentSummary.PresencesEntry.value:type_name -> yorkie.v1.Presence
-	181, // [181:181] is the sub-list for method output_type
-	181, // [181:181] is the sub-list for method input_type
-	181, // [181:181] is the sub-list for extension type_name
-	181, // [181:181] is the sub-list for extension extendee
-	0,   // [0:181] is the sub-list for field type_name
+	76,  // 88: yorkie.v1.Presence.data:type_name -> yorkie.v1.Presence.DataEntry
+	35,  // 89: yorkie.v1.TextNodePos.created_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 90: yorkie.v1.RestoreSpan.created_at:type_name -> yorkie.v1.TimeTicket
+	77,  // 91: yorkie.v1.RestoreSpan.attributes:type_name -> yorkie.v1.RestoreSpan.AttributesEntry
+	20,  // 92: yorkie.v1.TreeRestoreSpan.id:type_name -> yorkie.v1.TreeNodeID
+	78,  // 93: yorkie.v1.TreeRestoreSpan.attributes:type_name -> yorkie.v1.TreeRestoreSpan.AttributesEntry
+	20,  // 94: yorkie.v1.TreeRestoreSpan.parent_id:type_name -> yorkie.v1.TreeNodeID
+	20,  // 95: yorkie.v1.TreeRestoreSpan.left_sibling_id:type_name -> yorkie.v1.TreeNodeID
+	20,  // 96: yorkie.v1.TreeRestoreSpan.right_sibling_id:type_name -> yorkie.v1.TreeNodeID
+	2,   // 97: yorkie.v1.DocEvent.type:type_name -> yorkie.v1.DocEventType
+	36,  // 98: yorkie.v1.DocEvent.body:type_name -> yorkie.v1.DocEventBody
+	4,   // 99: yorkie.v1.ChannelEvent.type:type_name -> yorkie.v1.ChannelEvent.Type
+	39,  // 100: yorkie.v1.DocSize.live:type_name -> yorkie.v1.DataSize
+	39,  // 101: yorkie.v1.DocSize.gc:type_name -> yorkie.v1.DataSize
+	43,  // 102: yorkie.v1.Schema.rules:type_name -> yorkie.v1.Rule
+	79,  // 103: yorkie.v1.Schema.created_at:type_name -> google.protobuf.Timestamp
+	42,  // 104: yorkie.v1.Rule.tree_nodes:type_name -> yorkie.v1.TreeNodeRule
+	79,  // 105: yorkie.v1.RevisionSummary.created_at:type_name -> google.protobuf.Timestamp
+	29,  // 106: yorkie.v1.Snapshot.PresencesEntry.value:type_name -> yorkie.v1.Presence
+	35,  // 107: yorkie.v1.Operation.Set.parent_created_at:type_name -> yorkie.v1.TimeTicket
+	11,  // 108: yorkie.v1.Operation.Set.value:type_name -> yorkie.v1.JSONElementSimple
+	35,  // 109: yorkie.v1.Operation.Set.executed_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 110: yorkie.v1.Operation.Add.parent_created_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 111: yorkie.v1.Operation.Add.prev_created_at:type_name -> yorkie.v1.TimeTicket
+	11,  // 112: yorkie.v1.Operation.Add.value:type_name -> yorkie.v1.JSONElementSimple
+	35,  // 113: yorkie.v1.Operation.Add.executed_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 114: yorkie.v1.Operation.Move.parent_created_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 115: yorkie.v1.Operation.Move.prev_created_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 116: yorkie.v1.Operation.Move.created_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 117: yorkie.v1.Operation.Move.executed_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 118: yorkie.v1.Operation.Remove.parent_created_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 119: yorkie.v1.Operation.Remove.created_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 120: yorkie.v1.Operation.Remove.executed_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 121: yorkie.v1.Operation.Edit.parent_created_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 122: yorkie.v1.Operation.Edit.from:type_name -> yorkie.v1.TextNodePos
+	32,  // 123: yorkie.v1.Operation.Edit.to:type_name -> yorkie.v1.TextNodePos
+	57,  // 124: yorkie.v1.Operation.Edit.created_at_map_by_actor:type_name -> yorkie.v1.Operation.Edit.CreatedAtMapByActorEntry
+	35,  // 125: yorkie.v1.Operation.Edit.executed_at:type_name -> yorkie.v1.TimeTicket
+	58,  // 126: yorkie.v1.Operation.Edit.attributes:type_name -> yorkie.v1.Operation.Edit.AttributesEntry
+	33,  // 127: yorkie.v1.Operation.Edit.restore_spans:type_name -> yorkie.v1.RestoreSpan
+	0,   // 128: yorkie.v1.Operation.Edit.restore_mode:type_name -> yorkie.v1.RestoreMode
+	33,  // 129: yorkie.v1.Operation.Edit.retombstone_spans:type_name -> yorkie.v1.RestoreSpan
+	35,  // 130: yorkie.v1.Operation.Style.parent_created_at:type_name -> yorkie.v1.TimeTicket
+	32,  // 131: yorkie.v1.Operation.Style.from:type_name -> yorkie.v1.TextNodePos
+	32,  // 132: yorkie.v1.Operation.Style.to:type_name -> yorkie.v1.TextNodePos
+	59,  // 133: yorkie.v1.Operation.Style.attributes:type_name -> yorkie.v1.Operation.Style.AttributesEntry
+	35,  // 134: yorkie.v1.Operation.Style.executed_at:type_name -> yorkie.v1.TimeTicket
+	60,  // 135: yorkie.v1.Operation.Style.created_at_map_by_actor:type_name -> yorkie.v1.Operation.Style.CreatedAtMapByActorEntry
+	35,  // 136: yorkie.v1.Operation.Increase.parent_created_at:type_name -> yorkie.v1.TimeTicket
+	11,  // 137: yorkie.v1.Operation.Increase.value:type_name -> yorkie.v1.JSONElementSimple
+	35,  // 138: yorkie.v1.Operation.Increase.executed_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 139: yorkie.v1.Operation.TreeEdit.parent_created_at:type_name -> yorkie.v1.TimeTicket
+	21,  // 140: yorkie.v1.Operation.TreeEdit.from:type_name -> yorkie.v1.TreePos
+	21,  // 141: yorkie.v1.Operation.TreeEdit.to:type_name -> yorkie.v1.TreePos
+	61,  // 142: yorkie.v1.Operation.TreeEdit.created_at_map_by_actor:type_name -> yorkie.v1.Operation.TreeEdit.CreatedAtMapByActorEntry
+	19,  // 143: yorkie.v1.Operation.TreeEdit.contents:type_name -> yorkie.v1.TreeNodes
+	35,  // 144: yorkie.v1.Operation.TreeEdit.executed_at:type_name -> yorkie.v1.TimeTicket
+	34,  // 145: yorkie.v1.Operation.TreeEdit.restore_spans:type_name -> yorkie.v1.TreeRestoreSpan
+	0,   // 146: yorkie.v1.Operation.TreeEdit.restore_mode:type_name -> yorkie.v1.RestoreMode
+	34,  // 147: yorkie.v1.Operation.TreeEdit.retombstone_spans:type_name -> yorkie.v1.TreeRestoreSpan
+	35,  // 148: yorkie.v1.Operation.TreeStyle.parent_created_at:type_name -> yorkie.v1.TimeTicket
+	21,  // 149: yorkie.v1.Operation.TreeStyle.from:type_name -> yorkie.v1.TreePos
+	21,  // 150: yorkie.v1.Operation.TreeStyle.to:type_name -> yorkie.v1.TreePos
+	62,  // 151: yorkie.v1.Operation.TreeStyle.attributes:type_name -> yorkie.v1.Operation.TreeStyle.AttributesEntry
+	35,  // 152: yorkie.v1.Operation.TreeStyle.executed_at:type_name -> yorkie.v1.TimeTicket
+	63,  // 153: yorkie.v1.Operation.TreeStyle.created_at_map_by_actor:type_name -> yorkie.v1.Operation.TreeStyle.CreatedAtMapByActorEntry
+	35,  // 154: yorkie.v1.Operation.ArraySet.parent_created_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 155: yorkie.v1.Operation.ArraySet.created_at:type_name -> yorkie.v1.TimeTicket
+	11,  // 156: yorkie.v1.Operation.ArraySet.value:type_name -> yorkie.v1.JSONElementSimple
+	35,  // 157: yorkie.v1.Operation.ArraySet.executed_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 158: yorkie.v1.Operation.Edit.CreatedAtMapByActorEntry.value:type_name -> yorkie.v1.TimeTicket
+	35,  // 159: yorkie.v1.Operation.Style.CreatedAtMapByActorEntry.value:type_name -> yorkie.v1.TimeTicket
+	35,  // 160: yorkie.v1.Operation.TreeEdit.CreatedAtMapByActorEntry.value:type_name -> yorkie.v1.TimeTicket
+	35,  // 161: yorkie.v1.Operation.TreeStyle.CreatedAtMapByActorEntry.value:type_name -> yorkie.v1.TimeTicket
+	13,  // 162: yorkie.v1.JSONElement.JSONObject.nodes:type_name -> yorkie.v1.RHTNode
+	35,  // 163: yorkie.v1.JSONElement.JSONObject.created_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 164: yorkie.v1.JSONElement.JSONObject.moved_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 165: yorkie.v1.JSONElement.JSONObject.removed_at:type_name -> yorkie.v1.TimeTicket
+	14,  // 166: yorkie.v1.JSONElement.JSONArray.nodes:type_name -> yorkie.v1.RGANode
+	35,  // 167: yorkie.v1.JSONElement.JSONArray.created_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 168: yorkie.v1.JSONElement.JSONArray.moved_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 169: yorkie.v1.JSONElement.JSONArray.removed_at:type_name -> yorkie.v1.TimeTicket
+	1,   // 170: yorkie.v1.JSONElement.Primitive.type:type_name -> yorkie.v1.ValueType
+	35,  // 171: yorkie.v1.JSONElement.Primitive.created_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 172: yorkie.v1.JSONElement.Primitive.moved_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 173: yorkie.v1.JSONElement.Primitive.removed_at:type_name -> yorkie.v1.TimeTicket
+	16,  // 174: yorkie.v1.JSONElement.Text.nodes:type_name -> yorkie.v1.TextNode
+	35,  // 175: yorkie.v1.JSONElement.Text.created_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 176: yorkie.v1.JSONElement.Text.moved_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 177: yorkie.v1.JSONElement.Text.removed_at:type_name -> yorkie.v1.TimeTicket
+	1,   // 178: yorkie.v1.JSONElement.Counter.type:type_name -> yorkie.v1.ValueType
+	35,  // 179: yorkie.v1.JSONElement.Counter.created_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 180: yorkie.v1.JSONElement.Counter.moved_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 181: yorkie.v1.JSONElement.Counter.removed_at:type_name -> yorkie.v1.TimeTicket
+	18,  // 182: yorkie.v1.JSONElement.Tree.nodes:type_name -> yorkie.v1.TreeNode
+	35,  // 183: yorkie.v1.JSONElement.Tree.created_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 184: yorkie.v1.JSONElement.Tree.moved_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 185: yorkie.v1.JSONElement.Tree.removed_at:type_name -> yorkie.v1.TimeTicket
+	15,  // 186: yorkie.v1.TextNode.AttributesEntry.value:type_name -> yorkie.v1.NodeAttr
+	15,  // 187: yorkie.v1.TreeNode.AttributesEntry.value:type_name -> yorkie.v1.NodeAttr
+	29,  // 188: yorkie.v1.DocumentSummary.PresencesEntry.value:type_name -> yorkie.v1.Presence
+	15,  // 189: yorkie.v1.TreeRestoreSpan.AttributesEntry.value:type_name -> yorkie.v1.NodeAttr
+	190, // [190:190] is the sub-list for method output_type
+	190, // [190:190] is the sub-list for method input_type
+	190, // [190:190] is the sub-list for extension type_name
+	190, // [190:190] is the sub-list for extension extendee
+	0,   // [0:190] is the sub-list for field type_name
 }
 
 func init() { file_yorkie_v1_resources_proto_init() }
@@ -5664,7 +5835,7 @@ func file_yorkie_v1_resources_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_yorkie_v1_resources_proto_rawDesc), len(file_yorkie_v1_resources_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   72,
+			NumMessages:   74,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/yorkie/v1/resources.proto
+++ b/api/yorkie/v1/resources.proto
@@ -132,6 +132,9 @@ message Operation {
     repeated TreeNodes contents = 5;
     int32 split_level = 7;
     TimeTicket executed_at = 6;
+    repeated TreeRestoreSpan restore_spans = 8; // identity-preserving undo/redo
+    RestoreMode restore_mode = 9;
+    repeated TreeRestoreSpan retombstone_spans = 10;
   }
   message TreeStyle {
     TimeTicket parent_created_at = 1;
@@ -450,6 +453,27 @@ enum RestoreMode {
   RESTORE_MODE_UNSPECIFIED = 0;
   RESTORE_MODE_RESTORE = 1;
   RESTORE_MODE_RETOMBSTONE = 2;
+}
+
+// TreeRestoreSpan carries a tree node run from a single deletion, addressed
+// by TreeNodeID identity, for identity-preserving Tree undo/redo. Unlike the
+// text RestoreSpan (flat offsets), a tree span records the node's structure
+// (type/attrs) and its position anchors, because in a tree id-order is not
+// sibling-order: left_sibling_id and right_sibling_id are redundant external
+// boundary anchors of the deleted run, so restore can reconstruct the run's
+// internal order from the op's own spans and needs only one surviving
+// boundary to place it. value/attributes are a deep copy so a GC-purged node
+// can be recreated.
+message TreeRestoreSpan {
+  TreeNodeID id = 1;
+  string node_type = 2;
+  bool is_text = 3;
+  int32 length = 4;
+  string value = 5;
+  map<string, NodeAttr> attributes = 6;
+  TreeNodeID parent_id = 7;
+  TreeNodeID left_sibling_id = 8;
+  TreeNodeID right_sibling_id = 9;
 }
 
 message TimeTicket {

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -588,6 +588,17 @@ func (n *TreeNode) remove(removedAt *time.Ticket) bool {
 	return false
 }
 
+// unremove clears the tombstone of this node (identity-preserving restore),
+// mirroring remove()'s ancestor-length bookkeeping so the node becomes visible
+// again in place.
+func (n *TreeNode) unremove() {
+	if n.removedAt == nil {
+		return
+	}
+	n.removedAt = nil
+	n.Index.UpdateAncestorsLength(n.Index.PaddedLength())
+}
+
 func (n *TreeNode) canDelete(removedAt *time.Ticket, creationKnown, tombstoneKnown bool) bool {
 	// NOTE(sigmaith): Skip if the node's creation was not visible to this operation.
 	if !creationKnown {
@@ -735,6 +746,27 @@ func (n *TreeNode) GCPairs() []GCPair {
 	return pairs
 }
 
+// TreeRestoreSpan identifies a node a deletion transitioned visible →
+// tombstoned, for identity-preserving Tree undo/redo. For text nodes the span
+// is the absolute-offset interval [ID.Offset, ID.Offset+Length) of the
+// original insertion (split-invariant); for element nodes it is the whole
+// node. Value/Attributes are a deep copy so a GC-purged node can be recreated.
+// LeftSiblingID/RightSiblingID are the deleted run's external boundary anchors
+// (redundant on purpose): since a run's spans travel together, restore rebuilds
+// the run's internal order from the op itself and needs only ONE surviving
+// boundary to place it (id-order is not sibling-order in a tree).
+type TreeRestoreSpan struct {
+	ID             *TreeNodeID
+	NodeType       string
+	IsText         bool
+	Length         int
+	Value          string
+	Attributes     *RHT
+	ParentID       *TreeNodeID
+	LeftSiblingID  *TreeNodeID
+	RightSiblingID *TreeNodeID
+}
+
 // Tree represents the tree of CRDT. It has doubly linked list structure and
 // index tree structure.
 type Tree struct {
@@ -827,18 +859,246 @@ func (t *Tree) Purge(child GCChild) error {
 
 	insPrevID := node.InsPrevID
 	insNextID := node.InsNextID
+	// NOTE: findFloorNode may return nil when the insertion neighbor was
+	// already purged (restore/recreate reorders GC so a neighbor can be
+	// collected first). Guard both derefs rather than assuming survival.
 	if insPrevID != nil {
-		insPrev := t.findFloorNode(insPrevID)
-		insPrev.InsNextID = insNextID
+		if insPrev := t.findFloorNode(insPrevID); insPrev != nil {
+			insPrev.InsNextID = insNextID
+		}
 	}
 	if insNextID != nil {
-		insNext := t.findFloorNode(insNextID)
-		insNext.InsPrevID = insPrevID
+		if insNext := t.findFloorNode(insNextID); insNext != nil {
+			insNext.InsPrevID = insPrevID
+		}
 	}
 	node.InsPrevID = nil
 	node.InsNextID = nil
 
 	return nil
+}
+
+// Restore re-establishes the nodes described by spans under their ORIGINAL
+// identities (identity-preserving Tree undo): live → skip (idempotent),
+// tombstoned → unremove in place, purged → recreate. Spans must be in
+// parent-before-child order. Returns (untombstoned, recreated); the caller
+// un-registers GC pairs for the un-tombstoned nodes and accounts recreated
+// sizes to Live. Mirrors the JS CRDTTree.restore.
+func (t *Tree) Restore(spans []*TreeRestoreSpan) (untombstoned, recreated []*TreeNode) {
+	for _, span := range spans {
+		if !span.IsText {
+			node := t.findFloorNode(span.ID)
+			if node != nil && node.id.Equal(span.ID) {
+				if node.IsRemoved() {
+					node.unremove()
+					untombstoned = append(untombstoned, node)
+				}
+				continue
+			}
+			if created := t.recreateFromSpan(span, span.ID.Offset, span.Length); created != nil {
+				recreated = append(recreated, created)
+			}
+			continue
+		}
+
+		// Text: surviving pieces may be split finer than the span.
+		start := span.ID.Offset
+		end := start + span.Length
+		pieces := t.findPiecesOverlapping(span.ID.CreatedAt, start, end)
+		cursor := start
+		pieceIdx := 0
+		for cursor < end {
+			if pieceIdx < len(pieces) && pieces[pieceIdx].id.Offset <= cursor {
+				piece := pieces[pieceIdx]
+				pieceStart := piece.id.Offset
+				pieceEnd := pieceStart + piece.Length()
+				if pieceEnd > end {
+					// Piece wider than the span. Under causal delivery the
+					// forward delete split at span boundaries on every replica
+					// before its undo could arrive, so this is unexpected; skip
+					// rather than un-tombstone beyond the span.
+					break
+				}
+				if piece.IsRemoved() {
+					piece.unremove()
+					untombstoned = append(untombstoned, piece)
+				}
+				cursor = min(pieceEnd, end)
+				if cursor >= pieceEnd {
+					pieceIdx++
+				}
+			} else {
+				gapEnd := end
+				if pieceIdx < len(pieces) {
+					gapEnd = min(pieces[pieceIdx].id.Offset, end)
+				}
+				if created := t.recreateFromSpan(span, cursor, gapEnd-cursor); created != nil {
+					recreated = append(recreated, created)
+				}
+				cursor = gapEnd
+			}
+		}
+	}
+	return untombstoned, recreated
+}
+
+// Retombstone re-removes the nodes described by spans (redo of an
+// identity-preserving undo). Live pieces only; idempotent. Returns GC pairs
+// for the newly tombstoned nodes. Mirrors the JS CRDTTree.retombstone.
+func (t *Tree) Retombstone(spans []*TreeRestoreSpan, executedAt *time.Ticket) []GCPair {
+	var pairs []GCPair
+	for _, span := range spans {
+		start := span.ID.Offset
+		length := span.Length
+		if length < 1 {
+			length = 1
+		}
+		end := start + length
+
+		var pieces []*TreeNode
+		if span.IsText {
+			pieces = t.findPiecesOverlapping(span.ID.CreatedAt, start, end)
+		} else if n := t.findFloorNode(span.ID); n != nil && n.id.Equal(span.ID) {
+			pieces = []*TreeNode{n}
+		}
+
+		for _, piece := range pieces {
+			if piece.IsRemoved() {
+				continue
+			}
+			if piece.IsText() && piece.id.Offset+piece.Length() > start+span.Length {
+				// Piece wider than the span; skip (see Restore).
+				continue
+			}
+			if piece.remove(executedAt) {
+				pairs = append(pairs, GCPair{Parent: t, Child: piece})
+			}
+		}
+	}
+	return pairs
+}
+
+// findPiecesOverlapping collects surviving pieces (live or tombstoned) of the
+// text insertion createdAt overlapping [start, end), ascending, via descending
+// floor probes. Mirrors the JS CRDTTree.findPiecesOverlapping.
+func (t *Tree) findPiecesOverlapping(createdAt *time.Ticket, start, end int) []*TreeNode {
+	var pieces []*TreeNode
+	probe := end - 1
+	for probe >= 0 {
+		node := t.findFloorNode(&TreeNodeID{CreatedAt: createdAt, Offset: probe})
+		if node == nil || !node.IsText() {
+			break
+		}
+		nodeStart := node.id.Offset
+		nodeEnd := nodeStart + node.Length()
+		if nodeEnd <= start {
+			break
+		}
+		if nodeStart < end && nodeEnd > start {
+			pieces = append(pieces, node)
+		}
+		if nodeStart <= start {
+			break
+		}
+		probe = nodeStart - 1
+	}
+	for i, j := 0, len(pieces)-1; i < j; i, j = i+1, j-1 {
+		pieces[i], pieces[j] = pieces[j], pieces[i]
+	}
+	return pieces
+}
+
+// recreateFromSpan rebuilds a purged node (or purged text sub-range) under its
+// original identity and attaches it via the anchor ladder (floor-lookup +
+// parent-identity check at each rung): (a) same-insertion successor/
+// predecessor piece → exact slot; (b) captured left boundary sibling → after
+// it; (c) captured right boundary sibling → before it; (d) deterministic
+// id-order fallback (first slot whose child id > node id — a pure function of
+// ids, identical on every replica). Parent genuinely absent → skip (B1).
+// Mirrors the JS CRDTTree.recreateFromSpan.
+func (t *Tree) recreateFromSpan(span *TreeRestoreSpan, offset, length int) *TreeNode {
+	if span.ParentID == nil {
+		return nil
+	}
+	parent := t.findFloorNode(span.ParentID)
+	if parent == nil || !parent.id.Equal(span.ParentID) {
+		return nil // B1: parent gone; leave the node unplaced.
+	}
+
+	var node *TreeNode
+	if span.IsText {
+		encoded := utf16.Encode([]rune(span.Value))
+		relStart := offset - span.ID.Offset
+		val := string(utf16.Decode(encoded[relStart : relStart+length]))
+		node = NewTreeNode(&TreeNodeID{CreatedAt: span.ID.CreatedAt, Offset: offset}, span.NodeType, nil, val)
+	} else {
+		var attrs *RHT
+		if span.Attributes != nil {
+			attrs = span.Attributes.DeepCopy()
+		}
+		node = NewTreeNode(span.ID, span.NodeType, attrs)
+	}
+
+	siblings := parent.Children(true)
+	childIndex := func(target *TreeNode) int {
+		for i, c := range siblings {
+			if c == target {
+				return i
+			}
+		}
+		return len(siblings)
+	}
+	sameParent := func(n *TreeNode) bool {
+		return n.Index.Parent != nil && n.Index.Parent.Value == parent
+	}
+
+	// (a) same-insertion successor / predecessor piece (text): exact slot.
+	if span.IsText {
+		succ := t.findFloorNode(&TreeNodeID{CreatedAt: span.ID.CreatedAt, Offset: offset + length})
+		if succ != nil && succ.IsText() && sameParent(succ) && succ.id.Offset == offset+length {
+			_ = parent.InsertAt(node, childIndex(succ))
+			t.NodeMapByID.Put(node.id, node)
+			return node
+		}
+		if offset > span.ID.Offset || offset > 0 {
+			pred := t.findFloorNode(&TreeNodeID{CreatedAt: span.ID.CreatedAt, Offset: offset - 1})
+			if pred != nil && pred.IsText() && sameParent(pred) {
+				_ = parent.InsertAfter(node, pred)
+				t.NodeMapByID.Put(node.id, node)
+				return node
+			}
+		}
+	}
+
+	// (b) captured left boundary sibling, if it still exists under this parent.
+	if span.LeftSiblingID != nil {
+		if left := t.findFloorNode(span.LeftSiblingID); left != nil && sameParent(left) {
+			_ = parent.InsertAfter(node, left)
+			t.NodeMapByID.Put(node.id, node)
+			return node
+		}
+	}
+
+	// (c) captured right boundary sibling (redundant anchor): insert before it.
+	if span.RightSiblingID != nil {
+		if right := t.findFloorNode(span.RightSiblingID); right != nil && sameParent(right) {
+			_ = parent.InsertAt(node, childIndex(right))
+			t.NodeMapByID.Put(node.id, node)
+			return node
+		}
+	}
+
+	// (d) deterministic id-order fallback: first slot whose child id > node id.
+	insertIdx := len(siblings)
+	for i, c := range siblings {
+		if c.id.Compare(node.id) > 0 {
+			insertIdx = i
+			break
+		}
+	}
+	_ = parent.InsertAt(node, insertIdx)
+	t.NodeMapByID.Put(node.id, node)
+	return node
 }
 
 // MetaSize returns the size of the metadata of this element.

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -884,7 +884,7 @@ func (t *Tree) Purge(child GCChild) error {
 // parent-before-child order. Returns (untombstoned, recreated); the caller
 // un-registers GC pairs for the un-tombstoned nodes and accounts recreated
 // sizes to Live. Mirrors the JS CRDTTree.restore.
-func (t *Tree) Restore(spans []*TreeRestoreSpan) (untombstoned, recreated []*TreeNode) {
+func (t *Tree) Restore(spans []*TreeRestoreSpan) (untombstoned, recreated []*TreeNode, err error) {
 	for _, span := range spans {
 		if !span.IsText {
 			node := t.findFloorNode(span.ID)
@@ -895,7 +895,11 @@ func (t *Tree) Restore(spans []*TreeRestoreSpan) (untombstoned, recreated []*Tre
 				}
 				continue
 			}
-			if created := t.recreateFromSpan(span, span.ID.Offset, span.Length); created != nil {
+			created, cErr := t.recreateFromSpan(span, span.ID.Offset, span.Length)
+			if cErr != nil {
+				return nil, nil, cErr
+			}
+			if created != nil {
 				recreated = append(recreated, created)
 			}
 			continue
@@ -912,11 +916,12 @@ func (t *Tree) Restore(spans []*TreeRestoreSpan) (untombstoned, recreated []*Tre
 				piece := pieces[pieceIdx]
 				pieceStart := piece.id.Offset
 				pieceEnd := pieceStart + piece.Length()
-				if pieceEnd > end {
-					// Piece wider than the span. Under causal delivery the
+				if pieceStart < start || pieceEnd > end {
+					// Piece straddles a span boundary. Under causal delivery the
 					// forward delete split at span boundaries on every replica
 					// before its undo could arrive, so this is unexpected; skip
-					// rather than un-tombstone beyond the span.
+					// rather than un-tombstone beyond the span. Mirrors the guard
+					// in Retombstone so undo/redo stay symmetric.
 					break
 				}
 				if piece.IsRemoved() {
@@ -932,14 +937,18 @@ func (t *Tree) Restore(spans []*TreeRestoreSpan) (untombstoned, recreated []*Tre
 				if pieceIdx < len(pieces) {
 					gapEnd = min(pieces[pieceIdx].id.Offset, end)
 				}
-				if created := t.recreateFromSpan(span, cursor, gapEnd-cursor); created != nil {
+				created, cErr := t.recreateFromSpan(span, cursor, gapEnd-cursor)
+				if cErr != nil {
+					return nil, nil, cErr
+				}
+				if created != nil {
 					recreated = append(recreated, created)
 				}
 				cursor = gapEnd
 			}
 		}
 	}
-	return untombstoned, recreated
+	return untombstoned, recreated, nil
 }
 
 // Retombstone re-removes the nodes described by spans (redo of an
@@ -966,8 +975,10 @@ func (t *Tree) Retombstone(spans []*TreeRestoreSpan, executedAt *time.Ticket) []
 			if piece.IsRemoved() {
 				continue
 			}
-			if piece.IsText() && piece.id.Offset+piece.Length() > start+span.Length {
-				// Piece wider than the span; skip (see Restore).
+			if piece.IsText() && (piece.id.Offset < start || piece.id.Offset+piece.Length() > end) {
+				// Piece straddles a span boundary (uses the same clamped end as
+				// findPiecesOverlapping); skip so we never re-tombstone content
+				// outside the span. Mirrors the guard in Restore.
 				continue
 			}
 			if piece.remove(executedAt) {
@@ -1016,13 +1027,13 @@ func (t *Tree) findPiecesOverlapping(createdAt *time.Ticket, start, end int) []*
 // id-order fallback (first slot whose child id > node id — a pure function of
 // ids, identical on every replica). Parent genuinely absent → skip (B1).
 // Mirrors the JS CRDTTree.recreateFromSpan.
-func (t *Tree) recreateFromSpan(span *TreeRestoreSpan, offset, length int) *TreeNode {
+func (t *Tree) recreateFromSpan(span *TreeRestoreSpan, offset, length int) (*TreeNode, error) {
 	if span.ParentID == nil {
-		return nil
+		return nil, nil
 	}
 	parent := t.findFloorNode(span.ParentID)
 	if parent == nil || !parent.id.Equal(span.ParentID) {
-		return nil // B1: parent gone; leave the node unplaced.
+		return nil, nil // B1: parent gone; leave the node unplaced.
 	}
 
 	var node *TreeNode
@@ -1052,20 +1063,27 @@ func (t *Tree) recreateFromSpan(span *TreeRestoreSpan, offset, length int) *Tree
 		return n.Index.Parent != nil && n.Index.Parent.Value == parent
 	}
 
+	// attach inserts node at the resolved slot and registers it. A failed
+	// insertion must not leave a half-attached node in NodeMapByID, so the
+	// error is returned before Put and Restore drops the node entirely.
+	attach := func(insert func() error) (*TreeNode, error) {
+		if err := insert(); err != nil {
+			return nil, err
+		}
+		t.NodeMapByID.Put(node.id, node)
+		return node, nil
+	}
+
 	// (a) same-insertion successor / predecessor piece (text): exact slot.
 	if span.IsText {
 		succ := t.findFloorNode(&TreeNodeID{CreatedAt: span.ID.CreatedAt, Offset: offset + length})
 		if succ != nil && succ.IsText() && sameParent(succ) && succ.id.Offset == offset+length {
-			_ = parent.InsertAt(node, childIndex(succ))
-			t.NodeMapByID.Put(node.id, node)
-			return node
+			return attach(func() error { return parent.InsertAt(node, childIndex(succ)) })
 		}
 		if offset > span.ID.Offset || offset > 0 {
 			pred := t.findFloorNode(&TreeNodeID{CreatedAt: span.ID.CreatedAt, Offset: offset - 1})
 			if pred != nil && pred.IsText() && sameParent(pred) {
-				_ = parent.InsertAfter(node, pred)
-				t.NodeMapByID.Put(node.id, node)
-				return node
+				return attach(func() error { return parent.InsertAfter(node, pred) })
 			}
 		}
 	}
@@ -1073,18 +1091,14 @@ func (t *Tree) recreateFromSpan(span *TreeRestoreSpan, offset, length int) *Tree
 	// (b) captured left boundary sibling, if it still exists under this parent.
 	if span.LeftSiblingID != nil {
 		if left := t.findFloorNode(span.LeftSiblingID); left != nil && sameParent(left) {
-			_ = parent.InsertAfter(node, left)
-			t.NodeMapByID.Put(node.id, node)
-			return node
+			return attach(func() error { return parent.InsertAfter(node, left) })
 		}
 	}
 
 	// (c) captured right boundary sibling (redundant anchor): insert before it.
 	if span.RightSiblingID != nil {
 		if right := t.findFloorNode(span.RightSiblingID); right != nil && sameParent(right) {
-			_ = parent.InsertAt(node, childIndex(right))
-			t.NodeMapByID.Put(node.id, node)
-			return node
+			return attach(func() error { return parent.InsertAt(node, childIndex(right)) })
 		}
 	}
 
@@ -1096,9 +1110,7 @@ func (t *Tree) recreateFromSpan(span *TreeRestoreSpan, offset, length int) *Tree
 			break
 		}
 	}
-	_ = parent.InsertAt(node, insertIdx)
-	t.NodeMapByID.Put(node.id, node)
-	return node
+	return attach(func() error { return parent.InsertAt(node, insertIdx) })
 }
 
 // MetaSize returns the size of the metadata of this element.

--- a/pkg/document/crdt/tree_restore_test.go
+++ b/pkg/document/crdt/tree_restore_test.go
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2024 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package crdt_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/pkg/document/crdt"
+	"github.com/yorkie-team/yorkie/pkg/document/operations"
+	"github.com/yorkie-team/yorkie/pkg/document/time"
+	"github.com/yorkie-team/yorkie/test/helper"
+)
+
+// Identity-preserving Tree restore tests. Undo revives deleted nodes under
+// their ORIGINAL identity (createdAt+offset) instead of copy-reinserting
+// fresh ones, so concurrent undos converge; redo re-tombstones them. When a
+// node was GC-purged before the undo, it is recreated from the carried span
+// and re-anchored via the ladder in recreateFromSpan (parent-before-child).
+
+// elementSpan builds a restore span describing an element node under parent.
+func elementSpan(node, parent *crdt.TreeNode) *crdt.TreeRestoreSpan {
+	return &crdt.TreeRestoreSpan{
+		ID:       node.ID(),
+		NodeType: node.Type(),
+		IsText:   false,
+		ParentID: parent.ID(),
+	}
+}
+
+// textSpan builds a restore span describing a whole text node under parent.
+func textSpan(node, parent *crdt.TreeNode) *crdt.TreeRestoreSpan {
+	return &crdt.TreeRestoreSpan{
+		ID:       node.ID(),
+		NodeType: node.Type(),
+		IsText:   true,
+		Length:   len([]rune(node.Value)),
+		Value:    node.Value,
+		ParentID: parent.ID(),
+	}
+}
+
+// TestTreeRestoreUnremove verifies that restoring a still-present (tombstoned,
+// not purged) node un-tombstones it IN PLACE under its original identity, and
+// that the tree's visible length returns to exactly its pre-delete value.
+func TestTreeRestoreUnremove(t *testing.T) {
+	ctx := helper.TextChangeContext(helper.TestRoot())
+	tree := createHelloTree(t, ctx) // <r><p>hello</p></r>
+	before := tree.Root().Len()
+
+	p := tree.Root().Children()[0]
+	text := p.Children()[0]
+	span := textSpan(text, p)
+
+	// Delete "hello" ([1,6)); the text node becomes a tombstone in place.
+	_, _, err := tree.EditT(1, 6, nil, 0, helper.TimeT(ctx), issueTicket(ctx))
+	assert.NoError(t, err)
+	assert.Equal(t, "<r><p></p></r>", tree.ToXML())
+
+	untombstoned, recreated := tree.Restore([]*crdt.TreeRestoreSpan{span})
+	assert.Len(t, untombstoned, 1, "the tombstone is revived in place")
+	assert.Empty(t, recreated, "nothing was purged, so nothing is recreated")
+	assert.Equal(t, "<r><p>hello</p></r>", tree.ToXML())
+	assert.Equal(t, before, tree.Root().Len(), "length must be symmetric")
+}
+
+// TestTreeRetombstoneThenRestore checks the redo/undo primitive symmetry:
+// retombstoning live nodes by identity removes them; restoring the same spans
+// revives them. This is the pair a redo (retombstone) / undo (restore) uses.
+func TestTreeRetombstoneThenRestore(t *testing.T) {
+	ctx := helper.TextChangeContext(helper.TestRoot())
+	tree := createHelloTree(t, ctx) // <r><p>hello</p></r>
+
+	p := tree.Root().Children()[0]
+	text := p.Children()[0]
+	// Parent-before-child order, as edit() emits it.
+	spans := []*crdt.TreeRestoreSpan{elementSpan(p, tree.Root()), textSpan(text, p)}
+
+	// Retombstone (redo of a deletion undo): the live subtree is removed.
+	pairs := tree.Retombstone(spans, helper.TimeT(ctx))
+	assert.NotEmpty(t, pairs, "removing live nodes yields GC pairs")
+	assert.Equal(t, "<r></r>", tree.ToXML())
+
+	// Restore (undo): the same identities come back, parent before child.
+	untombstoned, recreated := tree.Restore(spans)
+	assert.Len(t, untombstoned, 2)
+	assert.Empty(t, recreated)
+	assert.Equal(t, "<r><p>hello</p></r>", tree.ToXML())
+}
+
+// TestTreeRestoreExecuteAfterGC exercises the full server execution path: a
+// deletion, a GC purge that physically removes the tombstones, then a restore
+// routed through operations.Execute. Because the nodes are gone, restore must
+// RECREATE them from the carried spans and re-anchor them — the element first,
+// then its text child under the just-recreated element (parent-before-child).
+func TestTreeRestoreExecuteAfterGC(t *testing.T) {
+	ctx := helper.TextChangeContext(helper.TestRoot())
+	root := helper.TestRoot()
+	tree := createHelloTree(t, ctx) // <r><p>hello</p></r>
+	root.RegisterElement(tree)
+	parent := tree.CreatedAt()
+
+	p := tree.Root().Children()[0]
+	text := p.Children()[0]
+	// Capture spans from the LIVE nodes, parent-before-child, before deleting.
+	spans := []*crdt.TreeRestoreSpan{elementSpan(p, tree.Root()), textSpan(text, p)}
+
+	// Delete the whole <p>hello</p> ([0,7)) via an executed op so GC pairs are
+	// registered on the root.
+	from, err := tree.FindPos(0)
+	assert.NoError(t, err)
+	to, err := tree.FindPos(7)
+	assert.NoError(t, err)
+	delOp := operations.NewTreeEdit(parent, from, to, nil, 0, helper.TimeT(ctx))
+	assert.NoError(t, delOp.Execute(root, nil))
+	assert.Equal(t, "<r></r>", tree.ToXML())
+
+	// Purge: the tombstones are physically removed, so restore cannot
+	// un-tombstone them — it must recreate.
+	n, err := root.GarbageCollect(helper.MaxVersionVector())
+	assert.NoError(t, err)
+	assert.Positive(t, n, "the deleted subtree should be purged")
+
+	// Restore through Execute (identity-addressed; positions unused). An empty
+	// version vector marks the trusted local path, skipping identity checks.
+	restoreOp := operations.NewRestoreTreeEdit(
+		parent, nil, nil, helper.TimeT(ctx),
+		spans, crdt.RestoreModeRestore, nil,
+	)
+	assert.NoError(t, restoreOp.Execute(root, helper.MaxVersionVector()))
+
+	assert.Equal(t, "<r><p>hello</p></r>", tree.ToXML(),
+		"the purged subtree is recreated under its original identity")
+	assert.Equal(t, 0, root.GarbageLen(), "restore leaves nothing registered for GC")
+}
+
+// TestTreeRestoreParentGoneSkip verifies the B1 rule: if a recreated node's
+// parent is genuinely absent (purged and not part of this restore's spans),
+// the node is skipped rather than mis-attached or panicking. Skipping is
+// convergent because every replica resolves parent-absent identically.
+func TestTreeRestoreParentGoneSkip(t *testing.T) {
+	ctx := helper.TextChangeContext(helper.TestRoot())
+	tree := createHelloTree(t, ctx) // <r><p>hello</p></r>
+
+	// A span whose parent id points at a node that does not exist in the tree.
+	ghostParent := crdt.NewTreeNodeID(helper.TimeT(ctx), 0)
+	orphan := &crdt.TreeRestoreSpan{
+		ID:       crdt.NewTreeNodeID(helper.TimeT(ctx), 0),
+		NodeType: "text",
+		IsText:   true,
+		Length:   1,
+		Value:    "x",
+		ParentID: ghostParent,
+	}
+
+	untombstoned, recreated := tree.Restore([]*crdt.TreeRestoreSpan{orphan})
+	assert.Empty(t, untombstoned)
+	assert.Empty(t, recreated, "a node with no surviving parent is skipped (B1)")
+	assert.Equal(t, "<r><p>hello</p></r>", tree.ToXML(), "tree is untouched")
+}
+
+// TestTreeRestoreRejectsForgedIdentity verifies that TreeEdit.Execute rejects a
+// restore span whose node identity the acting change could not causally have
+// observed. Execute materializes spans into authoritative server state, so
+// without this guard a client could forge a live node under another actor's
+// (actor, lamport) identity. Parity with the Text restore path; victimActor
+// and restoreActor are defined in text_restore_test.go (same test package).
+func TestTreeRestoreRejectsForgedIdentity(t *testing.T) {
+	ctx := helper.TextChangeContext(helper.TestRoot())
+	root := helper.TestRoot()
+	tree := createHelloTree(t, ctx) // <r><p>hello</p></r>
+	root.RegisterElement(tree)
+	parent := tree.CreatedAt()
+
+	forged := &crdt.TreeRestoreSpan{
+		ID:       crdt.NewTreeNodeID(time.NewTicket(999, 0, victimActor), 0),
+		NodeType: "text",
+		IsText:   true,
+		Length:   2,
+		Value:    "XY",
+		ParentID: tree.Root().ID(),
+	}
+	op := operations.NewRestoreTreeEdit(parent, nil, nil, helper.TimeT(ctx),
+		[]*crdt.TreeRestoreSpan{forged}, crdt.RestoreModeRestore, nil)
+
+	// The acting change knows only restoreActor, never victimActor, so the
+	// forged identity is uncausal and must be rejected.
+	vv := helper.VersionVectorOf(map[time.ActorID]int64{restoreActor: time.MaxLamport})
+	assert.ErrorIs(t, op.Execute(root, vv), operations.ErrUnknownRestoreIdentity)
+	assert.Equal(t, "<r><p>hello</p></r>", tree.ToXML(), "state untouched on rejection")
+}

--- a/pkg/document/crdt/tree_restore_test.go
+++ b/pkg/document/crdt/tree_restore_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Yorkie Authors. All rights reserved.
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/document/crdt/tree_restore_test.go
+++ b/pkg/document/crdt/tree_restore_test.go
@@ -21,9 +21,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/yorkie-team/yorkie/pkg/document/change"
 	"github.com/yorkie-team/yorkie/pkg/document/crdt"
 	"github.com/yorkie-team/yorkie/pkg/document/operations"
 	"github.com/yorkie-team/yorkie/pkg/document/time"
+	"github.com/yorkie-team/yorkie/pkg/index"
 	"github.com/yorkie-team/yorkie/test/helper"
 )
 
@@ -208,4 +210,280 @@ func TestTreeRestoreRejectsForgedIdentity(t *testing.T) {
 	vv := helper.VersionVectorOf(map[time.ActorID]int64{restoreActor: time.MaxLamport})
 	assert.ErrorIs(t, op.Execute(root, vv), operations.ErrUnknownRestoreIdentity)
 	assert.Equal(t, "<r><p>hello</p></r>", tree.ToXML(), "state untouched on rejection")
+}
+
+// treeRestoreActorA/B are two actors distinct from InitialActorID (which
+// createHelloTree uses to create nodes), so a version vector that knows only
+// InitialActorID sees both actors' operations as concurrent.
+var treeRestoreActorA, _ = time.ActorIDFromHex("00000000000000000000000a")
+var treeRestoreActorB, _ = time.ActorIDFromHex("00000000000000000000000b")
+
+// elementPaddingLength mirrors the unexported constant of the same name in
+// pkg/index: an element node occupies its content length plus an open and a
+// close token.
+const elementPaddingLength = 2
+
+// expectVisibleLength recomputes a node's VisibleLength from its subtree
+// without mutating anything. It mirrors Node.PaddedLength: a removed child
+// contributes nothing to its parent, an element child contributes its own
+// length plus padding.
+//
+// NOTE: index.Node.UpdateDescendantsLength cannot be used for verification
+// because it ACCUMULATES into VisibleLength rather than assigning it, so
+// calling it on an already-computed tree double counts.
+func expectVisibleLength(n *index.Node[*crdt.TreeNode]) int {
+	if n.IsText() {
+		return n.Value.Length()
+	}
+
+	sum := 0
+	for _, child := range n.Children(true) {
+		length := expectVisibleLength(child)
+		if child.Value.IsRemoved() {
+			continue
+		}
+		if child.IsText() {
+			sum += length
+		} else {
+			sum += length + elementPaddingLength
+		}
+	}
+	return sum
+}
+
+// assertLengthCacheSound checks every node's cached VisibleLength against the
+// recomputation. Restore mutates tombstones in place through unremove(), which
+// hand-maintains the ancestor length cache; if that bookkeeping drifts, the
+// tree still renders correctly but every later index-based edit resolves to
+// the wrong offset. This assertion is what catches that.
+func assertLengthCacheSound(t *testing.T, tree *crdt.Tree, label string) {
+	t.Helper()
+
+	var walk func(*index.Node[*crdt.TreeNode])
+	walk = func(node *index.Node[*crdt.TreeNode]) {
+		want := expectVisibleLength(node)
+		assert.Equal(t, want, node.VisibleLength,
+			"%s: stale VisibleLength cache on %q", label, node.Type)
+
+		if node.IsText() {
+			return
+		}
+		for _, child := range node.Children(true) {
+			walk(child)
+		}
+	}
+	walk(tree.IndexTree.Root())
+}
+
+// TestTreeLengthCacheChecker validates assertLengthCacheSound itself against
+// states produced WITHOUT any restore code. Without this, a bug in the checker
+// would silently make the integrity tests below vacuous.
+func TestTreeLengthCacheChecker(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		start, end int
+	}{
+		{"pristine", 0, 0},
+		{"whole text deleted", 1, 6},
+		{"text partially deleted (splits)", 2, 4},
+		{"subtree deleted", 0, 7},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := helper.TextChangeContext(helper.TestRoot())
+			tree := createHelloTree(t, ctx)
+			if tc.start != tc.end {
+				_, _, err := tree.EditT(tc.start, tc.end, nil, 0, helper.TimeT(ctx), issueTicket(ctx))
+				assert.NoError(t, err)
+			}
+			assertLengthCacheSound(t, tree, tc.name)
+		})
+	}
+}
+
+// TestTreeRestoreLengthCacheIntegrity pins unremove()'s ancestor bookkeeping.
+// remove() decrements ancestor VisibleLength and stops at the first removed
+// ancestor; unremove() must mirror that exactly, in EITHER span order, or the
+// index cache silently drifts.
+func TestTreeRestoreLengthCacheIntegrity(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		childFirst bool
+	}{
+		{"parent before child", false},
+		{"child before parent", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := helper.TextChangeContext(helper.TestRoot())
+			tree := createHelloTree(t, ctx) // <r><p>hello</p></r>
+			before := tree.Root().Len()
+
+			p := tree.Root().Children()[0]
+			text := p.Children()[0]
+			spans := []*crdt.TreeRestoreSpan{elementSpan(p, tree.Root()), textSpan(text, p)}
+			if tc.childFirst {
+				spans = []*crdt.TreeRestoreSpan{textSpan(text, p), elementSpan(p, tree.Root())}
+			}
+
+			_, _, err := tree.EditT(0, 7, nil, 0, helper.TimeT(ctx), issueTicket(ctx))
+			assert.NoError(t, err)
+			assert.Equal(t, "<r></r>", tree.ToXML())
+
+			_, _, err = tree.Restore(spans)
+			assert.NoError(t, err)
+
+			assert.Equal(t, "<r><p>hello</p></r>", tree.ToXML())
+			assert.Equal(t, before, tree.Root().Len(), "visible length is restored exactly")
+			assertLengthCacheSound(t, tree, tc.name)
+		})
+	}
+}
+
+// TestTreeRestoreRecreateKeepsTreeEditable covers the recreateFromSpan path:
+// after a GC purge the nodes are rebuilt from scratch and spliced in by the
+// anchor ladder. A node spliced in with a wrong length cache renders fine but
+// misplaces the NEXT index-based edit, so the test edits afterwards.
+func TestTreeRestoreRecreateKeepsTreeEditable(t *testing.T) {
+	ctx := helper.TextChangeContext(helper.TestRoot())
+	root := helper.TestRoot()
+	tree := createHelloTree(t, ctx) // <r><p>hello</p></r>
+	root.RegisterElement(tree)
+	parent := tree.CreatedAt()
+
+	p := tree.Root().Children()[0]
+	text := p.Children()[0]
+	spans := []*crdt.TreeRestoreSpan{elementSpan(p, tree.Root()), textSpan(text, p)}
+
+	from, err := tree.FindPos(0)
+	assert.NoError(t, err)
+	to, err := tree.FindPos(7)
+	assert.NoError(t, err)
+	assert.NoError(t, operations.NewTreeEdit(parent, from, to, nil, 0,
+		helper.TimeT(ctx)).Execute(root, nil))
+	n, err := root.GarbageCollect(helper.MaxVersionVector())
+	assert.NoError(t, err)
+	assert.Positive(t, n, "the deleted subtree should be purged")
+
+	assert.NoError(t, operations.NewRestoreTreeEdit(parent, nil, nil,
+		helper.TimeT(ctx), spans, crdt.RestoreModeRestore, nil).
+		Execute(root, helper.MaxVersionVector()))
+	assert.Equal(t, "<r><p>hello</p></r>", tree.ToXML())
+	assertLengthCacheSound(t, tree, "after recreate")
+
+	// The recreated subtree must behave like any other: an edit at index 3
+	// lands between "he" and "llo".
+	_, _, err = tree.EditT(3, 3, []*crdt.TreeNode{
+		crdt.NewTreeNode(helper.PosT(ctx), "text", nil, "Z"),
+	}, 0, helper.TimeT(ctx), issueTicket(ctx))
+	assert.NoError(t, err)
+	assert.Equal(t, "<r><p>heZllo</p></r>", tree.ToXML(),
+		"index-based edits resolve correctly after a recreate")
+	assertLengthCacheSound(t, tree, "after edit on recreated subtree")
+}
+
+// TestTreeRestoreDocSizeSymmetry pins the GC accounting in TreeEdit.Execute.
+// Restore moves a tombstone's size GC->Live via UnregisterGCPair + diff.Add,
+// and retombstone moves it back. Either half getting the removedAt ticket
+// wrong leaks size permanently, which only shows up as drifting doc-size
+// metrics in production.
+func TestTreeRestoreDocSizeSymmetry(t *testing.T) {
+	ctx := helper.TextChangeContext(helper.TestRoot())
+	root := helper.TestRoot()
+	tree := createHelloTree(t, ctx) // <r><p>hello</p></r>
+	root.RegisterElement(tree)
+	parent := tree.CreatedAt()
+
+	p := tree.Root().Children()[0]
+	text := p.Children()[0]
+	spans := []*crdt.TreeRestoreSpan{elementSpan(p, tree.Root()), textSpan(text, p)}
+
+	baseline := root.DocSize()
+
+	from, err := tree.FindPos(0)
+	assert.NoError(t, err)
+	to, err := tree.FindPos(7)
+	assert.NoError(t, err)
+	assert.NoError(t, operations.NewTreeEdit(parent, from, to, nil, 0,
+		helper.TimeT(ctx)).Execute(root, nil))
+	afterDelete := root.DocSize()
+	assert.NotEqual(t, baseline, afterDelete, "the delete must move size Live->GC")
+
+	// Undo: every byte comes back to Live and GC empties out.
+	assert.NoError(t, operations.NewRestoreTreeEdit(parent, nil, nil,
+		helper.TimeT(ctx), spans, crdt.RestoreModeRestore, nil).
+		Execute(root, helper.MaxVersionVector()))
+	assert.Equal(t, "<r><p>hello</p></r>", tree.ToXML())
+	assert.Equal(t, baseline, root.DocSize(), "restore returns docSize to baseline")
+
+	// Redo: RestoreModeRetombstone swaps the span sets, so the spans in the
+	// restore slot are the ones re-tombstoned.
+	assert.NoError(t, operations.NewRestoreTreeEdit(parent, nil, nil,
+		helper.TimeT(ctx), spans, crdt.RestoreModeRetombstone, nil).
+		Execute(root, helper.MaxVersionVector()))
+	assert.Equal(t, "<r></r>", tree.ToXML())
+	assert.Equal(t, afterDelete, root.DocSize(), "redo returns docSize to the post-delete state")
+}
+
+// TestTreeRestoreConvergesUnderConcurrentEdit is the regression test for this
+// feature's whole reason to exist: reviving by identity converges where
+// copy-reinsertion diverged. Two replicas apply the same three operations --
+// a delete D, its undo U, and a CONCURRENT insert X by another actor -- in two
+// different causally legal orders, and must agree.
+func TestTreeRestoreConvergesUnderConcurrentEdit(t *testing.T) {
+	tD := time.NewTicket(100, 0, treeRestoreActorA)
+	tX := time.NewTicket(150, 0, treeRestoreActorB)
+
+	// Knows InitialActorID, so the nodes' creation is causally visible, but
+	// knows neither A nor B, so D and X are concurrent with each other.
+	vv := helper.MaxVersionVector()
+
+	// Both replicas are built from identical tickets, so node identities (and
+	// therefore D's positions and U's span) are portable between them.
+	newReplica := func() (*crdt.Tree, *change.Context, *crdt.TreePos, *crdt.TreePos, *crdt.TreeRestoreSpan) {
+		ctx := helper.TextChangeContext(helper.TestRoot())
+		tree := createHelloTree(t, ctx)
+		p := tree.Root().Children()[0]
+		text := p.Children()[0]
+
+		// D addresses the pristine state, as it would on the replica that
+		// generated it before ever seeing X.
+		from, err := tree.FindPos(1)
+		assert.NoError(t, err)
+		to, err := tree.FindPos(6)
+		assert.NoError(t, err)
+		return tree, ctx, from, to, textSpan(text, p)
+	}
+
+	applyD := func(tree *crdt.Tree, ctx *change.Context, from, to *crdt.TreePos) {
+		_, _, err := tree.Edit(from, to, nil, 0, tD, issueTicket(ctx), vv)
+		assert.NoError(t, err)
+	}
+	applyU := func(tree *crdt.Tree, span *crdt.TreeRestoreSpan) {
+		_, _, err := tree.Restore([]*crdt.TreeRestoreSpan{span})
+		assert.NoError(t, err)
+	}
+	applyX := func(tree *crdt.Tree, ctx *change.Context) {
+		_, _, err := tree.EditT(3, 3, []*crdt.TreeNode{
+			crdt.NewTreeNode(crdt.NewTreeNodeID(tX, 0), "text", nil, "W"),
+		}, 0, tX, issueTicket(ctx))
+		assert.NoError(t, err)
+	}
+
+	// Replica 1 sees X last: D -> U -> X.
+	r1, ctx1, from1, to1, span1 := newReplica()
+	applyD(r1, ctx1, from1, to1)
+	applyU(r1, span1)
+	applyX(r1, ctx1)
+
+	// Replica 2 sees X first: X -> D -> U. U stays after D, which is the only
+	// ordering causality actually requires.
+	r2, ctx2, from2, to2, span2 := newReplica()
+	applyX(r2, ctx2)
+	applyD(r2, ctx2, from2, to2)
+	applyU(r2, span2)
+
+	assert.Equal(t, r1.ToXML(), r2.ToXML(), "replicas must converge on the same content")
+	assert.Equal(t, "<r><p>heWllo</p></r>", r1.ToXML(),
+		"the undo revives the original text and the concurrent insert survives")
+	assertLengthCacheSound(t, r1, "replica 1")
+	assertLengthCacheSound(t, r2, "replica 2")
 }

--- a/pkg/document/crdt/tree_restore_test.go
+++ b/pkg/document/crdt/tree_restore_test.go
@@ -49,7 +49,8 @@ func textSpan(node, parent *crdt.TreeNode) *crdt.TreeRestoreSpan {
 		ID:       node.ID(),
 		NodeType: node.Type(),
 		IsText:   true,
-		Length:   len([]rune(node.Value)),
+		// Length is UTF-16 code units, per TreeRestoreSpan's contract.
+		Length:   node.Length(),
 		Value:    node.Value,
 		ParentID: parent.ID(),
 	}
@@ -72,7 +73,8 @@ func TestTreeRestoreUnremove(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "<r><p></p></r>", tree.ToXML())
 
-	untombstoned, recreated := tree.Restore([]*crdt.TreeRestoreSpan{span})
+	untombstoned, recreated, err := tree.Restore([]*crdt.TreeRestoreSpan{span})
+	assert.NoError(t, err)
 	assert.Len(t, untombstoned, 1, "the tombstone is revived in place")
 	assert.Empty(t, recreated, "nothing was purged, so nothing is recreated")
 	assert.Equal(t, "<r><p>hello</p></r>", tree.ToXML())
@@ -97,7 +99,8 @@ func TestTreeRetombstoneThenRestore(t *testing.T) {
 	assert.Equal(t, "<r></r>", tree.ToXML())
 
 	// Restore (undo): the same identities come back, parent before child.
-	untombstoned, recreated := tree.Restore(spans)
+	untombstoned, recreated, err := tree.Restore(spans)
+	assert.NoError(t, err)
 	assert.Len(t, untombstoned, 2)
 	assert.Empty(t, recreated)
 	assert.Equal(t, "<r><p>hello</p></r>", tree.ToXML())
@@ -136,8 +139,9 @@ func TestTreeRestoreExecuteAfterGC(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Positive(t, n, "the deleted subtree should be purged")
 
-	// Restore through Execute (identity-addressed; positions unused). An empty
-	// version vector marks the trusted local path, skipping identity checks.
+	// Restore through Execute (identity-addressed; positions unused). A max
+	// version vector places every actor's clock at the maximum, so all restore
+	// tickets fall within known range and pass identity validation.
 	restoreOp := operations.NewRestoreTreeEdit(
 		parent, nil, nil, helper.TimeT(ctx),
 		spans, crdt.RestoreModeRestore, nil,
@@ -168,7 +172,8 @@ func TestTreeRestoreParentGoneSkip(t *testing.T) {
 		ParentID: ghostParent,
 	}
 
-	untombstoned, recreated := tree.Restore([]*crdt.TreeRestoreSpan{orphan})
+	untombstoned, recreated, err := tree.Restore([]*crdt.TreeRestoreSpan{orphan})
+	assert.NoError(t, err)
 	assert.Empty(t, untombstoned)
 	assert.Empty(t, recreated, "a node with no surviving parent is skipped (B1)")
 	assert.Equal(t, "<r><p>hello</p></r>", tree.ToXML(), "tree is untouched")

--- a/pkg/document/operations/edit.go
+++ b/pkg/document/operations/edit.go
@@ -201,13 +201,32 @@ func validateRestoreIdentities(
 	spans []*crdt.RestoreSpan,
 	versionVector time.VersionVector,
 ) error {
-	if len(spans) == 0 || len(versionVector) == 0 {
+	if len(spans) == 0 {
+		return nil
+	}
+	createdAts := make([]*time.Ticket, 0, len(spans))
+	for _, span := range spans {
+		createdAts = append(createdAts, span.CreatedAt)
+	}
+	return validateRestoreTickets(createdAts, versionVector)
+}
+
+// validateRestoreTickets rejects any restore identity the acting change could
+// not causally have observed (actor absent from the version vector, or a
+// lamport beyond the actor's known clock). An empty version vector marks the
+// trusted local path (json application). Shared by the Text and Tree restore
+// paths.
+func validateRestoreTickets(
+	createdAts []*time.Ticket,
+	versionVector time.VersionVector,
+) error {
+	if len(createdAts) == 0 || len(versionVector) == 0 {
 		return nil
 	}
 
-	for _, span := range spans {
-		known, ok := versionVector.Get(span.CreatedAt.ActorID())
-		if !ok || span.CreatedAt.Lamport() > known {
+	for _, createdAt := range createdAts {
+		known, ok := versionVector.Get(createdAt.ActorID())
+		if !ok || createdAt.Lamport() > known {
 			return ErrUnknownRestoreIdentity
 		}
 	}

--- a/pkg/document/operations/tree_edit.go
+++ b/pkg/document/operations/tree_edit.go
@@ -127,12 +127,15 @@ func (e *TreeEdit) Execute(root *crdt.Root, versionVector time.VersionVector) er
 				root.RegisterGCPair(pair)
 				root.AdjustDiffForGCPair(&diff, pair)
 			}
-			// 2. Revive (restore) by identity: un-tombstoned nodes move
-			// gc->live via UnregisterGCPair (after removedAt is cleared, which
-			// Restore does); recreated nodes are brand new, so add to Live.
+			// 2. Revive (restore) by identity. For an un-tombstoned node
+			// (removedAt already cleared by Restore) UnregisterGCPair removes
+			// its size from docSize.GC, and diff.Add books the same size into
+			// Live — the node just became visible. Recreated nodes are brand
+			// new, so they only need the Live addition. Mirrors Text restore.
 			untombstoned, recreated := obj.Restore(toRestore)
 			for _, node := range untombstoned {
 				root.UnregisterGCPair(crdt.GCPair{Parent: obj, Child: node})
+				diff.Add(node.DataSize())
 			}
 			for _, node := range recreated {
 				diff.Add(node.DataSize())

--- a/pkg/document/operations/tree_edit.go
+++ b/pkg/document/operations/tree_edit.go
@@ -18,6 +18,7 @@ package operations
 
 import (
 	"github.com/yorkie-team/yorkie/pkg/document/crdt"
+	"github.com/yorkie-team/yorkie/pkg/document/resource"
 	"github.com/yorkie-team/yorkie/pkg/document/time"
 )
 
@@ -41,6 +42,16 @@ type TreeEdit struct {
 
 	// executedAt is the time the operation was executed.
 	executedAt *time.Ticket
+
+	// restoreSpans/restoreMode/retombstoneSpans carry identity-preserving
+	// Tree undo/redo, mirroring Edit. restoreMode selects direction: an undo
+	// (Restore) revives restoreSpans and re-removes retombstoneSpans by
+	// identity; the redo (Retombstone) does the opposite. RestoreModeNone for
+	// ordinary edits. Reverse ops are generated client-side; the server only
+	// executes the mode the wire op specifies.
+	restoreSpans     []*crdt.TreeRestoreSpan
+	restoreMode      crdt.RestoreMode
+	retombstoneSpans []*crdt.TreeRestoreSpan
 }
 
 // NewTreeEdit creates a new instance of TreeEdit.
@@ -59,6 +70,30 @@ func NewTreeEdit(
 		contents:        contents,
 		splitLevel:      splitLevel,
 		executedAt:      executedAt,
+		restoreMode:     crdt.RestoreModeNone,
+	}
+}
+
+// NewRestoreTreeEdit creates a TreeEdit that revives (RestoreModeRestore) or
+// re-removes (RestoreModeRetombstone) tree nodes under their original
+// identities, carried in spans.
+func NewRestoreTreeEdit(
+	parentCreatedAt *time.Ticket,
+	from *crdt.TreePos,
+	to *crdt.TreePos,
+	executedAt *time.Ticket,
+	restoreSpans []*crdt.TreeRestoreSpan,
+	restoreMode crdt.RestoreMode,
+	retombstoneSpans []*crdt.TreeRestoreSpan,
+) *TreeEdit {
+	return &TreeEdit{
+		parentCreatedAt:  parentCreatedAt,
+		from:             from,
+		to:               to,
+		executedAt:       executedAt,
+		restoreSpans:     restoreSpans,
+		restoreMode:      restoreMode,
+		retombstoneSpans: retombstoneSpans,
 	}
 }
 
@@ -68,6 +103,44 @@ func (e *TreeEdit) Execute(root *crdt.Root, versionVector time.VersionVector) er
 
 	switch obj := parent.(type) {
 	case *crdt.Tree:
+		// Identity-preserving restore/retombstone path (mirrors Edit).
+		// restoreMode selects direction; an undo revives restoreSpans and
+		// re-removes retombstoneSpans, the redo does the opposite. Both span
+		// sets carry client-supplied identities materialized into authoritative
+		// state, so reject any the acting change could not causally observe.
+		if len(e.restoreSpans) > 0 || len(e.retombstoneSpans) > 0 {
+			if err := validateTreeRestoreIdentities(e.restoreSpans, versionVector); err != nil {
+				return err
+			}
+			if err := validateTreeRestoreIdentities(e.retombstoneSpans, versionVector); err != nil {
+				return err
+			}
+
+			toRestore, toRetombstone := e.restoreSpans, e.retombstoneSpans
+			if e.restoreMode == crdt.RestoreModeRetombstone {
+				toRestore, toRetombstone = e.retombstoneSpans, e.restoreSpans
+			}
+
+			var diff resource.DataSize
+			// 1. Re-remove (retombstone) by identity.
+			for _, pair := range obj.Retombstone(toRetombstone, e.executedAt) {
+				root.RegisterGCPair(pair)
+				root.AdjustDiffForGCPair(&diff, pair)
+			}
+			// 2. Revive (restore) by identity: un-tombstoned nodes move
+			// gc->live via UnregisterGCPair (after removedAt is cleared, which
+			// Restore does); recreated nodes are brand new, so add to Live.
+			untombstoned, recreated := obj.Restore(toRestore)
+			for _, node := range untombstoned {
+				root.UnregisterGCPair(crdt.GCPair{Parent: obj, Child: node})
+			}
+			for _, node := range recreated {
+				diff.Add(node.DataSize())
+			}
+			root.Acc(diff)
+			return nil
+		}
+
 		var contents []*crdt.TreeNode
 		var err error
 		if len(e.Contents()) != 0 {
@@ -161,4 +234,36 @@ func (e *TreeEdit) SplitLevel() int {
 // ExecutedAt returns execution time of this operation.
 func (e *TreeEdit) ExecutedAt() *time.Ticket {
 	return e.executedAt
+}
+
+// RestoreSpans returns the identity-preserving restore payload, if any.
+func (e *TreeEdit) RestoreSpans() []*crdt.TreeRestoreSpan {
+	return e.restoreSpans
+}
+
+// RestoreMode returns the identity-preserving mode of this op.
+func (e *TreeEdit) RestoreMode() crdt.RestoreMode {
+	return e.restoreMode
+}
+
+// RetombstoneSpans returns the companion span set, if any.
+func (e *TreeEdit) RetombstoneSpans() []*crdt.TreeRestoreSpan {
+	return e.retombstoneSpans
+}
+
+// validateTreeRestoreIdentities rejects any restore span whose node identity
+// the acting change could not causally have observed (shared rule with the
+// Text restore path).
+func validateTreeRestoreIdentities(
+	spans []*crdt.TreeRestoreSpan,
+	versionVector time.VersionVector,
+) error {
+	if len(spans) == 0 {
+		return nil
+	}
+	createdAts := make([]*time.Ticket, 0, len(spans))
+	for _, span := range spans {
+		createdAts = append(createdAts, span.ID.CreatedAt)
+	}
+	return validateRestoreTickets(createdAts, versionVector)
 }

--- a/pkg/document/operations/tree_edit.go
+++ b/pkg/document/operations/tree_edit.go
@@ -132,7 +132,10 @@ func (e *TreeEdit) Execute(root *crdt.Root, versionVector time.VersionVector) er
 			// its size from docSize.GC, and diff.Add books the same size into
 			// Live — the node just became visible. Recreated nodes are brand
 			// new, so they only need the Live addition. Mirrors Text restore.
-			untombstoned, recreated := obj.Restore(toRestore)
+			untombstoned, recreated, err := obj.Restore(toRestore)
+			if err != nil {
+				return err
+			}
 			for _, node := range untombstoned {
 				root.UnregisterGCPair(crdt.GCPair{Parent: obj, Child: node})
 				diff.Add(node.DataSize())


### PR DESCRIPTION
## Summary

Extends identity-preserving restore (merged for Text in #1875) to **Tree**
undo/redo. Undo of a Tree node deletion now revives the **original** nodes by
identity (`createdAt`+`offset`) instead of copy-reinserting fresh ones; redo
re-tombstones them. Fresh-node reinsertion reconciled by index and diverged
under concurrency — reviving by identity converges.

This repo only **executes** restore ops (to keep server snapshots consistent
with clients); reverse-op generation is client-side (yorkie-js-sdk).

- **Wire**: new `TreeRestoreSpan` message + `restore_spans` / `restore_mode` /
  `retombstone_spans` fields on `Operation.TreeEdit` (reusing the `RestoreMode`
  enum).
- **CRDT**: `Tree.Restore`/`Retombstone`/`unremove`, and `recreateFromSpan` for
  a GC-purged node — floor-lookup + parent-identity check, an anchor ladder
  (same-insertion text neighbor → carried left/right boundary siblings →
  deterministic id-order fallback that is a pure function of ids, so it is
  convergent), and a B1 skip when the parent is genuinely gone. Hardened
  `Tree.Purge` with nil guards (restore reorders GC so a neighbor can be purged
  first).
- **Security**: restore/retombstone spans carry client-supplied identities that
  `Execute` materializes into authoritative state, so each is validated against
  the change's version vector (parity with #1875), rejecting forged identities.

Scope (v1, matching the Text feature): pure-deletion/insertion undo; merge/split
reverses keep the existing copy-reinsert path. No delete-ownership gating (it is
non-commutative — see the #1875 discussion).

## Test plan

- `pkg/document/crdt/tree_restore_test.go` — unremove size symmetry,
  retombstone/restore round-trip, recreate-after-GC-purge via `Execute`,
  parent-gone B1 skip, forged-identity rejection.
- `api/converter/converter_tree_restore_test.go` — `TreeRestoreSpan` protobuf
  round-trip (parent/left/right anchors + per-node attributes) + nil-`created_at`
  rejection at the wire boundary.
- `go build/vet`, `golangci-lint`, and `go test ./pkg/document/... ./api/converter/...`
  all green.
- **End-to-end**: built a server from this branch and ran the yorkie-js-sdk Tree
  integration suite against it — all `history_tree` tests pass and replicas
  converge (incl. the reconcile cases that were previously skipped there).

Note: server-side execution here only keeps snapshots consistent; undo/redo
itself stays client-driven (the documented `docs/design/undo-redo.md` non-goal),
mirroring #1875. Opening as a draft pending sign-off, as with the Text PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added identity-preserving tree undo and redo, including ordered restoration with parent and sibling anchors, node content, and attributes.
  * Added API support for serializing and deserializing restore and retombstone spans.
* **Bug Fixes**
  * Improved tree purge stability when neighboring nodes have already been removed.
* **Tests**
  * Added coverage for restoration after garbage collection, missing parents, forged identities, concurrent edits, round trips, and invalid span data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->