### PR TITLE
Move tombstones with merge to preserve tree RGA anchors

### DIFF
--- a/docs/design/concurrent-merge-split.md
+++ b/docs/design/concurrent-merge-split.md
@@ -74,6 +74,11 @@ execution and rebuilt from the persisted `MergedFrom` field on
 snapshot load via `rebuildMergeState`. This enables a fast nil-check
 on the hot path without persisting a separate field.
 
+This redirect fires only for a *left-most* position, whose anchor is
+the tombstoned parent itself. A position with a left-sibling anchor
+resolves through the normal path, because the merge moves the sibling
+(live or tombstone) into the target — see §6.1.
+
 ### §1.2 Inverted Range Guard
 
 **Function**: `traverseInPosRange`
@@ -186,6 +191,26 @@ merge-target (`fromParent`). Each moved child receives:
   merge timestamp must be stable for version-vector checks.
 - **`mergedInto`** (runtime cache): set on the source node, pointing
   to the target. Rebuilt from `MergedFrom` on snapshot load.
+
+Both live and **tombstoned** children are moved, in child order
+(`collectBetween` collects them with `Children(true)`). Moving the
+tombstones preserves the source's full RGA sequence in the target, so
+a concurrent insert anchored on a removed sibling (e.g. `c` in a
+`cd → c,d` split whose `c` was deleted) resolves in the target through
+the normal path and is ordered against the other concurrent inserts by
+the RGA `CreatedAt` tie-break (`FindTreeNodesWithSplitText` step 04).
+This is what makes the merging replica converge with a replica that
+applied the insert *before* the merge, including when several clients
+insert at the same anchor.
+
+The relocation uses `index.Node.MoveChild`, which keeps both length
+dimensions correct on **both** parents. A tombstone occupies no visible
+index positions — `remove()` already debited its `VisibleLength` from
+its ancestors — so for a removed node `MoveChild` relocates only the
+include-removed `TotalLength` and leaves `VisibleLength` untouched on
+source and target alike. (Reusing the alive-node `DetachChild`/`Append`
+pair would double-count the tombstone's visible length on the target and
+under-count it on the source.)
 
 ### §6.2 Delete Propagation to Merge-Moved Children
 
@@ -418,3 +443,4 @@ For traceability from git history (commit messages reference Fix N).
 | Fix 16 | §7.3 | Boundary insert migration in SplitElement |
 | Fix 17 | §7.4 | Empty sibling re-parenting in Split |
 | Fix 18 | §3 | Cross-parent range narrowing |
+| Fix 19 | §6.1 | Move tombstones with merge to preserve RGA anchors |

--- a/docs/tasks/active/20260802-tree-insert-into-merged-parent-lessons.md
+++ b/docs/tasks/active/20260802-tree-insert-into-merged-parent-lessons.md
@@ -1,0 +1,30 @@
+# Lessons: converge concurrent insert into a merged parent
+
+**Created**: 2026-08-02
+
+- Fix at the layer where the invariant is actually broken. The visible
+  symptom pointed at position resolution (`FindTreeNodesWithSplitText`),
+  but the real defect was upstream: the merge dropped the RGA anchor.
+  Patching the resolver produced a plausible-but-wrong fix that a code
+  review broke with a two-concurrent-insert case. Moving the fix into
+  the merge (preserve tombstone anchors) let the existing, well-tested
+  RGA path do the ordering — smaller diff, fewer edge cases.
+- The concurrency test harness (`RunTestTreeConcurrency`) `t.Skip`s on
+  divergence instead of failing. A divergence bug can hide as a skipped
+  subtest. Baseline pass/skip/fail counts before a CRDT change and diff
+  them after — a new SKIP is a silent regression.
+- A single-interleaving convergence test is not enough for CRDT work.
+  The first attempt passed the 2-client test but diverged with 3 clients
+  inserting at the same anchor. Add multi-insert and reversed-order cases.
+- Index length accounting: `remove()` subtracts a node's length from its
+  *ancestors* and keeps the node's own `VisibleLength`. So relocating a
+  tombstone with the alive-node `DetachChild`/`Append` pair double-counts
+  its visible length (over-adds on the target, over-subtracts on the
+  source). The first fix only patched the target; a review caught the
+  source side. The right fix is a dedicated `index.Node.MoveChild` that is
+  visible-neutral for removed nodes on both parents (moves only
+  `TotalLength`). Lesson: when a primitive is documented "for alive nodes",
+  don't reuse it on tombstones with a patch — add the correct primitive.
+- Two independent review rounds each killed a wrong-but-plausible fix that
+  passed the current tests. For CRDT convergence work, adversarial review
+  plus multi-client/multi-shape tests are worth more than a green run.

