### PR TITLE
Add an Admin REST API for broadcasting channel events

### DIFF
--- a/api/docs/yorkie/v1/admin.openapi.yaml
+++ b/api/docs/yorkie/v1/admin.openapi.yaml
@@ -22,6 +22,18 @@ paths:
           $ref: '#/components/responses/connect.error'
       tags:
       - yorkie.v1.AdminService
+  /yorkie.v1.AdminService/BroadcastByAdmin:
+    post:
+      description: ""
+      requestBody:
+        $ref: '#/components/requestBodies/yorkie.v1.AdminService.BroadcastByAdmin.yorkie.v1.BroadcastByAdminRequest'
+      responses:
+        "200":
+          $ref: '#/components/responses/yorkie.v1.AdminService.BroadcastByAdmin.yorkie.v1.BroadcastByAdminResponse'
+        default:
+          $ref: '#/components/responses/connect.error'
+      tags:
+      - yorkie.v1.AdminService
   /yorkie.v1.AdminService/ChangePassword:
     post:
       description: ""
@@ -453,6 +465,15 @@ components:
           schema:
             $ref: '#/components/schemas/yorkie.v1.AcceptInviteRequest'
       required: true
+    yorkie.v1.AdminService.BroadcastByAdmin.yorkie.v1.BroadcastByAdminRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.BroadcastByAdminRequest'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.BroadcastByAdminRequest'
+      required: true
     yorkie.v1.AdminService.ChangePassword.yorkie.v1.ChangePasswordRequest:
       content:
         application/json:
@@ -786,6 +807,15 @@ components:
         application/proto:
           schema:
             $ref: '#/components/schemas/yorkie.v1.AcceptInviteResponse'
+      description: ""
+    yorkie.v1.AdminService.BroadcastByAdmin.yorkie.v1.BroadcastByAdminResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.BroadcastByAdminResponse'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.BroadcastByAdminResponse'
       description: ""
     yorkie.v1.AdminService.ChangePassword.yorkie.v1.ChangePasswordResponse:
       content:
@@ -1321,6 +1351,33 @@ components:
           title: member
           type: object
       title: AcceptInviteResponse
+      type: object
+    yorkie.v1.BroadcastByAdminRequest:
+      additionalProperties: false
+      description: ""
+      properties:
+        channelKey:
+          additionalProperties: false
+          description: ""
+          title: channel_key
+          type: string
+        payload:
+          additionalProperties: false
+          description: ""
+          format: byte
+          title: payload
+          type: string
+        topic:
+          additionalProperties: false
+          description: ""
+          title: topic
+          type: string
+      title: BroadcastByAdminRequest
+      type: object
+    yorkie.v1.BroadcastByAdminResponse:
+      additionalProperties: false
+      description: ""
+      title: BroadcastByAdminResponse
       type: object
     yorkie.v1.Change:
       additionalProperties: false

--- a/api/docs/yorkie/v1/cluster.openapi.yaml
+++ b/api/docs/yorkie/v1/cluster.openapi.yaml
@@ -10,6 +10,18 @@ servers:
 - description: Local server
   url: http://localhost:8080
 paths:
+  /yorkie.v1.ClusterService/Broadcast:
+    post:
+      description: ""
+      requestBody:
+        $ref: '#/components/requestBodies/yorkie.v1.ClusterService.Broadcast.yorkie.v1.ClusterServiceBroadcastRequest'
+      responses:
+        "200":
+          $ref: '#/components/responses/yorkie.v1.ClusterService.Broadcast.yorkie.v1.ClusterServiceBroadcastResponse'
+        default:
+          $ref: '#/components/responses/connect.error'
+      tags:
+      - yorkie.v1.ClusterService
   /yorkie.v1.ClusterService/CompactDocument:
     post:
       description: ""
@@ -108,6 +120,15 @@ paths:
       - yorkie.v1.ClusterService
 components:
   requestBodies:
+    yorkie.v1.ClusterService.Broadcast.yorkie.v1.ClusterServiceBroadcastRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.ClusterServiceBroadcastRequest'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.ClusterServiceBroadcastRequest'
+      required: true
     yorkie.v1.ClusterService.CompactDocument.yorkie.v1.ClusterServiceCompactDocumentRequest:
       content:
         application/json:
@@ -189,6 +210,15 @@ components:
         application/proto:
           schema:
             $ref: '#/components/schemas/connect.error'
+      description: ""
+    yorkie.v1.ClusterService.Broadcast.yorkie.v1.ClusterServiceBroadcastResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.ClusterServiceBroadcastResponse'
+        application/proto:
+          schema:
+            $ref: '#/components/schemas/yorkie.v1.ClusterServiceBroadcastResponse'
       description: ""
     yorkie.v1.ClusterService.CompactDocument.yorkie.v1.ClusterServiceCompactDocumentResponse:
       content:
@@ -413,6 +443,38 @@ components:
           title: session_count
           type: integer
       title: ChannelSummary
+      type: object
+    yorkie.v1.ClusterServiceBroadcastRequest:
+      additionalProperties: false
+      description: ""
+      properties:
+        channelKey:
+          additionalProperties: false
+          description: ""
+          title: channel_key
+          type: string
+        payload:
+          additionalProperties: false
+          description: ""
+          format: byte
+          title: payload
+          type: string
+        projectId:
+          additionalProperties: false
+          description: ""
+          title: project_id
+          type: string
+        topic:
+          additionalProperties: false
+          description: ""
+          title: topic
+          type: string
+      title: ClusterServiceBroadcastRequest
+      type: object
+    yorkie.v1.ClusterServiceBroadcastResponse:
+      additionalProperties: false
+      description: ""
+      title: ClusterServiceBroadcastResponse
       type: object
     yorkie.v1.ClusterServiceCompactDocumentRequest:
       additionalProperties: false

--- a/api/yorkie/v1/admin.pb.go
+++ b/api/yorkie/v1/admin.pb.go
@@ -3736,6 +3736,102 @@ func (x *CompactDocumentByAdminResponse) GetCompacted() bool {
 	return false
 }
 
