### PR TITLE
Keep style ranges from crossing a concurrent merge anchor

### DIFF
--- a/docs/design/concurrent-merge-split.md
+++ b/docs/design/concurrent-merge-split.md
@@ -419,6 +419,30 @@ attribute deep-copy in §7.2 — causing divergence.
 Helper: `ticketKnown(vv, ticket)` — reused for the unknown-sibling
 check.
 
+### §9.3 Range Boundary at Merged-Away Anchors
+
+A style position anchored at the left-most position inside a parent
+that a concurrent merge removed must not resolve to the insertion
+boundary of §1.1. The insertion boundary sits before the first child
+moved by the merge, so nodes concurrently inserted between the
+merge-source tombstone and the moved children fall inside the styled
+range on the applying replica — while the styling replica saw them
+outside its range, after the then-live parent. Replicas then diverge
+on attributes.
+
+`FindTreeNodesWithSplitText` takes a boundary mode: `BoundaryInsert`
+(default, §1.1 behavior for edits) and `BoundaryRange`, used by
+`Style`/`RemoveStyle`, which resolves the position to right after the
+merge-source tombstone. In visible coordinates this lands before both
+the concurrent inserts and the moved children, so a range end excludes
+them and a range start includes them — matching the styling replica in
+both directions. Ranges that genuinely cover the merged content
+(anchored outside the merged parent) are unaffected.
+
+A range end anchored after a moved child (a non-left-most position in
+the merged parent) does not go through the §1.1 redirect and can still
+diverge; this remains a follow-up.
+
 ## Key Design Decisions
 
 | Decision | Reason |
@@ -496,3 +520,4 @@ For traceability from git history (commit messages reference Fix N).
 | Fix 18 | §3 | Cross-parent range narrowing |
 | Fix 19 | §6.1 | Move tombstones with merge to preserve RGA anchors |
 | Fix 20 | §6.3 | Flatten chained merge (P→Q→R) for redirect + snapshot consistency |
+| Fix 21 | §9.3 | Style range boundary right after merge-source tombstone |

--- a/docs/tasks/active/20260803-tree-style-merge-anchor-lessons.md
+++ b/docs/tasks/active/20260803-tree-style-merge-anchor-lessons.md
@@ -1,0 +1,17 @@
+# Lessons: tree style merge-anchor boundary
+
+**Created**: 2026-08-03
+
+- The §1.1 insertion-boundary redirect is correct for inserts (RGA
+  tie-break needs the position before the first moved child) but wrong
+  for range boundaries: one position semantics cannot serve both, so
+  the resolver takes an explicit boundary mode.
+- The "right after the merge-source tombstone" position fixes both
+  range directions at once: in visible coordinates it lands before the
+  concurrent inserts and the moved children, so a range end excludes
+  them and a range start includes them, matching the styling replica.
+- Property-based testing surfaced this within one run of the pinned
+  seed after Fix 19/20 landed — the shrunk counterexample was three
+  operations. Convergence work benefits from keeping the PBT running
+  after every fix; the next shrink immediately exposed the non-left-most
+  variant (range end anchored after a moved child), now the follow-up.

