### PR TITLE
Release v0.7.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and Yorkie adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## [v0.7.14] - 2026-08-09
+
+### Added
+
+- Identity-preserving restore for Tree undo/redo by @harrykim8672 in https://github.com/yorkie-team/yorkie/pull/1893
+- Add an Admin REST API for broadcasting channel events by @lshtar13 in https://github.com/yorkie-team/yorkie/pull/1895
+
+### Changed
+
+- Add HTTP server timeouts to prevent Slowloris attacks by @nasagong in https://github.com/yorkie-team/yorkie/pull/1902
+
+### Fixed
+
+- Recreate purged text runs in order on restore, not reversed by @harrykim8672 in https://github.com/yorkie-team/yorkie/pull/1913
+- Keep style ranges from crossing a concurrent merge anchor by @Nahee-Park in https://github.com/yorkie-team/yorkie/pull/1909
+- Flatten chained merge to converge an anchored concurrent insert by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1906
+- Move tombstones with merge to preserve tree RGA anchors by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1905
+
 ## [v0.7.13] - 2026-07-23
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-YORKIE_VERSION := 0.7.13
+YORKIE_VERSION := 0.7.14
 
 GO_PROJECT = github.com/yorkie-team/yorkie
 

--- a/api/docs/yorkie.base.yaml
+++ b/api/docs/yorkie.base.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Yorkie
   description: "Yorkie is an open source document store for building collaborative editing applications."
-  version: v0.7.13
+  version: v0.7.14
 servers:
   - url: https://api.yorkie.dev
     description: Production server

--- a/api/docs/yorkie/v1/admin.openapi.yaml
+++ b/api/docs/yorkie/v1/admin.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.13
+  version: v0.7.14
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/api/docs/yorkie/v1/resources.openapi.yaml
+++ b/api/docs/yorkie/v1/resources.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.13
+  version: v0.7.14
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/api/docs/yorkie/v1/yorkie.openapi.yaml
+++ b/api/docs/yorkie/v1/yorkie.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.13
+  version: v0.7.14
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/build/charts/yorkie-cluster/Chart.yaml
+++ b/build/charts/yorkie-cluster/Chart.yaml
@@ -9,8 +9,8 @@ maintainers:
 
 sources:
   - https://github.com/yorkie-team/yorkie
-version: 0.7.13
-appVersion: "0.7.13"
+version: 0.7.14
+appVersion: "0.7.14"
 kubeVersion: ">=1.28.0-0"
 
 dependencies:


### PR DESCRIPTION
## Summary

Bump version to v0.7.14.

- `Makefile`: `YORKIE_VERSION := 0.7.14`
- `build/charts/yorkie-cluster/Chart.yaml`: version, appVersion
- `api/docs/*.yaml`: version v0.7.14 (4 files)
- `CHANGELOG.md`: v0.7.14 entry (Added / Changed / Fixed)

yorkie-monitoring chart unchanged since v0.7.13, so its version is left at 0.7.7.
`cluster.openapi.yaml` is on a separate track and stays at v0.7.8.

Excluded from the CHANGELOG: test-only (#1912, #1900, #1892, #1883, #1918) and
docs-only (#1914) changes.

## Test plan

- CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved restoration support for Tree undo and redo operations.
  - Added broadcasting of Admin channel events.

- **Bug Fixes**
  - Improved reliability for concurrent Tree and text merges.
  - Fixed issues affecting Tree and text restoration.
  - Added more consistent HTTP timeout handling.

- **Release**
  - Updated the Yorkie release and deployment artifacts to version 0.7.14.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->