+type BroadcastByAdminRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ChannelKey    string                 `protobuf:"bytes,1,opt,name=channel_key,json=channelKey,proto3" json:"channel_key,omitempty"`
+	Topic         string                 `protobuf:"bytes,2,opt,name=topic,proto3" json:"topic,omitempty"`
+	Payload       []byte                 `protobuf:"bytes,3,opt,name=payload,proto3" json:"payload,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BroadcastByAdminRequest) Reset() {
+	*x = BroadcastByAdminRequest{}
+	mi := &file_yorkie_v1_admin_proto_msgTypes[72]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BroadcastByAdminRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BroadcastByAdminRequest) ProtoMessage() {}
+
+func (x *BroadcastByAdminRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_yorkie_v1_admin_proto_msgTypes[72]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BroadcastByAdminRequest.ProtoReflect.Descriptor instead.
+func (*BroadcastByAdminRequest) Descriptor() ([]byte, []int) {
+	return file_yorkie_v1_admin_proto_rawDescGZIP(), []int{72}
+}
+
+func (x *BroadcastByAdminRequest) GetChannelKey() string {
+	if x != nil {
+		return x.ChannelKey
+	}
+	return ""
+}
+
+func (x *BroadcastByAdminRequest) GetTopic() string {
+	if x != nil {
+		return x.Topic
+	}
+	return ""
+}
+
+func (x *BroadcastByAdminRequest) GetPayload() []byte {
+	if x != nil {
+		return x.Payload
+	}
+	return nil
+}
+
+type BroadcastByAdminResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BroadcastByAdminResponse) Reset() {
+	*x = BroadcastByAdminResponse{}
+	mi := &file_yorkie_v1_admin_proto_msgTypes[73]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BroadcastByAdminResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BroadcastByAdminResponse) ProtoMessage() {}
+
+func (x *BroadcastByAdminResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_yorkie_v1_admin_proto_msgTypes[73]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BroadcastByAdminResponse.ProtoReflect.Descriptor instead.
+func (*BroadcastByAdminResponse) Descriptor() ([]byte, []int) {
+	return file_yorkie_v1_admin_proto_rawDescGZIP(), []int{73}
+}
+
 var File_yorkie_v1_admin_proto protoreflect.FileDescriptor
 
 const file_yorkie_v1_admin_proto_rawDesc = "" +
@@ -3962,12 +4058,18 @@ const file_yorkie_v1_admin_proto_rawDesc = "" +
 	"\fdocument_key\x18\x01 \x01(\tR\vdocumentKey\x12\x14\n" +
 	"\x05force\x18\x02 \x01(\bR\x05force\">\n" +
 	"\x1eCompactDocumentByAdminResponse\x12\x1c\n" +
-	"\tcompacted\x18\x01 \x01(\bR\tcompacted*\xae\x01\n" +
+	"\tcompacted\x18\x01 \x01(\bR\tcompacted\"j\n" +
+	"\x17BroadcastByAdminRequest\x12\x1f\n" +
+	"\vchannel_key\x18\x01 \x01(\tR\n" +
+	"channelKey\x12\x14\n" +
+	"\x05topic\x18\x02 \x01(\tR\x05topic\x12\x18\n" +
+	"\apayload\x18\x03 \x01(\fR\apayload\"\x1a\n" +
+	"\x18BroadcastByAdminResponse*\xae\x01\n" +
 	"\x12InviteExpireOption\x12$\n" +
 	" INVITE_EXPIRE_OPTION_UNSPECIFIED\x10\x00\x12!\n" +
 	"\x1dINVITE_EXPIRE_OPTION_ONE_HOUR\x10\x01\x12*\n" +
 	"&INVITE_EXPIRE_OPTION_TWENTY_FOUR_HOURS\x10\x02\x12#\n" +
-	"\x1fINVITE_EXPIRE_OPTION_SEVEN_DAYS\x10\x032\xd0\x18\n" +
+	"\x1fINVITE_EXPIRE_OPTION_SEVEN_DAYS\x10\x032\xaf\x19\n" +
 	"\fAdminService\x12?\n" +
 	"\x06SignUp\x12\x18.yorkie.v1.SignUpRequest\x1a\x19.yorkie.v1.SignUpResponse\"\x00\x12<\n" +
 	"\x05LogIn\x12\x17.yorkie.v1.LogInRequest\x1a\x18.yorkie.v1.LogInResponse\"\x00\x12T\n" +
@@ -4005,6 +4107,7 @@ const file_yorkie_v1_admin_proto_rawDesc = "" +
 	"\x16RestoreRevisionByAdmin\x12(.yorkie.v1.RestoreRevisionByAdminRequest\x1a).yorkie.v1.RestoreRevisionByAdminResponse\"\x00\x12Q\n" +
 	"\fListChannels\x12\x1e.yorkie.v1.ListChannelsRequest\x1a\x1f.yorkie.v1.ListChannelsResponse\"\x00\x12N\n" +
 	"\vGetChannels\x12\x1d.yorkie.v1.GetChannelsRequest\x1a\x1e.yorkie.v1.GetChannelsResponse\"\x00\x12]\n" +
+	"\x10BroadcastByAdmin\x12\".yorkie.v1.BroadcastByAdminRequest\x1a#.yorkie.v1.BroadcastByAdminResponse\"\x00\x12]\n" +
 	"\x10GetServerVersion\x12\".yorkie.v1.GetServerVersionRequest\x1a#.yorkie.v1.GetServerVersionResponse\"\x00\x12o\n" +
 	"\x16CompactDocumentByAdmin\x12(.yorkie.v1.CompactDocumentByAdminRequest\x1a).yorkie.v1.CompactDocumentByAdminResponse\"\x00BE\n" +
 	"\x11dev.yorkie.api.v1P\x01Z.github.com/yorkie-team/yorkie/api/yorkie/v1;v1b\x06proto3"
@@ -4022,7 +4125,7 @@ func file_yorkie_v1_admin_proto_rawDescGZIP() []byte {
 }
 
 var file_yorkie_v1_admin_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_yorkie_v1_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 72)
+var file_yorkie_v1_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 74)
 var file_yorkie_v1_admin_proto_goTypes = []any{
 	(InviteExpireOption)(0),                // 0: yorkie.v1.InviteExpireOption
 	(GetProjectStatsRequest_DateRange)(0),  // 1: yorkie.v1.GetProjectStatsRequest.DateRange
@@ -4098,57 +4201,59 @@ var file_yorkie_v1_admin_proto_goTypes = []any{
 	(*RestoreRevisionByAdminResponse)(nil), // 71: yorkie.v1.RestoreRevisionByAdminResponse
 	(*CompactDocumentByAdminRequest)(nil),  // 72: yorkie.v1.CompactDocumentByAdminRequest
 	(*CompactDocumentByAdminResponse)(nil), // 73: yorkie.v1.CompactDocumentByAdminResponse
-	(*Member)(nil),                         // 74: yorkie.v1.Member
-	(*User)(nil),                           // 75: yorkie.v1.User
-	(*Project)(nil),                        // 76: yorkie.v1.Project
-	(*UpdatableProjectFields)(nil),         // 77: yorkie.v1.UpdatableProjectFields
-	(*MetricPoint)(nil),                    // 78: yorkie.v1.MetricPoint
-	(*timestamppb.Timestamp)(nil),          // 79: google.protobuf.Timestamp
-	(*DocumentSummary)(nil),                // 80: yorkie.v1.DocumentSummary
-	(*VersionVector)(nil),                  // 81: yorkie.v1.VersionVector
-	(*ChannelSummary)(nil),                 // 82: yorkie.v1.ChannelSummary
-	(*Change)(nil),                         // 83: yorkie.v1.Change
-	(*Rule)(nil),                           // 84: yorkie.v1.Rule
-	(*Schema)(nil),                         // 85: yorkie.v1.Schema
-	(*RevisionSummary)(nil),                // 86: yorkie.v1.RevisionSummary
+	(*BroadcastByAdminRequest)(nil),        // 74: yorkie.v1.BroadcastByAdminRequest
+	(*BroadcastByAdminResponse)(nil),       // 75: yorkie.v1.BroadcastByAdminResponse
+	(*Member)(nil),                         // 76: yorkie.v1.Member
+	(*User)(nil),                           // 77: yorkie.v1.User
+	(*Project)(nil),                        // 78: yorkie.v1.Project
+	(*UpdatableProjectFields)(nil),         // 79: yorkie.v1.UpdatableProjectFields
+	(*MetricPoint)(nil),                    // 80: yorkie.v1.MetricPoint
+	(*timestamppb.Timestamp)(nil),          // 81: google.protobuf.Timestamp
+	(*DocumentSummary)(nil),                // 82: yorkie.v1.DocumentSummary
+	(*VersionVector)(nil),                  // 83: yorkie.v1.VersionVector
+	(*ChannelSummary)(nil),                 // 84: yorkie.v1.ChannelSummary
+	(*Change)(nil),                         // 85: yorkie.v1.Change
+	(*Rule)(nil),                           // 86: yorkie.v1.Rule
+	(*Schema)(nil),                         // 87: yorkie.v1.Schema
+	(*RevisionSummary)(nil),                // 88: yorkie.v1.RevisionSummary
 }
 var file_yorkie_v1_admin_proto_depIdxs = []int32{
 	0,  // 0: yorkie.v1.CreateInviteRequest.expire_option:type_name -> yorkie.v1.InviteExpireOption
-	74, // 1: yorkie.v1.AcceptInviteResponse.member:type_name -> yorkie.v1.Member
-	75, // 2: yorkie.v1.SignUpResponse.user:type_name -> yorkie.v1.User
-	76, // 3: yorkie.v1.CreateProjectResponse.project:type_name -> yorkie.v1.Project
-	76, // 4: yorkie.v1.GetProjectResponse.project:type_name -> yorkie.v1.Project
-	76, // 5: yorkie.v1.ListProjectsResponse.projects:type_name -> yorkie.v1.Project
-	77, // 6: yorkie.v1.UpdateProjectRequest.fields:type_name -> yorkie.v1.UpdatableProjectFields
-	76, // 7: yorkie.v1.UpdateProjectResponse.project:type_name -> yorkie.v1.Project
+	76, // 1: yorkie.v1.AcceptInviteResponse.member:type_name -> yorkie.v1.Member
+	77, // 2: yorkie.v1.SignUpResponse.user:type_name -> yorkie.v1.User
+	78, // 3: yorkie.v1.CreateProjectResponse.project:type_name -> yorkie.v1.Project
+	78, // 4: yorkie.v1.GetProjectResponse.project:type_name -> yorkie.v1.Project
+	78, // 5: yorkie.v1.ListProjectsResponse.projects:type_name -> yorkie.v1.Project
+	79, // 6: yorkie.v1.UpdateProjectRequest.fields:type_name -> yorkie.v1.UpdatableProjectFields
+	78, // 7: yorkie.v1.UpdateProjectResponse.project:type_name -> yorkie.v1.Project
 	1,  // 8: yorkie.v1.GetProjectStatsRequest.date_range:type_name -> yorkie.v1.GetProjectStatsRequest.DateRange
-	78, // 9: yorkie.v1.GetProjectStatsResponse.active_users:type_name -> yorkie.v1.MetricPoint
-	78, // 10: yorkie.v1.GetProjectStatsResponse.active_channels:type_name -> yorkie.v1.MetricPoint
-	78, // 11: yorkie.v1.GetProjectStatsResponse.sessions:type_name -> yorkie.v1.MetricPoint
-	78, // 12: yorkie.v1.GetProjectStatsResponse.peak_sessions_per_channel:type_name -> yorkie.v1.MetricPoint
-	78, // 13: yorkie.v1.GetProjectStatsResponse.active_documents:type_name -> yorkie.v1.MetricPoint
-	78, // 14: yorkie.v1.GetProjectStatsResponse.active_clients:type_name -> yorkie.v1.MetricPoint
-	79, // 15: yorkie.v1.GetProjectStatsResponse.stats_updated_at:type_name -> google.protobuf.Timestamp
-	74, // 16: yorkie.v1.ListMembersResponse.members:type_name -> yorkie.v1.Member
-	74, // 17: yorkie.v1.UpdateMemberRoleResponse.member:type_name -> yorkie.v1.Member
-	80, // 18: yorkie.v1.CreateDocumentResponse.document:type_name -> yorkie.v1.DocumentSummary
-	80, // 19: yorkie.v1.ListDocumentsResponse.documents:type_name -> yorkie.v1.DocumentSummary
-	80, // 20: yorkie.v1.GetDocumentResponse.document:type_name -> yorkie.v1.DocumentSummary
-	80, // 21: yorkie.v1.GetDocumentsResponse.documents:type_name -> yorkie.v1.DocumentSummary
-	80, // 22: yorkie.v1.UpdateDocumentResponse.document:type_name -> yorkie.v1.DocumentSummary
-	81, // 23: yorkie.v1.GetSnapshotMetaResponse.version_vector:type_name -> yorkie.v1.VersionVector
-	80, // 24: yorkie.v1.SearchDocumentsResponse.documents:type_name -> yorkie.v1.DocumentSummary
-	82, // 25: yorkie.v1.ListChannelsResponse.channels:type_name -> yorkie.v1.ChannelSummary
-	82, // 26: yorkie.v1.GetChannelsResponse.channels:type_name -> yorkie.v1.ChannelSummary
-	83, // 27: yorkie.v1.ListChangesResponse.changes:type_name -> yorkie.v1.Change
-	84, // 28: yorkie.v1.CreateSchemaRequest.rules:type_name -> yorkie.v1.Rule
-	85, // 29: yorkie.v1.CreateSchemaResponse.schema:type_name -> yorkie.v1.Schema
-	85, // 30: yorkie.v1.ListSchemasResponse.schemas:type_name -> yorkie.v1.Schema
-	85, // 31: yorkie.v1.GetSchemaResponse.schema:type_name -> yorkie.v1.Schema
-	85, // 32: yorkie.v1.GetSchemasResponse.schemas:type_name -> yorkie.v1.Schema
-	76, // 33: yorkie.v1.RotateProjectKeysResponse.project:type_name -> yorkie.v1.Project
-	86, // 34: yorkie.v1.ListRevisionsByAdminResponse.revisions:type_name -> yorkie.v1.RevisionSummary
-	86, // 35: yorkie.v1.GetRevisionByAdminResponse.revision:type_name -> yorkie.v1.RevisionSummary
+	80, // 9: yorkie.v1.GetProjectStatsResponse.active_users:type_name -> yorkie.v1.MetricPoint
+	80, // 10: yorkie.v1.GetProjectStatsResponse.active_channels:type_name -> yorkie.v1.MetricPoint
+	80, // 11: yorkie.v1.GetProjectStatsResponse.sessions:type_name -> yorkie.v1.MetricPoint
+	80, // 12: yorkie.v1.GetProjectStatsResponse.peak_sessions_per_channel:type_name -> yorkie.v1.MetricPoint
+	80, // 13: yorkie.v1.GetProjectStatsResponse.active_documents:type_name -> yorkie.v1.MetricPoint
+	80, // 14: yorkie.v1.GetProjectStatsResponse.active_clients:type_name -> yorkie.v1.MetricPoint
+	81, // 15: yorkie.v1.GetProjectStatsResponse.stats_updated_at:type_name -> google.protobuf.Timestamp
+	76, // 16: yorkie.v1.ListMembersResponse.members:type_name -> yorkie.v1.Member
+	76, // 17: yorkie.v1.UpdateMemberRoleResponse.member:type_name -> yorkie.v1.Member
+	82, // 18: yorkie.v1.CreateDocumentResponse.document:type_name -> yorkie.v1.DocumentSummary
+	82, // 19: yorkie.v1.ListDocumentsResponse.documents:type_name -> yorkie.v1.DocumentSummary
+	82, // 20: yorkie.v1.GetDocumentResponse.document:type_name -> yorkie.v1.DocumentSummary
+	82, // 21: yorkie.v1.GetDocumentsResponse.documents:type_name -> yorkie.v1.DocumentSummary
+	82, // 22: yorkie.v1.UpdateDocumentResponse.document:type_name -> yorkie.v1.DocumentSummary
+	83, // 23: yorkie.v1.GetSnapshotMetaResponse.version_vector:type_name -> yorkie.v1.VersionVector
+	82, // 24: yorkie.v1.SearchDocumentsResponse.documents:type_name -> yorkie.v1.DocumentSummary
+	84, // 25: yorkie.v1.ListChannelsResponse.channels:type_name -> yorkie.v1.ChannelSummary
+	84, // 26: yorkie.v1.GetChannelsResponse.channels:type_name -> yorkie.v1.ChannelSummary
+	85, // 27: yorkie.v1.ListChangesResponse.changes:type_name -> yorkie.v1.Change
+	86, // 28: yorkie.v1.CreateSchemaRequest.rules:type_name -> yorkie.v1.Rule
+	87, // 29: yorkie.v1.CreateSchemaResponse.schema:type_name -> yorkie.v1.Schema
+	87, // 30: yorkie.v1.ListSchemasResponse.schemas:type_name -> yorkie.v1.Schema
+	87, // 31: yorkie.v1.GetSchemaResponse.schema:type_name -> yorkie.v1.Schema
+	87, // 32: yorkie.v1.GetSchemasResponse.schemas:type_name -> yorkie.v1.Schema
+	78, // 33: yorkie.v1.RotateProjectKeysResponse.project:type_name -> yorkie.v1.Project
+	88, // 34: yorkie.v1.ListRevisionsByAdminResponse.revisions:type_name -> yorkie.v1.RevisionSummary
+	88, // 35: yorkie.v1.GetRevisionByAdminResponse.revision:type_name -> yorkie.v1.RevisionSummary
 	6,  // 36: yorkie.v1.AdminService.SignUp:input_type -> yorkie.v1.SignUpRequest
 	8,  // 37: yorkie.v1.AdminService.LogIn:input_type -> yorkie.v1.LogInRequest
 	10, // 38: yorkie.v1.AdminService.DeleteAccount:input_type -> yorkie.v1.DeleteAccountRequest
@@ -4183,46 +4288,48 @@ var file_yorkie_v1_admin_proto_depIdxs = []int32{
 	70, // 67: yorkie.v1.AdminService.RestoreRevisionByAdmin:input_type -> yorkie.v1.RestoreRevisionByAdminRequest
 	46, // 68: yorkie.v1.AdminService.ListChannels:input_type -> yorkie.v1.ListChannelsRequest
 	48, // 69: yorkie.v1.AdminService.GetChannels:input_type -> yorkie.v1.GetChannelsRequest
-	62, // 70: yorkie.v1.AdminService.GetServerVersion:input_type -> yorkie.v1.GetServerVersionRequest
-	72, // 71: yorkie.v1.AdminService.CompactDocumentByAdmin:input_type -> yorkie.v1.CompactDocumentByAdminRequest
-	7,  // 72: yorkie.v1.AdminService.SignUp:output_type -> yorkie.v1.SignUpResponse
-	9,  // 73: yorkie.v1.AdminService.LogIn:output_type -> yorkie.v1.LogInResponse
-	11, // 74: yorkie.v1.AdminService.DeleteAccount:output_type -> yorkie.v1.DeleteAccountResponse
-	13, // 75: yorkie.v1.AdminService.ChangePassword:output_type -> yorkie.v1.ChangePasswordResponse
-	15, // 76: yorkie.v1.AdminService.CreateProject:output_type -> yorkie.v1.CreateProjectResponse
-	19, // 77: yorkie.v1.AdminService.ListProjects:output_type -> yorkie.v1.ListProjectsResponse
-	17, // 78: yorkie.v1.AdminService.GetProject:output_type -> yorkie.v1.GetProjectResponse
-	23, // 79: yorkie.v1.AdminService.GetProjectStats:output_type -> yorkie.v1.GetProjectStatsResponse
-	21, // 80: yorkie.v1.AdminService.UpdateProject:output_type -> yorkie.v1.UpdateProjectResponse
-	65, // 81: yorkie.v1.AdminService.RotateProjectKeys:output_type -> yorkie.v1.RotateProjectKeysResponse
-	25, // 82: yorkie.v1.AdminService.RemoveMember:output_type -> yorkie.v1.RemoveMemberResponse
-	27, // 83: yorkie.v1.AdminService.ListMembers:output_type -> yorkie.v1.ListMembersResponse
-	29, // 84: yorkie.v1.AdminService.UpdateMemberRole:output_type -> yorkie.v1.UpdateMemberRoleResponse
-	3,  // 85: yorkie.v1.AdminService.CreateInvite:output_type -> yorkie.v1.CreateInviteResponse
-	5,  // 86: yorkie.v1.AdminService.AcceptInvite:output_type -> yorkie.v1.AcceptInviteResponse
-	31, // 87: yorkie.v1.AdminService.CreateDocument:output_type -> yorkie.v1.CreateDocumentResponse
-	33, // 88: yorkie.v1.AdminService.ListDocuments:output_type -> yorkie.v1.ListDocumentsResponse
-	35, // 89: yorkie.v1.AdminService.GetDocument:output_type -> yorkie.v1.GetDocumentResponse
-	37, // 90: yorkie.v1.AdminService.GetDocuments:output_type -> yorkie.v1.GetDocumentsResponse
-	45, // 91: yorkie.v1.AdminService.SearchDocuments:output_type -> yorkie.v1.SearchDocumentsResponse
-	39, // 92: yorkie.v1.AdminService.UpdateDocument:output_type -> yorkie.v1.UpdateDocumentResponse
-	41, // 93: yorkie.v1.AdminService.RemoveDocumentByAdmin:output_type -> yorkie.v1.RemoveDocumentByAdminResponse
-	43, // 94: yorkie.v1.AdminService.GetSnapshotMeta:output_type -> yorkie.v1.GetSnapshotMetaResponse
-	51, // 95: yorkie.v1.AdminService.ListChanges:output_type -> yorkie.v1.ListChangesResponse
-	53, // 96: yorkie.v1.AdminService.CreateSchema:output_type -> yorkie.v1.CreateSchemaResponse
-	55, // 97: yorkie.v1.AdminService.ListSchemas:output_type -> yorkie.v1.ListSchemasResponse
-	57, // 98: yorkie.v1.AdminService.GetSchema:output_type -> yorkie.v1.GetSchemaResponse
-	59, // 99: yorkie.v1.AdminService.GetSchemas:output_type -> yorkie.v1.GetSchemasResponse
-	61, // 100: yorkie.v1.AdminService.RemoveSchema:output_type -> yorkie.v1.RemoveSchemaResponse
-	67, // 101: yorkie.v1.AdminService.ListRevisionsByAdmin:output_type -> yorkie.v1.ListRevisionsByAdminResponse
-	69, // 102: yorkie.v1.AdminService.GetRevisionByAdmin:output_type -> yorkie.v1.GetRevisionByAdminResponse
-	71, // 103: yorkie.v1.AdminService.RestoreRevisionByAdmin:output_type -> yorkie.v1.RestoreRevisionByAdminResponse
-	47, // 104: yorkie.v1.AdminService.ListChannels:output_type -> yorkie.v1.ListChannelsResponse
-	49, // 105: yorkie.v1.AdminService.GetChannels:output_type -> yorkie.v1.GetChannelsResponse
-	63, // 106: yorkie.v1.AdminService.GetServerVersion:output_type -> yorkie.v1.GetServerVersionResponse
-	73, // 107: yorkie.v1.AdminService.CompactDocumentByAdmin:output_type -> yorkie.v1.CompactDocumentByAdminResponse
-	72, // [72:108] is the sub-list for method output_type
-	36, // [36:72] is the sub-list for method input_type
+	74, // 70: yorkie.v1.AdminService.BroadcastByAdmin:input_type -> yorkie.v1.BroadcastByAdminRequest
+	62, // 71: yorkie.v1.AdminService.GetServerVersion:input_type -> yorkie.v1.GetServerVersionRequest
+	72, // 72: yorkie.v1.AdminService.CompactDocumentByAdmin:input_type -> yorkie.v1.CompactDocumentByAdminRequest
+	7,  // 73: yorkie.v1.AdminService.SignUp:output_type -> yorkie.v1.SignUpResponse
+	9,  // 74: yorkie.v1.AdminService.LogIn:output_type -> yorkie.v1.LogInResponse
+	11, // 75: yorkie.v1.AdminService.DeleteAccount:output_type -> yorkie.v1.DeleteAccountResponse
+	13, // 76: yorkie.v1.AdminService.ChangePassword:output_type -> yorkie.v1.ChangePasswordResponse
+	15, // 77: yorkie.v1.AdminService.CreateProject:output_type -> yorkie.v1.CreateProjectResponse
+	19, // 78: yorkie.v1.AdminService.ListProjects:output_type -> yorkie.v1.ListProjectsResponse
+	17, // 79: yorkie.v1.AdminService.GetProject:output_type -> yorkie.v1.GetProjectResponse
+	23, // 80: yorkie.v1.AdminService.GetProjectStats:output_type -> yorkie.v1.GetProjectStatsResponse
+	21, // 81: yorkie.v1.AdminService.UpdateProject:output_type -> yorkie.v1.UpdateProjectResponse
+	65, // 82: yorkie.v1.AdminService.RotateProjectKeys:output_type -> yorkie.v1.RotateProjectKeysResponse
+	25, // 83: yorkie.v1.AdminService.RemoveMember:output_type -> yorkie.v1.RemoveMemberResponse
+	27, // 84: yorkie.v1.AdminService.ListMembers:output_type -> yorkie.v1.ListMembersResponse
+	29, // 85: yorkie.v1.AdminService.UpdateMemberRole:output_type -> yorkie.v1.UpdateMemberRoleResponse
+	3,  // 86: yorkie.v1.AdminService.CreateInvite:output_type -> yorkie.v1.CreateInviteResponse
+	5,  // 87: yorkie.v1.AdminService.AcceptInvite:output_type -> yorkie.v1.AcceptInviteResponse
+	31, // 88: yorkie.v1.AdminService.CreateDocument:output_type -> yorkie.v1.CreateDocumentResponse
+	33, // 89: yorkie.v1.AdminService.ListDocuments:output_type -> yorkie.v1.ListDocumentsResponse
+	35, // 90: yorkie.v1.AdminService.GetDocument:output_type -> yorkie.v1.GetDocumentResponse
+	37, // 91: yorkie.v1.AdminService.GetDocuments:output_type -> yorkie.v1.GetDocumentsResponse
+	45, // 92: yorkie.v1.AdminService.SearchDocuments:output_type -> yorkie.v1.SearchDocumentsResponse
+	39, // 93: yorkie.v1.AdminService.UpdateDocument:output_type -> yorkie.v1.UpdateDocumentResponse
+	41, // 94: yorkie.v1.AdminService.RemoveDocumentByAdmin:output_type -> yorkie.v1.RemoveDocumentByAdminResponse
+	43, // 95: yorkie.v1.AdminService.GetSnapshotMeta:output_type -> yorkie.v1.GetSnapshotMetaResponse
+	51, // 96: yorkie.v1.AdminService.ListChanges:output_type -> yorkie.v1.ListChangesResponse
+	53, // 97: yorkie.v1.AdminService.CreateSchema:output_type -> yorkie.v1.CreateSchemaResponse
+	55, // 98: yorkie.v1.AdminService.ListSchemas:output_type -> yorkie.v1.ListSchemasResponse
+	57, // 99: yorkie.v1.AdminService.GetSchema:output_type -> yorkie.v1.GetSchemaResponse
+	59, // 100: yorkie.v1.AdminService.GetSchemas:output_type -> yorkie.v1.GetSchemasResponse
+	61, // 101: yorkie.v1.AdminService.RemoveSchema:output_type -> yorkie.v1.RemoveSchemaResponse
+	67, // 102: yorkie.v1.AdminService.ListRevisionsByAdmin:output_type -> yorkie.v1.ListRevisionsByAdminResponse
+	69, // 103: yorkie.v1.AdminService.GetRevisionByAdmin:output_type -> yorkie.v1.GetRevisionByAdminResponse
+	71, // 104: yorkie.v1.AdminService.RestoreRevisionByAdmin:output_type -> yorkie.v1.RestoreRevisionByAdminResponse
+	47, // 105: yorkie.v1.AdminService.ListChannels:output_type -> yorkie.v1.ListChannelsResponse
+	49, // 106: yorkie.v1.AdminService.GetChannels:output_type -> yorkie.v1.GetChannelsResponse
+	75, // 107: yorkie.v1.AdminService.BroadcastByAdmin:output_type -> yorkie.v1.BroadcastByAdminResponse
+	63, // 108: yorkie.v1.AdminService.GetServerVersion:output_type -> yorkie.v1.GetServerVersionResponse
+	73, // 109: yorkie.v1.AdminService.CompactDocumentByAdmin:output_type -> yorkie.v1.CompactDocumentByAdminResponse
+	73, // [73:110] is the sub-list for method output_type
+	36, // [36:73] is the sub-list for method input_type
 	36, // [36:36] is the sub-list for extension type_name
 	36, // [36:36] is the sub-list for extension extendee
 	0,  // [0:36] is the sub-list for field type_name
@@ -4240,7 +4347,7 @@ func file_yorkie_v1_admin_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_yorkie_v1_admin_proto_rawDesc), len(file_yorkie_v1_admin_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   72,
+			NumMessages:   74,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/yorkie/v1/admin.proto
+++ b/api/yorkie/v1/admin.proto
@@ -68,6 +68,7 @@ service AdminService {
 
   rpc ListChannels (ListChannelsRequest) returns (ListChannelsResponse) {}
   rpc GetChannels (GetChannelsRequest) returns (GetChannelsResponse) {}
+  rpc BroadcastByAdmin (BroadcastByAdminRequest) returns (BroadcastByAdminResponse) {}
   
   rpc GetServerVersion (GetServerVersionRequest) returns (GetServerVersionResponse) {}
 
@@ -425,3 +426,11 @@ message CompactDocumentByAdminRequest {
 message CompactDocumentByAdminResponse {
   bool compacted = 1;
 }
+
+message BroadcastByAdminRequest {
+  string channel_key = 1;
+  string topic = 2;
+  bytes payload = 3;
+}
+
+message BroadcastByAdminResponse {}

--- a/api/yorkie/v1/cluster.pb.go
+++ b/api/yorkie/v1/cluster.pb.go
@@ -720,6 +720,110 @@ func (x *ClusterServiceGetChannelsResponse) GetChannels() []*ChannelSummary {
 	return nil
 }
 
+type ClusterServiceBroadcastRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ProjectId     string                 `protobuf:"bytes,1,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
+	ChannelKey    string                 `protobuf:"bytes,2,opt,name=channel_key,json=channelKey,proto3" json:"channel_key,omitempty"`
+	Topic         string                 `protobuf:"bytes,3,opt,name=topic,proto3" json:"topic,omitempty"`
+	Payload       []byte                 `protobuf:"bytes,4,opt,name=payload,proto3" json:"payload,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ClusterServiceBroadcastRequest) Reset() {
+	*x = ClusterServiceBroadcastRequest{}
+	mi := &file_yorkie_v1_cluster_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ClusterServiceBroadcastRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClusterServiceBroadcastRequest) ProtoMessage() {}
+
+func (x *ClusterServiceBroadcastRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_yorkie_v1_cluster_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClusterServiceBroadcastRequest.ProtoReflect.Descriptor instead.
+func (*ClusterServiceBroadcastRequest) Descriptor() ([]byte, []int) {
+	return file_yorkie_v1_cluster_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *ClusterServiceBroadcastRequest) GetProjectId() string {
+	if x != nil {
+		return x.ProjectId
+	}
+	return ""
+}
+
+func (x *ClusterServiceBroadcastRequest) GetChannelKey() string {
+	if x != nil {
+		return x.ChannelKey
+	}
+	return ""
+}
+
+func (x *ClusterServiceBroadcastRequest) GetTopic() string {
+	if x != nil {
+		return x.Topic
+	}
+	return ""
+}
+
+func (x *ClusterServiceBroadcastRequest) GetPayload() []byte {
+	if x != nil {
+		return x.Payload
+	}
+	return nil
+}
+
+type ClusterServiceBroadcastResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ClusterServiceBroadcastResponse) Reset() {
+	*x = ClusterServiceBroadcastResponse{}
+	mi := &file_yorkie_v1_cluster_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ClusterServiceBroadcastResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClusterServiceBroadcastResponse) ProtoMessage() {}
+
+func (x *ClusterServiceBroadcastResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_yorkie_v1_cluster_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClusterServiceBroadcastResponse.ProtoReflect.Descriptor instead.
+func (*ClusterServiceBroadcastResponse) Descriptor() ([]byte, []int) {
+	return file_yorkie_v1_cluster_proto_rawDescGZIP(), []int{13}
+}
+
 type ClusterServiceGetChannelCountRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	ProjectId     string                 `protobuf:"bytes,1,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
