### PR TITLE
Add HTTP server timeouts to prevent Slowloris attacks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,9 +31,6 @@ linters:
     generated: lax
     rules:
       - linters:
-          - gosec
-        text: 'G112:'
-      - linters:
           - lll
         path: api/types/updatable_project_fields.go
     paths:

--- a/cmd/yorkie/server.go
+++ b/cmd/yorkie/server.go
@@ -40,6 +40,9 @@ var (
 	flagConfPath string
 	flagLogLevel string
 
+	rpcReadHeaderTimeout time.Duration
+	rpcIdleTimeout       time.Duration
+
 	adminTokenDuration            time.Duration
 	authGitHubClientID            string
 	authGitHubClientSecret        string
@@ -100,6 +103,9 @@ func newServerCmd() *cobra.Command {
 		Use:   "server [options]",
 		Short: "Start Yorkie server",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			conf.RPC.ReadHeaderTimeout = rpcReadHeaderTimeout.String()
+			conf.RPC.IdleTimeout = rpcIdleTimeout.String()
+
 			conf.Backend.AdminTokenDuration = adminTokenDuration.String()
 			conf.RPC.Auth.GitHubClientID = authGitHubClientID
 			conf.RPC.Auth.GitHubClientSecret = authGitHubClientSecret
@@ -263,6 +269,19 @@ func init() {
 		"rpc-key-file",
 		"",
 		"RPC key file's path",
+	)
+	cmd.Flags().DurationVar(
+		&rpcReadHeaderTimeout,
+		"rpc-read-header-timeout",
+		server.DefaultRPCReadHeaderTimeout,
+		"Maximum duration for reading request headers (Slowloris protection)",
+	)
+	cmd.Flags().DurationVar(
+		&rpcIdleTimeout,
+		"rpc-idle-timeout",
+		server.DefaultRPCIdleTimeout,
+		"Maximum duration to wait for the next request on idle keep-alive connections. "+
+			"Should exceed the idle timeout of any fronting load balancer.",
 	)
 	cmd.Flags().IntVar(
 		&conf.Profiling.Port,

--- a/server/config.go
+++ b/server/config.go
@@ -37,8 +37,10 @@ import (
 
 // Below are the values of the default values of Yorkie config.
 const (
-	DefaultRPCPort       = 8080
-	DefaultProfilingPort = 8081
+	DefaultRPCPort              = 8080
+	DefaultRPCReadHeaderTimeout = 5 * time.Second
+	DefaultRPCIdleTimeout       = 2 * time.Minute
+	DefaultProfilingPort        = 8081
 
 	DefaultMembershipLeaseDuration   = 15 * time.Second
 	DefaultMembershipRenewalInterval = 5 * time.Second
@@ -185,6 +187,12 @@ func (c *Config) ensureRPCDefaultValue() {
 	}
 	if c.RPC.Port == 0 {
 		c.RPC.Port = DefaultRPCPort
+	}
+	if c.RPC.ReadHeaderTimeout == "" {
+		c.RPC.ReadHeaderTimeout = DefaultRPCReadHeaderTimeout.String()
+	}
+	if c.RPC.IdleTimeout == "" {
+		c.RPC.IdleTimeout = DefaultRPCIdleTimeout.String()
 	}
 	if c.RPC.Auth.GitHubAuthURL == "" {
 		c.RPC.Auth.GitHubAuthURL = DefaultGitHubAuthURL

--- a/server/config.sample.yml
+++ b/server/config.sample.yml
@@ -9,6 +9,14 @@ RPC:
   # KeyFile is the file containing the TLS private key.
   KeyFile: ""
 
+  # ReadHeaderTimeout is the maximum duration for reading request headers,
+  # protecting against Slowloris attacks (default: "5s").
+  ReadHeaderTimeout: "5s"
+
+  # IdleTimeout is the maximum duration to wait for the next request on idle
+  # keep-alive connections (default: "2m").
+  IdleTimeout: "2m"
+
   # Auth is the configuration of AuthHandler for cookie-based session management.
   Auth:
     # GitHubClientID is GitHub OAuth Client ID.

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -40,6 +40,8 @@ func assertDefaultConfig(t *testing.T, conf *server.Config) {
 	assert.Equal(t, server.DefaultRPCPort, conf.RPC.Port)
 	assert.Equal(t, "", conf.RPC.CertFile)
 	assert.Equal(t, "", conf.RPC.KeyFile)
+	assertDurationEqual(t, server.DefaultRPCReadHeaderTimeout, conf.RPC.ReadHeaderTimeout)
+	assertDurationEqual(t, server.DefaultRPCIdleTimeout, conf.RPC.IdleTimeout)
 
 	assert.Equal(t, server.DefaultGitHubUserURL, conf.RPC.Auth.GitHubUserURL)
 	assert.Equal(t, server.DefaultGitHubDeviceAuthURL, conf.RPC.Auth.GitHubDeviceAuthURL)

--- a/server/packs/pushpull_test.go
+++ b/server/packs/pushpull_test.go
@@ -115,7 +115,9 @@ func TestMain(m *testing.M) {
 
 	testRPCServer, err = rpc.NewServer(
 		&rpc.Config{
-			Port: helper.RPCPort,
+			Port:              helper.RPCPort,
+			ReadHeaderTimeout: helper.RPCReadHeaderTimeout,
+			IdleTimeout:       helper.RPCIdleTimeout,
 		}, testBackend,
 	)
 	if err != nil {

--- a/server/profiling/server.go
+++ b/server/profiling/server.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/pprof"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
@@ -59,9 +60,12 @@ func NewServer(conf *Config, metrics *prometheus.Metrics) *Server {
 	}
 
 	return &Server{
-		conf:       conf,
-		serveMux:   serveMux,
-		httpServer: &http.Server{Addr: fmt.Sprintf(":%d", conf.Port)},
+		conf:     conf,
+		serveMux: serveMux,
+		httpServer: &http.Server{
+			Addr:              fmt.Sprintf(":%d", conf.Port),
+			ReadHeaderTimeout: 5 * time.Second, // Slowloris protection (gosec G112)
+		},
 	}
 }
 

--- a/server/rpc/config.go
+++ b/server/rpc/config.go
@@ -19,6 +19,7 @@ package rpc
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/yorkie-team/yorkie/pkg/errors"
 	"github.com/yorkie-team/yorkie/server/rpc/auth"
@@ -45,6 +46,14 @@ type Config struct {
 	// KeyFile is the path to the key file.
 	KeyFile string `yaml:"KeyFile"`
 
+	// ReadHeaderTimeout is the maximum duration for reading request headers
+	// (Slowloris protection). Default is "5s".
+	ReadHeaderTimeout string `yaml:"ReadHeaderTimeout"`
+
+	// IdleTimeout is the maximum duration to wait for the next request on
+	// idle keep-alive connections. Default is "2m".
+	IdleTimeout string `yaml:"IdleTimeout"`
+
 	// Auth is the configuration for authentication.
 	Auth auth.Config `yaml:"Auth"`
 }
@@ -68,5 +77,47 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	if c.ReadHeaderTimeout != "" {
+		if _, err := time.ParseDuration(c.ReadHeaderTimeout); err != nil {
+			return fmt.Errorf(
+				`invalid argument "%s" for "--rpc-read-header-timeout" flag: %w`,
+				c.ReadHeaderTimeout,
+				err,
+			)
+		}
+	}
+
+	if c.IdleTimeout != "" {
+		if _, err := time.ParseDuration(c.IdleTimeout); err != nil {
+			return fmt.Errorf(
+				`invalid argument "%s" for "--rpc-idle-timeout" flag: %w`,
+				c.IdleTimeout,
+				err,
+			)
+		}
+	}
+
 	return nil
+}
+
+// ParseReadHeaderTimeout returns the timeout for reading request headers.
+func (c *Config) ParseReadHeaderTimeout() time.Duration {
+	result, err := time.ParseDuration(c.ReadHeaderTimeout)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "parse read header timeout: %v\n", err)
+		os.Exit(1)
+	}
+
+	return result
+}
+
+// ParseIdleTimeout returns the timeout for idle keep-alive connections.
+func (c *Config) ParseIdleTimeout() time.Duration {
+	result, err := time.ParseDuration(c.IdleTimeout)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "parse idle timeout: %v\n", err)
+		os.Exit(1)
+	}
+
+	return result
 }

--- a/server/rpc/config.go
+++ b/server/rpc/config.go
@@ -77,47 +77,37 @@ func (c *Config) Validate() error {
 		}
 	}
 
-	if c.ReadHeaderTimeout != "" {
-		if _, err := time.ParseDuration(c.ReadHeaderTimeout); err != nil {
-			return fmt.Errorf(
-				`invalid argument "%s" for "--rpc-read-header-timeout" flag: %w`,
-				c.ReadHeaderTimeout,
-				err,
-			)
-		}
+	if _, err := c.ParseReadHeaderTimeout(); err != nil {
+		return err
 	}
 
-	if c.IdleTimeout != "" {
-		if _, err := time.ParseDuration(c.IdleTimeout); err != nil {
-			return fmt.Errorf(
-				`invalid argument "%s" for "--rpc-idle-timeout" flag: %w`,
-				c.IdleTimeout,
-				err,
-			)
-		}
+	if _, err := c.ParseIdleTimeout(); err != nil {
+		return err
 	}
 
 	return nil
 }
 
 // ParseReadHeaderTimeout returns the timeout for reading request headers.
-func (c *Config) ParseReadHeaderTimeout() time.Duration {
-	result, err := time.ParseDuration(c.ReadHeaderTimeout)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "parse read header timeout: %v\n", err)
-		os.Exit(1)
-	}
-
-	return result
+func (c *Config) ParseReadHeaderTimeout() (time.Duration, error) {
+	return parseTimeout(c.ReadHeaderTimeout, "--rpc-read-header-timeout")
 }
 
 // ParseIdleTimeout returns the timeout for idle keep-alive connections.
-func (c *Config) ParseIdleTimeout() time.Duration {
-	result, err := time.ParseDuration(c.IdleTimeout)
+func (c *Config) ParseIdleTimeout() (time.Duration, error) {
+	return parseTimeout(c.IdleTimeout, "--rpc-idle-timeout")
+}
+
+// parseTimeout parses the given duration string and rejects non-positive
+// values, which would silently disable the timeout.
+func parseTimeout(value, flag string) (time.Duration, error) {
+	result, err := time.ParseDuration(value)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "parse idle timeout: %v\n", err)
-		os.Exit(1)
+		return 0, fmt.Errorf(`invalid argument "%s" for "%s" flag: %w`, value, flag, err)
+	}
+	if result <= 0 {
+		return 0, fmt.Errorf(`invalid argument "%s" for "%s" flag: must be greater than 0`, value, flag)
 	}
 
-	return result
+	return result, nil
 }

--- a/server/rpc/config_test.go
+++ b/server/rpc/config_test.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rpc_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/server/rpc"
+)
+
+func TestConfigValidate(t *testing.T) {
+	validConf := rpc.Config{
+		Port:              11101,
+		ReadHeaderTimeout: "5s",
+		IdleTimeout:       "2m",
+	}
+	assert.NoError(t, validConf.Validate())
+
+	for _, invalid := range []string{"", "0s", "-5s", "5x"} {
+		conf := validConf
+		conf.ReadHeaderTimeout = invalid
+		assert.Error(t, conf.Validate(), "ReadHeaderTimeout=%q", invalid)
+
+		conf = validConf
+		conf.IdleTimeout = invalid
+		assert.Error(t, conf.Validate(), "IdleTimeout=%q", invalid)
+	}
+
+	readHeaderTimeout, err := validConf.ParseReadHeaderTimeout()
+	assert.NoError(t, err)
+	assert.Equal(t, 5*time.Second, readHeaderTimeout)
+
+	idleTimeout, err := validConf.ParseIdleTimeout()
+	assert.NoError(t, err)
+	assert.Equal(t, 2*time.Minute, idleTimeout)
+}

