### PR TITLE
Release v0.7.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and Yorkie adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## [v0.7.15] - 2026-08-13
+
+### Changed
+
+- Speed up GetProjectStats with approximate, concurrent reads by @raararaara in https://github.com/yorkie-team/yorkie/pull/1925
+- Validate Checkpoint in ChangePack for PushPull API requests by @YBSeok in https://github.com/yorkie-team/yorkie/pull/1910
+
+### Fixed
+
+- Isolate spans in Tree restore so overlapping undo converges by @harrykim8672 in https://github.com/yorkie-team/yorkie/pull/1924
+- Add fuzz coverage for tree and snapshot decoding by @lemon0333 in https://github.com/yorkie-team/yorkie/pull/1920
+
 ## [v0.7.14] - 2026-08-09
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-YORKIE_VERSION := 0.7.14
+YORKIE_VERSION := 0.7.15
 
 GO_PROJECT = github.com/yorkie-team/yorkie
 

--- a/api/docs/yorkie.base.yaml
+++ b/api/docs/yorkie.base.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Yorkie
   description: "Yorkie is an open source document store for building collaborative editing applications."
-  version: v0.7.14
+  version: v0.7.15
 servers:
   - url: https://api.yorkie.dev
     description: Production server

--- a/api/docs/yorkie/v1/admin.openapi.yaml
+++ b/api/docs/yorkie/v1/admin.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.14
+  version: v0.7.15
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/api/docs/yorkie/v1/resources.openapi.yaml
+++ b/api/docs/yorkie/v1/resources.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.14
+  version: v0.7.15
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/api/docs/yorkie/v1/yorkie.openapi.yaml
+++ b/api/docs/yorkie/v1/yorkie.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.14
+  version: v0.7.15
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/build/charts/yorkie-cluster/Chart.yaml
+++ b/build/charts/yorkie-cluster/Chart.yaml
@@ -9,8 +9,8 @@ maintainers:
 
 sources:
   - https://github.com/yorkie-team/yorkie
-version: 0.7.14
-appVersion: "0.7.14"
+version: 0.7.15
+appVersion: "0.7.15"
 kubeVersion: ">=1.28.0-0"
 
 dependencies:


### PR DESCRIPTION
## Summary

Bump to v0.7.15 across the Makefile, the `yorkie-cluster` chart, and the four
OpenAPI docs on the release track, and add the CHANGELOG entry.

Left alone — separate version tracks, and no commit since v0.7.14 touched them:
`yorkie-monitoring` chart (`0.7.7`), `api/docs/yorkie/v1/cluster.openapi.yaml`
(`v0.7.8`).

### CHANGELOG derivation

`v0.7.14..main` is 5 commits. Four are listed:

- #1925 and #1910 under `Changed`
- #1924 and #1920 under `Fixed`

Excluded: #1923, which adds fuzz corpus files under `test/fuzz` with no
production diff — same rule v0.7.13 and v0.7.14 applied to test-only PRs.

#1920 is listed even though its title reads test-only. The fuzzing it adds
surfaced nil-pointer panics, and the PR guards `api/converter/from_bytes.go`
and `from_pb.go` so malformed snapshots and trees return an error instead of
panicking. That is a user-visible fix.

## Test plan

- `make build` succeeds; `./bin/yorkie version` reports `Yorkie Client: 0.7.15`
- No production code changes in this PR beyond version strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Released version 0.7.15, including updated release notes.
  * Updated application, API documentation, and deployment package version information to 0.7.15.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->