@@ -729,7 +833,7 @@ type ClusterServiceGetChannelCountRequest struct {
 
 func (x *ClusterServiceGetChannelCountRequest) Reset() {
 	*x = ClusterServiceGetChannelCountRequest{}
-	mi := &file_yorkie_v1_cluster_proto_msgTypes[12]
+	mi := &file_yorkie_v1_cluster_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -741,7 +845,7 @@ func (x *ClusterServiceGetChannelCountRequest) String() string {
 func (*ClusterServiceGetChannelCountRequest) ProtoMessage() {}
 
 func (x *ClusterServiceGetChannelCountRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_cluster_proto_msgTypes[12]
+	mi := &file_yorkie_v1_cluster_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -754,7 +858,7 @@ func (x *ClusterServiceGetChannelCountRequest) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use ClusterServiceGetChannelCountRequest.ProtoReflect.Descriptor instead.
 func (*ClusterServiceGetChannelCountRequest) Descriptor() ([]byte, []int) {
-	return file_yorkie_v1_cluster_proto_rawDescGZIP(), []int{12}
+	return file_yorkie_v1_cluster_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ClusterServiceGetChannelCountRequest) GetProjectId() string {
@@ -773,7 +877,7 @@ type ClusterServiceGetChannelCountResponse struct {
 
 func (x *ClusterServiceGetChannelCountResponse) Reset() {
 	*x = ClusterServiceGetChannelCountResponse{}
-	mi := &file_yorkie_v1_cluster_proto_msgTypes[13]
+	mi := &file_yorkie_v1_cluster_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -785,7 +889,7 @@ func (x *ClusterServiceGetChannelCountResponse) String() string {
 func (*ClusterServiceGetChannelCountResponse) ProtoMessage() {}
 
 func (x *ClusterServiceGetChannelCountResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_cluster_proto_msgTypes[13]
+	mi := &file_yorkie_v1_cluster_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -798,7 +902,7 @@ func (x *ClusterServiceGetChannelCountResponse) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use ClusterServiceGetChannelCountResponse.ProtoReflect.Descriptor instead.
 func (*ClusterServiceGetChannelCountResponse) Descriptor() ([]byte, []int) {
-	return file_yorkie_v1_cluster_proto_rawDescGZIP(), []int{13}
+	return file_yorkie_v1_cluster_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ClusterServiceGetChannelCountResponse) GetChannelCount() int32 {
@@ -818,7 +922,7 @@ type InvalidateCacheRequest struct {
 
 func (x *InvalidateCacheRequest) Reset() {
 	*x = InvalidateCacheRequest{}
-	mi := &file_yorkie_v1_cluster_proto_msgTypes[14]
+	mi := &file_yorkie_v1_cluster_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -830,7 +934,7 @@ func (x *InvalidateCacheRequest) String() string {
 func (*InvalidateCacheRequest) ProtoMessage() {}
 
 func (x *InvalidateCacheRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_cluster_proto_msgTypes[14]
+	mi := &file_yorkie_v1_cluster_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -843,7 +947,7 @@ func (x *InvalidateCacheRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InvalidateCacheRequest.ProtoReflect.Descriptor instead.
 func (*InvalidateCacheRequest) Descriptor() ([]byte, []int) {
-	return file_yorkie_v1_cluster_proto_rawDescGZIP(), []int{14}
+	return file_yorkie_v1_cluster_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *InvalidateCacheRequest) GetCacheType() CacheType {
@@ -869,7 +973,7 @@ type InvalidateCacheResponse struct {
 
 func (x *InvalidateCacheResponse) Reset() {
 	*x = InvalidateCacheResponse{}
-	mi := &file_yorkie_v1_cluster_proto_msgTypes[15]
+	mi := &file_yorkie_v1_cluster_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -881,7 +985,7 @@ func (x *InvalidateCacheResponse) String() string {
 func (*InvalidateCacheResponse) ProtoMessage() {}
 
 func (x *InvalidateCacheResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yorkie_v1_cluster_proto_msgTypes[15]
+	mi := &file_yorkie_v1_cluster_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -894,7 +998,7 @@ func (x *InvalidateCacheResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InvalidateCacheResponse.ProtoReflect.Descriptor instead.
 func (*InvalidateCacheResponse) Descriptor() ([]byte, []int) {
-	return file_yorkie_v1_cluster_proto_rawDescGZIP(), []int{15}
+	return file_yorkie_v1_cluster_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *InvalidateCacheResponse) GetSuccess() bool {
@@ -952,7 +1056,15 @@ const file_yorkie_v1_cluster_proto_rawDesc = "" +
 	"\fchannel_keys\x18\x02 \x03(\tR\vchannelKeys\x12(\n" +
 	"\x10include_sub_path\x18\x03 \x01(\bR\x0eincludeSubPath\"Z\n" +
 	"!ClusterServiceGetChannelsResponse\x125\n" +
-	"\bchannels\x18\x01 \x03(\v2\x19.yorkie.v1.ChannelSummaryR\bchannels\"E\n" +
+	"\bchannels\x18\x01 \x03(\v2\x19.yorkie.v1.ChannelSummaryR\bchannels\"\x90\x01\n" +
+	"\x1eClusterServiceBroadcastRequest\x12\x1d\n" +
+	"\n" +
+	"project_id\x18\x01 \x01(\tR\tprojectId\x12\x1f\n" +
+	"\vchannel_key\x18\x02 \x01(\tR\n" +
+	"channelKey\x12\x14\n" +
+	"\x05topic\x18\x03 \x01(\tR\x05topic\x12\x18\n" +
+	"\apayload\x18\x04 \x01(\fR\apayload\"!\n" +
+	"\x1fClusterServiceBroadcastResponse\"E\n" +
 	"$ClusterServiceGetChannelCountRequest\x12\x1d\n" +
 	"\n" +
 	"project_id\x18\x01 \x01(\tR\tprojectId\"L\n" +
@@ -968,14 +1080,15 @@ const file_yorkie_v1_cluster_proto_rawDesc = "" +
 	"\x16CACHE_TYPE_UNSPECIFIED\x10\x00\x12\x16\n" +
 	"\x12CACHE_TYPE_PROJECT\x10\x01\x12\x15\n" +
 	"\x11CACHE_TYPE_CLIENT\x10\x02\x12\x17\n" +
-	"\x13CACHE_TYPE_DOCUMENT\x10\x032\x8a\a\n" +
+	"\x13CACHE_TYPE_DOCUMENT\x10\x032\xf0\a\n" +
 	"\x0eClusterService\x12s\n" +
 	"\x0eDetachDocument\x12..yorkie.v1.ClusterServiceDetachDocumentRequest\x1a/.yorkie.v1.ClusterServiceDetachDocumentResponse\"\x00\x12v\n" +
 	"\x0fCompactDocument\x12/.yorkie.v1.ClusterServiceCompactDocumentRequest\x1a0.yorkie.v1.ClusterServiceCompactDocumentResponse\"\x00\x12p\n" +
 	"\rPurgeDocument\x12-.yorkie.v1.ClusterServicePurgeDocumentRequest\x1a..yorkie.v1.ClusterServicePurgeDocumentResponse\"\x00\x12j\n" +
 	"\vGetDocument\x12+.yorkie.v1.ClusterServiceGetDocumentRequest\x1a,.yorkie.v1.ClusterServiceGetDocumentResponse\"\x00\x12m\n" +
 	"\fListChannels\x12,.yorkie.v1.ClusterServiceListChannelsRequest\x1a-.yorkie.v1.ClusterServiceListChannelsResponse\"\x00\x12j\n" +
-	"\vGetChannels\x12+.yorkie.v1.ClusterServiceGetChannelsRequest\x1a,.yorkie.v1.ClusterServiceGetChannelsResponse\"\x00\x12v\n" +
+	"\vGetChannels\x12+.yorkie.v1.ClusterServiceGetChannelsRequest\x1a,.yorkie.v1.ClusterServiceGetChannelsResponse\"\x00\x12d\n" +
+	"\tBroadcast\x12).yorkie.v1.ClusterServiceBroadcastRequest\x1a*.yorkie.v1.ClusterServiceBroadcastResponse\"\x00\x12v\n" +
 	"\x0fGetChannelCount\x12/.yorkie.v1.ClusterServiceGetChannelCountRequest\x1a0.yorkie.v1.ClusterServiceGetChannelCountResponse\"\x00\x12Z\n" +
 	"\x0fInvalidateCache\x12!.yorkie.v1.InvalidateCacheRequest\x1a\".yorkie.v1.InvalidateCacheResponse\"\x00BE\n" +
 	"\x11dev.yorkie.api.v1P\x01Z.github.com/yorkie-team/yorkie/api/yorkie/v1;v1b\x06proto3"
@@ -993,7 +1106,7 @@ func file_yorkie_v1_cluster_proto_rawDescGZIP() []byte {
 }
 
 var file_yorkie_v1_cluster_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_yorkie_v1_cluster_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
+var file_yorkie_v1_cluster_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_yorkie_v1_cluster_proto_goTypes = []any{
 	(CacheType)(0), // 0: yorkie.v1.CacheType
 	(*ClusterServiceDetachDocumentRequest)(nil),   // 1: yorkie.v1.ClusterServiceDetachDocumentRequest
@@ -1008,20 +1121,22 @@ var file_yorkie_v1_cluster_proto_goTypes = []any{
 	(*ClusterServiceListChannelsResponse)(nil),    // 10: yorkie.v1.ClusterServiceListChannelsResponse
 	(*ClusterServiceGetChannelsRequest)(nil),      // 11: yorkie.v1.ClusterServiceGetChannelsRequest
 	(*ClusterServiceGetChannelsResponse)(nil),     // 12: yorkie.v1.ClusterServiceGetChannelsResponse
-	(*ClusterServiceGetChannelCountRequest)(nil),  // 13: yorkie.v1.ClusterServiceGetChannelCountRequest
-	(*ClusterServiceGetChannelCountResponse)(nil), // 14: yorkie.v1.ClusterServiceGetChannelCountResponse
-	(*InvalidateCacheRequest)(nil),                // 15: yorkie.v1.InvalidateCacheRequest
-	(*InvalidateCacheResponse)(nil),               // 16: yorkie.v1.InvalidateCacheResponse
-	(*Project)(nil),                               // 17: yorkie.v1.Project
-	(*DocumentSummary)(nil),                       // 18: yorkie.v1.DocumentSummary
-	(*ChannelSummary)(nil),                        // 19: yorkie.v1.ChannelSummary
+	(*ClusterServiceBroadcastRequest)(nil),        // 13: yorkie.v1.ClusterServiceBroadcastRequest
+	(*ClusterServiceBroadcastResponse)(nil),       // 14: yorkie.v1.ClusterServiceBroadcastResponse
+	(*ClusterServiceGetChannelCountRequest)(nil),  // 15: yorkie.v1.ClusterServiceGetChannelCountRequest
+	(*ClusterServiceGetChannelCountResponse)(nil), // 16: yorkie.v1.ClusterServiceGetChannelCountResponse
+	(*InvalidateCacheRequest)(nil),                // 17: yorkie.v1.InvalidateCacheRequest
+	(*InvalidateCacheResponse)(nil),               // 18: yorkie.v1.InvalidateCacheResponse
+	(*Project)(nil),                               // 19: yorkie.v1.Project
+	(*DocumentSummary)(nil),                       // 20: yorkie.v1.DocumentSummary
+	(*ChannelSummary)(nil),                        // 21: yorkie.v1.ChannelSummary
 }
 var file_yorkie_v1_cluster_proto_depIdxs = []int32{
-	17, // 0: yorkie.v1.ClusterServiceDetachDocumentRequest.project:type_name -> yorkie.v1.Project
-	17, // 1: yorkie.v1.ClusterServiceGetDocumentRequest.project:type_name -> yorkie.v1.Project
-	18, // 2: yorkie.v1.ClusterServiceGetDocumentResponse.document:type_name -> yorkie.v1.DocumentSummary
-	19, // 3: yorkie.v1.ClusterServiceListChannelsResponse.channels:type_name -> yorkie.v1.ChannelSummary
-	19, // 4: yorkie.v1.ClusterServiceGetChannelsResponse.channels:type_name -> yorkie.v1.ChannelSummary
+	19, // 0: yorkie.v1.ClusterServiceDetachDocumentRequest.project:type_name -> yorkie.v1.Project
+	19, // 1: yorkie.v1.ClusterServiceGetDocumentRequest.project:type_name -> yorkie.v1.Project
+	20, // 2: yorkie.v1.ClusterServiceGetDocumentResponse.document:type_name -> yorkie.v1.DocumentSummary
+	21, // 3: yorkie.v1.ClusterServiceListChannelsResponse.channels:type_name -> yorkie.v1.ChannelSummary
+	21, // 4: yorkie.v1.ClusterServiceGetChannelsResponse.channels:type_name -> yorkie.v1.ChannelSummary
 	0,  // 5: yorkie.v1.InvalidateCacheRequest.cache_type:type_name -> yorkie.v1.CacheType
 	1,  // 6: yorkie.v1.ClusterService.DetachDocument:input_type -> yorkie.v1.ClusterServiceDetachDocumentRequest
 	3,  // 7: yorkie.v1.ClusterService.CompactDocument:input_type -> yorkie.v1.ClusterServiceCompactDocumentRequest
@@ -1029,18 +1144,20 @@ var file_yorkie_v1_cluster_proto_depIdxs = []int32{
 	7,  // 9: yorkie.v1.ClusterService.GetDocument:input_type -> yorkie.v1.ClusterServiceGetDocumentRequest
 	9,  // 10: yorkie.v1.ClusterService.ListChannels:input_type -> yorkie.v1.ClusterServiceListChannelsRequest
 	11, // 11: yorkie.v1.ClusterService.GetChannels:input_type -> yorkie.v1.ClusterServiceGetChannelsRequest
-	13, // 12: yorkie.v1.ClusterService.GetChannelCount:input_type -> yorkie.v1.ClusterServiceGetChannelCountRequest
-	15, // 13: yorkie.v1.ClusterService.InvalidateCache:input_type -> yorkie.v1.InvalidateCacheRequest
-	2,  // 14: yorkie.v1.ClusterService.DetachDocument:output_type -> yorkie.v1.ClusterServiceDetachDocumentResponse
-	4,  // 15: yorkie.v1.ClusterService.CompactDocument:output_type -> yorkie.v1.ClusterServiceCompactDocumentResponse
-	6,  // 16: yorkie.v1.ClusterService.PurgeDocument:output_type -> yorkie.v1.ClusterServicePurgeDocumentResponse
-	8,  // 17: yorkie.v1.ClusterService.GetDocument:output_type -> yorkie.v1.ClusterServiceGetDocumentResponse
-	10, // 18: yorkie.v1.ClusterService.ListChannels:output_type -> yorkie.v1.ClusterServiceListChannelsResponse
-	12, // 19: yorkie.v1.ClusterService.GetChannels:output_type -> yorkie.v1.ClusterServiceGetChannelsResponse
-	14, // 20: yorkie.v1.ClusterService.GetChannelCount:output_type -> yorkie.v1.ClusterServiceGetChannelCountResponse
-	16, // 21: yorkie.v1.ClusterService.InvalidateCache:output_type -> yorkie.v1.InvalidateCacheResponse
-	14, // [14:22] is the sub-list for method output_type
-	6,  // [6:14] is the sub-list for method input_type
+	13, // 12: yorkie.v1.ClusterService.Broadcast:input_type -> yorkie.v1.ClusterServiceBroadcastRequest
+	15, // 13: yorkie.v1.ClusterService.GetChannelCount:input_type -> yorkie.v1.ClusterServiceGetChannelCountRequest
+	17, // 14: yorkie.v1.ClusterService.InvalidateCache:input_type -> yorkie.v1.InvalidateCacheRequest
+	2,  // 15: yorkie.v1.ClusterService.DetachDocument:output_type -> yorkie.v1.ClusterServiceDetachDocumentResponse
+	4,  // 16: yorkie.v1.ClusterService.CompactDocument:output_type -> yorkie.v1.ClusterServiceCompactDocumentResponse
+	6,  // 17: yorkie.v1.ClusterService.PurgeDocument:output_type -> yorkie.v1.ClusterServicePurgeDocumentResponse
+	8,  // 18: yorkie.v1.ClusterService.GetDocument:output_type -> yorkie.v1.ClusterServiceGetDocumentResponse
+	10, // 19: yorkie.v1.ClusterService.ListChannels:output_type -> yorkie.v1.ClusterServiceListChannelsResponse
+	12, // 20: yorkie.v1.ClusterService.GetChannels:output_type -> yorkie.v1.ClusterServiceGetChannelsResponse
+	14, // 21: yorkie.v1.ClusterService.Broadcast:output_type -> yorkie.v1.ClusterServiceBroadcastResponse
+	16, // 22: yorkie.v1.ClusterService.GetChannelCount:output_type -> yorkie.v1.ClusterServiceGetChannelCountResponse
+	18, // 23: yorkie.v1.ClusterService.InvalidateCache:output_type -> yorkie.v1.InvalidateCacheResponse
+	15, // [15:24] is the sub-list for method output_type
+	6,  // [6:15] is the sub-list for method input_type
 	6,  // [6:6] is the sub-list for extension type_name
 	6,  // [6:6] is the sub-list for extension extendee
 	0,  // [0:6] is the sub-list for field type_name
@@ -1058,7 +1175,7 @@ func file_yorkie_v1_cluster_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_yorkie_v1_cluster_proto_rawDesc), len(file_yorkie_v1_cluster_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   16,
+			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/yorkie/v1/cluster.proto
+++ b/api/yorkie/v1/cluster.proto
@@ -32,6 +32,7 @@ service ClusterService {
   rpc GetDocument (ClusterServiceGetDocumentRequest) returns (ClusterServiceGetDocumentResponse) {}
   rpc ListChannels (ClusterServiceListChannelsRequest) returns (ClusterServiceListChannelsResponse) {}
   rpc GetChannels (ClusterServiceGetChannelsRequest) returns (ClusterServiceGetChannelsResponse) {}
+  rpc Broadcast (ClusterServiceBroadcastRequest) returns (ClusterServiceBroadcastResponse) {}
   rpc GetChannelCount (ClusterServiceGetChannelCountRequest) returns (ClusterServiceGetChannelCountResponse) {}
   rpc InvalidateCache (InvalidateCacheRequest) returns (InvalidateCacheResponse) {}
 }
@@ -94,6 +95,15 @@ message ClusterServiceGetChannelsRequest {
 message ClusterServiceGetChannelsResponse {
   repeated ChannelSummary channels = 1;
 }
+
+message ClusterServiceBroadcastRequest {
+  string project_id = 1;
+  string channel_key = 2;
+  string topic = 3;
+  bytes payload = 4;
+}
+
+message ClusterServiceBroadcastResponse {}
 
 message ClusterServiceGetChannelCountRequest {
   string project_id = 1;

--- a/api/yorkie/v1/v1connect/admin.connect.go
+++ b/api/yorkie/v1/v1connect/admin.connect.go
@@ -145,6 +145,9 @@ const (
 	// AdminServiceGetChannelsProcedure is the fully-qualified name of the AdminService's GetChannels
 	// RPC.
 	AdminServiceGetChannelsProcedure = "/yorkie.v1.AdminService/GetChannels"
+	// AdminServiceBroadcastByAdminProcedure is the fully-qualified name of the AdminService's
+	// BroadcastByAdmin RPC.
+	AdminServiceBroadcastByAdminProcedure = "/yorkie.v1.AdminService/BroadcastByAdmin"
 	// AdminServiceGetServerVersionProcedure is the fully-qualified name of the AdminService's
 	// GetServerVersion RPC.
 	AdminServiceGetServerVersionProcedure = "/yorkie.v1.AdminService/GetServerVersion"
@@ -189,6 +192,7 @@ type AdminServiceClient interface {
 	RestoreRevisionByAdmin(context.Context, *connect.Request[v1.RestoreRevisionByAdminRequest]) (*connect.Response[v1.RestoreRevisionByAdminResponse], error)
 	ListChannels(context.Context, *connect.Request[v1.ListChannelsRequest]) (*connect.Response[v1.ListChannelsResponse], error)
 	GetChannels(context.Context, *connect.Request[v1.GetChannelsRequest]) (*connect.Response[v1.GetChannelsResponse], error)
+	BroadcastByAdmin(context.Context, *connect.Request[v1.BroadcastByAdminRequest]) (*connect.Response[v1.BroadcastByAdminResponse], error)
 	GetServerVersion(context.Context, *connect.Request[v1.GetServerVersionRequest]) (*connect.Response[v1.GetServerVersionResponse], error)
 	CompactDocumentByAdmin(context.Context, *connect.Request[v1.CompactDocumentByAdminRequest]) (*connect.Response[v1.CompactDocumentByAdminResponse], error)
 }
@@ -373,6 +377,11 @@ func NewAdminServiceClient(httpClient connect.HTTPClient, baseURL string, opts .
 			baseURL+AdminServiceGetChannelsProcedure,
 			opts...,
 		),
+		broadcastByAdmin: connect.NewClient[v1.BroadcastByAdminRequest, v1.BroadcastByAdminResponse](
+			httpClient,
+			baseURL+AdminServiceBroadcastByAdminProcedure,
+			opts...,
+		),
 		getServerVersion: connect.NewClient[v1.GetServerVersionRequest, v1.GetServerVersionResponse](
 			httpClient,
 			baseURL+AdminServiceGetServerVersionProcedure,
@@ -422,6 +431,7 @@ type adminServiceClient struct {
 	restoreRevisionByAdmin *connect.Client[v1.RestoreRevisionByAdminRequest, v1.RestoreRevisionByAdminResponse]
 	listChannels           *connect.Client[v1.ListChannelsRequest, v1.ListChannelsResponse]
 	getChannels            *connect.Client[v1.GetChannelsRequest, v1.GetChannelsResponse]
+	broadcastByAdmin       *connect.Client[v1.BroadcastByAdminRequest, v1.BroadcastByAdminResponse]
 	getServerVersion       *connect.Client[v1.GetServerVersionRequest, v1.GetServerVersionResponse]
 	compactDocumentByAdmin *connect.Client[v1.CompactDocumentByAdminRequest, v1.CompactDocumentByAdminResponse]
 }
@@ -596,6 +606,11 @@ func (c *adminServiceClient) GetChannels(ctx context.Context, req *connect.Reque
 	return c.getChannels.CallUnary(ctx, req)
 }
 
+// BroadcastByAdmin calls yorkie.v1.AdminService.BroadcastByAdmin.
+func (c *adminServiceClient) BroadcastByAdmin(ctx context.Context, req *connect.Request[v1.BroadcastByAdminRequest]) (*connect.Response[v1.BroadcastByAdminResponse], error) {
+	return c.broadcastByAdmin.CallUnary(ctx, req)
+}
+
 // GetServerVersion calls yorkie.v1.AdminService.GetServerVersion.
 func (c *adminServiceClient) GetServerVersion(ctx context.Context, req *connect.Request[v1.GetServerVersionRequest]) (*connect.Response[v1.GetServerVersionResponse], error) {
 	return c.getServerVersion.CallUnary(ctx, req)
@@ -642,6 +657,7 @@ type AdminServiceHandler interface {
 	RestoreRevisionByAdmin(context.Context, *connect.Request[v1.RestoreRevisionByAdminRequest]) (*connect.Response[v1.RestoreRevisionByAdminResponse], error)
 	ListChannels(context.Context, *connect.Request[v1.ListChannelsRequest]) (*connect.Response[v1.ListChannelsResponse], error)
 	GetChannels(context.Context, *connect.Request[v1.GetChannelsRequest]) (*connect.Response[v1.GetChannelsResponse], error)
+	BroadcastByAdmin(context.Context, *connect.Request[v1.BroadcastByAdminRequest]) (*connect.Response[v1.BroadcastByAdminResponse], error)
 	GetServerVersion(context.Context, *connect.Request[v1.GetServerVersionRequest]) (*connect.Response[v1.GetServerVersionResponse], error)
 	CompactDocumentByAdmin(context.Context, *connect.Request[v1.CompactDocumentByAdminRequest]) (*connect.Response[v1.CompactDocumentByAdminResponse], error)
 }
@@ -822,6 +838,11 @@ func NewAdminServiceHandler(svc AdminServiceHandler, opts ...connect.HandlerOpti
 		svc.GetChannels,
 		opts...,
 	)
+	adminServiceBroadcastByAdminHandler := connect.NewUnaryHandler(
+		AdminServiceBroadcastByAdminProcedure,
+		svc.BroadcastByAdmin,
+		opts...,
+	)
 	adminServiceGetServerVersionHandler := connect.NewUnaryHandler(
 		AdminServiceGetServerVersionProcedure,
 		svc.GetServerVersion,
@@ -902,6 +923,8 @@ func NewAdminServiceHandler(svc AdminServiceHandler, opts ...connect.HandlerOpti
 			adminServiceListChannelsHandler.ServeHTTP(w, r)
 		case AdminServiceGetChannelsProcedure:
 			adminServiceGetChannelsHandler.ServeHTTP(w, r)
+		case AdminServiceBroadcastByAdminProcedure:
+			adminServiceBroadcastByAdminHandler.ServeHTTP(w, r)
 		case AdminServiceGetServerVersionProcedure:
 			adminServiceGetServerVersionHandler.ServeHTTP(w, r)
 		case AdminServiceCompactDocumentByAdminProcedure:
@@ -1049,6 +1072,10 @@ func (UnimplementedAdminServiceHandler) ListChannels(context.Context, *connect.R
 
 func (UnimplementedAdminServiceHandler) GetChannels(context.Context, *connect.Request[v1.GetChannelsRequest]) (*connect.Response[v1.GetChannelsResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("yorkie.v1.AdminService.GetChannels is not implemented"))
+}
+
+func (UnimplementedAdminServiceHandler) BroadcastByAdmin(context.Context, *connect.Request[v1.BroadcastByAdminRequest]) (*connect.Response[v1.BroadcastByAdminResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("yorkie.v1.AdminService.BroadcastByAdmin is not implemented"))
 }
 
 func (UnimplementedAdminServiceHandler) GetServerVersion(context.Context, *connect.Request[v1.GetServerVersionRequest]) (*connect.Response[v1.GetServerVersionResponse], error) {

--- a/api/yorkie/v1/v1connect/cluster.connect.go
+++ b/api/yorkie/v1/v1connect/cluster.connect.go
@@ -66,6 +66,9 @@ const (
 	// ClusterServiceGetChannelsProcedure is the fully-qualified name of the ClusterService's
 	// GetChannels RPC.
 	ClusterServiceGetChannelsProcedure = "/yorkie.v1.ClusterService/GetChannels"
+	// ClusterServiceBroadcastProcedure is the fully-qualified name of the ClusterService's Broadcast
+	// RPC.
+	ClusterServiceBroadcastProcedure = "/yorkie.v1.ClusterService/Broadcast"
 	// ClusterServiceGetChannelCountProcedure is the fully-qualified name of the ClusterService's
 	// GetChannelCount RPC.
 	ClusterServiceGetChannelCountProcedure = "/yorkie.v1.ClusterService/GetChannelCount"
@@ -82,6 +85,7 @@ type ClusterServiceClient interface {
 	GetDocument(context.Context, *connect.Request[v1.ClusterServiceGetDocumentRequest]) (*connect.Response[v1.ClusterServiceGetDocumentResponse], error)
 	ListChannels(context.Context, *connect.Request[v1.ClusterServiceListChannelsRequest]) (*connect.Response[v1.ClusterServiceListChannelsResponse], error)
 	GetChannels(context.Context, *connect.Request[v1.ClusterServiceGetChannelsRequest]) (*connect.Response[v1.ClusterServiceGetChannelsResponse], error)
+	Broadcast(context.Context, *connect.Request[v1.ClusterServiceBroadcastRequest]) (*connect.Response[v1.ClusterServiceBroadcastResponse], error)
 	GetChannelCount(context.Context, *connect.Request[v1.ClusterServiceGetChannelCountRequest]) (*connect.Response[v1.ClusterServiceGetChannelCountResponse], error)
 	InvalidateCache(context.Context, *connect.Request[v1.InvalidateCacheRequest]) (*connect.Response[v1.InvalidateCacheResponse], error)
 }
@@ -126,6 +130,11 @@ func NewClusterServiceClient(httpClient connect.HTTPClient, baseURL string, opts
 			baseURL+ClusterServiceGetChannelsProcedure,
 			opts...,
 		),
+		broadcast: connect.NewClient[v1.ClusterServiceBroadcastRequest, v1.ClusterServiceBroadcastResponse](
+			httpClient,
+			baseURL+ClusterServiceBroadcastProcedure,
+			opts...,
+		),
 		getChannelCount: connect.NewClient[v1.ClusterServiceGetChannelCountRequest, v1.ClusterServiceGetChannelCountResponse](
 			httpClient,
 			baseURL+ClusterServiceGetChannelCountProcedure,
@@ -147,6 +156,7 @@ type clusterServiceClient struct {
 	getDocument     *connect.Client[v1.ClusterServiceGetDocumentRequest, v1.ClusterServiceGetDocumentResponse]
 	listChannels    *connect.Client[v1.ClusterServiceListChannelsRequest, v1.ClusterServiceListChannelsResponse]
 	getChannels     *connect.Client[v1.ClusterServiceGetChannelsRequest, v1.ClusterServiceGetChannelsResponse]
+	broadcast       *connect.Client[v1.ClusterServiceBroadcastRequest, v1.ClusterServiceBroadcastResponse]
 	getChannelCount *connect.Client[v1.ClusterServiceGetChannelCountRequest, v1.ClusterServiceGetChannelCountResponse]
 	invalidateCache *connect.Client[v1.InvalidateCacheRequest, v1.InvalidateCacheResponse]
 }
@@ -181,6 +191,11 @@ func (c *clusterServiceClient) GetChannels(ctx context.Context, req *connect.Req
 	return c.getChannels.CallUnary(ctx, req)
 }
 
+// Broadcast calls yorkie.v1.ClusterService.Broadcast.
+func (c *clusterServiceClient) Broadcast(ctx context.Context, req *connect.Request[v1.ClusterServiceBroadcastRequest]) (*connect.Response[v1.ClusterServiceBroadcastResponse], error) {
+	return c.broadcast.CallUnary(ctx, req)
+}
+
 // GetChannelCount calls yorkie.v1.ClusterService.GetChannelCount.
 func (c *clusterServiceClient) GetChannelCount(ctx context.Context, req *connect.Request[v1.ClusterServiceGetChannelCountRequest]) (*connect.Response[v1.ClusterServiceGetChannelCountResponse], error) {
 	return c.getChannelCount.CallUnary(ctx, req)
@@ -199,6 +214,7 @@ type ClusterServiceHandler interface {
 	GetDocument(context.Context, *connect.Request[v1.ClusterServiceGetDocumentRequest]) (*connect.Response[v1.ClusterServiceGetDocumentResponse], error)
 	ListChannels(context.Context, *connect.Request[v1.ClusterServiceListChannelsRequest]) (*connect.Response[v1.ClusterServiceListChannelsResponse], error)
 	GetChannels(context.Context, *connect.Request[v1.ClusterServiceGetChannelsRequest]) (*connect.Response[v1.ClusterServiceGetChannelsResponse], error)
+	Broadcast(context.Context, *connect.Request[v1.ClusterServiceBroadcastRequest]) (*connect.Response[v1.ClusterServiceBroadcastResponse], error)
 	GetChannelCount(context.Context, *connect.Request[v1.ClusterServiceGetChannelCountRequest]) (*connect.Response[v1.ClusterServiceGetChannelCountResponse], error)
 	InvalidateCache(context.Context, *connect.Request[v1.InvalidateCacheRequest]) (*connect.Response[v1.InvalidateCacheResponse], error)
 }
@@ -239,6 +255,11 @@ func NewClusterServiceHandler(svc ClusterServiceHandler, opts ...connect.Handler
 		svc.GetChannels,
 		opts...,
 	)
+	clusterServiceBroadcastHandler := connect.NewUnaryHandler(
+		ClusterServiceBroadcastProcedure,
+		svc.Broadcast,
+		opts...,
+	)
 	clusterServiceGetChannelCountHandler := connect.NewUnaryHandler(
 		ClusterServiceGetChannelCountProcedure,
 		svc.GetChannelCount,
@@ -263,6 +284,8 @@ func NewClusterServiceHandler(svc ClusterServiceHandler, opts ...connect.Handler
 			clusterServiceListChannelsHandler.ServeHTTP(w, r)
 		case ClusterServiceGetChannelsProcedure:
 			clusterServiceGetChannelsHandler.ServeHTTP(w, r)
+		case ClusterServiceBroadcastProcedure:
+			clusterServiceBroadcastHandler.ServeHTTP(w, r)
 		case ClusterServiceGetChannelCountProcedure:
 			clusterServiceGetChannelCountHandler.ServeHTTP(w, r)
 		case ClusterServiceInvalidateCacheProcedure:
@@ -298,6 +321,10 @@ func (UnimplementedClusterServiceHandler) ListChannels(context.Context, *connect
 
 func (UnimplementedClusterServiceHandler) GetChannels(context.Context, *connect.Request[v1.ClusterServiceGetChannelsRequest]) (*connect.Response[v1.ClusterServiceGetChannelsResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("yorkie.v1.ClusterService.GetChannels is not implemented"))
+}
+
+func (UnimplementedClusterServiceHandler) Broadcast(context.Context, *connect.Request[v1.ClusterServiceBroadcastRequest]) (*connect.Response[v1.ClusterServiceBroadcastResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("yorkie.v1.ClusterService.Broadcast is not implemented"))
 }
 
 func (UnimplementedClusterServiceHandler) GetChannelCount(context.Context, *connect.Request[v1.ClusterServiceGetChannelCountRequest]) (*connect.Response[v1.ClusterServiceGetChannelCountResponse], error) {

--- a/cluster/client.go
+++ b/cluster/client.go
@@ -34,6 +34,7 @@ import (
 	"github.com/yorkie-team/yorkie/api/types"
 	api "github.com/yorkie-team/yorkie/api/yorkie/v1"
 	"github.com/yorkie-team/yorkie/api/yorkie/v1/v1connect"
+	"github.com/yorkie-team/yorkie/pkg/channel"
 	"github.com/yorkie-team/yorkie/pkg/document/time"
 	"github.com/yorkie-team/yorkie/pkg/errors"
 	"github.com/yorkie-team/yorkie/pkg/key"
@@ -350,6 +351,38 @@ func (c *Client) GetChannels(
 	}
 
 	return channels, nil
+}
+
+// Broadcast broadcasts an event to clients watching the given channel.
+func (c *Client) Broadcast(
+	ctx context.Context,
+	project *types.Project,
+	channelKey key.Key,
+	topic string,
+	payload []byte,
+) error {
+	ctx, cancel := context.WithTimeout(ctx, c.rpcTimeout)
+	defer cancel()
+
+	firstPath, err := channel.FirstKeyPath(channelKey)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.client.Broadcast(
+		ctx,
+		withShardKey(connect.NewRequest(&api.ClusterServiceBroadcastRequest{
+			ProjectId:  project.ID.String(),
+			ChannelKey: channelKey.String(),
+			Topic:      topic,
+			Payload:    payload,
+		}), project.PublicKey, firstPath),
+	)
+	if err != nil {
+		return fromConnectError(err)
+	}
+
+	return nil
 }
 
 // GetChannelCount gets the channel count for the given project.

--- a/server/rpc/admin_server.go
+++ b/server/rpc/admin_server.go
@@ -893,6 +893,34 @@ func (s *adminServer) GetChannels(
 	}), nil
 }
 
+// BroadcastByAdmin broadcasts an event to clients watching the given channel.
+func (s *adminServer) BroadcastByAdmin(
+	ctx context.Context,
+	req *connect.Request[api.BroadcastByAdminRequest],
+) (*connect.Response[api.BroadcastByAdminResponse], error) {
+	channelKey := key.Key(req.Msg.ChannelKey)
+	if err := channelKey.Validate(); err != nil {
+		return nil, err
+	}
+
+	project := projects.From(ctx)
+	clusterClient, err := s.backend.ClusterClient()
+	if err != nil {
+		return nil, err
+	}
+	if err := clusterClient.Broadcast(
+		ctx,
+		project,
+		channelKey,
+		req.Msg.Topic,
+		req.Msg.Payload,
+	); err != nil {
+		return nil, err
+	}
+
+	return connect.NewResponse(&api.BroadcastByAdminResponse{}), nil
+}
+
 // makeChannelSessionCountCacheKey creates a cache key for session count.
 func makeChannelSessionCountCacheKey(projectID types.ID, channelKey key.Key, includeSubPath bool) string {
 	return fmt.Sprintf("%s:%s:%t", projectID, channelKey, includeSubPath)

--- a/server/rpc/cluster_server.go
+++ b/server/rpc/cluster_server.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/yorkie-team/yorkie/api/converter"
 	"github.com/yorkie-team/yorkie/api/types"
+	"github.com/yorkie-team/yorkie/api/types/events"
 	api "github.com/yorkie-team/yorkie/api/yorkie/v1"
 	"github.com/yorkie-team/yorkie/pkg/document"
 	"github.com/yorkie-team/yorkie/pkg/document/change"
@@ -316,6 +317,30 @@ func (s *clusterServer) GetChannels(
 	return connect.NewResponse(&api.ClusterServiceGetChannelsResponse{
 		Channels: channels,
 	}), nil
+}
+
+// Broadcast broadcasts an event to clients watching the given channel.
+func (s *clusterServer) Broadcast(
+	ctx context.Context,
+	req *connect.Request[api.ClusterServiceBroadcastRequest],
+) (*connect.Response[api.ClusterServiceBroadcastResponse], error) {
+	channelKey := key.Key(req.Msg.ChannelKey)
+	if err := channelKey.Validate(); err != nil {
+		return nil, err
+	}
+
+	s.backend.PubSub.PublishChannel(ctx, events.ChannelEvent{
+		Type: events.ChannelBroadcast,
+		Key: types.ChannelRefKey{
+			ProjectID:  types.ID(req.Msg.ProjectId),
+			ChannelKey: channelKey,
+		},
+		Publisher: time.InitialActorID,
+		Topic:     req.Msg.Topic,
+		Payload:   req.Msg.Payload,
+	})
+
+	return connect.NewResponse(&api.ClusterServiceBroadcastResponse{}), nil
 }
 
 // GetChannelCount gets the channel count for the given project.

--- a/test/integration/restapi_test.go
+++ b/test/integration/restapi_test.go
@@ -27,11 +27,14 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yorkie-team/yorkie/api/types"
 	"github.com/yorkie-team/yorkie/client"
+	"github.com/yorkie-team/yorkie/pkg/channel"
 	"github.com/yorkie-team/yorkie/pkg/document"
 	"github.com/yorkie-team/yorkie/pkg/document/json"
 	"github.com/yorkie-team/yorkie/pkg/document/presence"
@@ -305,6 +308,65 @@ func TestRESTAPI(t *testing.T) {
 			})
 		}
 		wg.Wait()
+	})
+
+	t.Run("broadcast by admin test", func(t *testing.T) {
+		ctx := context.Background()
+		project := helper.CreateProject(t, defaultServer, t.Name())
+
+		cli, err := client.Dial(
+			defaultServer.RPCAddr(),
+			client.WithAPIKey(project.PublicKey),
+		)
+		require.NoError(t, err)
+		require.NoError(t, cli.Activate(ctx))
+		defer func() {
+			assert.NoError(t, cli.Deactivate(ctx))
+			assert.NoError(t, cli.Close())
+		}()
+
+		ch, err := channel.New(key.Key("room-1"))
+		require.NoError(t, err)
+		require.NoError(t, cli.Attach(ctx, ch))
+
+		eventCh := make(chan []byte, 1)
+		ch.SubscribeBroadcastEvent(
+			"mention",
+			func(_ string, _ string, payload []byte) error {
+				eventCh <- payload
+				return nil
+			},
+		)
+
+		countCh, closeWatch, err := cli.WatchChannel(ctx, ch)
+		require.NoError(t, err)
+		defer closeWatch()
+
+		select {
+		case <-countCh:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout waiting for channel watch initialization")
+		}
+
+		res := post(
+			t,
+			project,
+			fmt.Sprintf("http://%s/yorkie.v1.AdminService/BroadcastByAdmin", defaultServer.RPCAddr()),
+			`{"channel_key":"room-1","topic":"mention","payload":"InlvcmtpZSI="}`,
+		)
+
+		var ack map[string]any
+		assert.NoError(t, gojson.Unmarshal(res, &ack))
+		assert.Empty(t, ack)
+
+		select {
+		case payload := <-eventCh:
+			var value string
+			assert.NoError(t, gojson.Unmarshal(payload, &value))
+			assert.Equal(t, "yorkie", value)
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout waiting for admin broadcast")
+		}
 	})
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Backend applications should be able to broadcast channel events without
activating a Yorkie client.

This PR introduces `AdminService.BroadcastByAdmin`, which allows a backend to
broadcast an event to clients watching a channel through the Admin API.

The AdminService validates the request, resolves the project, and forwards it
to `ClusterService.Broadcast` using the channel shard key. The owning pod then
publishes the event through its local Channel PubSub.

It also adds an integration test that verifies the topic and payload are
delivered to a watching SDK client.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #1352

**Special notes for your reviewer**:

- The shard key is derived from the project public key and the channel's first
  key path, matching the existing SDK Channel routing behavior.
- The internal ClusterService request contains the project ID and full channel
  key so the owning pod can publish to the correct Channel subscription.
- Since `payload` is a Protobuf `bytes` field, it is represented as a base64
  string when the API is called using ProtoJSON.
- The integration test covers the Admin REST request, ClusterService
  forwarding, PubSub delivery, and SDK topic handler execution.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Add an Admin API for broadcasting events to clients watching a channel without
requiring a Yorkie client connection.
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs
- [OpenAPI]: api/docs/yorkie/v1/admin.openapi.yaml
```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an admin API endpoint to broadcast a binary payload to a specified channel and topic.
  - Added a cluster-level broadcast RPC so messages can be forwarded to relevant subscribers.
  - Added API schema support for broadcast request/response payloads, including project-scoped delivery parameters.

- **Tests**
  - Extended REST API integration coverage with a new “broadcast by admin” scenario to verify broadcast delivery to subscribed clients and validate received payload contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->