### PR TITLE
Speed up GetProjectStats with approximate, concurrent reads

### DIFF
--- a/docs/tasks/active/20260813-rpc-start-bind-sync-lessons.md
+++ b/docs/tasks/active/20260813-rpc-start-bind-sync-lessons.md
@@ -1,0 +1,42 @@
+# Lessons: RPC start bind sync
+
+**Created**: 2026-08-13
+
+## A red CI job on a PR is not always the PR's fault
+
+The diff on #1925 touched `server/backend/warehouse` and
+`server/projects` only. Neither is reachable from `test/bench`. Checking
+that first — before reading any of the changed code — pointed straight
+at the harness instead of the change, and `main` being green just meant
+the race had not been lost there yet.
+
+## "connection refused" names its own root cause
+
+`ECONNREFUSED` means no socket is bound, not that the server is slow or
+the handler is broken. That narrows the search to the listen path
+immediately. `Start` spawning a goroutine and returning `nil` was
+visible in six lines of `listenAndServe`.
+
+## Grep for the existing workaround
+
+`helper.WaitForServerToStart` existed and was used by exactly the two
+test packages that build an `rpc.Server` by hand. A readiness poll that
+only some callers use is a sign the thing being polled should be
+synchronous. Fixing `Start` removes the need for the workaround rather
+than spreading it to more callers.
+
+## A silent failure hides a second one
+
+Making `Start` return the bind error immediately exposed that
+`server/packs` and `server/rpc` had been fighting over port 11101, with
+packs' tests silently running against the other package's server. Errors
+that are only logged do not just hide themselves — they let unrelated
+bugs live behind them.
+
+## Don't take a timing race's local pass as evidence
+
+The "port accepts connections immediately after Start" assertion passed
+on an unloaded laptop *before* the fix; the race window is nanoseconds.
+The deterministic RED had to come from the other half of the same root
+cause — `Start` returning `nil` on a taken port. When a race won't
+reproduce, look for a non-racy symptom of the same defect to test.

--- a/docs/tasks/active/20260813-rpc-start-bind-sync-lessons.md
+++ b/docs/tasks/active/20260813-rpc-start-bind-sync-lessons.md
@@ -33,6 +33,15 @@ packs' tests silently running against the other package's server. Errors
 that are only logged do not just hide themselves — they let unrelated
 bugs live behind them.
 
+## Replacing a stdlib wrapper means inheriting what it did for you
+
+Swapping `ListenAndServeTLS` for `ServeTLS` looked like a pure "hoist
+the listen out" refactor. It was not: `ListenAndServeTLS` carries a
+`defer ln.Close()` that `ServeTLS` does not, precisely because
+`ServeTLS` can return before `Serve` takes ownership. Read the wrapper
+being replaced line by line — the difference between it and the inner
+call *is* the thing you now have to do yourself.
+
 ## Don't take a timing race's local pass as evidence
 
 The "port accepts connections immediately after Start" assertion passed

--- a/docs/tasks/active/20260813-rpc-start-bind-sync-todo.md
+++ b/docs/tasks/active/20260813-rpc-start-bind-sync-todo.md
@@ -68,6 +68,26 @@ so ports below `RPCPort` stay free for fixed-port packages.
 - `test/helper/helper.go` — `PacksRPCPort`
 - `server/packs/pushpull_test.go` — uses `PacksRPCPort`
 
+## Review round 1 (CodeRabbit)
+
+Both findings landed on this commit and both were valid:
+
+- **`ServeTLS` leaks the listener.** `Serve` closes the listener itself
+  (`net/http/server.go` `defer l.Close()`), but `ServeTLS` returns early
+  on HTTP/2 setup or `LoadX509KeyPair` failure, before it ever reaches
+  `Serve`. `ListenAndServeTLS` — the call this commit replaced — has a
+  compensating `defer ln.Close()`, so dropping it was a regression: a
+  bad key pair would leave the port bound, so clients would connect and
+  hang instead of being refused. Added `defer lis.Close()` to the TLS
+  branch, plus a test that a bogus key pair releases the port.
+- **`assert` in test setup.** `rpc.NewServer` returns `nil` on error and
+  `net.Dial`/`net.Listen` return nil values, so a setup failure panicked
+  the test binary instead of failing the subtest — which would have
+  destroyed the diagnostic value of the very test meant to catch a
+  regression here. Setup calls now use `require`.
+
+## Notes
+
 `server/profiling/server.go` has the same goroutine-wrapped
 `ListenAndServe`. It is left alone here: nothing dials the profiling
 port right after `Start`, and changing it would turn a currently silent

--- a/docs/tasks/active/20260813-rpc-start-bind-sync-todo.md
+++ b/docs/tasks/active/20260813-rpc-start-bind-sync-todo.md
@@ -1,0 +1,74 @@
+# RPC: bind the listener before Start returns
+
+**Created**: 2026-08-13
+
+The `bench` job on yorkie-team/yorkie#1925 failed with
+`unavailable: dial tcp [::1]:11501: connect: connection refused`, right
+after `BenchmarkGetChannels` finished and `BenchmarkGetDocuments` started
+its own server. The PR's diff (warehouse/project stats) does not reach
+the benchmark path, so the failure is a pre-existing race the loaded CI
+runner happened to lose.
+
+## Problem
+
+`rpc.Server.listenAndServe` ran `http.Server.ListenAndServe` inside a
+goroutine and returned `nil` immediately:
+
+```go
+func (s *Server) listenAndServe() error {
+	go func() {
+		if err := s.httpServer.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+			logging.DefaultLogger().Errorf("HTTP server ListenAndServe: %v", err)
+		}
+	}()
+	return nil
+}
+```
+
+`net.Listen` therefore happens after `Start` has already returned. Two
+consequences:
+
+1. A client dialing right after `Start` can get `ECONNREFUSED` because
+   the socket is not bound yet. `helper.TestServerWithSnapshotCfg` dials
+   the admin client immediately after `y.Start()`, and every benchmark
+   that builds a server goes through it — hence the flaky `bench` job.
+   `server/rpc` and `server/packs` already worked around this with
+   `helper.WaitForServerToStart`; the shared test helpers never did.
+2. A bind failure is only logged. `Start` reports success while nothing
+   is listening, so a port conflict looks like a healthy server.
+
+## Plan
+
+- [x] Reproduce the second consequence deterministically (RED):
+      `Start` returns `nil` when the port is already taken
+- [x] Open the listener in `listenAndServe` and hand it to
+      `Serve`/`ServeTLS`, so `Start` returns only once the port accepts
+      connections and a bind error propagates
+- [x] Give `server/packs` its own RPC port — see below
+- [x] `make lint`, full `-tags integration` suite,
+      `BenchmarkGetChannels`/`BenchmarkGetDocuments` back to back
+
+## Fallout: server/packs shared server/rpc's port
+
+Both test packages bound `helper.RPCPort` (11101). Whenever the two ran
+concurrently, packs' bind failed silently and
+`WaitForServerToStart("localhost:11101")` connected to *server/rpc's*
+server — so packs' tests ran against a different backend instance than
+the one they set up, including its mock DB. With `Start` now returning
+the bind error, that turns into a hard failure, so packs gets
+`helper.PacksRPCPort` (11001). `TestConfig` hands out `RPCPort + 100n`,
+so ports below `RPCPort` stay free for fixed-port packages.
+
+## Review
+
+- `server/rpc/server.go` — listener opened in `listenAndServe`;
+  `ListenAndServe`/`ListenAndServeTLS` → `Serve`/`ServeTLS`
+- `server/rpc/server_test.go` — `TestServerStart`: port accepts
+  connections immediately after `Start`; `Start` errors on a taken port
+- `test/helper/helper.go` — `PacksRPCPort`
+- `server/packs/pushpull_test.go` — uses `PacksRPCPort`
+
+`server/profiling/server.go` has the same goroutine-wrapped
+`ListenAndServe`. It is left alone here: nothing dials the profiling
+port right after `Start`, and changing it would turn a currently silent
+profiling bind conflict into a startup failure — worth its own change.

