### PR TITLE
Stamp merge-bound inserts and filter style-range interlopers

### DIFF
--- a/docs/design/concurrent-merge-split.md
+++ b/docs/design/concurrent-merge-split.md
@@ -440,8 +440,79 @@ both directions. Ranges that genuinely cover the merged content
 (anchored outside the merged parent) are unaffected.
 
 A range end anchored after a moved child (a non-left-most position in
-the merged parent) does not go through the §1.1 redirect and can still
-diverge; this remains a follow-up.
+the merged parent) does not go through the §1.1 redirect; §9.4 covers
+it with a per-node filter.
+
+### §9.4 Per-Node Filter at Moved Anchors
+
+A range end anchored after a moved child resolves through the moved
+child directly into the merge target. Nodes that sit between the
+merge-source tombstone and the moved children — concurrent inserts
+anchored at the tombstone — then fall inside the traversal, although
+the styling client saw them outside its range, after the then-live
+parent. The version-vector check in `canStyle` does not help: the
+interloper may be the styling client's own insert, causally known but
+positionally excluded.
+
+Two mechanisms close this:
+
+1. **Intended-parent stamp.** An insert whose position was declared
+   inside a merged-away parent physically lands in the merge target.
+   `intendedMergeParent` stamps such content with
+   `MergedFrom = declared parent` (merge ticket taken from a moved
+   sibling), making it indistinguishable from merge-moved children —
+   which is what it logically is. This also aligns merge-delete
+   propagation: when the declared parent is later fully deleted, the
+   insert dies with it, matching the replica that applied the insert
+   into the live parent and cascaded the delete.
+2. **Interloper filter.** `mergedAnchorInterloperGuard` activates when
+   the range-end position's declared parent is a merged-away tombstone
+   sitting directly under the merge target and the merge is unknown to
+   the styling client's version vector. During the style traversal it
+   skips element nodes under the target, positioned after the
+   tombstone, that carry **no merge stamp at all** — only such nodes
+   (concurrent inserts anchored at the tombstone) are positively
+   identifiable as interlopers. Any node with a `MergedFrom` fails
+   open: a child that reached the declared parent via an earlier merge
+   keeps the *original* source in `MergedFrom` (first-move stamp rule,
+   Fix 20), and path compression on `mergedInto` makes "was it inside
+   the declared parent" unrecoverable afterwards, so stamped nodes
+   fall back to pre-§9.4 behavior rather than risk skipping a node the
+   styler legitimately covered. Each traversed node is judged by its
+   highest ancestor directly under the target, so an interloper's
+   descendants are skipped with it. Moved children and stamped inserts
+   pass the filter; nodes before the tombstone are untouched.
+
+`SplitElement` copies `MergedFrom`/`MergedAt` to the split product
+(as `SplitText` always has), so a split half of a merge-moved element
+carries the same provenance under either merge-then-split or
+split-then-merge application order and is judged identically by the
+filter.
+
+**Known limitations** (tracked as follow-ups):
+
+- A range *start* anchored after a moved child shrinks the traversal
+  on the applying replica instead of growing it (the interlopers sit
+  before the start), which a skip filter cannot compensate; likewise
+  an edit-only divergence independent of styling.
+- A node moved into the target by an *earlier, different* merge that
+  the styler knew (and therefore saw outside its range) also fails
+  open and is styled on the applying replica — the pre-§9.4 behavior;
+  distinguishing it from an earlier merge *into* the declared parent
+  would require provenance that path compression discards.
+- A relay-only merged parent (one whose children all arrived via an
+  earlier merge and keep the older source's `MergedFrom`) never gets
+  `mergedInto` set, so neither the stamp nor the filter activates in
+  that shape.
+- The stamp's `MergedAt` fallback reads the declared parent's
+  `removedAt` when no moved sibling survives to donate the immutable
+  merge ticket; `removedAt` is LWW-mutable, so the fallback can
+  disagree across replicas in GC-timing corners.
+- Stamped inserts participate in `propagateMergeDeletes` and in the
+  §1.1 redirect boundary scan; the delete cascade is intended
+  (declared-parent deletion should take the insert with it), but both
+  interactions widen `MergedFrom`'s original "physically moved"
+  meaning.
 
 ## Key Design Decisions
 
@@ -521,3 +592,4 @@ For traceability from git history (commit messages reference Fix N).
 | Fix 19 | §6.1 | Move tombstones with merge to preserve RGA anchors |
 | Fix 20 | §6.3 | Flatten chained merge (P→Q→R) for redirect + snapshot consistency |
 | Fix 21 | §9.3 | Style range boundary right after merge-source tombstone |
+| Fix 22 | §9.4 | Intended-parent stamp + interloper filter at moved anchors |

--- a/docs/tasks/active/20260808-tree-style-moved-anchor-lessons.md
+++ b/docs/tasks/active/20260808-tree-style-moved-anchor-lessons.md
@@ -1,0 +1,32 @@
+# Lessons: tree style moved-anchor filter
+
+**Created**: 2026-08-08
+
+- The version-vector oracle has a blind spot for the styler's own
+  concurrent inserts: causally known, positionally excluded. Filtering
+  needs positional intent, not causality — hence the intended-parent
+  stamp at insert time.
+- `MergedFrom` turned out to be the right vocabulary for "logically
+  belongs to that parent's sequence": stamping redirected inserts with
+  it made the interloper filter a one-liner and aligned merge-delete
+  propagation semantics for free.
+- Guard-correctness tests (cases the filter must NOT touch) were as
+  important as the divergence repro: the own-insert-inside-range case
+  converges on main and would have silently broken under a stamp-less
+  filter.
+- Triage every remaining PBT counterexample against main before
+  concluding: both survivors (from-side variant, edit-only 3-client)
+  pre-exist, which separates "my regression" from "next finding" with
+  one stash-run each.
+- The filter's first exemption key (`MergedFrom == declaredParent`)
+  was wrong for chained merges: Fix 20 keeps the ORIGINAL source on
+  re-moved children, and mergedInto path compression destroys the
+  "was it inside the declared parent" fact. A skip filter must fail
+  open on anything it cannot positively classify — never diverge
+  where main converged.
+- Marshal is a weak oracle for attribute state: it hides both empty
+  RHTs and removed-attr tombstones. The RemoveStyle guard was
+  entirely unpinned (mutation run: disabling it stayed green) until
+  the test asserted internal `Attrs` entries directly. Remote op
+  deserialization allocates an empty RHT, so assert on entries, not
+  container nilness.

--- a/docs/tasks/active/20260808-tree-style-moved-anchor-todo.md
+++ b/docs/tasks/active/20260808-tree-style-moved-anchor-todo.md
@@ -1,0 +1,74 @@
+# Tree: converge style ranges ending after a merge-moved child
+
+**Created**: 2026-08-08
+
+Fixes #1916 (yorkie-team/yorkie-js-sdk#1311). The follow-up variant
+documented in #1909/§9.3: a style range end anchored after a moved
+child resolves through the moved child directly, never reaching the
+§9.3 boundary redirect, and styles a concurrently inserted node on
+only one replica.
+
+## Problem
+
+Initial `<r><p>ab</p><p>cd</p></r>`. Concurrently:
+- A: `edit(8, 8, <p/>)`, then `style(0, 6, bold=x)` — the range end is
+  anchored after `c`, a non-left-most position inside p2
+- B: `edit(0, 5)` — merge across the paragraphs
+
+On B the inserted `<p>` sits between the p2 tombstone and the moved
+`c`, inside the resolved range; on A it was outside. The `canStyle`
+version-vector check cannot help: the interloper is A's own insert,
+causally known but positionally excluded.
+
+## Plan
+
+- [x] Reproduce with failing complex test (RED)
+- [x] Stamp inserts declared inside a merged-away parent with
+      `MergedFrom = declared parent` (`intendedMergeParent`) so they
+      stay distinguishable from never-inside nodes
+- [x] Per-node filter in `Style`/`RemoveStyle`
+      (`mergedAnchorInterloperGuard`): skip elements under the merge
+      target, after the tombstone, without a matching `MergedFrom`
+- [x] Guard-correctness tests: own insert inside the styled range
+      stays styled; sibling before the tombstone stays styled
+- [x] Judge interlopers by their highest ancestor under the merge
+      target so descendants are skipped with them (found by probing
+      a nested insert; diverged before this)
+- [x] RemoveStyle-variant complex test (the one-sided empty RHT that
+      Marshal hides); unit tests pinning the stamp in both repos
+- [x] Triage remaining PBT counterexamples against main: the from-side
+      style variant and a 3-client edit-only divergence both reproduce
+      WITHOUT this change — pre-existing, tracked as follow-ups
+- [x] Fail open on any merge-stamped node instead of exempting only
+      `MergedFrom == declared parent`: children brought in by an
+      earlier synced merge keep the original source (first-move stamp
+      rule) and were wrongly skipped — diverged vs main before this
+      (found by review; pinned by
+      `TestTreeConcurrencyStyleCoversEarlierMergedChild`)
+- [x] Copy `MergedFrom`/`MergedAt` in `SplitElement` (SplitText
+      parity) so the filter judges split halves identically under
+      either application order; unit test pins the copy
+- [x] Pin the RemoveStyle guard against the Marshal blind spot: the
+      complex test asserts no attribute entry materializes on the
+      interloper (fails with the RemoveStyle guard disabled)
+- [x] Fold the duplicated skip logic into `styleSkipPredicate`;
+      precompute the after-tombstone set instead of a per-node
+      linear scan
+- [x] Design doc §9.4 + Fix 22; known-limitations list
+- [x] `golangci-lint run ./...` 0 issues; unit/complex/integration
+      tree lanes green
+- [ ] Mirror in yorkie-js-sdk 
+
+## Out of scope
+
+- A range *start* anchored after a moved child shrinks the applier's
+  traversal instead of growing it; a skip filter cannot compensate.
+- An edit-only 3-client divergence (no style involved) reproduces on
+  main independently of this change.
+- Known-limitation corners listed in §9.4: earlier different-target
+  merges fail open (pre-§9.4 behavior), relay-only merged parents
+  never activate the guard, the `MergedAt` fallback reads LWW-mutable
+  `removedAt`, and stamped inserts feed `propagateMergeDeletes` and
+  the §1.1 redirect boundary scan.
+All tracked as follow-ups; the first two are next-cycle issues from
+the #1298 property-based test.

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -149,8 +149,11 @@ type TreeNode struct {
 	//it means that the node is an element node.
 	Attrs *RHT
 
-	// MergedFrom records the source parent's ID when this node was moved
-	// by a concurrent merge operation. Persisted in the snapshot
+	// MergedFrom records the parent this node logically belongs to when a
+	// merge relocated it into the merge target: either the source parent
+	// it was physically moved out of, or — for a concurrent insert whose
+	// position was declared inside a merged-away parent — that declared
+	// parent (§9.4 intended-parent stamp). Persisted in the snapshot
 	// encoding as the witness of the merge relationship.
 	MergedFrom *TreeNodeID
 
@@ -452,6 +455,8 @@ func (n *TreeNode) SplitElement(
 	}
 	split := NewTreeNode(&TreeNodeID{CreatedAt: issueTimeTicket(), Offset: 0}, n.Type(), splitAttrs)
 	split.removedAt = n.removedAt
+	split.MergedFrom = n.MergedFrom
+	split.MergedAt = n.MergedAt
 	if err := n.Index.Parent.InsertAfterInternal(split.Index, n.Index); err != nil {
 		return nil, diff, err
 	}
@@ -1478,6 +1483,8 @@ func (t *Tree) Edit(
 
 	// Phase 8: Insert — insert the given node at the given position.
 	if len(contents) != 0 {
+		intendedParent, intendedMergedAt := t.intendedMergeParent(from, fromParent)
+
 		leftInChildren := fromLeft
 
 		for _, content := range contents {
@@ -1491,6 +1498,11 @@ func (t *Tree) Edit(
 				if err != nil {
 					return append(pairs, t.drainPendingGCPairs()...), diff, err
 				}
+			}
+
+			if intendedParent != nil {
+				content.MergedFrom = intendedParent.id
+				content.MergedAt = intendedMergedAt
 			}
 
 			leftInChildren = content
@@ -1515,6 +1527,119 @@ func (t *Tree) Edit(
 	pairs = append(pairs, t.drainPendingGCPairs()...)
 
 	return pairs, diff, nil
+}
+
+// intendedMergeParent resolves the §9.4 stamp for an insert whose position
+// was declared inside a parent that a concurrent merge removed: the content
+// lands in the merge target, so stamp it as merged-from the declared parent
+// to keep it distinguishable from nodes that were never inside that parent
+// (the §9.4 filter and merge-delete propagation key on this). The merge
+// ticket comes from a sibling the merge moved, since the parent's own
+// removedAt may be overwritten by a later LWW tombstone.
+func (t *Tree) intendedMergeParent(
+	from *TreePos,
+	fromParent *TreeNode,
+) (*TreeNode, *time.Ticket) {
+	declaredFromParent, _ := t.ToTreeNodes(from)
+	if declaredFromParent == nil || declaredFromParent == fromParent ||
+		!declaredFromParent.IsRemoved() || declaredFromParent.mergedInto == nil ||
+		t.resolveMergeTarget(declaredFromParent) != fromParent {
+		return nil, nil
+	}
+	for _, child := range fromParent.Index.Children(true) {
+		if child.Value.MergedFrom != nil &&
+			child.Value.MergedFrom.Equal(declaredFromParent.id) &&
+			child.Value.MergedAt != nil {
+			return declaredFromParent, child.Value.MergedAt
+		}
+	}
+	return declaredFromParent, declaredFromParent.removedAt
+}
+
+// mergedAnchorInterloperGuard prepares the §9.4 per-node filter for a style
+// range whose end position was declared inside a parent that a merge unknown
+// to the styling client removed. The moved anchor child resolves in the
+// merge target, so the traversal covers nodes sitting between the
+// merge-source tombstone and the moved children — nodes the styling client
+// saw outside its range, after the then-live parent. The predicate skips
+// exactly those interlopers.
+func (t *Tree) mergedAnchorInterloperGuard(
+	pos *TreePos,
+	versionVector time.VersionVector,
+) func(*TreeNode) bool {
+	if len(versionVector) == 0 {
+		return nil
+	}
+	declaredParent, _ := t.ToTreeNodes(pos)
+	if declaredParent == nil || !declaredParent.IsRemoved() ||
+		declaredParent.mergedInto == nil || declaredParent.removedAt == nil ||
+		ticketKnown(versionVector, declaredParent.removedAt) {
+		return nil
+	}
+	target := t.resolveMergeTarget(declaredParent)
+	// Restricted to the shape where the tombstone sits directly under the
+	// merge target; in other shapes the resolved range already excludes
+	// the interlopers.
+	if target == declaredParent || declaredParent.Index.Parent == nil ||
+		declaredParent.Index.Parent.Value != target {
+		return nil
+	}
+	// Collect the target's children positioned after the merge-source
+	// tombstone in one pass, so the predicate is O(depth) per node.
+	afterTombstone := make(map[*TreeNode]bool)
+	seenTombstone := false
+	for _, child := range target.Index.Children(true) {
+		if child.Value == declaredParent {
+			seenTombstone = true
+			continue
+		}
+		if seenTombstone {
+			afterTombstone[child.Value] = true
+		}
+	}
+	return func(node *TreeNode) bool {
+		// Judge by the node's highest ancestor directly under the merge
+		// target, so an interloper's descendants are skipped with it.
+		top := node
+		for top.Index.Parent != nil && top.Index.Parent.Value != target {
+			top = top.Index.Parent.Value
+		}
+		if top.Index.Parent == nil || top.Index.Parent.Value != target {
+			return false
+		}
+		// Fail open for any node carrying a merge stamp: a child that
+		// arrived via an earlier merge keeps the ORIGINAL source in
+		// MergedFrom (first-move rule, Fix 20), so membership in the
+		// declared parent is unrecoverable. Only stamp-free nodes are
+		// positively identifiable as interlopers (§9.4).
+		if top.MergedFrom != nil {
+			return false
+		}
+		return afterTombstone[top]
+	}
+}
+
+// styleSkipPredicate builds the per-token skip checks shared by Style and
+// RemoveStyle: the End-token unknown-split-sibling exclusion and the §9.4
+// merged-anchor interloper filter for the range-end position.
+func (t *Tree) styleSkipPredicate(
+	to *TreePos,
+	versionVector time.VersionVector,
+) func(index.TreeToken[*TreeNode]) bool {
+	isVersionVectorEmpty := len(versionVector) == 0
+	isAnchorInterloper := t.mergedAnchorInterloperGuard(to, versionVector)
+	return func(token index.TreeToken[*TreeNode]) bool {
+		// Skip styling via End token when the node has an unknown
+		// split sibling. The End token is in the range only because
+		// a concurrent split extended the range into the sibling.
+		if token.TokenType == index.End && !isVersionVectorEmpty &&
+			t.hasUnknownSplitSibling(token.Node, versionVector) {
+			return true
+		}
+		// §9.4: the node is in the range only because an unknown merge
+		// pulled the range-end anchor past it.
+		return isAnchorInterloper != nil && isAnchorInterloper(token.Node)
+	}
 }
 
 // resolveMergeTarget follows the mergedInto forwarding chain from the given
@@ -2035,6 +2160,7 @@ func (t *Tree) Style(
 	}
 
 	isVersionVectorEmpty := len(versionVector) == 0
+	shouldSkipToken := t.styleSkipPredicate(to, versionVector)
 
 	var pairs []GCPair
 	if err = t.traverseInPosRange(fromParent, fromLeft, toParent, toLeft, func(token index.TreeToken[*TreeNode], _ bool) {
@@ -2056,11 +2182,7 @@ func (t *Tree) Style(
 		}
 
 		if node.canStyle(editedAt, clientLamportAtChange) && len(attrs) > 0 {
-			// Skip styling via End token when the node has an unknown
-			// split sibling. The End token is in the range only because
-			// a concurrent split extended the range into the sibling.
-			if token.TokenType == index.End && !isVersionVectorEmpty &&
-				t.hasUnknownSplitSibling(node, versionVector) {
+			if shouldSkipToken(token) {
 				return
 			}
 
@@ -2143,6 +2265,7 @@ func (t *Tree) RemoveStyle(
 	}
 
 	isVersionVectorEmpty := len(versionVector) == 0
+	shouldSkipToken := t.styleSkipPredicate(to, versionVector)
 
 	var pairs []GCPair
 	if err = t.traverseInPosRange(fromParent, fromLeft, toParent, toLeft, func(token index.TreeToken[*TreeNode], _ bool) {
@@ -2164,11 +2287,7 @@ func (t *Tree) RemoveStyle(
 		}
 
 		if node.canStyle(editedAt, clientLamportAtChange) && len(attrs) > 0 {
-			// Skip styling via End token when the node has an unknown
-			// split sibling. The End token is in the range only because
-			// a concurrent split extended the range into the sibling.
-			if token.TokenType == index.End && !isVersionVectorEmpty &&
-				t.hasUnknownSplitSibling(node, versionVector) {
+			if shouldSkipToken(token) {
 				return
 			}
 

--- a/pkg/document/crdt/tree_test.go
+++ b/pkg/document/crdt/tree_test.go
@@ -505,18 +505,24 @@ func TestTreeEdit(t *testing.T) {
 
 		// 02. Merge the second paragraph into the first, then apply an
 		// insert that still declares the merged-away paragraph as parent.
-		_, _, err = tree.EditT(3, 5, nil, 0, helper.TimeT(ctx), issueTicket(ctx))
+		// A later delete LWW-overwrites the tombstone first, so the merge
+		// ticket is only recoverable from the moved sibling.
+		mergeTicket := helper.TimeT(ctx)
+		_, _, err = tree.EditT(3, 5, nil, 0, mergeTicket, issueTicket(ctx))
 		assert.NoError(t, err)
 		assert.Equal(t, "<root><p>abcd</p></root>", tree.ToXML())
+		p2Node.SetRemovedAt(helper.TimeT(ctx))
 		content := crdt.NewTreeNode(helper.PosT(ctx), "b", nil)
 		_, _, err = tree.Edit(pos, pos, []*crdt.TreeNode{content}, 0,
 			helper.TimeT(ctx), issueTicket(ctx), nil)
 		assert.NoError(t, err)
 
 		// 03. The content lands in the merge target but is stamped as
-		// merged-from the declared parent, like a merge-moved child.
+		// merged-from the declared parent, like a merge-moved child,
+		// carrying the moved sibling's merge ticket.
 		assert.NotNil(t, content.MergedFrom)
 		assert.True(t, content.MergedFrom.Equal(p2Node.ID()))
+		assert.Equal(t, mergeTicket, content.MergedAt)
 	})
 
 	t.Run("delete nodes between element nodes in different levels test", func(t *testing.T) {

--- a/pkg/document/crdt/tree_test.go
+++ b/pkg/document/crdt/tree_test.go
@@ -128,6 +128,34 @@ func TestTreeNode(t *testing.T) {
 		assert.Equal(t, `<p bold="true">world</p>`, crdt.ToXML(split))
 	})
 
+	t.Run("split element should copy merge stamp", func(t *testing.T) {
+		root := crdt.NewTreeNode(dummyTreeNodeID, "r", nil)
+		para := crdt.NewTreeNode(dummyTreeNodeID, "p", nil)
+		assert.NoError(t, root.Append(para))
+		assert.NoError(t, para.Append(crdt.NewTreeNode(dummyTreeNodeID, "text", nil, "helloworld")))
+
+		// The paragraph was previously moved by a merge.
+		mergedFrom := &crdt.TreeNodeID{CreatedAt: time.InitialTicket, Offset: 7}
+		para.MergedFrom = mergedFrom
+		para.MergedAt = time.InitialTicket
+
+		left, err := para.Child(0)
+		assert.NoError(t, err)
+		_, _, err = left.SplitText(5, 0)
+		assert.NoError(t, err)
+
+		split, _, err := para.SplitElement(1, func() *time.Ticket {
+			return time.InitialTicket
+		}, nil)
+		assert.NoError(t, err)
+
+		// The split product holds the other half of the same moved node,
+		// so it must carry the same merge stamp (as SplitText does).
+		assert.NotNil(t, split.MergedFrom)
+		assert.True(t, split.MergedFrom.Equal(mergedFrom))
+		assert.Equal(t, time.InitialTicket, split.MergedAt)
+	})
+
 	t.Run("UTF-16 code unit test", func(t *testing.T) {
 		tests := []struct {
 			length int
@@ -452,6 +480,43 @@ func TestTreeEdit(t *testing.T) {
 		idx, err = tree.ToIndex(rangeParent, rangeLeft)
 		assert.NoError(t, err)
 		assert.Equal(t, 6, idx)
+	})
+
+	t.Run("stamps an insert declared inside a merged-away parent", func(t *testing.T) {
+		// 01. Create <root><p>ab</p><p>cd</p></root> and capture the
+		// leftmost position inside the second paragraph before the merge.
+		ctx := helper.TextChangeContext(helper.TestRoot())
+		tree := crdt.NewTree(crdt.NewTreeNode(helper.PosT(ctx), "root", nil), helper.TimeT(ctx))
+		_, _, err := tree.EditT(0, 0, []*crdt.TreeNode{crdt.NewTreeNode(helper.PosT(ctx), "p", nil)}, 0,
+			helper.TimeT(ctx), issueTicket(ctx))
+		assert.NoError(t, err)
+		_, _, err = tree.EditT(1, 1, []*crdt.TreeNode{
+			crdt.NewTreeNode(helper.PosT(ctx), "text", nil, "ab"),
+		}, 0, helper.TimeT(ctx), issueTicket(ctx))
+		assert.NoError(t, err)
+		p2Node := crdt.NewTreeNode(helper.PosT(ctx), "p", nil)
+		_, _, err = tree.EditT(4, 4, []*crdt.TreeNode{p2Node}, 0, helper.TimeT(ctx), issueTicket(ctx))
+		assert.NoError(t, err)
+		_, _, err = tree.EditT(5, 5, []*crdt.TreeNode{
+			crdt.NewTreeNode(helper.PosT(ctx), "text", nil, "cd"),
+		}, 0, helper.TimeT(ctx), issueTicket(ctx))
+		assert.NoError(t, err)
+		pos := crdt.NewTreePos(p2Node.ID(), p2Node.ID())
+
+		// 02. Merge the second paragraph into the first, then apply an
+		// insert that still declares the merged-away paragraph as parent.
+		_, _, err = tree.EditT(3, 5, nil, 0, helper.TimeT(ctx), issueTicket(ctx))
+		assert.NoError(t, err)
+		assert.Equal(t, "<root><p>abcd</p></root>", tree.ToXML())
+		content := crdt.NewTreeNode(helper.PosT(ctx), "b", nil)
+		_, _, err = tree.Edit(pos, pos, []*crdt.TreeNode{content}, 0,
+			helper.TimeT(ctx), issueTicket(ctx), nil)
+		assert.NoError(t, err)
+
+		// 03. The content lands in the merge target but is stamped as
+		// merged-from the declared parent, like a merge-moved child.
+		assert.NotNil(t, content.MergedFrom)
+		assert.True(t, content.MergedFrom.Equal(p2Node.ID()))
 	})
 
 	t.Run("delete nodes between element nodes in different levels test", func(t *testing.T) {

--- a/test/complex/tree_concurrency_test.go
+++ b/test/complex/tree_concurrency_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/yorkie-team/yorkie/pkg/document"
+	"github.com/yorkie-team/yorkie/pkg/document/crdt"
 	"github.com/yorkie-team/yorkie/pkg/document/json"
 	"github.com/yorkie-team/yorkie/pkg/document/presence"
 	"github.com/yorkie-team/yorkie/test/helper"
@@ -813,4 +814,324 @@ func TestTreeConcurrencyStyleAcrossChainedMerge(t *testing.T) {
 	assert.True(t, flag, "d1: %s\nd2: %s",
 		d1.Root().GetTree("t").ToXML(), d2.Root().GetTree("t").ToXML())
 	assert.Equal(t, `<r><p bold="x">abcdef</p><p></p></r>`, d1.Root().GetTree("t").ToXML())
+}
+
+// TestTreeConcurrencyStyleAfterMovedAnchor verifies that a style range
+// ending after a merge-moved child does not style a node concurrently
+// inserted at the merged anchor (yorkie-team/yorkie#1916).
+func TestTreeConcurrencyStyleAfterMovedAnchor(t *testing.T) {
+	clients := activeClients(t, 2)
+	c1, c2 := clients[0], clients[1]
+	defer deactivateAndCloseClients(t, clients)
+
+	ctx := context.Background()
+	d1 := document.New(helper.TestKey(t))
+	assert.NoError(t, c1.Attach(ctx, d1))
+	d2 := document.New(helper.TestKey(t))
+	assert.NoError(t, c2.Attach(ctx, d2))
+
+	initialState := json.TreeNode{
+		Type: "r",
+		Children: []json.TreeNode{
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "ab"}}},
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "cd"}}},
+		},
+	}
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.SetNewTree("t", initialState)
+		return nil
+	}))
+	assert.NoError(t, c1.Sync(ctx))
+	assert.NoError(t, c2.Sync(ctx))
+
+	// d1: insert an empty <p> at the end, then style [0, 6) - the range end
+	// is anchored after `c`, a non-left-most position inside p2.
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(8, 8, &json.TreeNode{Type: "p"}, 0)
+		return nil
+	}))
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Style(0, 6, map[string]string{"bold": "x"})
+		return nil
+	}))
+	assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(0, 5, nil, 0)
+		return nil
+	}))
+
+	flag := syncClientsThenCheckEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
+	assert.True(t, flag, "d1: %s\nd2: %s",
+		d1.Root().GetTree("t").ToXML(), d2.Root().GetTree("t").ToXML())
+	assert.Equal(t, `<r><p></p>cd</r>`, d1.Root().GetTree("t").ToXML())
+}
+
+// TestTreeConcurrencyStyleCoversOwnInsertIntoMergedRange verifies that an
+// insert declared inside the merged parent, covered by the styled range,
+// stays styled on both replicas (the stamped-insert exemption).
+func TestTreeConcurrencyStyleCoversOwnInsertIntoMergedRange(t *testing.T) {
+	clients := activeClients(t, 2)
+	c1, c2 := clients[0], clients[1]
+	defer deactivateAndCloseClients(t, clients)
+
+	ctx := context.Background()
+	d1 := document.New(helper.TestKey(t))
+	assert.NoError(t, c1.Attach(ctx, d1))
+	d2 := document.New(helper.TestKey(t))
+	assert.NoError(t, c2.Attach(ctx, d2))
+
+	initialState := json.TreeNode{
+		Type: "r",
+		Children: []json.TreeNode{
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "ab"}}},
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "cd"}}},
+		},
+	}
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.SetNewTree("t", initialState)
+		return nil
+	}))
+	assert.NoError(t, c1.Sync(ctx))
+	assert.NoError(t, c2.Sync(ctx))
+
+	// d1: insert <b> inside p2 before `c`, then style a range covering it.
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(5, 5, &json.TreeNode{Type: "b"}, 0)
+		return nil
+	}))
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Style(0, 8, map[string]string{"bold": "x"})
+		return nil
+	}))
+	assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(0, 5, nil, 0)
+		return nil
+	}))
+
+	flag := syncClientsThenCheckEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
+	assert.True(t, flag, "d1: %s\nd2: %s",
+		d1.Root().GetTree("t").ToXML(), d2.Root().GetTree("t").ToXML())
+	assert.Equal(t, `<r><b bold="x"></b>cd</r>`, d1.Root().GetTree("t").ToXML())
+}
+
+// TestTreeConcurrencyStyleSiblingBeforeTombstone verifies that a sibling
+// positioned before the merge-source tombstone stays styled.
+func TestTreeConcurrencyStyleSiblingBeforeTombstone(t *testing.T) {
+	clients := activeClients(t, 2)
+	c1, c2 := clients[0], clients[1]
+	defer deactivateAndCloseClients(t, clients)
+
+	ctx := context.Background()
+	d1 := document.New(helper.TestKey(t))
+	assert.NoError(t, c1.Attach(ctx, d1))
+	d2 := document.New(helper.TestKey(t))
+	assert.NoError(t, c2.Attach(ctx, d2))
+
+	initialState := json.TreeNode{
+		Type: "r",
+		Children: []json.TreeNode{
+			{Type: "b"},
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "ab"}}},
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "cd"}}},
+		},
+	}
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.SetNewTree("t", initialState)
+		return nil
+	}))
+	assert.NoError(t, c1.Sync(ctx))
+	assert.NoError(t, c2.Sync(ctx))
+
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Style(0, 8, map[string]string{"bold": "x"})
+		return nil
+	}))
+	assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(2, 7, nil, 0)
+		return nil
+	}))
+
+	flag := syncClientsThenCheckEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
+	assert.True(t, flag, "d1: %s\nd2: %s",
+		d1.Root().GetTree("t").ToXML(), d2.Root().GetTree("t").ToXML())
+	assert.Equal(t, `<r><b bold="x"></b>cd</r>`, d1.Root().GetTree("t").ToXML())
+}
+
+// TestTreeConcurrencyStyleSkipsInterloperDescendants verifies that a nested
+// element inside a node concurrently inserted at the merged anchor is
+// skipped together with its parent.
+func TestTreeConcurrencyStyleSkipsInterloperDescendants(t *testing.T) {
+	clients := activeClients(t, 2)
+	c1, c2 := clients[0], clients[1]
+	defer deactivateAndCloseClients(t, clients)
+
+	ctx := context.Background()
+	d1 := document.New(helper.TestKey(t))
+	assert.NoError(t, c1.Attach(ctx, d1))
+	d2 := document.New(helper.TestKey(t))
+	assert.NoError(t, c2.Attach(ctx, d2))
+
+	initialState := json.TreeNode{
+		Type: "r",
+		Children: []json.TreeNode{
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "ab"}}},
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "cd"}}},
+		},
+	}
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.SetNewTree("t", initialState)
+		return nil
+	}))
+	assert.NoError(t, c1.Sync(ctx))
+	assert.NoError(t, c2.Sync(ctx))
+
+	// d1: insert <p> at the end with a nested <b>, then style [0, 6).
+	// Both are outside the styled range on d1.
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(8, 8, &json.TreeNode{Type: "p"}, 0)
+		return nil
+	}))
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(9, 9, &json.TreeNode{Type: "b"}, 0)
+		return nil
+	}))
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Style(0, 6, map[string]string{"bold": "x"})
+		return nil
+	}))
+	assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(0, 5, nil, 0)
+		return nil
+	}))
+
+	flag := syncClientsThenCheckEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
+	assert.True(t, flag, "d1: %s\nd2: %s",
+		d1.Root().GetTree("t").ToXML(), d2.Root().GetTree("t").ToXML())
+	assert.Equal(t, `<r><p><b></b></p>cd</r>`, d1.Root().GetTree("t").ToXML())
+}
+
+// TestTreeConcurrencyStyleCoversEarlierMergedChild verifies that a child
+// that arrived in the styled parent via an earlier, fully synced merge
+// stays styled when a later concurrent merge moves it again: the child
+// keeps the original source's MergedFrom (first-move stamp rule), which
+// must not demote it to an interloper.
+func TestTreeConcurrencyStyleCoversEarlierMergedChild(t *testing.T) {
+	clients := activeClients(t, 2)
+	c1, c2 := clients[0], clients[1]
+	defer deactivateAndCloseClients(t, clients)
+
+	ctx := context.Background()
+	d1 := document.New(helper.TestKey(t))
+	assert.NoError(t, c1.Attach(ctx, d1))
+	d2 := document.New(helper.TestKey(t))
+	assert.NoError(t, c2.Attach(ctx, d2))
+
+	initialState := json.TreeNode{
+		Type: "r",
+		Children: []json.TreeNode{
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "ab"}}},
+			{Type: "s", Children: []json.TreeNode{{Type: "i"}}},
+		},
+	}
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.SetNewTree("t", initialState)
+		return nil
+	}))
+	assert.NoError(t, c1.Sync(ctx))
+	assert.NoError(t, c2.Sync(ctx))
+
+	// Fully synced merge: <s> into <p> — <i> moves into <p> and keeps
+	// MergedFrom=s forever (stamped only on the first move).
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(3, 5, nil, 0)
+		return nil
+	}))
+	assert.NoError(t, c1.Sync(ctx))
+	assert.NoError(t, c2.Sync(ctx))
+	assert.Equal(t, `<r><p>ab<i></i></p></r>`, d1.Root().GetTree("t").ToXML())
+	assert.Equal(t, `<r><p>ab<i></i></p></r>`, d2.Root().GetTree("t").ToXML())
+
+	// d1: style [0, 5) — the range end is anchored after <i>, a
+	// non-left-most position inside <p>, and covers <i>.
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Style(0, 5, map[string]string{"bold": "x"})
+		return nil
+	}))
+	// d2: concurrently merge <p> into <r>.
+	assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(0, 1, nil, 0)
+		return nil
+	}))
+
+	flag := syncClientsThenCheckEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
+	assert.True(t, flag, "d1: %s\nd2: %s",
+		d1.Root().GetTree("t").ToXML(), d2.Root().GetTree("t").ToXML())
+	assert.Equal(t, `<r>ab<i bold="x"></i></r>`, d1.Root().GetTree("t").ToXML())
+}
+
+// TestTreeConcurrencyRemoveStyleAfterMovedAnchor verifies the RemoveStyle
+// variant: no attribute container may materialize on a node concurrently
+// inserted at the merged anchor (yorkie-team/yorkie-js-sdk#1311 notes the
+// one-sided empty RHT that Marshal hides).
+func TestTreeConcurrencyRemoveStyleAfterMovedAnchor(t *testing.T) {
+	clients := activeClients(t, 2)
+	c1, c2 := clients[0], clients[1]
+	defer deactivateAndCloseClients(t, clients)
+
+	ctx := context.Background()
+	d1 := document.New(helper.TestKey(t))
+	assert.NoError(t, c1.Attach(ctx, d1))
+	d2 := document.New(helper.TestKey(t))
+	assert.NoError(t, c2.Attach(ctx, d2))
+
+	initialState := json.TreeNode{
+		Type: "r",
+		Children: []json.TreeNode{
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "ab"}}},
+			{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "cd"}}},
+		},
+	}
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.SetNewTree("t", initialState)
+		return nil
+	}))
+	assert.NoError(t, c1.Sync(ctx))
+	assert.NoError(t, c2.Sync(ctx))
+
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(8, 8, &json.TreeNode{Type: "p"}, 0)
+		return nil
+	}))
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").RemoveStyle(0, 6, []string{"bold"})
+		return nil
+	}))
+	assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(0, 5, nil, 0)
+		return nil
+	}))
+
+	flag := syncClientsThenCheckEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
+	assert.True(t, flag, "d1: %s\nd2: %s",
+		d1.Root().GetTree("t").ToXML(), d2.Root().GetTree("t").ToXML())
+
+	// The Marshal oracle above cannot see the removed-attribute tombstone
+	// that an unguarded RemoveAttr materializes (Remove on a missing key
+	// still records an isRemoved entry), so pin the internal state: the
+	// concurrently inserted <p> must have no attribute entries at all on
+	// either replica. Attrs itself may be a non-nil empty container on
+	// the remote replica — operation deserialization always allocates one.
+	for i, pair := range []clientAndDocPair{{c1, d1}, {c2, d2}} {
+		tree, ok := pair.doc.RootObject().Members()["t"].(*crdt.Tree)
+		assert.True(t, ok)
+		var interloper *crdt.TreeNode
+		for _, child := range tree.Root().Children(true) {
+			if child.Type() == "p" && !child.IsRemoved() {
+				interloper = child
+			}
+		}
+		assert.NotNil(t, interloper, "d%d: live <p> not found", i+1)
+		if interloper.Attrs != nil {
+			assert.Empty(t, interloper.Attrs.Nodes(), "d%d: attribute entry materialized", i+1)
+		}
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
A concurrent `Tree.Style`/`Tree.RemoveStyle` whose range end is anchored after a merge-moved child styles a node concurrently inserted at the merged anchor on the applying replica only. 
From `<r><p>ab</p><p>cd</p></r>`: 
- A inserts an empty `<p>` at index 8 and styles `[0,6)`
- B concurrently removes `[0,5)` 

After a full sync, the `<p>` ends up `bold="x"` on B only.

The anchor resolves through the moved child, so the §9.3 redirect from #1909 never fires, and the `canStyle` version-vector check passes because the interloper is the styling client's own insert.

This PR fixes the issue in two steps:
1. It stamps inserts declared inside a merged-away parent with `MergedFrom` = declared parent.
2. During style traversal, it skips nodes under the merge target that appear after the merge-source tombstone and have no merge stamp. Each node is judged by its highest ancestor under the target, so an interloper's descendants are skipped with it.

Nodes carrying any `MergedFrom` fail open because an earlier merge leaves the original source in the stamp (first-move rule), so stamp equality cannot prove the node was outside the range.
`SplitElement` copies `MergedFrom`/`MergedAt` to the split product (`SplitText` parity) so the judgment is application-order independent.
The skip checks are shared between `Style` and `RemoveStyle` via a single predicate with a precomputed after-tombstone set.

Tests include six new complex cases:
- the reported case, which fails without this fix
- a RemoveStyle variant that also verifies no attribute entry is created on the interloper, which Marshal alone cannot detect
- interloper descendants
- an own insert inside the style range
- a sibling before the tombstone
- a child brought in by an earlier synced merge that should remain styled

Unit tests also verify the merge stamp and that SplitElement copies the stamp correctly.

All tree test lanes and golangci-lint pass.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #1916

**Special notes for your reviewer**:
- Found by the property-based Tree test for yorkie-team/yorkie-js-sdk#1298 right after #1909 landed; the JS SDK diverges identically (yorkie-team/yorkie-js-sdk#1311) and a mirror PR follows.
- Design: `docs/design/concurrent-merge-split.md` §9.4 (Fix 22), added here, including a known-limitations list (relay-only merged parents, the `MergedAt` fallback, stamped inserts in the delete cascade and the §1.1 boundary scan).
- Two variants remain and reproduce on main without this change (a range *start* anchored after a moved child; an edit-only divergence); both are next-cycle issues.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Fix Tree.Style and Tree.RemoveStyle styling a node concurrently inserted at a merge-removed anchor on only one replica.
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs
- [Design]: docs/design/concurrent-merge-split.md §9.4 (Fix 22)
```

**Checklist**:

- [x] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved concurrent tree editing when content is merged, split, moved, or inserted into previously merged locations.
  - Prevented incorrect styling and style removal around moved anchors, nested descendants, and inserted content.
  - Preserved merge information across split operations for more consistent results across replicas.

- **Documentation**
  - Added guidance on merge provenance, moved-anchor filtering, known limitations, and follow-up work.

- **Tests**
  - Added regression and concurrency coverage validating document structure, styling, and replica consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->