### PR TITLE
Recreate purged text runs in order on restore, not reversed

### DIFF
--- a/pkg/document/crdt/rga_tree_split.go
+++ b/pkg/document/crdt/rga_tree_split.go
@@ -733,7 +733,17 @@ func subValue[V RGATreeSplitValue](full V, from, to int) V {
 //     register them before un-registering (keeps GC accounting balanced)
 func (s *RGATreeSplit[V]) restore(
 	spans []restoreSpanValue[V],
+	fromPos *RGATreeSplitNodePos,
+	executedAt *time.Ticket,
 ) (untombstoned, recreated []*RGATreeSplitNode[V], stillTombstoned []GCPair) {
+	// chainAnchor is the node last placed at the current cursor (un-tombstoned
+	// or recreated), in document order. When a recreated fragment has no
+	// surviving same-insertion anchor, chaining after this keeps a purged
+	// multi-fragment run in left-to-right order instead of each fragment
+	// prepending at the same fixed fallback (initialHead), which would rebuild
+	// the run reversed. Spans arrive in document order, so this is always the
+	// recreated fragment's left neighbour.
+	var chainAnchor *RGATreeSplitNode[V]
 	for _, span := range spans {
 		pieces := s.findPiecesOverlapping(span.createdAt, span.start, span.end)
 
@@ -755,6 +765,9 @@ func (s *RGATreeSplit[V]) restore(
 					target.SetRemovedAt(nil)
 					s.treeByIndex.Splay(target.indexNode)
 					untombstoned = append(untombstoned, target)
+					chainAnchor = target
+				} else {
+					chainAnchor = piece
 				}
 				cursor = overlapEnd
 				if overlapEnd >= pieceEnd {
@@ -765,9 +778,11 @@ func (s *RGATreeSplit[V]) restore(
 				val := subValue(span.value, cursor-span.start, gapEnd-span.start)
 				newNode := NewRGATreeSplitNode(
 					NewRGATreeSplitNodeID(span.createdAt, cursor), val)
-				prev := s.findRestoreAnchor(span.createdAt, cursor, gapEnd)
+				prev := s.findRestoreAnchor(
+					span.createdAt, cursor, gapEnd, chainAnchor, fromPos, executedAt)
 				s.InsertAfter(prev, newNode)
 				recreated = append(recreated, newNode)
+				chainAnchor = newNode
 				cursor = gapEnd
 			}
 		}
@@ -892,9 +907,17 @@ func (s *RGATreeSplit[V]) isolateRange(
 //	(a) piece covering gapEnd → before it (exact original slot)
 //	(b) nearest surviving piece left of gapStart → after it
 //	(c) rightmost surviving piece (right of gap) → before it
-//	(d) head (deterministic last resort when the whole insertion is purged)
+//	(d) chain anchor: the fragment placed just before this one in the same
+//	    restore (document order) → after it, so a purged multi-fragment run is
+//	    rebuilt left-to-right rather than reversed
+//	(e) the operation's from position (refined) → the surviving left neighbour
+//	    of the run, anchoring the first fragment when its whole insertion is
+//	    purged; mirrors the JS fallbackAnchor (see design-doc caveat)
+//	(f) head (deterministic last resort)
 func (s *RGATreeSplit[V]) findRestoreAnchor(
 	createdAt *time.Ticket, gapStart, gapEnd int,
+	chainAnchor *RGATreeSplitNode[V],
+	fromPos *RGATreeSplitNodePos, executedAt *time.Ticket,
 ) *RGATreeSplitNode[V] {
 	if succ := s.findPieceCovering(createdAt, gapEnd); succ != nil {
 		return succ.prev
@@ -909,6 +932,14 @@ func (s *RGATreeSplit[V]) findRestoreAnchor(
 	if key, node := s.treeByID.Floor(rightmostID); key != nil &&
 		key.hasSameCreatedAt(rightmostID) && node.ID().Offset() >= gapEnd {
 		return node.prev
+	}
+	if chainAnchor != nil {
+		return chainAnchor
+	}
+	if fromPos != nil && executedAt != nil {
+		if left, _, _, err := s.findNodeWithSplit(fromPos, executedAt); err == nil && left != nil {
+			return left
+		}
 	}
 	return s.initialHead
 }

--- a/pkg/document/crdt/text.go
+++ b/pkg/document/crdt/text.go
@@ -347,6 +347,7 @@ func (t *Text) Edit(
 func (t *Text) Restore(
 	spans []*RestoreSpan,
 	executedAt *time.Ticket,
+	from *RGATreeSplitNodePos,
 ) (untombstoned, recreated []*RGATreeSplitNode[*TextValue], stillTombstoned []GCPair) {
 	internal := make([]restoreSpanValue[*TextValue], 0, len(spans))
 	for _, s := range spans {
@@ -361,7 +362,10 @@ func (t *Text) Restore(
 			value:     NewTextValue(s.Content, attrs),
 		})
 	}
-	return t.rgaTreeSplit.restore(internal)
+	// `from` is the op's left boundary; it anchors a fragment whose whole
+	// insertion was purged (fallback rung in findRestoreAnchor). Identity
+	// (createdAt+offset) still addresses every surviving piece first.
+	return t.rgaTreeSplit.restore(internal, from, executedAt)
 }
 
 // Retombstone re-removes a previously restored range under its original

--- a/pkg/document/crdt/text_restore_test.go
+++ b/pkg/document/crdt/text_restore_test.go
@@ -82,8 +82,8 @@ func TestTextRestore(t *testing.T) {
 		_, _, _, err = a.Edit(ag1, ag2, "", nil, tick(3), nil)
 		assert.NoError(t, err)
 		assert.Equal(t, "0189", a.String())
-		a.Restore(spanD1(seed), tick(4))
-		a.Restore(spanD2(seed), tick(5))
+		a.Restore(spanD1(seed), tick(4), nil)
+		a.Restore(spanD2(seed), tick(5), nil)
 
 		// Replica B: identical deletes, restore u2 then u1.
 		b := seededText(t, seed)
@@ -93,8 +93,8 @@ func TestTextRestore(t *testing.T) {
 		assert.NoError(t, err)
 		_, _, _, err = b.Edit(bg1, bg2, "", nil, tick(3), nil)
 		assert.NoError(t, err)
-		b.Restore(spanD2(seed), tick(5))
-		b.Restore(spanD1(seed), tick(4))
+		b.Restore(spanD2(seed), tick(5), nil)
+		b.Restore(spanD1(seed), tick(4), nil)
 
 		assert.Equal(t, "0123456789", a.String(), "replica A")
 		assert.Equal(t, "0123456789", b.String(), "replica B")
@@ -113,10 +113,10 @@ func TestTextRestore(t *testing.T) {
 		// Undo only d1: it clears the tombstone on the "45" nodes, so "45"
 		// reappears while "23"/"67" stay tombstoned by d2 (design doc's
 		// "Order B": "01" + "45" + "89").
-		text.Restore(spanD1(seed), tick(4))
+		text.Restore(spanD1(seed), tick(4), nil)
 		assert.Equal(t, "014589", text.String())
 		// Undo d2 as well: the full range comes back exactly once.
-		text.Restore(spanD2(seed), tick(5))
+		text.Restore(spanD2(seed), tick(5), nil)
 		assert.Equal(t, "0123456789", text.String())
 	})
 
@@ -129,8 +129,8 @@ func TestTextRestore(t *testing.T) {
 		_, _, _, _ = text.Edit(g1, g2, "", nil, tick(3), nil)
 		assert.Equal(t, "016789", text.String())
 
-		text.Restore([]*crdt.RestoreSpan{{CreatedAt: seed, Start: 4, End: 6, Content: "45"}}, tick(4))
-		text.Restore([]*crdt.RestoreSpan{{CreatedAt: seed, Start: 2, End: 5, Content: "234"}}, tick(5))
+		text.Restore([]*crdt.RestoreSpan{{CreatedAt: seed, Start: 4, End: 6, Content: "45"}}, tick(4), nil)
+		text.Restore([]*crdt.RestoreSpan{{CreatedAt: seed, Start: 2, End: 5, Content: "234"}}, tick(5), nil)
 		assert.Equal(t, "0123456789", text.String())
 		assert.True(t, text.RGATreeSplit().CheckWeight())
 	})
@@ -141,13 +141,13 @@ func TestTextRestore(t *testing.T) {
 		deleteRange(t, text, 4, 6, tick(2))
 		assert.Equal(t, "01236789", text.String())
 
-		text.Restore(spanD1(seed), tick(3))
+		text.Restore(spanD1(seed), tick(3), nil)
 		assert.Equal(t, "0123456789", text.String())
 
 		text.Retombstone(spanD1(seed), tick(4))
 		assert.Equal(t, "01236789", text.String())
 
-		text.Restore(spanD1(seed), tick(5))
+		text.Restore(spanD1(seed), tick(5), nil)
 		assert.Equal(t, "0123456789", text.String())
 		assert.True(t, text.RGATreeSplit().CheckWeight())
 	})
@@ -156,8 +156,8 @@ func TestTextRestore(t *testing.T) {
 		seed := tick(1)
 		text := seededText(t, seed)
 		deleteRange(t, text, 4, 6, tick(2))
-		text.Restore(spanD1(seed), tick(3))
-		text.Restore(spanD1(seed), tick(3)) // duplicate delivery
+		text.Restore(spanD1(seed), tick(3), nil)
+		text.Restore(spanD1(seed), tick(3), nil) // duplicate delivery
 		assert.Equal(t, "0123456789", text.String())
 		assert.True(t, text.RGATreeSplit().CheckWeight())
 	})
@@ -305,6 +305,69 @@ func TestTextRestoreDocSizeAccounting(t *testing.T) {
 	assert.Zero(t, gc.Data, "GC data must be zero after purging all tombstones")
 	assert.Zero(t, gc.Meta, "GC meta must be zero after purging all tombstones")
 	assert.Equal(t, "014589", text.String())
+}
+
+// TestTextRestoreAfterGCKeepsOrderAcrossInsertions reproduces wafflebase#629:
+// text typed character-by-character makes each character its own single-char
+// insertion (distinct createdAt, offset 0). Deleting a contiguous run and then
+// restoring it after the tombstones were GC-purged forces every character down
+// the recreate path. Because no character shares an insertion with any other,
+// none of the same-insertion anchor rungs fire; each fragment must chain after
+// the one placed just before it, or the run comes back reversed
+// ("my name" -> "eman ym"). Unlike TestTextRestoreExecuteAfterGC (a single
+// "0123456789" insertion, one recreate), this exercises the multi-fragment
+// ordering the chain anchor exists for.
+func TestTextRestoreAfterGCKeepsOrderAcrossInsertions(t *testing.T) {
+	const s = "hello my name is"
+	textTicket := tick(1)
+	text := crdt.NewText(crdt.NewRGATreeSplit(crdt.InitialTextNode()), textTicket)
+	root := helper.TestRoot()
+	root.RegisterElement(text)
+
+	// Type char by char: each Edit is a distinct insertion (createdAt = tick).
+	charAt := make([]*time.Ticket, len(s))
+	for i := 0; i < len(s); i++ {
+		charAt[i] = tick(int64(2000 + i))
+		f, e, err := text.CreateRange(i, i)
+		assert.NoError(t, err)
+		_, _, _, err = text.Edit(f, e, string(s[i]), nil, charAt[i], nil)
+		assert.NoError(t, err)
+	}
+	assert.Equal(t, s, text.String())
+
+	// Delete the contiguous run "my name" ([6,13)).
+	f, e, err := text.CreateRange(6, 13)
+	assert.NoError(t, err)
+	op := operations.NewEdit(textTicket, f, e, "", nil, tick(3000))
+	assert.NoError(t, op.Execute(root, nil))
+	assert.Equal(t, "hello  is", text.String())
+
+	// Purge the tombstones so restore must recreate rather than un-tombstone.
+	n, err := root.GarbageCollect(helper.MaxVersionVector(restoreActor))
+	assert.NoError(t, err)
+	assert.Positive(t, n, "the deleted run should be purged")
+
+	// The reverse op carries the delete's left boundary as its `from`, the
+	// fallback anchor for the first recreated fragment (its whole insertion is
+	// purged). Resolve it against the current (post-delete) text.
+	restoreFrom, _, err := text.CreateRange(6, 6)
+	assert.NoError(t, err)
+
+	// One restore span per deleted character, in document order — exactly what
+	// the client's reverse op carries.
+	spans := make([]*crdt.RestoreSpan, 0, 7)
+	for i := 6; i < 13; i++ {
+		spans = append(spans, &crdt.RestoreSpan{
+			CreatedAt: charAt[i], Start: 0, End: 1, Content: string(s[i]),
+		})
+	}
+	restoreOp := operations.NewRestoreEdit(textTicket, restoreFrom, nil, tick(3001),
+		spans, crdt.RestoreModeRestore, nil)
+	assert.NoError(t, restoreOp.Execute(root, helper.MaxVersionVector(restoreActor)))
+
+	assert.Equal(t, s, text.String(),
+		"a purged multi-insertion run must be recreated in document order, not reversed")
+	assert.True(t, text.RGATreeSplit().CheckWeight())
 }
 
 // victimActor is a distinct identity used to forge cross-actor restore spans

--- a/pkg/document/operations/edit.go
+++ b/pkg/document/operations/edit.go
@@ -150,7 +150,7 @@ func (e *Edit) Execute(root *crdt.Root, versionVector time.VersionVector) error 
 			// 2. Revive the content the reversed edit removed (by identity).
 			if len(toRestore) > 0 {
 				untombstoned, recreated, stillTombstoned := obj.Restore(
-					toRestore, e.executedAt)
+					toRestore, e.executedAt, e.from)
 
 				// Register the still-tombstoned split remainders (which include
 				// any split-born target) BEFORE un-registering the


### PR DESCRIPTION
## Summary

Identity-preserving Text restore reverses a deleted run when undoing **after the run's tombstones were GC-purged**. Reported via wafflebase notes undo: type "hello my name is", delete "my name", undo → "hello **eman ym** is". A page refresh showed the correct text because the server still had the tombstones and un-tombstoned them, while the client had already GC'd and took the recreate path.

**Root cause.** Typing character-by-character makes each character its own single-character insertion (distinct `createdAt`, offset 0). When the run is purged, `restore` must recreate each fragment. In `findRestoreAnchor` the same-insertion rungs (a/b/c) never fire — no character shares another's `createdAt`, and `gapStart` is always 0 — so every fragment fell through to the same fixed fallback anchor, and `InsertAfter(sameLeft, node)` repeatedly *prepended*, rebuilding the run backwards. Un-tombstoning in place (no GC) always preserved order, which is why it only surfaced post-GC.

## Changes

- Thread a **chain anchor** — the fragment placed just before this one in the same restore (spans arrive in document order) — and anchor after it when no same-insertion piece survives, so a purged run is rebuilt left-to-right.
- Thread the op's **`from` position** as the first fragment's fallback anchor. `findRestoreAnchor` previously fell back to `initialHead`, which placed a fully-purged run at the front (`my namehello  is`). This matches the JS SDK's `fallbackAnchor` so server snapshots converge with clients.
- Rung order is now: (a/b/c) same-insertion identity → (d) chain anchor → (e) `from` position → (f) head.

## Test plan

- `TestTextRestoreExecuteAfterGC` used a single `"0123456789"` insertion (one recreate) and never exercised multi-fragment ordering — added `TestTextRestoreAfterGCKeepsOrderAcrossInsertions` covering the char-by-char purge-then-undo case.
- `go test ./pkg/document/... ./api/converter/` green; `golangci-lint` 0 issues.
- Verified end-to-end against the JS SDK companion fix: `history_text` + text/gc integration suites pass against a server built from this branch.

Companion PR: yorkie-team/yorkie-js-sdk (client-side fix).
Fixes the SDK side of wafflebase/wafflebase#629.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restoring text after deleted content has been garbage-collected now preserves the original left-to-right character order.
  * Restoration more reliably places content near its original position, even when surrounding fragments no longer exist.

* **Tests**
  * Added coverage for restoring multiple insertions after garbage collection while preserving document content and structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->