--- a/docs/tasks/active/20260802-tree-insert-into-merged-parent-todo.md
+++ b/docs/tasks/active/20260802-tree-insert-into-merged-parent-todo.md
@@ -1,0 +1,66 @@
+# Tree: converge concurrent insert into a merged (removed) parent
+
+**Created**: 2026-08-02
+
+Fixes yorkie-team/yorkie-js-sdk#1302. Concurrent `Tree.Edit` that inserts
+into a range concurrently removed by a merge diverged between replicas.
+
+## Problem
+
+Initial `<r><p>ab</p><p>cd</p></r>`. Concurrently:
+- A: `edit(6, 6, <p/>)` — insert empty `<p>` between `c` and `d` (inside p2)
+- B: `edit(0, 6)` — remove `<p>ab</p>` + p2 open tag + `c` (p2 becomes a
+  merge boundary; `d` is moved up to `r`)
+
+Replicas diverged:
+- A (insert then remove): `<r><p></p>d</r>` — insert moved up with `d`
+- B (remove then insert): `<r>d</r>` — insert tombstoned
+
+Root cause: the merge left the insert's RGA anchor (`c`) behind as a
+tombstone in the removed parent, so it was not in the merge target. A
+late concurrent insert then targeted the removed parent and Phase 8's
+parent-deletion guard tombstoned it. A first attempt (generalizing the
+`FindTreeNodesWithSplitText` §1.1 redirect to non-leftmost inserts) was
+abandoned: a code review proved it still diverged for multiple
+concurrent inserts at the same anchor, because the redirect returned
+before step 04's RGA `CreatedAt` tie-break.
+
+## Plan
+
+- [x] Reproduce with failing complex tests (RED): single insert AND
+  three-client multi-insert (same-anchor ordering)
+- [x] Fix in the merge, not the redirect: `mergeNodes` moves tombstoned
+  children too (in order), preserving the source RGA sequence in the
+  target so late inserts resolve normally and order via step 04's RGA
+  tie-break
+  - `collectBetween` collects moved children with `Children(true)`
+  - add `index.Node.MoveChild`: a size-correct relocation that is
+    visible-neutral for tombstones on BOTH parents (only `TotalLength`
+    moves for a removed node); replaces the earlier reuse of the
+    alive-node `DetachChild`/`Append` pair with a target-only undo, which
+    a code review showed under-counted the source's `VisibleLength`
+  - guard nil source parent in `mergeNodes` (skip untracked moves)
+  - `FindTreeNodesWithSplitText` reverted to original (left-most redirect
+    only); no change to the shared position resolver
+- [x] Verify convergence (GREEN): single → `<r><p></p>d</r>` on both;
+  multi-insert → `<r><b></b><i></i>d</r>` on all three
+- [x] Two code-review rounds (workflow, high). R1 killed the redirect
+  approach (same-anchor multi-insert divergence). R2 caught the
+  source-side length accounting → fixed with `MoveChild`.
+- [x] Regression: full tree concurrency matrix (1599), integration
+  Tree/GC/Snapshot (169), whole-repo `go test ./...`, crdt unit incl.
+  new element-tombstone accounting test, `gofmt`, `golangci-lint`
+- [ ] Open PR
+- [ ] Port the same fix to yorkie-js-sdk (`packages/sdk/src/document/crdt/tree.ts`)
+
+## Notes
+
+- Final diff: `MoveChild` in the index package + two changes in the merge
+  path + a comment in `FindTreeNodesWithSplitText`. The shared position
+  resolver is untouched, sidestepping the review's `to`-boundary concern.
+- Residual (out of #1302 scope, unconfirmed / pre-existing): chained
+  double-merge `MergedFrom` overwrite; a non-leftmost insert whose anchor
+  was NOT moved because §4.3 skipped its merge; and a separate pre-existing
+  ordering divergence for an insert anchored at the end of merged text.
+- JS mirrors the Go structure; the same divergence reproduces there and
+  needs the same merge change.

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -1199,24 +1199,27 @@ func (t *Tree) mergeNodes(
 	editedAt *time.Ticket,
 ) error {
 	for _, node := range toBeMovedToFromParents {
-		if node.removedAt == nil {
-			// Record source parent and merge ticket on the moved child.
-			// Both fields are persisted; MergedAt must be stored
-			// explicitly because source.removedAt can be overwritten
-			// by later concurrent deletes (LWW).
-			if node.Index.Parent != nil {
-				node.MergedFrom = node.Index.Parent.Value.id
-				node.MergedAt = editedAt
-			}
-			// Detach from old parent to prevent ghost references.
-			if node.Index.Parent != nil {
-				if err := node.Index.Parent.DetachChild(node.Index); err != nil {
-					return err
-				}
-			}
-			if err := fromParent.Append(node); err != nil {
-				return err
-			}
+		// A moved child must have a source parent to record; skip
+		// otherwise rather than append an untracked node (a node without
+		// MergedFrom is invisible to propagateMergeDeletes and
+		// rebuildMergeState).
+		if node.Index.Parent == nil {
+			continue
+		}
+		// Record source parent and merge ticket on the moved child.
+		// Both fields are persisted; MergedAt must be stored explicitly
+		// because source.removedAt can be overwritten by later concurrent
+		// deletes (LWW). Tombstoned children are moved too (kept removed):
+		// they stay as RGA anchors so a concurrent insert referencing one
+		// resolves in the merge target and orders via the RGA tie-break,
+		// converging with the replica that inserted before the merge.
+		// MoveChild relocates the node with correct length accounting for
+		// both live and tombstoned children (visible-neutral for the
+		// latter), so index positions stay correct on both parents.
+		node.MergedFrom = node.Index.Parent.Value.id
+		node.MergedAt = editedAt
+		if err := fromParent.Index.MoveChild(node.Index); err != nil {
+			return err
 		}
 	}
 	// Set forwarding pointer on merge-source nodes.
@@ -1329,7 +1332,11 @@ func (t *Tree) collectBetween(
 				// artifact of a concurrent split, not an intentional merge.
 				if ticketKnown(versionVector, node.id.CreatedAt) {
 					toBeMergedNodes = append(toBeMergedNodes, node)
-					for _, child := range node.Index.Children() {
+					// Include removed children (Children(true)) so tombstones
+					// move with the merge and survive as RGA anchors; a
+					// concurrent insert referencing one then resolves in the
+					// merge target and orders via the RGA tie-break.
+					for _, child := range node.Index.Children(true) {
 						toBeMovedToFromParents = append(toBeMovedToFromParents, child.Value)
 					}
 				}
@@ -1833,10 +1840,13 @@ func (t *Tree) FindTreeNodesWithSplitText(pos *TreePos, editedAt *time.Ticket) (
 	}
 
 	// 02-1. If the parent has been tombstoned by a merge, redirect to the
-	// merge destination using the forwarding pointer. The insertion
-	// boundary is the first child in the target whose MergedFrom points
-	// back at the tombstoned parent (i.e. the first child moved by the
-	// merge, in target child order).
+	// merge destination using the forwarding pointer. The merge moved the
+	// parent's children (including tombstones) here, so a left-sibling
+	// anchor already resolves in the target via the normal path; only a
+	// left-most position still points at the emptied tombstone. The
+	// insertion boundary is the first child in the target whose MergedFrom
+	// points back at the tombstoned parent (i.e. the first child moved by
+	// the merge, in target child order).
 	if realParentNode.IsRemoved() && isLeftMost && realParentNode.mergedInto != nil {
 		mergeTarget := t.findFloorNode(realParentNode.mergedInto)
 		if mergeTarget != nil && !mergeTarget.IsRemoved() {

--- a/pkg/document/crdt/tree_test.go
+++ b/pkg/document/crdt/tree_test.go
@@ -369,6 +369,44 @@ func TestTreeEdit(t *testing.T) {
 		assert.Equal(t, "<root><p>@ad</p></root>", tree.ToXML())
 	})
 
+	t.Run("merge moves an element tombstone with correct length accounting", func(t *testing.T) {
+		// 01. Create <root><p>ab</p><p><b></b>cd</p></root>.
+		//       0   1 2 3    4   5   6    7 8 9    10
+		// <root> <p> a b </p> <p> <b> </b> c d </p>  </root>
+		ctx := helper.TextChangeContext(helper.TestRoot())
+		tree := crdt.NewTree(crdt.NewTreeNode(helper.PosT(ctx), "root", nil), helper.TimeT(ctx))
+		_, _, err := tree.EditT(0, 0, []*crdt.TreeNode{crdt.NewTreeNode(helper.PosT(ctx), "p", nil)}, 0,
+			helper.TimeT(ctx), issueTicket(ctx))
+		assert.NoError(t, err)
+		_, _, err = tree.EditT(1, 1, []*crdt.TreeNode{
+			crdt.NewTreeNode(helper.PosT(ctx), "text", nil, "ab"),
+		}, 0, helper.TimeT(ctx), issueTicket(ctx))
+		assert.NoError(t, err)
+		_, _, err = tree.EditT(4, 4, []*crdt.TreeNode{crdt.NewTreeNode(helper.PosT(ctx), "p", nil)}, 0,
+			helper.TimeT(ctx), issueTicket(ctx))
+		assert.NoError(t, err)
+		_, _, err = tree.EditT(5, 5, []*crdt.TreeNode{crdt.NewTreeNode(helper.PosT(ctx), "b", nil)}, 0,
+			helper.TimeT(ctx), issueTicket(ctx))
+		assert.NoError(t, err)
+		_, _, err = tree.EditT(7, 7, []*crdt.TreeNode{
+			crdt.NewTreeNode(helper.PosT(ctx), "text", nil, "cd"),
+		}, 0, helper.TimeT(ctx), issueTicket(ctx))
+		assert.NoError(t, err)
+		assert.Equal(t, "<root><p>ab</p><p><b></b>cd</p></root>", tree.ToXML())
+
+		// 02. Delete b, the second paragraph's open tag, the <b></b>
+		// element and c, merging the paragraph. The <b></b> element becomes
+		// a tombstone moved into the first paragraph. Its padding must not
+		// inflate the visible length of the (surviving) first paragraph.
+		_, _, err = tree.EditT(2, 8, nil, 0, helper.TimeT(ctx), issueTicket(ctx))
+		assert.NoError(t, err)
+		assert.Equal(t, "<root><p>ad</p></root>", tree.ToXML())
+
+		node := tree.ToTreeNodeForTest()
+		assert.Equal(t, 4, node.Size)
+		assert.Equal(t, 2, node.Children[0].Size)
+	})
+
 	t.Run("delete nodes between element nodes in different levels test", func(t *testing.T) {
 		// 01. Create a tree with 2 paragraphs.
 		//       0   1   2 3 4    5    6   7 8 9    10

--- a/pkg/index/tree.go
+++ b/pkg/index/tree.go
@@ -650,6 +650,53 @@ func (n *Node[V]) DetachChild(child *Node[V]) error {
 	return nil
 }
 
+// MoveChild detaches the given child from its current parent (if any) and
+// appends it to this node, preserving both length dimensions on both
+// parents. Unlike DetachChild followed by Append, it is correct for
+// tombstoned children: a removed node contributes no VisibleLength to
+// either parent (remove() already excluded it from its ancestors), so only
+// the include-removed TotalLength is relocated. It is used by merge to move
+// tombstones as RGA anchors without corrupting index positions.
+func (n *Node[V]) MoveChild(child *Node[V]) error {
+	if n.IsText() {
+		return ErrInvalidMethodCallForTextNode
+	}
+
+	removed := child.Value.IsRemoved()
+
+	if child.Parent != nil {
+		offset := -1
+		for i, c := range child.Parent.children {
+			if c == child {
+				offset = i
+				break
+			}
+		}
+		if offset == -1 {
+			return ErrChildNotFound
+		}
+
+		child.Parent.children = append(
+			child.Parent.children[:offset],
+			child.Parent.children[offset+1:]...,
+		)
+		if !removed {
+			child.UpdateAncestorsLength(-(child.PaddedLength()))
+		}
+		child.UpdateAncestorsLength(-(child.PaddedLength(true)), true)
+		child.Parent = nil
+	}
+
+	n.children = append(n.children, child)
+	child.Parent = n
+	if !removed {
+		child.UpdateAncestorsLength(child.PaddedLength())
+	}
+	child.UpdateAncestorsLength(child.PaddedLength(true), true)
+
+	return nil
+}
+
 // InsertBefore inserts the given node before the given child.
 func (n *Node[V]) InsertBefore(newNode, referenceNode *Node[V]) error {
 	if n.IsText() {

--- a/test/complex/tree_concurrency_test.go
+++ b/test/complex/tree_concurrency_test.go
@@ -526,3 +526,98 @@ func TestTreeConcurrencyEditStyle(t *testing.T) {
 
 	RunTestTreeConcurrency("concurrently-edit-style-test", t, initialState, initialXML, ranges, editOperations, styleOperations)
 }
+
+// TestTreeConcurrencyInsertIntoRemovedRange reproduces issue #1302:
+// a concurrent Tree.Edit that inserts into a range concurrently removed
+// by a merge must converge on both replicas.
+func TestTreeConcurrencyInsertIntoRemovedRange(t *testing.T) {
+	clients := activeClients(t, 2)
+	c1, c2 := clients[0], clients[1]
+	defer deactivateAndCloseClients(t, clients)
+
+	ctx := context.Background()
+	d1 := document.New(helper.TestKey(t))
+	assert.NoError(t, c1.Attach(ctx, d1))
+	d2 := document.New(helper.TestKey(t))
+	assert.NoError(t, c2.Attach(ctx, d2))
+
+	initialState := json.TreeNode{
+		Type: "r",
+		Children: []json.TreeNode{
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "ab"}}},
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "cd"}}},
+		},
+	}
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.SetNewTree("t", initialState)
+		return nil
+	}))
+	assert.NoError(t, c1.Sync(ctx))
+	assert.NoError(t, c2.Sync(ctx))
+	assert.Equal(t, `<r><p>ab</p><p>cd</p></r>`, d1.Root().GetTree("t").ToXML())
+	assert.Equal(t, `<r><p>ab</p><p>cd</p></r>`, d2.Root().GetTree("t").ToXML())
+
+	// c1 inserts an empty <p> at index 6 (inside the 2nd paragraph,
+	// between 'c' and 'd'); c2 removes range [0,6).
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(6, 6, &json.TreeNode{Type: "p"}, 0)
+		return nil
+	}))
+	assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(0, 6, nil, 0)
+		return nil
+	}))
+
+	flag := syncClientsThenCheckEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
+	assert.True(t, flag, "d1: %s\nd2: %s",
+		d1.Root().GetTree("t").ToXML(), d2.Root().GetTree("t").ToXML())
+}
+
+// TestTreeConcurrencyInsertIntoRemovedRangeMultiInsert probes whether two
+// concurrent inserts at the same index inside a concurrently-removed range
+// converge across all three replicas (issue #1302, multi-insert variant).
+func TestTreeConcurrencyInsertIntoRemovedRangeMultiInsert(t *testing.T) {
+	clients := activeClients(t, 3)
+	c1, c2, c3 := clients[0], clients[1], clients[2]
+	defer deactivateAndCloseClients(t, clients)
+
+	ctx := context.Background()
+	d1 := document.New(helper.TestKey(t))
+	assert.NoError(t, c1.Attach(ctx, d1))
+	d2 := document.New(helper.TestKey(t))
+	assert.NoError(t, c2.Attach(ctx, d2))
+	d3 := document.New(helper.TestKey(t))
+	assert.NoError(t, c3.Attach(ctx, d3))
+
+	initialState := json.TreeNode{
+		Type: "r",
+		Children: []json.TreeNode{
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "ab"}}},
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "cd"}}},
+		},
+	}
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.SetNewTree("t", initialState)
+		return nil
+	}))
+	assert.NoError(t, c1.Sync(ctx))
+	assert.NoError(t, c2.Sync(ctx))
+	assert.NoError(t, c3.Sync(ctx))
+
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(6, 6, &json.TreeNode{Type: "i"}, 0)
+		return nil
+	}))
+	assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(6, 6, &json.TreeNode{Type: "b"}, 0)
+		return nil
+	}))
+	assert.NoError(t, d3.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(0, 6, nil, 0)
+		return nil
+	}))
+
+	flag := syncClientsThenCheckEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}, {c3, d3}})
+	assert.True(t, flag, "d1: %s\nd2: %s\nd3: %s",
+		d1.Root().GetTree("t").ToXML(), d2.Root().GetTree("t").ToXML(), d3.Root().GetTree("t").ToXML())
+}


