### PR TITLE
Isolate spans in Tree restore so overlapping undo converges

### DIFF
--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -887,6 +887,16 @@ func (t *Tree) Purge(child GCChild) error {
 func (t *Tree) Restore(spans []*TreeRestoreSpan) (
 	untombstoned, recreated []*TreeNode, pairs []GCPair, diff resource.DataSize, err error,
 ) {
+	// Splitting a removed straddler buffers born-removed remainders as pending
+	// GC pairs (see TreeNode.Split). Drain them into the returned pairs on EVERY
+	// path — including a mid-restore error — so they can never linger to
+	// contaminate the next operation's drain. The caller registers these BEFORE
+	// un-registering the un-tombstoned targets, so a split-born target is walked
+	// gc->live correctly (mirrors the Text path).
+	defer func() {
+		pairs = append(pairs, t.drainPendingGCPairs()...)
+	}()
+
 	for _, span := range spans {
 		if !span.IsText {
 			node := t.findFloorNode(span.ID)
@@ -899,7 +909,7 @@ func (t *Tree) Restore(spans []*TreeRestoreSpan) (
 			}
 			created, cErr := t.recreateFromSpan(span, span.ID.Offset, span.Length)
 			if cErr != nil {
-				return nil, nil, nil, resource.DataSize{}, cErr
+				return nil, nil, nil, diff, cErr
 			}
 			if created != nil {
 				recreated = append(recreated, created)
@@ -926,7 +936,7 @@ func (t *Tree) Restore(spans []*TreeRestoreSpan) (
 				overlapEnd := min(pieceEnd, end)
 				target, iErr := t.isolateTextRange(piece, cursor, overlapEnd, &diff)
 				if iErr != nil {
-					return nil, nil, nil, resource.DataSize{}, iErr
+					return nil, nil, nil, diff, iErr
 				}
 				if target.IsRemoved() {
 					target.unremove()
@@ -943,7 +953,7 @@ func (t *Tree) Restore(spans []*TreeRestoreSpan) (
 				}
 				created, cErr := t.recreateFromSpan(span, cursor, gapEnd-cursor)
 				if cErr != nil {
-					return nil, nil, nil, resource.DataSize{}, cErr
+					return nil, nil, nil, diff, cErr
 				}
 				if created != nil {
 					recreated = append(recreated, created)
@@ -953,12 +963,7 @@ func (t *Tree) Restore(spans []*TreeRestoreSpan) (
 		}
 	}
 
-	// Splitting a removed straddler buffers born-removed remainders as pending
-	// GC pairs (see TreeNode.Split). The caller registers these BEFORE
-	// un-registering the un-tombstoned targets, so a split-born target is
-	// walked gc->live correctly (mirrors the Text path).
-	pairs = t.drainPendingGCPairs()
-	return untombstoned, recreated, pairs, diff, nil
+	return untombstoned, recreated, nil, diff, nil
 }
 
 // isolateTextRange splits piece so that a node exactly covering the absolute
@@ -981,6 +986,9 @@ func (t *Tree) isolateTextRange(
 		diff.Add(d)
 		// Split's right half is registered under offset `from`; pick it up.
 		node = t.findFloorNode(&TreeNodeID{CreatedAt: node.id.CreatedAt, Offset: from})
+		if node == nil {
+			return nil, ErrNodeNotFound
+		}
 	}
 	if to < node.id.Offset+node.Length() {
 		d, err := node.Split(t, to-node.id.Offset, nil, nil)

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -884,7 +884,9 @@ func (t *Tree) Purge(child GCChild) error {
 // parent-before-child order. Returns (untombstoned, recreated); the caller
 // un-registers GC pairs for the un-tombstoned nodes and accounts recreated
 // sizes to Live. Mirrors the JS CRDTTree.restore.
-func (t *Tree) Restore(spans []*TreeRestoreSpan) (untombstoned, recreated []*TreeNode, err error) {
+func (t *Tree) Restore(spans []*TreeRestoreSpan) (
+	untombstoned, recreated []*TreeNode, pairs []GCPair, diff resource.DataSize, err error,
+) {
 	for _, span := range spans {
 		if !span.IsText {
 			node := t.findFloorNode(span.ID)
@@ -897,7 +899,7 @@ func (t *Tree) Restore(spans []*TreeRestoreSpan) (untombstoned, recreated []*Tre
 			}
 			created, cErr := t.recreateFromSpan(span, span.ID.Offset, span.Length)
 			if cErr != nil {
-				return nil, nil, cErr
+				return nil, nil, nil, resource.DataSize{}, cErr
 			}
 			if created != nil {
 				recreated = append(recreated, created)
@@ -905,7 +907,13 @@ func (t *Tree) Restore(spans []*TreeRestoreSpan) (untombstoned, recreated []*Tre
 			continue
 		}
 
-		// Text: surviving pieces may be split finer than the span.
+		// Text: pieces may be split finer than the span, and a concurrent op or
+		// a post-GC recreate can leave pieces whose boundaries straddle it.
+		// Isolate the exact [start, end) sub-range out of every overlapping
+		// piece — splitting at the span boundaries, live or removed — so all
+		// replicas converge on identical segmentation (the tree analogue of
+		// RGATreeSplit.isolateRange), then revive removed parts and recreate
+		// purged gaps.
 		start := span.ID.Offset
 		end := start + span.Length
 		pieces := t.findPiecesOverlapping(span.ID.CreatedAt, start, end)
@@ -914,22 +922,18 @@ func (t *Tree) Restore(spans []*TreeRestoreSpan) (untombstoned, recreated []*Tre
 		for cursor < end {
 			if pieceIdx < len(pieces) && pieces[pieceIdx].id.Offset <= cursor {
 				piece := pieces[pieceIdx]
-				pieceStart := piece.id.Offset
-				pieceEnd := pieceStart + piece.Length()
-				if pieceStart < start || pieceEnd > end {
-					// Piece straddles a span boundary. Under causal delivery the
-					// forward delete split at span boundaries on every replica
-					// before its undo could arrive, so this is unexpected; skip
-					// rather than un-tombstone beyond the span. Mirrors the guard
-					// in Retombstone so undo/redo stay symmetric.
-					break
+				pieceEnd := piece.id.Offset + piece.Length()
+				overlapEnd := min(pieceEnd, end)
+				target, iErr := t.isolateTextRange(piece, cursor, overlapEnd, &diff)
+				if iErr != nil {
+					return nil, nil, nil, resource.DataSize{}, iErr
 				}
-				if piece.IsRemoved() {
-					piece.unremove()
-					untombstoned = append(untombstoned, piece)
+				if target.IsRemoved() {
+					target.unremove()
+					untombstoned = append(untombstoned, target)
 				}
-				cursor = min(pieceEnd, end)
-				if cursor >= pieceEnd {
+				cursor = overlapEnd
+				if overlapEnd >= pieceEnd {
 					pieceIdx++
 				}
 			} else {
@@ -939,7 +943,7 @@ func (t *Tree) Restore(spans []*TreeRestoreSpan) (untombstoned, recreated []*Tre
 				}
 				created, cErr := t.recreateFromSpan(span, cursor, gapEnd-cursor)
 				if cErr != nil {
-					return nil, nil, cErr
+					return nil, nil, nil, resource.DataSize{}, cErr
 				}
 				if created != nil {
 					recreated = append(recreated, created)
@@ -948,14 +952,58 @@ func (t *Tree) Restore(spans []*TreeRestoreSpan) (untombstoned, recreated []*Tre
 			}
 		}
 	}
-	return untombstoned, recreated, nil
+
+	// Splitting a removed straddler buffers born-removed remainders as pending
+	// GC pairs (see TreeNode.Split). The caller registers these BEFORE
+	// un-registering the un-tombstoned targets, so a split-born target is
+	// walked gc->live correctly (mirrors the Text path).
+	pairs = t.drainPendingGCPairs()
+	return untombstoned, recreated, pairs, diff, nil
+}
+
+// isolateTextRange splits piece so that a node exactly covering the absolute
+// offset interval [from, to) of its insertion exists, and returns it. Splitting
+// at the caller's boundaries — rather than skipping a straddler — is what lets
+// concurrent restores converge on identical text-node segmentation across
+// replicas (the tree analogue of RGATreeSplit.isolateRange). A live split's
+// metadata overhead is added to diff; a removed split buffers a pending GC pair
+// internally (zero here). Requires pieceStart <= from < to <= pieceEnd. Mirrors
+// the JS CRDTTree.isolateTextRange.
+func (t *Tree) isolateTextRange(
+	piece *TreeNode, from, to int, diff *resource.DataSize,
+) (*TreeNode, error) {
+	node := piece
+	if from > node.id.Offset {
+		d, err := node.Split(t, from-node.id.Offset, nil, nil)
+		if err != nil {
+			return nil, err
+		}
+		diff.Add(d)
+		// Split's right half is registered under offset `from`; pick it up.
+		node = t.findFloorNode(&TreeNodeID{CreatedAt: node.id.CreatedAt, Offset: from})
+	}
+	if to < node.id.Offset+node.Length() {
+		d, err := node.Split(t, to-node.id.Offset, nil, nil)
+		if err != nil {
+			return nil, err
+		}
+		diff.Add(d)
+	}
+	return node, nil
 }
 
 // Retombstone re-removes the nodes described by spans (redo of an
-// identity-preserving undo). Live pieces only; idempotent. Returns GC pairs
-// for the newly tombstoned nodes. Mirrors the JS CRDTTree.retombstone.
-func (t *Tree) Retombstone(spans []*TreeRestoreSpan, executedAt *time.Ticket) []GCPair {
+// identity-preserving undo). Live pieces only; idempotent. A piece that
+// straddles a span boundary is split at that boundary so only the in-span range
+// is re-removed (symmetric with Restore's isolate, so undo/redo stay mirror
+// images and segmentation stays convergent). Returns the GC pairs for the newly
+// tombstoned nodes and the live-split overhead. Mirrors the JS
+// CRDTTree.retombstone.
+func (t *Tree) Retombstone(
+	spans []*TreeRestoreSpan, executedAt *time.Ticket,
+) ([]GCPair, resource.DataSize, error) {
 	var pairs []GCPair
+	var diff resource.DataSize
 	for _, span := range spans {
 		start := span.ID.Offset
 		length := span.Length
@@ -975,18 +1023,22 @@ func (t *Tree) Retombstone(spans []*TreeRestoreSpan, executedAt *time.Ticket) []
 			if piece.IsRemoved() {
 				continue
 			}
-			if piece.IsText() && (piece.id.Offset < start || piece.id.Offset+piece.Length() > end) {
-				// Piece straddles a span boundary (uses the same clamped end as
-				// findPiecesOverlapping); skip so we never re-tombstone content
-				// outside the span. Mirrors the guard in Restore.
-				continue
+			target := piece
+			if piece.IsText() {
+				from := max(piece.id.Offset, start)
+				to := min(piece.id.Offset+piece.Length(), end)
+				var iErr error
+				target, iErr = t.isolateTextRange(piece, from, to, &diff)
+				if iErr != nil {
+					return nil, resource.DataSize{}, iErr
+				}
 			}
-			if piece.remove(executedAt) {
-				pairs = append(pairs, GCPair{Parent: t, Child: piece})
+			if target.remove(executedAt) {
+				pairs = append(pairs, GCPair{Parent: t, Child: target})
 			}
 		}
 	}
-	return pairs
+	return pairs, diff, nil
 }
 
 // findPiecesOverlapping collects surviving pieces (live or tombstoned) of the

--- a/pkg/document/crdt/tree_restore_test.go
+++ b/pkg/document/crdt/tree_restore_test.go
@@ -75,7 +75,7 @@ func TestTreeRestoreUnremove(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "<r><p></p></r>", tree.ToXML())
 
-	untombstoned, recreated, err := tree.Restore([]*crdt.TreeRestoreSpan{span})
+	untombstoned, recreated, _, _, err := tree.Restore([]*crdt.TreeRestoreSpan{span})
 	assert.NoError(t, err)
 	assert.Len(t, untombstoned, 1, "the tombstone is revived in place")
 	assert.Empty(t, recreated, "nothing was purged, so nothing is recreated")
@@ -96,12 +96,12 @@ func TestTreeRetombstoneThenRestore(t *testing.T) {
 	spans := []*crdt.TreeRestoreSpan{elementSpan(p, tree.Root()), textSpan(text, p)}
 
 	// Retombstone (redo of a deletion undo): the live subtree is removed.
-	pairs := tree.Retombstone(spans, helper.TimeT(ctx))
+	pairs, _, _ := tree.Retombstone(spans, helper.TimeT(ctx))
 	assert.NotEmpty(t, pairs, "removing live nodes yields GC pairs")
 	assert.Equal(t, "<r></r>", tree.ToXML())
 
 	// Restore (undo): the same identities come back, parent before child.
-	untombstoned, recreated, err := tree.Restore(spans)
+	untombstoned, recreated, _, _, err := tree.Restore(spans)
 	assert.NoError(t, err)
 	assert.Len(t, untombstoned, 2)
 	assert.Empty(t, recreated)
@@ -174,7 +174,7 @@ func TestTreeRestoreParentGoneSkip(t *testing.T) {
 		ParentID: ghostParent,
 	}
 
-	untombstoned, recreated, err := tree.Restore([]*crdt.TreeRestoreSpan{orphan})
+	untombstoned, recreated, _, _, err := tree.Restore([]*crdt.TreeRestoreSpan{orphan})
 	assert.NoError(t, err)
 	assert.Empty(t, untombstoned)
 	assert.Empty(t, recreated, "a node with no surviving parent is skipped (B1)")
@@ -328,7 +328,7 @@ func TestTreeRestoreLengthCacheIntegrity(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, "<r></r>", tree.ToXML())
 
-			_, _, err = tree.Restore(spans)
+			_, _, _, _, err = tree.Restore(spans)
 			assert.NoError(t, err)
 
 			assert.Equal(t, "<r><p>hello</p></r>", tree.ToXML())
@@ -458,7 +458,7 @@ func TestTreeRestoreConvergesUnderConcurrentEdit(t *testing.T) {
 		assert.NoError(t, err)
 	}
 	applyU := func(tree *crdt.Tree, span *crdt.TreeRestoreSpan) {
-		_, _, err := tree.Restore([]*crdt.TreeRestoreSpan{span})
+		_, _, _, _, err := tree.Restore([]*crdt.TreeRestoreSpan{span})
 		assert.NoError(t, err)
 	}
 	applyX := func(tree *crdt.Tree, ctx *change.Context) {

--- a/pkg/document/crdt/tree_restore_test.go
+++ b/pkg/document/crdt/tree_restore_test.go
@@ -96,7 +96,8 @@ func TestTreeRetombstoneThenRestore(t *testing.T) {
 	spans := []*crdt.TreeRestoreSpan{elementSpan(p, tree.Root()), textSpan(text, p)}
 
 	// Retombstone (redo of a deletion undo): the live subtree is removed.
-	pairs, _, _ := tree.Retombstone(spans, helper.TimeT(ctx))
+	pairs, _, rErr := tree.Retombstone(spans, helper.TimeT(ctx))
+	assert.NoError(t, rErr)
 	assert.NotEmpty(t, pairs, "removing live nodes yields GC pairs")
 	assert.Equal(t, "<r></r>", tree.ToXML())
 

--- a/pkg/document/operations/tree_edit.go
+++ b/pkg/document/operations/tree_edit.go
@@ -122,24 +122,38 @@ func (e *TreeEdit) Execute(root *crdt.Root, versionVector time.VersionVector) er
 			}
 
 			var diff resource.DataSize
-			// 1. Re-remove (retombstone) by identity.
-			for _, pair := range obj.Retombstone(toRetombstone, e.executedAt) {
+			// 1. Re-remove (retombstone) by identity. Isolating a straddling
+			// piece splits it (live-split overhead accounted to diff).
+			retombstonePairs, retombstoneDiff, err := obj.Retombstone(toRetombstone, e.executedAt)
+			if err != nil {
+				return err
+			}
+			diff.Add(retombstoneDiff)
+			for _, pair := range retombstonePairs {
 				root.RegisterGCPair(pair)
 				root.AdjustDiffForGCPair(&diff, pair)
 			}
-			// 2. Revive (restore) by identity. For an un-tombstoned node
-			// (removedAt already cleared by Restore) UnregisterGCPair removes
-			// its size from docSize.GC, and diff.Add books the same size into
-			// Live — the node just became visible. Recreated nodes are brand
-			// new, so they only need the Live addition. Mirrors Text restore.
-			untombstoned, recreated, err := obj.Restore(toRestore)
+			// 2. Revive (restore) by identity. Isolating a range out of a
+			// straddling piece can split off born-removed remainders as pending
+			// GC pairs; register them FIRST so a split-born un-tombstoned target
+			// is walked gc->live correctly by the UnregisterGCPair below. For an
+			// un-tombstoned node (removedAt already cleared by Restore)
+			// UnregisterGCPair removes its size from docSize.GC, and diff.Add
+			// books the same size into Live — the node just became visible.
+			// Recreated nodes are brand new, so they only need the Live
+			// addition, plus any live-split overhead. Mirrors Text restore.
+			untombstoned, recreated, restorePairs, restoreDiff, err := obj.Restore(toRestore)
 			if err != nil {
 				return err
+			}
+			for _, pair := range restorePairs {
+				root.RegisterGCPair(pair)
 			}
 			for _, node := range untombstoned {
 				root.UnregisterGCPair(crdt.GCPair{Parent: obj, Child: node})
 				diff.Add(node.DataSize())
 			}
+			diff.Add(restoreDiff)
 			for _, node := range recreated {
 				diff.Add(node.DataSize())
 			}


### PR DESCRIPTION
## Summary

Concurrent multi-user Tree undo can diverge and corrupt a document. Two clients that concurrently delete **overlapping** text and both undo diverge once GC has purged the tombstones (so restore takes the recreate path). Each replica rebuilds its run as a monolithic node with misaligned boundaries, and restore's straddle guard `break`s on a piece that crosses a span boundary — dropping the rest of the run. Reported in wafflebase docs multi-user undo.

The existing `history_tree` reconcile cases undo *before* GC runs, so they never exercise this recreate path — which is why it slipped through.

## Change

`Restore` and `Retombstone` now **isolate** the exact `[start, end)` sub-range out of every overlapping piece, splitting at the span boundaries (live or removed), so all replicas converge on the same text-node segmentation — the tree analogue of `RGATreeSplit.isolateRange`. Kept **byte-parallel with the JS SDK** so server snapshots match clients. The live-split metadata overhead and the pending GC pairs from splitting a removed straddler are threaded back through `Restore`/`Retombstone` so the caller's docSize/GC accounting stays exact.

## Test plan

- `go test ./pkg/document/... ./api/converter/` green; `golangci-lint` 0 issues.
- Verified end-to-end against the SDK companion PR: a new `history_tree_concurrent_test.ts` covering every overlap relationship (contained_by / contains / overlap_start / overlap_end / identical / adjacent) under undo and undo+redo after GC passes against a server built from this branch, and **all 135 existing `history_tree` tests still pass**.

## Known limitation

Deleting a **whole element** concurrently with a text edit *inside* it, then both undo after GC, converges on visible content but can still differ in internal text-node segmentation. A child sub-restore is skipped while its parent is transiently purged, so the replicas keep different split points and the element's monolithic span cannot re-introduce them. Tracked as two skipped tests on the SDK side. A sound fix needs the child restore's split points to survive a transiently-purged parent (e.g. undo-stack-aware GC). Merge-normalizing segmentation was tried and rejected as non-commutative (it broke GC/tombstone symmetry after redo).

Companion PR: yorkie-team/yorkie-js-sdk (client-side fix + tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restoration of text and document content, including partially overlapping ranges.
  * Correctly revives deleted content and recreates content that was previously removed.
  * Improved handling of cleanup and data-size changes during restore and retombstone operations.
  * Errors encountered during these operations are now handled and reported more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->