### PR TITLE
Add fuzz coverage for primitive value decoding

### DIFF
--- a/pkg/document/crdt/primitive.go
+++ b/pkg/document/crdt/primitive.go
@@ -48,22 +48,37 @@ func ValueFromBytes(valueType ValueType, value []byte) (interface{}, error) {
 	case Null:
 		return nil, nil
 	case Boolean:
+		if len(value) < 1 {
+			return nil, fmt.Errorf("invalid boolean payload: got %d bytes, want 1", len(value))
+		}
 		if value[0] == 1 {
 			return true, nil
 		}
 		return false, nil
 	case Integer:
+		if len(value) < 4 {
+			return nil, fmt.Errorf("invalid integer payload: got %d bytes, want 4", len(value))
+		}
 		val := int32(binary.LittleEndian.Uint32(value))
 		return val, nil
 	case Long:
+		if len(value) < 8 {
+			return nil, fmt.Errorf("invalid long payload: got %d bytes, want 8", len(value))
+		}
 		return int64(binary.LittleEndian.Uint64(value)), nil
 	case Double:
+		if len(value) < 8 {
+			return nil, fmt.Errorf("invalid double payload: got %d bytes, want 8", len(value))
+		}
 		return math.Float64frombits(binary.LittleEndian.Uint64(value)), nil
 	case String:
 		return string(value), nil
 	case Bytes:
 		return value, nil
 	case Date:
+		if len(value) < 8 {
+			return nil, fmt.Errorf("invalid date payload: got %d bytes, want 8", len(value))
+		}
 		v := int64(binary.LittleEndian.Uint64(value))
 		return gotime.UnixMilli(v), nil
 	default:

--- a/test/fuzz/fuzz_test.go
+++ b/test/fuzz/fuzz_test.go
@@ -54,6 +54,21 @@ func FuzzCounterValueFromBytes(f *testing.F) {
 	})
 }
 
+func FuzzValueFromBytes(f *testing.F) {
+	f.Add(byte(crdt.Null), []byte{})
+	f.Add(byte(crdt.Boolean), []byte{1})
+	f.Add(byte(crdt.Integer), []byte{0, 0, 0, 0})
+	f.Add(byte(crdt.Long), []byte{0, 0, 0, 0, 0, 0, 0, 0})
+	f.Add(byte(crdt.Double), []byte{0, 0, 0, 0, 0, 0, 0, 0})
+	f.Add(byte(crdt.String), []byte("yorkie"))
+	f.Add(byte(crdt.Bytes), []byte("yorkie"))
+	f.Add(byte(crdt.Date), []byte{0, 0, 0, 0, 0, 0, 0, 0})
+
+	f.Fuzz(func(t *testing.T, rawValueType byte, value []byte) {
+		_, _ = crdt.ValueFromBytes(crdt.ValueType(rawValueType), value)
+	})
+}
+
 func addProtoSeeds(f *testing.F, messages ...proto.Message) {
 	f.Helper()
 	for _, message := range messages {

--- a/test/fuzz/testdata/fuzz/FuzzValueFromBytes/d85e4bb7cd3261ef
+++ b/test/fuzz/testdata/fuzz/FuzzValueFromBytes/d85e4bb7cd3261ef
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x03')
+[]byte("0")

--- a/test/fuzz/testdata/fuzz/FuzzValueFromBytes/short_boolean_payload
+++ b/test/fuzz/testdata/fuzz/FuzzValueFromBytes/short_boolean_payload
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x01')
+[]byte("")

--- a/test/fuzz/testdata/fuzz/FuzzValueFromBytes/short_date_payload
+++ b/test/fuzz/testdata/fuzz/FuzzValueFromBytes/short_date_payload
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x07')
+[]byte("0000000")

--- a/test/fuzz/testdata/fuzz/FuzzValueFromBytes/short_double_payload
+++ b/test/fuzz/testdata/fuzz/FuzzValueFromBytes/short_double_payload
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x04')
+[]byte("0000000")

--- a/test/fuzz/testdata/fuzz/FuzzValueFromBytes/short_integer_payload
+++ b/test/fuzz/testdata/fuzz/FuzzValueFromBytes/short_integer_payload
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x02')
+[]byte("000")

--- a/test/fuzz/testdata/fuzz/FuzzValueFromBytes/short_long_payload
+++ b/test/fuzz/testdata/fuzz/FuzzValueFromBytes/short_long_payload
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x03')
+[]byte("0000000")


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds fuzz coverage for `crdt.ValueFromBytes` and includes regression corpus for malformed primitive value payloads that previously caused panics during decoding.


The fix checks payload lengths before decoding fixed-width primitive values such as booleans, integers, longs, doubles, and dates, and returns errors instead of panicking on malformed input.

**Which issue(s) this PR fixes**:

Refs #1898

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation**:

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for incomplete boolean, numeric, and date value data.
  * Invalid or truncated payloads now return descriptive errors instead of causing decoding failures.

* **Tests**
  * Expanded fuzz testing across supported value types.
  * Added coverage for short and malformed payloads to improve decoder reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->