### PR DESCRIPTION
## Summary

A concurrent `Tree.Edit` that inserts into a range concurrently removed by a
merge diverged between replicas (yorkie-team/yorkie-js-sdk#1302).

Starting from `<r><p>ab</p><p>cd</p></r>`, with client A inserting an empty
`<p>` at index 6 and client B removing `[0,6)`:

- A (insert then remove): `<r><p></p>d</r>`
- B (remove then insert): `<r>d</r>` — the inserted node is dropped

**Root cause:** the merge moved only the *live* children of the merged
paragraph to the target and left the insert's RGA anchor (`c`) behind as a
tombstone in the removed parent. A late concurrent insert then resolved
against the removed parent and was tombstoned by the insert guard. With
several clients inserting at the same anchor, even the survivors ordered
inconsistently, because the merging replica never ran the RGA `CreatedAt`
tie-break for them.

**Fix (in the merge, not the resolver):** move tombstoned children with the
merge too, in child order, so the source's full RGA sequence is preserved in
the target. A late insert then resolves in the target through the normal
path and is ordered by the existing step-04 RGA tie-break, converging with
the replica that applied the insert before the merge — including the
multi-client same-anchor case.

The relocation uses a new `index.Node.MoveChild` that keeps both length
dimensions correct on both parents: a tombstone occupies no visible index
positions, so only `TotalLength` moves for a removed node and `VisibleLength`
is left untouched on source and target alike. (Reusing the alive-node
`DetachChild`/`Append` pair double-counts a tombstone's visible length.)
`FindTreeNodesWithSplitText` is unchanged (comment only); the shared position
resolver is not touched.

Design: `docs/design/concurrent-merge-split.md` §6.1 (Fix 19).
Fixes #1904

## Test plan

- New complex convergence tests (all converge):
  - `TestTreeConcurrencyInsertIntoRemovedRange` — the filed 2-client case
  - `TestTreeConcurrencyInsertIntoRemovedRangeMultiInsert` — three clients,
    two inserts at the same anchor into the removed range
- New unit test `TestTreeEdit/merge moves an element tombstone with correct
  length accounting` — guards the element-padding accounting of the move
- Regression (all green, no new skips/failures):
  - `go test -tags complex ./test/complex/ -run TestTreeConcurrency` — 1599 pass
  - `go test -tags integration ./test/integration/ -run 'Tree|GC|Snapshot'` — 169 pass
  - `go test ./...` — whole-repo unit tests pass
  - `gofmt` clean, `golangci-lint` 0 issues

## Follow-up

- Port the same merge change to `yorkie-js-sdk`
  (`packages/sdk/src/document/crdt/tree.ts`), which mirrors this structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved convergence for concurrent inserts into paragraphs removed during merges.
  * Preserved ordering and placement of nested content, including deleted content, during paragraph merges.
  * Corrected visible and structural length tracking when moving content between merged paragraphs.

* **Tests**
  * Added regression coverage for two- and three-replica concurrent editing scenarios.
  * Added coverage for preserving deleted nested elements during merges.

* **Documentation**
  * Documented merge behavior, ordering guarantees, troubleshooting lessons, and follow-up tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->