--- a/docs/tasks/active/20260803-tree-style-merge-anchor-todo.md
+++ b/docs/tasks/active/20260803-tree-style-merge-anchor-todo.md
@@ -1,0 +1,48 @@
+# Tree: keep style ranges from crossing a concurrent merge anchor
+
+**Created**: 2026-08-03
+
+Concurrent `Tree.Style`/`Tree.RemoveStyle` whose range ends inside an
+element removed by a concurrent merge styled a node concurrently
+inserted at the merged anchor on the applying replica — replicas
+diverged on attributes. Found by the property-based Tree test for
+yorkie-team/yorkie-js-sdk#1298 right after Fix 19/20 landed.
+
+## Problem
+
+Initial `<r><p>ab</p><p>cd</p></r>`. Concurrently:
+- A: `edit(8, 8, <p/>)` — insert empty `<p>` after p2, then
+  `style(0, 5, bold=x)` — range ends inside p2; the inserted `<p>` is
+  outside the styled range on A's view
+- B: `edit(0, 5)` — remove `<p>ab</p>` + p2 open tag (merge)
+
+Replicas diverged:
+- A: surviving inserted `<p>` unstyled
+- B: the same `<p>` got `bold="x"` — the §1.1 insertion-boundary
+  redirect resolved the style range end past it
+
+## Plan
+
+- [x] Reproduce with failing complex tests (RED): style, removeStyle
+- [x] Add `BoundaryRange` mode to `FindTreeNodesWithSplitText`; use it
+      from `Style`/`RemoveStyle` (position right after the merge-source
+      tombstone)
+- [x] Keep `BoundaryInsert` (§1.1) for edits
+- [x] Positive case: range genuinely covering the merged content still
+      styles it
+- [x] Chained-merge case (p3 into p2, then p2 into p1) asserting the
+      exact converged value
+- [x] Unit test pinning the boundary indexes for both modes
+      (`FindTreeNodesWithSplitText` insert vs range)
+- [x] Design doc §9.3 + Fix 21 row
+- [x] `golangci-lint run ./...` 0 issues; unit/complex/integration tree
+      lanes green
+- [x] Mirror in yorkie-js-sdk (same fix, `findNodesAndSplitText`
+      `boundary` param)
+
+## Out of scope
+
+A range end anchored after a moved child (non-left-most position in
+the merged parent) does not go through the §1.1 redirect and still
+diverges — needs a per-node guard during traversal; tracked as
+follow-up.

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -1683,11 +1683,11 @@ func (t *Tree) Style(
 ) ([]GCPair, resource.DataSize, error) {
 	var diff resource.DataSize
 
-	fromParent, fromLeft, diffFrom, err := t.FindTreeNodesWithSplitText(from, editedAt)
+	fromParent, fromLeft, diffFrom, err := t.FindTreeNodesWithSplitText(from, editedAt, BoundaryRange)
 	if err != nil {
 		return t.drainPendingGCPairs(), diff, err
 	}
-	toParent, toLeft, diffTo, err := t.FindTreeNodesWithSplitText(to, editedAt)
+	toParent, toLeft, diffTo, err := t.FindTreeNodesWithSplitText(to, editedAt, BoundaryRange)
 	if err != nil {
 		diff.Add(diffFrom)
 		return t.drainPendingGCPairs(), diff, err
@@ -1791,11 +1791,11 @@ func (t *Tree) RemoveStyle(
 ) ([]GCPair, resource.DataSize, error) {
 	var diff resource.DataSize
 
-	fromParent, fromLeft, diffFrom, err := t.FindTreeNodesWithSplitText(from, editedAt)
+	fromParent, fromLeft, diffFrom, err := t.FindTreeNodesWithSplitText(from, editedAt, BoundaryRange)
 	if err != nil {
 		return t.drainPendingGCPairs(), diff, err
 	}
-	toParent, toLeft, diffTo, err := t.FindTreeNodesWithSplitText(to, editedAt)
+	toParent, toLeft, diffTo, err := t.FindTreeNodesWithSplitText(to, editedAt, BoundaryRange)
 	if err != nil {
 		diff.Add(diffFrom)
 		return t.drainPendingGCPairs(), diff, err
@@ -1883,14 +1883,37 @@ func (t *Tree) RemoveStyle(
 	return pairs, diff, nil
 }
 
+// PosBoundary selects how a position inside a merged-away parent resolves
+// in FindTreeNodesWithSplitText.
+type PosBoundary int
+
+const (
+	// BoundaryInsert places the position at the insertion boundary in the
+	// merge target (before the first moved child), so RGA ordering breaks
+	// ties between concurrent inserts at the same anchor.
+	BoundaryInsert PosBoundary = iota
+
+	// BoundaryRange places the position right after the merge-source
+	// tombstone, so a style range neither grows over nor shrinks past
+	// nodes concurrently inserted at that anchor.
+	BoundaryRange
+)
+
 // FindTreeNodesWithSplitText finds TreeNode of the given crdt.TreePos and
 // splits the text node if the position is in the middle of the text node.
 // crdt.TreePos is a position in the CRDT perspective. This is different
 // from indexTree.TreePos which is a position of the tree in physical
 // perspective.
-func (t *Tree) FindTreeNodesWithSplitText(pos *TreePos, editedAt *time.Ticket) (
+// The optional boundary selects how a position inside a merged-away parent
+// resolves; it defaults to BoundaryInsert.
+func (t *Tree) FindTreeNodesWithSplitText(pos *TreePos, editedAt *time.Ticket, boundary ...PosBoundary) (
 	*TreeNode, *TreeNode, resource.DataSize, error,
 ) {
+	mode := BoundaryInsert
+	if len(boundary) > 0 {
+		mode = boundary[0]
+	}
+
 	var diff resource.DataSize
 	// 01. Find the parent and left sibling nodes of the given position.
 	parentNode, leftNode := t.ToTreeNodes(pos)
@@ -1915,6 +1938,16 @@ func (t *Tree) FindTreeNodesWithSplitText(pos *TreePos, editedAt *time.Ticket) (
 	// points back at the tombstoned parent (i.e. the first child moved by
 	// the merge, in target child order).
 	if realParentNode.IsRemoved() && isLeftMost && realParentNode.mergedInto != nil {
+		// §9.3 Range Boundary at Merged-Away Anchors: a range boundary
+		// resolves to the position right after the merge-source tombstone,
+		// not the insertion boundary below. The insertion boundary sits
+		// before the first moved child, so it would extend a style range
+		// over nodes concurrently inserted between the tombstone and the
+		// moved children — nodes the styling client saw outside its range
+		// (after the then-live parent).
+		if mode == BoundaryRange && realParentNode.Index.Parent != nil {
+			return realParentNode.Index.Parent.Value, realParentNode, diff, nil
+		}
 		mergeTarget := t.findFloorNode(realParentNode.mergedInto)
 		if mergeTarget != nil && !mergeTarget.IsRemoved() {
 			targetChildren := mergeTarget.Index.Children(true)

--- a/pkg/document/crdt/tree_test.go
+++ b/pkg/document/crdt/tree_test.go
@@ -407,6 +407,53 @@ func TestTreeEdit(t *testing.T) {
 		assert.Equal(t, 2, node.Children[0].Size)
 	})
 
+	t.Run("resolves a range boundary right after the merge-source tombstone", func(t *testing.T) {
+		// 01. Create <root><p>ab</p><p>cd</p></root>.
+		//       0   1 2 3    4   5 6 7     8
+		// <root> <p> a b </p> <p> c d </p>  </root>
+		ctx := helper.TextChangeContext(helper.TestRoot())
+		tree := crdt.NewTree(crdt.NewTreeNode(helper.PosT(ctx), "root", nil), helper.TimeT(ctx))
+		_, _, err := tree.EditT(0, 0, []*crdt.TreeNode{crdt.NewTreeNode(helper.PosT(ctx), "p", nil)}, 0,
+			helper.TimeT(ctx), issueTicket(ctx))
+		assert.NoError(t, err)
+		_, _, err = tree.EditT(1, 1, []*crdt.TreeNode{
+			crdt.NewTreeNode(helper.PosT(ctx), "text", nil, "ab"),
+		}, 0, helper.TimeT(ctx), issueTicket(ctx))
+		assert.NoError(t, err)
+		p2Node := crdt.NewTreeNode(helper.PosT(ctx), "p", nil)
+		_, _, err = tree.EditT(4, 4, []*crdt.TreeNode{p2Node}, 0, helper.TimeT(ctx), issueTicket(ctx))
+		assert.NoError(t, err)
+		_, _, err = tree.EditT(5, 5, []*crdt.TreeNode{
+			crdt.NewTreeNode(helper.PosT(ctx), "text", nil, "cd"),
+		}, 0, helper.TimeT(ctx), issueTicket(ctx))
+		assert.NoError(t, err)
+		assert.Equal(t, "<root><p>ab</p><p>cd</p></root>", tree.ToXML())
+
+		// 02. Capture the leftmost position inside the second paragraph,
+		// then merge the second paragraph into the first.
+		pos := crdt.NewTreePos(p2Node.ID(), p2Node.ID())
+		_, _, err = tree.EditT(3, 5, nil, 0, helper.TimeT(ctx), issueTicket(ctx))
+		assert.NoError(t, err)
+		assert.Equal(t, "<root><p>abcd</p></root>", tree.ToXML())
+
+		// 03. An insert boundary resolves into the merge target before the
+		// moved children, while a range boundary resolves right after the
+		// merge-source tombstone, leaving the moved children outside.
+		insertParent, insertLeft, _, err := tree.FindTreeNodesWithSplitText(pos, helper.TimeT(ctx))
+		assert.NoError(t, err)
+		idx, err := tree.ToIndex(insertParent, insertLeft)
+		assert.NoError(t, err)
+		assert.Equal(t, 3, idx)
+
+		rangeParent, rangeLeft, _, err := tree.FindTreeNodesWithSplitText(
+			pos, helper.TimeT(ctx), crdt.BoundaryRange)
+		assert.NoError(t, err)
+		assert.True(t, rangeLeft.IsRemoved())
+		idx, err = tree.ToIndex(rangeParent, rangeLeft)
+		assert.NoError(t, err)
+		assert.Equal(t, 6, idx)
+	})
+
 	t.Run("delete nodes between element nodes in different levels test", func(t *testing.T) {
 		// 01. Create a tree with 2 paragraphs.
 		//       0   1   2 3 4    5    6   7 8 9    10

--- a/test/complex/tree_concurrency_test.go
+++ b/test/complex/tree_concurrency_test.go
@@ -621,3 +621,196 @@ func TestTreeConcurrencyInsertIntoRemovedRangeMultiInsert(t *testing.T) {
 	assert.True(t, flag, "d1: %s\nd2: %s\nd3: %s",
 		d1.Root().GetTree("t").ToXML(), d2.Root().GetTree("t").ToXML(), d3.Root().GetTree("t").ToXML())
 }
+
+// TestTreeConcurrencyStyleAcrossMergedAnchor verifies that a concurrent
+// Tree.Style whose range ends inside a merge-removed paragraph does not
+// style a node concurrently inserted at the merged anchor.
+func TestTreeConcurrencyStyleAcrossMergedAnchor(t *testing.T) {
+	clients := activeClients(t, 2)
+	c1, c2 := clients[0], clients[1]
+	defer deactivateAndCloseClients(t, clients)
+
+	ctx := context.Background()
+	d1 := document.New(helper.TestKey(t))
+	assert.NoError(t, c1.Attach(ctx, d1))
+	d2 := document.New(helper.TestKey(t))
+	assert.NoError(t, c2.Attach(ctx, d2))
+
+	initialState := json.TreeNode{
+		Type: "r",
+		Children: []json.TreeNode{
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "ab"}}},
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "cd"}}},
+		},
+	}
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.SetNewTree("t", initialState)
+		return nil
+	}))
+	assert.NoError(t, c1.Sync(ctx))
+	assert.NoError(t, c2.Sync(ctx))
+
+	// c1 inserts an empty <p> after the second paragraph, then styles a
+	// range ending inside the second paragraph; the inserted <p> is outside
+	// the styled range on c1's view. c2 concurrently removes [0,5),
+	// merging across the paragraphs.
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(8, 8, &json.TreeNode{Type: "p"}, 0)
+		return nil
+	}))
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Style(0, 5, map[string]string{"bold": "x"})
+		return nil
+	}))
+	assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(0, 5, nil, 0)
+		return nil
+	}))
+
+	flag := syncClientsThenCheckEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
+	assert.True(t, flag, "d1: %s\nd2: %s",
+		d1.Root().GetTree("t").ToXML(), d2.Root().GetTree("t").ToXML())
+}
+
+// TestTreeConcurrencyRemoveStyleAcrossMergedAnchor is the RemoveStyle
+// variant: it must not leave an attribute container on a node concurrently
+// inserted at the merged anchor.
+func TestTreeConcurrencyRemoveStyleAcrossMergedAnchor(t *testing.T) {
+	clients := activeClients(t, 2)
+	c1, c2 := clients[0], clients[1]
+	defer deactivateAndCloseClients(t, clients)
+
+	ctx := context.Background()
+	d1 := document.New(helper.TestKey(t))
+	assert.NoError(t, c1.Attach(ctx, d1))
+	d2 := document.New(helper.TestKey(t))
+	assert.NoError(t, c2.Attach(ctx, d2))
+
+	initialState := json.TreeNode{
+		Type: "r",
+		Children: []json.TreeNode{
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "ab"}}},
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "cd"}}},
+		},
+	}
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.SetNewTree("t", initialState)
+		return nil
+	}))
+	assert.NoError(t, c1.Sync(ctx))
+	assert.NoError(t, c2.Sync(ctx))
+
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(8, 8, &json.TreeNode{Type: "p"}, 0)
+		return nil
+	}))
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").RemoveStyle(0, 5, []string{"bold"})
+		return nil
+	}))
+	assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(0, 5, nil, 0)
+		return nil
+	}))
+
+	flag := syncClientsThenCheckEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
+	assert.True(t, flag, "d1: %s\nd2: %s",
+		d1.Root().GetTree("t").ToXML(), d2.Root().GetTree("t").ToXML())
+}
+
+// TestTreeConcurrencyStyleCoveringMergedContent verifies the style still
+// lands when the range genuinely covers the merged paragraph.
+func TestTreeConcurrencyStyleCoveringMergedContent(t *testing.T) {
+	clients := activeClients(t, 2)
+	c1, c2 := clients[0], clients[1]
+	defer deactivateAndCloseClients(t, clients)
+
+	ctx := context.Background()
+	d1 := document.New(helper.TestKey(t))
+	assert.NoError(t, c1.Attach(ctx, d1))
+	d2 := document.New(helper.TestKey(t))
+	assert.NoError(t, c2.Attach(ctx, d2))
+
+	initialState := json.TreeNode{
+		Type: "r",
+		Children: []json.TreeNode{
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "ab"}}},
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "cd"}}},
+		},
+	}
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.SetNewTree("t", initialState)
+		return nil
+	}))
+	assert.NoError(t, c1.Sync(ctx))
+	assert.NoError(t, c2.Sync(ctx))
+
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Style(4, 8, map[string]string{"bold": "x"})
+		return nil
+	}))
+	assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(0, 4, nil, 0)
+		return nil
+	}))
+
+	flag := syncClientsThenCheckEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
+	assert.True(t, flag, "d1: %s\nd2: %s",
+		d1.Root().GetTree("t").ToXML(), d2.Root().GetTree("t").ToXML())
+	assert.Equal(t, `<r><p bold="x">cd</p></r>`, d1.Root().GetTree("t").ToXML())
+}
+
+// TestTreeConcurrencyStyleAcrossChainedMerge verifies the style range
+// boundary also converges when its anchor parent was chain-merged
+// (p3 into p2, then p2 into p1 - the merge target itself removed).
+func TestTreeConcurrencyStyleAcrossChainedMerge(t *testing.T) {
+	clients := activeClients(t, 2)
+	c1, c2 := clients[0], clients[1]
+	defer deactivateAndCloseClients(t, clients)
+
+	ctx := context.Background()
+	d1 := document.New(helper.TestKey(t))
+	assert.NoError(t, c1.Attach(ctx, d1))
+	d2 := document.New(helper.TestKey(t))
+	assert.NoError(t, c2.Attach(ctx, d2))
+
+	initialState := json.TreeNode{
+		Type: "r",
+		Children: []json.TreeNode{
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "ab"}}},
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "cd"}}},
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "ef"}}},
+		},
+	}
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.SetNewTree("t", initialState)
+		return nil
+	}))
+	assert.NoError(t, c1.Sync(ctx))
+	assert.NoError(t, c2.Sync(ctx))
+
+	// d1: insert an empty <p> at the end, then style a range ending at the
+	// leftmost position inside the third paragraph.
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(12, 12, &json.TreeNode{Type: "p"}, 0)
+		return nil
+	}))
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Style(0, 9, map[string]string{"bold": "x"})
+		return nil
+	}))
+	// d2: chain-merge concurrently - p3 into p2, then p2 into p1.
+	assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(7, 9, nil, 0)
+		return nil
+	}))
+	assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(3, 5, nil, 0)
+		return nil
+	}))
+
+	flag := syncClientsThenCheckEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
+	assert.True(t, flag, "d1: %s\nd2: %s",
+		d1.Root().GetTree("t").ToXML(), d2.Root().GetTree("t").ToXML())
+	assert.Equal(t, `<r><p bold="x">abcdef</p><p></p></r>`, d1.Root().GetTree("t").ToXML())
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fixes a Tree attribute-divergence: a concurrent `Tree.Style`/`Tree.RemoveStyle` whose range ends inside an element removed by a merge styled a node concurrently inserted at the merged anchor on only one replica.