--- a/server/backend/warehouse/dummy.go
+++ b/server/backend/warehouse/dummy.go
@@ -17,6 +17,7 @@
 package warehouse
 
 import (
+	"context"
 	"time"
 
 	"github.com/yorkie-team/yorkie/api/types"
@@ -27,62 +28,110 @@ import (
 type DummyWarehouse struct{}
 
 // GetActiveUsers does nothing.
-func (w *DummyWarehouse) GetActiveUsers(id types.ID, from, to time.Time) ([]types.MetricPoint, error) {
+func (w *DummyWarehouse) GetActiveUsers(
+	ctx context.Context,
+	id types.ID,
+	from, to time.Time,
+) ([]types.MetricPoint, error) {
 	return nil, nil
 }
 
 // GetActiveUsersCount does nothing.
-func (w *DummyWarehouse) GetActiveUsersCount(id types.ID, from, to time.Time) (int, error) {
+func (w *DummyWarehouse) GetActiveUsersCount(
+	ctx context.Context,
+	id types.ID,
+	from, to time.Time,
+) (int, error) {
 	return 0, nil
 }
 
 // GetActiveDocuments does nothing.
-func (w *DummyWarehouse) GetActiveDocuments(id types.ID, from, to time.Time) ([]types.MetricPoint, error) {
+func (w *DummyWarehouse) GetActiveDocuments(
+	ctx context.Context,
+	id types.ID,
+	from, to time.Time,
+) ([]types.MetricPoint, error) {
 	return nil, nil
 }
 
 // GetActiveDocumentsCount does nothing.
-func (w *DummyWarehouse) GetActiveDocumentsCount(id types.ID, from, to time.Time) (int, error) {
+func (w *DummyWarehouse) GetActiveDocumentsCount(
+	ctx context.Context,
+	id types.ID,
+	from, to time.Time,
+) (int, error) {
 	return 0, nil
 }
 
 // GetActiveClients does nothing.
-func (w *DummyWarehouse) GetActiveClients(id types.ID, from, to time.Time) ([]types.MetricPoint, error) {
+func (w *DummyWarehouse) GetActiveClients(
+	ctx context.Context,
+	id types.ID,
+	from, to time.Time,
+) ([]types.MetricPoint, error) {
 	return nil, nil
 }
 
 // GetActiveClientsCount does nothing.
-func (w *DummyWarehouse) GetActiveClientsCount(id types.ID, from, to time.Time) (int, error) {
+func (w *DummyWarehouse) GetActiveClientsCount(
+	ctx context.Context,
+	id types.ID,
+	from, to time.Time,
+) (int, error) {
 	return 0, nil
 }
 
 // GetActiveChannels does nothing.
-func (w *DummyWarehouse) GetActiveChannels(id types.ID, from, to time.Time) ([]types.MetricPoint, error) {
+func (w *DummyWarehouse) GetActiveChannels(
+	ctx context.Context,
+	id types.ID,
+	from, to time.Time,
+) ([]types.MetricPoint, error) {
 	return nil, nil
 }
 
 // GetActiveChannelsCount does nothing.
-func (w *DummyWarehouse) GetActiveChannelsCount(id types.ID, from, to time.Time) (int, error) {
+func (w *DummyWarehouse) GetActiveChannelsCount(
+	ctx context.Context,
+	id types.ID,
+	from, to time.Time,
+) (int, error) {
 	return 0, nil
 }
 
 // GetSessions does nothing.
-func (w *DummyWarehouse) GetSessions(id types.ID, from, to time.Time) ([]types.MetricPoint, error) {
+func (w *DummyWarehouse) GetSessions(
+	ctx context.Context,
+	id types.ID,
+	from, to time.Time,
+) ([]types.MetricPoint, error) {
 	return nil, nil
 }
 
 // GetSessionsCount does nothing.
-func (w *DummyWarehouse) GetSessionsCount(id types.ID, from, to time.Time) (int, error) {
+func (w *DummyWarehouse) GetSessionsCount(
+	ctx context.Context,
+	id types.ID,
+	from, to time.Time,
+) (int, error) {
 	return 0, nil
 }
 
 // GetPeakSessionsPerChannel does nothing.
-func (w *DummyWarehouse) GetPeakSessionsPerChannel(id types.ID, from, to time.Time) ([]types.MetricPoint, error) {
+func (w *DummyWarehouse) GetPeakSessionsPerChannel(
+	ctx context.Context,
+	id types.ID,
+	from, to time.Time,
+) ([]types.MetricPoint, error) {
 	return nil, nil
 }
 
 // GetPeakSessionsPerChannelCount does nothing.
-func (w *DummyWarehouse) GetPeakSessionsPerChannelCount(id types.ID, from, to time.Time) (int, error) {
+func (w *DummyWarehouse) GetPeakSessionsPerChannelCount(
+	ctx context.Context,
+	id types.ID,
+	from, to time.Time,
+) (int, error) {
 	return 0, nil
 }
 

--- a/server/backend/warehouse/starrocks.go
+++ b/server/backend/warehouse/starrocks.go
@@ -17,6 +17,7 @@
 package warehouse
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"time"
@@ -50,7 +51,11 @@ func (r *StarRocks) dial(dsn string) error {
 }
 
 // GetActiveUsers returns the number of active users in the given time range.
-func (r *StarRocks) GetActiveUsers(id types.ID, from, to time.Time) ([]types.MetricPoint, error) {
+func (r *StarRocks) GetActiveUsers(
+	ctx context.Context,
+	id types.ID,
+	from, to time.Time,
+) ([]types.MetricPoint, error) {
 	if err := validateTimeRange(from, to); err != nil {
 		return nil, err
 	}
@@ -61,7 +66,7 @@ func (r *StarRocks) GetActiveUsers(id types.ID, from, to time.Time) ([]types.Met
 	query := fmt.Sprintf(`
 	SELECT 
 	    DATE(timestamp) AS event_date, 
-	    COUNT(DISTINCT user_id) AS active_users
+	    APPROX_COUNT_DISTINCT(user_id) AS active_users
 	FROM 
 	    user_events
 	WHERE
@@ -74,7 +79,7 @@ func (r *StarRocks) GetActiveUsers(id types.ID, from, to time.Time) ([]types.Met
 	    event_date ASC;
 	`, id.String(), from.Format("2006-01-02"), to.Format("2006-01-02"))
 
-	metrics, err := r.queryMetrics(query)
+	metrics, err := r.queryMetrics(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("get active users: %w", err)
 	}
@@ -82,7 +87,11 @@ func (r *StarRocks) GetActiveUsers(id types.ID, from, to time.Time) ([]types.Met
 }
 
 // GetActiveUsersCount returns the total number of active users in the given time range.
-func (r *StarRocks) GetActiveUsersCount(id types.ID, from, to time.Time) (int, error) {
+func (r *StarRocks) GetActiveUsersCount(
+	ctx context.Context,
+	id types.ID,
+	from, to time.Time,
+) (int, error) {
 	if err := validateTimeRange(from, to); err != nil {
 		return 0, err
 	}
@@ -92,7 +101,7 @@ func (r *StarRocks) GetActiveUsersCount(id types.ID, from, to time.Time) (int, e
 	//nolint:gosec
 	query := fmt.Sprintf(`
 	SELECT 
-	    COUNT(DISTINCT user_id) AS active_users
+	    APPROX_COUNT_DISTINCT(user_id) AS active_users
 	FROM 
 	    user_events
 	WHERE
@@ -101,7 +110,7 @@ func (r *StarRocks) GetActiveUsersCount(id types.ID, from, to time.Time) (int, e
 		AND timestamp < '%s';
 	`, id.String(), from.Format("2006-01-02"), to.Format("2006-01-02"))
 
-	count, err := r.queryCount(query)
+	count, err := r.queryCount(ctx, query)
 	if err != nil {
 		return 0, fmt.Errorf("get active users count: %w", err)
 	}
@@ -109,7 +118,11 @@ func (r *StarRocks) GetActiveUsersCount(id types.ID, from, to time.Time) (int, e
 }
 
 // GetActiveDocuments returns the number of active documents in the given time range.
-func (r *StarRocks) GetActiveDocuments(id types.ID, from, to time.Time) ([]types.MetricPoint, error) {
+func (r *StarRocks) GetActiveDocuments(
+	ctx context.Context,
+	id types.ID,
+	from, to time.Time,
+) ([]types.MetricPoint, error) {
 	if err := validateTimeRange(from, to); err != nil {
 		return nil, err
 	}
@@ -120,7 +133,7 @@ func (r *StarRocks) GetActiveDocuments(id types.ID, from, to time.Time) ([]types
 	query := fmt.Sprintf(`
 	SELECT 
 	    DATE(timestamp) AS event_date, 
-	    COUNT(DISTINCT document_key) AS active_documents
+	    APPROX_COUNT_DISTINCT(document_key) AS active_documents
 	FROM 
 	    document_events
 	WHERE
@@ -133,7 +146,7 @@ func (r *StarRocks) GetActiveDocuments(id types.ID, from, to time.Time) ([]types
 	    event_date ASC;
 	`, id.String(), from.Format("2006-01-02"), to.Format("2006-01-02"))
 
-	metrics, err := r.queryMetrics(query)
+	metrics, err := r.queryMetrics(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("get active documents: %w", err)
 	}
@@ -141,7 +154,11 @@ func (r *StarRocks) GetActiveDocuments(id types.ID, from, to time.Time) ([]types
 }
 
 // GetActiveDocumentsCount returns the total number of active documents in the given time range.
-func (r *StarRocks) GetActiveDocumentsCount(id types.ID, from, to time.Time) (int, error) {
+func (r *StarRocks) GetActiveDocumentsCount(
+	ctx context.Context,
+	id types.ID,
+	from, to time.Time,
+) (int, error) {
 	if err := validateTimeRange(from, to); err != nil {
 		return 0, err
 	}
@@ -151,7 +168,7 @@ func (r *StarRocks) GetActiveDocumentsCount(id types.ID, from, to time.Time) (in
 	//nolint:gosec
 	query := fmt.Sprintf(`
 	SELECT 
-		COUNT(DISTINCT document_key) AS active_documents
+		APPROX_COUNT_DISTINCT(document_key) AS active_documents
 	FROM 
 		document_events
 	WHERE
@@ -160,7 +177,7 @@ func (r *StarRocks) GetActiveDocumentsCount(id types.ID, from, to time.Time) (in
 		AND timestamp < '%s';
 	`, id.String(), from.Format("2006-01-02"), to.Format("2006-01-02"))
 
-	count, err := r.queryCount(query)
+	count, err := r.queryCount(ctx, query)
 	if err != nil {
 		return 0, fmt.Errorf("get active documents count: %w", err)
 	}
@@ -168,7 +185,11 @@ func (r *StarRocks) GetActiveDocumentsCount(id types.ID, from, to time.Time) (in
 }
 
 // GetActiveClients returns the number of active clients in the given time range.
-func (r *StarRocks) GetActiveClients(id types.ID, from, to time.Time) ([]types.MetricPoint, error) {
+func (r *StarRocks) GetActiveClients(
+	ctx context.Context,
+	id types.ID,
+	from, to time.Time,
+) ([]types.MetricPoint, error) {
 	if err := validateTimeRange(from, to); err != nil {
 		return nil, err
 	}
@@ -179,7 +200,7 @@ func (r *StarRocks) GetActiveClients(id types.ID, from, to time.Time) ([]types.M
 	query := fmt.Sprintf(`
 	SELECT
 	    DATE(timestamp) AS event_date,
-	    COUNT(DISTINCT client_id) AS active_clients
+	    APPROX_COUNT_DISTINCT(client_id) AS active_clients
 	FROM
 	    client_events
 	WHERE
@@ -193,7 +214,7 @@ func (r *StarRocks) GetActiveClients(id types.ID, from, to time.Time) ([]types.M
 	    event_date ASC;
 	`, id.String(), events.ClientActivatedEvent, from.Format("2006-01-02"), to.Format("2006-01-02"))
 
-	metrics, err := r.queryMetrics(query)
+	metrics, err := r.queryMetrics(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("get active clients: %w", err)
 	}
@@ -201,7 +222,11 @@ func (r *StarRocks) GetActiveClients(id types.ID, from, to time.Time) ([]types.M
 }
 
 // GetActiveClientsCount returns the total number of active clients in the given time range.
-func (r *StarRocks) GetActiveClientsCount(id types.ID, from, to time.Time) (int, error) {
+func (r *StarRocks) GetActiveClientsCount(
+	ctx context.Context,
+	id types.ID,
+	from, to time.Time,
+) (int, error) {
 	if err := validateTimeRange(from, to); err != nil {
 		return 0, err
 	}
@@ -211,7 +236,7 @@ func (r *StarRocks) GetActiveClientsCount(id types.ID, from, to time.Time) (int,
 	//nolint:gosec
 	query := fmt.Sprintf(`
 	SELECT
-		COUNT(DISTINCT client_id) AS active_clients
+		APPROX_COUNT_DISTINCT(client_id) AS active_clients
 	FROM
 		client_events
 	WHERE
@@ -221,7 +246,7 @@ func (r *StarRocks) GetActiveClientsCount(id types.ID, from, to time.Time) (int,
 		AND timestamp < '%s';
 	`, id.String(), events.ClientActivatedEvent, from.Format("2006-01-02"), to.Format("2006-01-02"))
 
-	count, err := r.queryCount(query)
+	count, err := r.queryCount(ctx, query)
 	if err != nil {
 		return 0, fmt.Errorf("get active clients count: %w", err)
 	}
@@ -229,7 +254,11 @@ func (r *StarRocks) GetActiveClientsCount(id types.ID, from, to time.Time) (int,
 }
 
 // GetActiveChannels returns the active channels of the given project.
-func (r *StarRocks) GetActiveChannels(id types.ID, from, to time.Time) ([]types.MetricPoint, error) {
+func (r *StarRocks) GetActiveChannels(
+	ctx context.Context,
+	id types.ID,
+	from, to time.Time,
+) ([]types.MetricPoint, error) {
 	if err := validateTimeRange(from, to); err != nil {
 		return nil, err
 	}
@@ -240,7 +269,7 @@ func (r *StarRocks) GetActiveChannels(id types.ID, from, to time.Time) ([]types.
 	query := fmt.Sprintf(`
 	SELECT 
 	    DATE(timestamp) AS event_date, 
-	    COUNT(DISTINCT channel_key) AS channels
+	    APPROX_COUNT_DISTINCT(channel_key) AS channels
 	FROM 
 	    channel_events
 	WHERE
@@ -253,7 +282,7 @@ func (r *StarRocks) GetActiveChannels(id types.ID, from, to time.Time) ([]types.
 	    event_date ASC;
 	`, id.String(), from.Format("2006-01-02"), to.Format("2006-01-02"))
 
-	metrics, err := r.queryMetrics(query)
+	metrics, err := r.queryMetrics(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("get active channels: %w", err)
 	}
@@ -261,7 +290,11 @@ func (r *StarRocks) GetActiveChannels(id types.ID, from, to time.Time) ([]types.
 }
 
 // GetActiveChannelsCount returns the active channels count of the given project.
-func (r *StarRocks) GetActiveChannelsCount(id types.ID, from, to time.Time) (int, error) {
+func (r *StarRocks) GetActiveChannelsCount(
+	ctx context.Context,
+	id types.ID,
+	from, to time.Time,
+) (int, error) {
 	if err := validateTimeRange(from, to); err != nil {
 		return 0, err
 	}
@@ -271,7 +304,7 @@ func (r *StarRocks) GetActiveChannelsCount(id types.ID, from, to time.Time) (int
 	//nolint:gosec
 	query := fmt.Sprintf(`
 	SELECT 
-	    COUNT(DISTINCT channel_key) AS channels
+	    APPROX_COUNT_DISTINCT(channel_key) AS channels
 	FROM 
 	    channel_events
 	WHERE
@@ -280,7 +313,7 @@ func (r *StarRocks) GetActiveChannelsCount(id types.ID, from, to time.Time) (int
 		AND timestamp < '%s';
 	`, id.String(), from.Format("2006-01-02"), to.Format("2006-01-02"))
 
-	count, err := r.queryCount(query)
+	count, err := r.queryCount(ctx, query)
 	if err != nil {
 		return 0, fmt.Errorf("get active channels count: %w", err)
 	}
@@ -288,7 +321,11 @@ func (r *StarRocks) GetActiveChannelsCount(id types.ID, from, to time.Time) (int
 }
 
 // GetSessions returns the sessions of the given project.
-func (r *StarRocks) GetSessions(id types.ID, from, to time.Time) ([]types.MetricPoint, error) {
+func (r *StarRocks) GetSessions(
+	ctx context.Context,
+	id types.ID,
+	from, to time.Time,
+) ([]types.MetricPoint, error) {
 	if err := validateTimeRange(from, to); err != nil {
 		return nil, err
 	}
@@ -299,7 +336,7 @@ func (r *StarRocks) GetSessions(id types.ID, from, to time.Time) ([]types.Metric
 	query := fmt.Sprintf(`
 	SELECT 
 	    DATE(timestamp) AS event_date, 
-	    COUNT(DISTINCT session_id) AS sessions
+	    APPROX_COUNT_DISTINCT(session_id) AS sessions
 	FROM 
 	    session_events
 	WHERE
@@ -312,7 +349,7 @@ func (r *StarRocks) GetSessions(id types.ID, from, to time.Time) ([]types.Metric
 	    event_date ASC;
 	`, id.String(), from.Format("2006-01-02"), to.Format("2006-01-02"))
 
-	metrics, err := r.queryMetrics(query)
+	metrics, err := r.queryMetrics(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("get sessions: %w", err)
 	}
@@ -320,7 +357,11 @@ func (r *StarRocks) GetSessions(id types.ID, from, to time.Time) ([]types.Metric
 }
 
 // GetSessionsCount returns the sessions count of the given project.
-func (r *StarRocks) GetSessionsCount(id types.ID, from, to time.Time) (int, error) {
+func (r *StarRocks) GetSessionsCount(
+	ctx context.Context,
+	id types.ID,
+	from, to time.Time,
+) (int, error) {
 	if err := validateTimeRange(from, to); err != nil {
 		return 0, err
 	}
@@ -330,7 +371,7 @@ func (r *StarRocks) GetSessionsCount(id types.ID, from, to time.Time) (int, erro
 	//nolint:gosec
 	query := fmt.Sprintf(`
 	SELECT 
-	    COUNT(DISTINCT session_id) AS sessions
+	    APPROX_COUNT_DISTINCT(session_id) AS sessions
 	FROM 
 	    session_events
 	WHERE
@@ -339,7 +380,7 @@ func (r *StarRocks) GetSessionsCount(id types.ID, from, to time.Time) (int, erro
 		AND timestamp < '%s';
 	`, id.String(), from.Format("2006-01-02"), to.Format("2006-01-02"))
 
-	count, err := r.queryCount(query)
+	count, err := r.queryCount(ctx, query)
 	if err != nil {
 		return 0, fmt.Errorf("get sessions count: %w", err)
 	}
@@ -347,7 +388,11 @@ func (r *StarRocks) GetSessionsCount(id types.ID, from, to time.Time) (int, erro
 }
 
 // GetPeakSessionsPerChannel returns the peak sessions per channel of the given project.
-func (r *StarRocks) GetPeakSessionsPerChannel(id types.ID, from, to time.Time) ([]types.MetricPoint, error) {
+func (r *StarRocks) GetPeakSessionsPerChannel(
+	ctx context.Context,
+	id types.ID,
+	from, to time.Time,
+) ([]types.MetricPoint, error) {
 	if err := validateTimeRange(from, to); err != nil {
 		return nil, err
 	}
@@ -363,7 +408,7 @@ func (r *StarRocks) GetPeakSessionsPerChannel(id types.ID, from, to time.Time) (
 	    SELECT 
 	        DATE(timestamp) AS event_date,
 	        channel_key,
-	        COUNT(DISTINCT session_id) AS session_count
+	        APPROX_COUNT_DISTINCT(session_id) AS session_count
 	    FROM 
 	        session_events
 	    WHERE
@@ -379,7 +424,7 @@ func (r *StarRocks) GetPeakSessionsPerChannel(id types.ID, from, to time.Time) (
 	    event_date ASC;
 	`, id.String(), from.Format("2006-01-02"), to.Format("2006-01-02"))
 
-	metrics, err := r.queryMetrics(query)
+	metrics, err := r.queryMetrics(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("get peak sessions per channel: %w", err)
 	}
@@ -387,7 +432,11 @@ func (r *StarRocks) GetPeakSessionsPerChannel(id types.ID, from, to time.Time) (
 }
 
 // GetPeakSessionsPerChannelCount returns the peak sessions per channel count of the given project.
-func (r *StarRocks) GetPeakSessionsPerChannelCount(id types.ID, from, to time.Time) (int, error) {
+func (r *StarRocks) GetPeakSessionsPerChannelCount(
+	ctx context.Context,
+	id types.ID,
+	from, to time.Time,
+) (int, error) {
 	if err := validateTimeRange(from, to); err != nil {
 		return 0, err
 	}
@@ -402,7 +451,7 @@ func (r *StarRocks) GetPeakSessionsPerChannelCount(id types.ID, from, to time.Ti
 	    SELECT 
 	        DATE(timestamp) AS event_date,
 	        channel_key,
-	        COUNT(DISTINCT session_id) AS session_count
+	        APPROX_COUNT_DISTINCT(session_id) AS session_count
 	    FROM 
 	        session_events
 	    WHERE
@@ -414,7 +463,7 @@ func (r *StarRocks) GetPeakSessionsPerChannelCount(id types.ID, from, to time.Ti
 	) AS channel_sessions;
 	`, id.String(), from.Format("2006-01-02"), to.Format("2006-01-02"))
 
-	count, err := r.queryCount(query)
+	count, err := r.queryCount(ctx, query)
 	if err != nil {
 		return 0, fmt.Errorf("get peak sessions per channel count: %w", err)
 	}
@@ -442,8 +491,8 @@ func validateTimeRange(from, to time.Time) error {
 }
 
 // queryMetrics queries the metrics from the StarRocks.
-func (r *StarRocks) queryMetrics(query string) ([]types.MetricPoint, error) {
-	rows, err := r.driver.Query(query)
+func (r *StarRocks) queryMetrics(ctx context.Context, query string) ([]types.MetricPoint, error) {
+	rows, err := r.driver.QueryContext(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("query metrics: %w", err)
 	}
@@ -479,8 +528,8 @@ func (r *StarRocks) queryMetrics(query string) ([]types.MetricPoint, error) {
 }
 
 // queryCount queries the count from the StarRocks.
-func (r *StarRocks) queryCount(query string) (int, error) {
-	rows, err := r.driver.Query(query)
+func (r *StarRocks) queryCount(ctx context.Context, query string) (int, error) {
+	rows, err := r.driver.QueryContext(ctx, query)
 	if err != nil {
 		return 0, fmt.Errorf("query count: %w", err)
 	}

--- a/server/backend/warehouse/warehouse.go
+++ b/server/backend/warehouse/warehouse.go
@@ -18,6 +18,7 @@
 package warehouse
 
 import (
+	"context"
 	"time"
 
 	"github.com/yorkie-team/yorkie/api/types"
@@ -34,40 +35,88 @@ type Warehouse interface {
 	Close() error
 
 	// GetActiveUsers returns the active users of the given project.
-	GetActiveUsers(id types.ID, from, to time.Time) ([]types.MetricPoint, error)
+	GetActiveUsers(
+		ctx context.Context,
+		id types.ID,
+		from, to time.Time,
+	) ([]types.MetricPoint, error)
 
 	// GetActiveUsersCount returns the active users count of the given project.
-	GetActiveUsersCount(id types.ID, from, to time.Time) (int, error)
+	GetActiveUsersCount(
+		ctx context.Context,
+		id types.ID,
+		from, to time.Time,
+	) (int, error)
 
 	// GetActiveDocuments returns the active documents of the given project.
-	GetActiveDocuments(id types.ID, from, to time.Time) ([]types.MetricPoint, error)
+	GetActiveDocuments(
+		ctx context.Context,
+		id types.ID,
+		from, to time.Time,
+	) ([]types.MetricPoint, error)
 
 	// GetActiveDocumentsCount returns the active documents count of the given project.
-	GetActiveDocumentsCount(id types.ID, from, to time.Time) (int, error)
+	GetActiveDocumentsCount(
+		ctx context.Context,
+		id types.ID,
+		from, to time.Time,
+	) (int, error)
 
 	// GetActiveClients returns the active clients of the given project.
-	GetActiveClients(id types.ID, from, to time.Time) ([]types.MetricPoint, error)
+	GetActiveClients(
+		ctx context.Context,
+		id types.ID,
+		from, to time.Time,
+	) ([]types.MetricPoint, error)
 
 	// GetActiveClientsCount returns the active clients count of the given project.
-	GetActiveClientsCount(id types.ID, from, to time.Time) (int, error)
+	GetActiveClientsCount(
+		ctx context.Context,
+		id types.ID,
+		from, to time.Time,
+	) (int, error)
 
 	// GetActiveChannels returns the active channels of the given project.
-	GetActiveChannels(id types.ID, from, to time.Time) ([]types.MetricPoint, error)
+	GetActiveChannels(
+		ctx context.Context,
+		id types.ID,
+		from, to time.Time,
+	) ([]types.MetricPoint, error)
 
 	// GetActiveChannelsCount returns the active channels count of the given project.
-	GetActiveChannelsCount(id types.ID, from, to time.Time) (int, error)
+	GetActiveChannelsCount(
+		ctx context.Context,
+		id types.ID,
+		from, to time.Time,
+	) (int, error)
 
 	// GetSessions returns the sessions of the given project.
-	GetSessions(id types.ID, from, to time.Time) ([]types.MetricPoint, error)
+	GetSessions(
+		ctx context.Context,
+		id types.ID,
+		from, to time.Time,
+	) ([]types.MetricPoint, error)
 
 	// GetSessionsCount returns the sessions count of the given project.
-	GetSessionsCount(id types.ID, from, to time.Time) (int, error)
+	GetSessionsCount(
+		ctx context.Context,
+		id types.ID,
+		from, to time.Time,
+	) (int, error)
 
 	// GetPeakSessionsPerChannel returns the peak sessions per channel of the given project.
-	GetPeakSessionsPerChannel(id types.ID, from, to time.Time) ([]types.MetricPoint, error)
+	GetPeakSessionsPerChannel(
+		ctx context.Context,
+		id types.ID,
+		from, to time.Time,
+	) ([]types.MetricPoint, error)
 
 	// GetPeakSessionsPerChannelCount returns the peak sessions per channel count of the given project.
-	GetPeakSessionsPerChannelCount(id types.ID, from, to time.Time) (int, error)
+	GetPeakSessionsPerChannelCount(
+		ctx context.Context,
+		id types.ID,
+		from, to time.Time,
+	) (int, error)
 }
 
 // Ensure creates a warehouse instance.

--- a/server/packs/pushpull_test.go
+++ b/server/packs/pushpull_test.go
@@ -56,7 +56,7 @@ var (
 
 var (
 	testRPCServer *rpc.Server
-	testRPCAddr   = fmt.Sprintf("localhost:%d", helper.RPCPort)
+	testRPCAddr   = fmt.Sprintf("localhost:%d", helper.PacksRPCPort)
 	testClient    v1connect.YorkieServiceClient
 	testBackend   *backend.Backend
 	testMockDB    *MockDB
@@ -115,7 +115,7 @@ func TestMain(m *testing.M) {
 
 	testRPCServer, err = rpc.NewServer(
 		&rpc.Config{
-			Port:              helper.RPCPort,
+			Port:              helper.PacksRPCPort,
 			ReadHeaderTimeout: helper.RPCReadHeaderTimeout,
 			IdleTimeout:       helper.RPCIdleTimeout,
 		}, testBackend,

--- a/server/projects/projects.go
+++ b/server/projects/projects.go
@@ -19,9 +19,11 @@ package projects
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/lithammer/shortuuid/v4"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/yorkie-team/yorkie/api/types"
 	"github.com/yorkie-team/yorkie/server/authz"
@@ -136,74 +138,88 @@ func GetProjectStats(
 	from time.Time,
 	to time.Time,
 ) (*types.ProjectStats, error) {
-	activeUsers, err := be.Warehouse.GetActiveUsers(id, from, to)
-	if err != nil {
-		return nil, err
-	}
+	// NOTE(raararaara): The warehouse (StarRocks) metrics, the cached counts
+	// (MongoDB), and the live channel count (cluster RPC) are independent reads.
+	// They are fetched concurrently so the dashboard entry latency is bounded by
+	// the slowest single read instead of the sum of all reads. errgroup cancels
+	// the derived context on the first error, so a slow query is not left running
+	// after the client has already given up.
+	var (
+		activeUsers                 []types.MetricPoint
+		activeUsersCount            int
+		activeDocuments             []types.MetricPoint
+		activeDocumentsCount        int
+		activeClients               []types.MetricPoint
+		activeClientsCount          int
+		activeChannels              []types.MetricPoint
+		activeChannelsCount         int
+		sessions                    []types.MetricPoint
+		sessionsCount               int
+		peakSessionsPerChannel      []types.MetricPoint
+		peakSessionsPerChannelCount int
+		counts                      *database.ProjectStatsCounts
+		channelsCount               int
+	)
 
-	activeUsersCount, err := be.Warehouse.GetActiveUsersCount(id, from, to)
-	if err != nil {
-		return nil, err
-	}
-
-	activeDocuments, err := be.Warehouse.GetActiveDocuments(id, from, to)
-	if err != nil {
-		return nil, err
-	}
-
-	activeDocumentsCount, err := be.Warehouse.GetActiveDocumentsCount(id, from, to)
-	if err != nil {
-		return nil, err
-	}
-
-	activeClients, err := be.Warehouse.GetActiveClients(id, from, to)
-	if err != nil {
-		return nil, err
-	}
-
-	activeClientsCount, err := be.Warehouse.GetActiveClientsCount(id, from, to)
-	if err != nil {
-		return nil, err
-	}
-
-	activeChannels, err := be.Warehouse.GetActiveChannels(id, from, to)
-	if err != nil {
-		return nil, err
-	}
-
-	activeChannelsCount, err := be.Warehouse.GetActiveChannelsCount(id, from, to)
-	if err != nil {
-		return nil, err
-	}
-
-	sessions, err := be.Warehouse.GetSessions(id, from, to)
-	if err != nil {
-		return nil, err
-	}
-
-	sessionsCount, err := be.Warehouse.GetSessionsCount(id, from, to)
-	if err != nil {
-		return nil, err
-	}
-
-	peakSessionsPerChannel, err := be.Warehouse.GetPeakSessionsPerChannel(id, from, to)
-	if err != nil {
-		return nil, err
-	}
-
-	peakSessionsPerChannelCount, err := be.Warehouse.GetPeakSessionsPerChannelCount(id, from, to)
-	if err != nil {
-		return nil, err
-	}
-
-	counts, err := be.DB.GetProjectStatsCounts(ctx, id)
-	if err != nil {
-		return nil, err
-	}
-
-	channelsCount, err := be.BroadcastChannelCount(ctx, id)
-	if err != nil {
-		return nil, err
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() (err error) {
+		activeUsers, err = be.Warehouse.GetActiveUsers(ctx, id, from, to)
+		return err
+	})
+	g.Go(func() (err error) {
+		activeUsersCount, err = be.Warehouse.GetActiveUsersCount(ctx, id, from, to)
+		return err
+	})
+	g.Go(func() (err error) {
+		activeDocuments, err = be.Warehouse.GetActiveDocuments(ctx, id, from, to)
+		return err
+	})
+	g.Go(func() (err error) {
+		activeDocumentsCount, err = be.Warehouse.GetActiveDocumentsCount(ctx, id, from, to)
+		return err
+	})
+	g.Go(func() (err error) {
+		activeClients, err = be.Warehouse.GetActiveClients(ctx, id, from, to)
+		return err
+	})
+	g.Go(func() (err error) {
+		activeClientsCount, err = be.Warehouse.GetActiveClientsCount(ctx, id, from, to)
+		return err
+	})
+	g.Go(func() (err error) {
+		activeChannels, err = be.Warehouse.GetActiveChannels(ctx, id, from, to)
+		return err
+	})
+	g.Go(func() (err error) {
+		activeChannelsCount, err = be.Warehouse.GetActiveChannelsCount(ctx, id, from, to)
+		return err
+	})
+	g.Go(func() (err error) {
+		sessions, err = be.Warehouse.GetSessions(ctx, id, from, to)
+		return err
+	})
+	g.Go(func() (err error) {
+		sessionsCount, err = be.Warehouse.GetSessionsCount(ctx, id, from, to)
+		return err
+	})
+	g.Go(func() (err error) {
+		peakSessionsPerChannel, err = be.Warehouse.GetPeakSessionsPerChannel(ctx, id, from, to)
+		return err
+	})
+	g.Go(func() (err error) {
+		peakSessionsPerChannelCount, err = be.Warehouse.GetPeakSessionsPerChannelCount(ctx, id, from, to)
+		return err
+	})
+	g.Go(func() (err error) {
+		counts, err = be.DB.GetProjectStatsCounts(ctx, id)
+		return err
+	})
+	g.Go(func() (err error) {
+		channelsCount, err = be.BroadcastChannelCount(ctx, id)
+		return err
+	})
+	if err := g.Wait(); err != nil {
+		return nil, fmt.Errorf("collect project stats: %w", err)
 	}
 
 	return &types.ProjectStats{

--- a/server/rpc/server.go
+++ b/server/rpc/server.go
@@ -153,6 +153,12 @@ func (s *Server) listenAndServe() error {
 		logging.DefaultLogger().Infof(fmt.Sprintf("serving RPC on %d", s.conf.Port))
 
 		if s.conf.CertFile != "" && s.conf.KeyFile != "" {
+			// NOTE(hackerwins): Serve closes the listener on its own, but
+			// ServeTLS can bail out on HTTP/2 setup or key loading before it
+			// reaches Serve. Close here so a failed start does not leave the
+			// port bound, accepting connections nobody serves.
+			defer func() { _ = lis.Close() }()
+
 			if err := s.httpServer.ServeTLS(lis, s.conf.CertFile, s.conf.KeyFile); !errors.Is(err, http.ErrServerClosed) {
 				logging.DefaultLogger().Errorf("HTTP server ServeTLS: %v", err)
 			}

--- a/server/rpc/server.go
+++ b/server/rpc/server.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net"
 	"net/http"
 	"time"
 
@@ -139,18 +140,27 @@ func (s *Server) Shutdown(graceful bool) {
 }
 
 func (s *Server) listenAndServe() error {
+	// NOTE(hackerwins): The listener is opened here instead of inside the
+	// goroutine below. Otherwise Start would return before the port is bound,
+	// so a bind failure would be silently swallowed and a client dialing right
+	// after Start could be refused.
+	lis, err := net.Listen("tcp", s.httpServer.Addr)
+	if err != nil {
+		return fmt.Errorf("listen %s: %w", s.httpServer.Addr, err)
+	}
+
 	go func() {
 		logging.DefaultLogger().Infof(fmt.Sprintf("serving RPC on %d", s.conf.Port))
 
 		if s.conf.CertFile != "" && s.conf.KeyFile != "" {
-			if err := s.httpServer.ListenAndServeTLS(s.conf.CertFile, s.conf.KeyFile); !errors.Is(err, http.ErrServerClosed) {
-				logging.DefaultLogger().Errorf("HTTP server ListenAndServeTLS: %v", err)
+			if err := s.httpServer.ServeTLS(lis, s.conf.CertFile, s.conf.KeyFile); !errors.Is(err, http.ErrServerClosed) {
+				logging.DefaultLogger().Errorf("HTTP server ServeTLS: %v", err)
 			}
 			return
 		}
 
-		if err := s.httpServer.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
-			logging.DefaultLogger().Errorf("HTTP server ListenAndServe: %v", err)
+		if err := s.httpServer.Serve(lis); !errors.Is(err, http.ErrServerClosed) {
+			logging.DefaultLogger().Errorf("HTTP server Serve: %v", err)
 		}
 	}()
 	return nil

--- a/server/rpc/server_test.go
+++ b/server/rpc/server_test.go
@@ -26,9 +26,11 @@ import (
 	"net/http"
 	"os"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yorkie-team/yorkie/admin"
 	api "github.com/yorkie-team/yorkie/api/yorkie/v1"
@@ -252,20 +254,20 @@ func TestServerStart(t *testing.T) {
 			ReadHeaderTimeout: helper.RPCReadHeaderTimeout,
 			IdleTimeout:       helper.RPCIdleTimeout,
 		}, testBackend)
-		assert.NoError(t, err)
-		assert.NoError(t, svr.Start())
+		require.NoError(t, err)
+		require.NoError(t, svr.Start())
 		defer svr.Shutdown(true)
 
 		// NOTE(hackerwins): Start should not return until the port is bound,
 		// so a client dialing right after it must not be refused.
 		conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", helper.RPCPort+10))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NoError(t, conn.Close())
 	})
 
 	t.Run("port already in use test", func(t *testing.T) {
 		lis, err := net.Listen("tcp", fmt.Sprintf(":%d", helper.RPCPort+11))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		defer func() { assert.NoError(t, lis.Close()) }()
 
 		svr, err := rpc.NewServer(&rpc.Config{
@@ -273,8 +275,32 @@ func TestServerStart(t *testing.T) {
 			ReadHeaderTimeout: helper.RPCReadHeaderTimeout,
 			IdleTimeout:       helper.RPCIdleTimeout,
 		}, testBackend)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Error(t, svr.Start())
+	})
+
+	t.Run("listener released when serving fails test", func(t *testing.T) {
+		// NOTE(hackerwins): server_test.go is a readable file but not a key
+		// pair, so ServeTLS fails while loading it, before it reaches Serve.
+		svr, err := rpc.NewServer(&rpc.Config{
+			Port:              helper.RPCPort + 12,
+			CertFile:          "server_test.go",
+			KeyFile:           "server_test.go",
+			ReadHeaderTimeout: helper.RPCReadHeaderTimeout,
+			IdleTimeout:       helper.RPCIdleTimeout,
+		}, testBackend)
+		require.NoError(t, err)
+		require.NoError(t, svr.Start())
+		defer svr.Shutdown(true)
+
+		// The port must not stay bound once serving has given up.
+		assert.Eventually(t, func() bool {
+			lis, err := net.Listen("tcp", fmt.Sprintf(":%d", helper.RPCPort+12))
+			if err != nil {
+				return false
+			}
+			return lis.Close() == nil
+		}, 3*time.Second, 10*time.Millisecond)
 	})
 }
 

--- a/server/rpc/server_test.go
+++ b/server/rpc/server_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"testing"
@@ -241,6 +242,39 @@ func TestAdminRPCServerBackend(t *testing.T) {
 
 	t.Run("admin get channels multi path test", func(t *testing.T) {
 		testcases.RunAdminGetChannelsMultiPathTest(t, testClient, testAdminClient)
+	})
+}
+
+func TestServerStart(t *testing.T) {
+	t.Run("listening before start returns test", func(t *testing.T) {
+		svr, err := rpc.NewServer(&rpc.Config{
+			Port:              helper.RPCPort + 10,
+			ReadHeaderTimeout: helper.RPCReadHeaderTimeout,
+			IdleTimeout:       helper.RPCIdleTimeout,
+		}, testBackend)
+		assert.NoError(t, err)
+		assert.NoError(t, svr.Start())
+		defer svr.Shutdown(true)
+
+		// NOTE(hackerwins): Start should not return until the port is bound,
+		// so a client dialing right after it must not be refused.
+		conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", helper.RPCPort+10))
+		assert.NoError(t, err)
+		assert.NoError(t, conn.Close())
+	})
+
+	t.Run("port already in use test", func(t *testing.T) {
+		lis, err := net.Listen("tcp", fmt.Sprintf(":%d", helper.RPCPort+11))
+		assert.NoError(t, err)
+		defer func() { assert.NoError(t, lis.Close()) }()
+
+		svr, err := rpc.NewServer(&rpc.Config{
+			Port:              helper.RPCPort + 11,
+			ReadHeaderTimeout: helper.RPCReadHeaderTimeout,
+			IdleTimeout:       helper.RPCIdleTimeout,
+		}, testBackend)
+		assert.NoError(t, err)
+		assert.Error(t, svr.Start())
 	})
 }
 

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -71,6 +71,12 @@ var (
 	RPCIdleTimeout       = server.DefaultRPCIdleTimeout.String()
 	ProfilingPort        = 11102
 
+	// PacksRPCPort is the port of the RPC server owned by the packs test
+	// package. Test packages run as concurrent processes, so a package that
+	// binds a fixed port needs one of its own. TestConfig hands out
+	// RPCPort + 100n, so ports below RPCPort stay free for this.
+	PacksRPCPort = 11001
+
 	MembershipLeaseDuration   = "15s"
 	MembershipRenewalInterval = "5s"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`GetProjectStats` backs the dashboard overview. It ran 12 warehouse `COUNT(DISTINCT)` queries sequentially, with no context, then read the cached counts and the live channel count. On large datasets an exact distinct count can take tens of seconds, so the entry can exceed the dashboard's ConnectRPC deadline and the charts fail to render. Worse, the server keeps running each query after the client has already given up.

Three changes bring the 7-day view back under the deadline:

- **Approximate counts**: Replace `COUNT(DISTINCT)` with `APPROX_COUNT_DISTINCT` (HLL) in the StarRocks queries. The dashboard shows trends, where the small approximation error is immaterial, and the approximate count is scan-linear instead of the exact count's superlinear cost.
- **Concurrent reads**: Fetch the 12 warehouse metrics, the cached counts, and the live channel count concurrently with `errgroup`, bounding entry latency to the slowest single read rather than their sum.
- **Context propagation**: Thread `context.Context` through the `Warehouse` interface and run the queries with `QueryContext`, so a cancelled request cancels the in-flight StarRocks query instead of leaking work.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

The `Warehouse` interface now takes `context.Context`; the dummy implementation is updated accordingly. `APPROX_COUNT_DISTINCT` trades a small counting error for scan-linear cost, which is acceptable for the dashboard's trend view.

**Does this PR introduce a user-facing change?**:

```release-note
Speed up dashboard project stats by using approximate, concurrent warehouse reads.
```

**Additional documentation**:

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [ ] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Project statistics now load warehouse, database, and broadcast-channel metrics concurrently.
  * Large-scale metric counts use optimized approximate calculations for faster results.

* **Reliability**
  * Metric queries support request cancellation and deadlines.
  * Project statistics provide clearer errors when metric retrieval fails.
  * RPC services now report port-binding failures immediately and release listeners cleanly on startup errors.

* **Testing**
  * Added coverage for RPC startup readiness and port-conflict handling.
  * Dedicated configuration improves reliability for concurrent packs integration tests.

* **Documentation**
  * Added guidance for diagnosing RPC startup and timing-related failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->