--- a/server/rpc/server.go
+++ b/server/rpc/server.go
@@ -75,6 +75,16 @@ func NewServer(conf *Config, be *backend.Backend) (*Server, error) {
 		v1connect.AdminServiceName,
 	)
 
+	readHeaderTimeout, err := conf.ParseReadHeaderTimeout()
+	if err != nil {
+		return nil, err
+	}
+
+	idleTimeout, err := conf.ParseIdleTimeout()
+	if err != nil {
+		return nil, err
+	}
+
 	yorkieServiceCtx, yorkieServiceCancel := context.WithCancel(context.Background())
 
 	mux := http.NewServeMux()
@@ -86,14 +96,13 @@ func NewServer(conf *Config, be *backend.Backend) (*Server, error) {
 	mux.Handle(httphealth.NewHandler(healthChecker))
 	mux.Handle(mcp.NewHandler(be))
 
-	idleTimeout := conf.ParseIdleTimeout()
 	return &Server{
 		conf: conf,
 		httpServer: &http.Server{
 			Addr: fmt.Sprintf(":%d", conf.Port),
 			// ReadTimeout and WriteTimeout stay unset. They would cut
 			// long-lived streams such as WatchDocument.
-			ReadHeaderTimeout: conf.ParseReadHeaderTimeout(),
+			ReadHeaderTimeout: readHeaderTimeout,
 			IdleTimeout:       idleTimeout,
 			Handler: h2c.NewHandler(newCORS().Handler(mux),
 				&http2.Server{

--- a/server/rpc/server.go
+++ b/server/rpc/server.go
@@ -86,14 +86,21 @@ func NewServer(conf *Config, be *backend.Backend) (*Server, error) {
 	mux.Handle(httphealth.NewHandler(healthChecker))
 	mux.Handle(mcp.NewHandler(be))
 
-	// TODO(hackerwins): We need to provide proper http server configuration.
+	idleTimeout := conf.ParseIdleTimeout()
 	return &Server{
 		conf: conf,
 		httpServer: &http.Server{
 			Addr: fmt.Sprintf(":%d", conf.Port),
+			// ReadTimeout and WriteTimeout stay unset. They would cut
+			// long-lived streams such as WatchDocument.
+			ReadHeaderTimeout: conf.ParseReadHeaderTimeout(),
+			IdleTimeout:       idleTimeout,
 			Handler: h2c.NewHandler(newCORS().Handler(mux),
 				&http2.Server{
 					MaxConcurrentStreams: math.MaxUint32,
+					// http.Server's IdleTimeout does not reach h2c
+					// connections, so it is set here as well.
+					IdleTimeout: idleTimeout,
 				},
 			),
 		},

--- a/server/rpc/server_test.go
+++ b/server/rpc/server_test.go
@@ -254,16 +254,20 @@ func TestConfig_Validate(t *testing.T) {
 		{config: &rpc.Config{Port: 8080, KeyFile: "noSuchKeyFile"}, expected: rpc.ErrInvalidKeyFile},
 		// not to use tls
 		{config: &rpc.Config{
-			Port:     8080,
-			CertFile: "",
-			KeyFile:  "",
+			Port:              8080,
+			CertFile:          "",
+			KeyFile:           "",
+			ReadHeaderTimeout: helper.RPCReadHeaderTimeout,
+			IdleTimeout:       helper.RPCIdleTimeout,
 		},
 			expected: nil},
 		// pass any file existing
 		{config: &rpc.Config{
-			Port:     8080,
-			CertFile: "server_test.go",
-			KeyFile:  "server_test.go",
+			Port:              8080,
+			CertFile:          "server_test.go",
+			KeyFile:           "server_test.go",
+			ReadHeaderTimeout: helper.RPCReadHeaderTimeout,
+			IdleTimeout:       helper.RPCIdleTimeout,
 		},
 			expected: nil},
 	}

--- a/server/rpc/server_test.go
+++ b/server/rpc/server_test.go
@@ -90,7 +90,9 @@ func TestMain(m *testing.M) {
 	}
 
 	testRPCServer, err = rpc.NewServer(&rpc.Config{
-		Port: helper.RPCPort,
+		Port:              helper.RPCPort,
+		ReadHeaderTimeout: helper.RPCReadHeaderTimeout,
+		IdleTimeout:       helper.RPCIdleTimeout,
 	}, be)
 	if err != nil {
 		log.Fatal(err)

--- a/test/complex/main_test.go
+++ b/test/complex/main_test.go
@@ -108,7 +108,9 @@ func TestMain(m *testing.M) {
 	}
 
 	testRPCServer, err = rpc.NewServer(&rpc.Config{
-		Port: helper.RPCPort,
+		Port:              helper.RPCPort,
+		ReadHeaderTimeout: helper.RPCReadHeaderTimeout,
+		IdleTimeout:       helper.RPCIdleTimeout,
 	}, be)
 	if err != nil {
 		log.Fatal(err)

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -66,8 +66,10 @@ var logger *zap.Logger
 
 // Below are the values of the Yorkie config used in the test.
 var (
-	RPCPort       = 11101
-	ProfilingPort = 11102
+	RPCPort              = 11101
+	RPCReadHeaderTimeout = server.DefaultRPCReadHeaderTimeout.String()
+	RPCIdleTimeout       = server.DefaultRPCIdleTimeout.String()
+	ProfilingPort        = 11102
 
 	MembershipLeaseDuration   = "15s"
 	MembershipRenewalInterval = "5s"
@@ -349,7 +351,9 @@ func TestConfig() *server.Config {
 	portOffset += 100
 	return &server.Config{
 		RPC: &rpc.Config{
-			Port: RPCPort + portOffset,
+			Port:              RPCPort + portOffset,
+			ReadHeaderTimeout: RPCReadHeaderTimeout,
+			IdleTimeout:       RPCIdleTimeout,
 		},
 		Profiling: &profiling.Config{
 			Port: ProfilingPort + portOffset,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
**What this PR does / why we need it**:

The RPC `http.Server` in `server/rpc/server.go` was created with only `Addr`
and `Handler`, with `TODO(hackerwins): We need to provide proper http server
configuration.` left since #703. No timeout was set, so a client that never
finishes its request headers or sits idle holds a connection open indefinitely.

This PR sets the two timeouts that cannot affect long-lived streams:

- `ReadHeaderTimeout` (default `5s`): bounds the header-read phase only.
- `IdleTimeout` (default `2m`): closes keep-alive connections with no active
  streams. Also set on the h2c `http2.Server`, since `http.Server`'s idle
  timer does not apply to h2c connections.

`ReadTimeout`/`WriteTimeout` stay unset. They meter the whole request/response
lifecycle and would cut `WatchDocument` streams.

Both values are configurable via `--rpc-read-header-timeout`/`--rpc-idle-timeout`
flags and `RPC.ReadHeaderTimeout`/`RPC.IdleTimeout` in the config file,
following the existing duration-string pattern (`ClusterRPCTimeout`).

The profiling server gets a fixed `5s` `ReadHeaderTimeout`, and the gosec G112
exclusion is removed from `.golangci.yml` so the linter checks future
`http.Server` additions.

**Which issue(s) this PR fixes**:

- N/A

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

**Special notes for your reviewer**:

Deployments behind a load balancer should keep `--rpc-idle-timeout` above the
balancer's idle timeout (the default `2m` exceeds the chart's envoy
`stream_idle_timeout: 60s`).

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Add `--rpc-read-header-timeout` (default 5s) and `--rpc-idle-timeout` (default 2m) flags and matching `RPC.ReadHeaderTimeout`/`RPC.IdleTimeout` config fields to the yorkie server.
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

- N/A

**Checklist**:

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything 	

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable RPC request-header and idle connection timeouts through CLI flags and configuration files.
  * Added default timeout values of 5 seconds for request headers and 2 minutes for idle connections.
  * Added validation for timeout duration settings.

* **Bug Fixes**
  * Added a five-second request-header timeout to the profiling server.
  * Improved protection against slow or idle connections while preserving long-lived RPC streams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->