From `<r><p>ab</p><p>cd</p></r>`, with client A inserting an empty `<p>` at index 8 and then styling `[0,5)` with `bold=x`, and client B concurrently removing `[0,5)`:

- A: the surviving inserted `<p>` has no attributes
- B: the same `<p>` carries `bold="x"` - the replicas diverge on attributes (the structure itself converges since #1905,#1906)

This happens because `FindTreeNodesWithSplitText` redirects a position inside a merged-away parent to the insertion boundary in the merge target, which sits before the first moved child. For an inserting edit this is intentional (the RGA `CreatedAt` tie-break needs that position), but for a style range end it extends the range over nodes concurrently inserted between the merge-source tombstone and the moved children - nodes the styling client saw outside its range, after the then-live parent.

This PR adds an optional boundary mode to `FindTreeNodesWithSplitText`. The default `BoundaryInsert` keeps the existing behavior for edits; `BoundaryRange`, used by `Style`/`RemoveStyle`, resolves the position right after the merge-source tombstone - before both the concurrent inserts and the moved children in visible coordinates, so a range end excludes them and a range start includes them, matching the styling replica in both directions. Ranges that genuinely cover the merged content still style it.

Tests:

- `test/complex/tree_concurrency_test.go` (new): `TestTreeConcurrencyStyleAcrossMergedAnchor` (fails without the fix), the `RemoveStyle` variant, a positive case where the range genuinely covers the merged content, and a chained-merge case asserting the exact converged value
- `pkg/document/crdt/tree_test.go` (new case): pins the boundary indexes for both modes
- `go test ./pkg/document/...`, `-tags complex` `TestTreeConcurrency*`, `-tags integration` `TestTree*` all green; `golangci-lint run ./...` reports 0 issues

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #1908

**Special notes for your reviewer**:

- Found by the property-based Tree test for yorkie-team/yorkie-js-sdk#1298 as the pinned seed's next shrunk counterexample after #1905/#1906 landed; the JS SDK diverges identically (yorkie-team/yorkie-js-sdk#1308). A mirror PR for yorkie-js-sdk follows.
- Design: `docs/design/concurrent-merge-split.md` §9.3 (Fix 21), added in this PR.
- A range end anchored after a moved child (a non-left-most position in the merged parent) does not go through the redirect and remains a separate follow-up; the property-based test shrinks to it once this fix lands.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Fix Tree.Style and Tree.RemoveStyle applying to a node concurrently inserted into a merge-removed range, which diverged replicas on attributes.
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs
- [Design]: docs/design/concurrent-merge-split.md §9.3 (Fix 21)
```

**Checklist**:

- [x] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrent styling and style removal across merged tree content.
  * Prevented incorrectly applying styles to concurrently inserted or moved content.
  * Added support for chained merge scenarios while preserving consistent replica results.

* **Documentation**
  * Documented merge-boundary behavior, known limitations, and recommended handling.

* **Tests**
  * Added regression and concurrency coverage for styling, style removal, and merged content boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->