### PR TITLE
Stop ordinary editing from putting two nodes under one ID

### DIFF
--- a/api/converter/from_pb.go
+++ b/api/converter/from_pb.go
@@ -769,14 +769,26 @@ func fromTreeEdit(pbTreeEdit *api.Operation_TreeEdit) (*operations.TreeEdit, err
 		), nil
 	}
 
-	return operations.NewTreeEdit(
+	edit := operations.NewTreeEdit(
 		parentCreatedAt,
 		from,
 		to,
 		nodes,
 		int(pbTreeEdit.SplitLevel),
 		executedAt,
-	), nil
+	)
+
+	var splitTickets []*time.Ticket
+	for _, pbTicket := range pbTreeEdit.SplitTickets {
+		ticket, err := fromTimeTicket(pbTicket)
+		if err != nil {
+			return nil, err
+		}
+		splitTickets = append(splitTickets, ticket)
+	}
+	edit.SetSplitTickets(splitTickets)
+
+	return edit, nil
 }
 
 func fromTreeStyle(pbTreeStyle *api.Operation_TreeStyle) (*operations.TreeStyle, error) {

--- a/api/converter/to_pb.go
+++ b/api/converter/to_pb.go
@@ -538,6 +538,9 @@ func toTreeEdit(e *operations.TreeEdit) (*api.Operation_TreeEdit_, error) {
 		pbTreeEdit.RetombstoneSpans = retombstoneSpans
 		pbTreeEdit.RestoreMode = toRestoreMode(e.RestoreMode())
 	}
+	for _, ticket := range e.SplitTickets() {
+		pbTreeEdit.SplitTickets = append(pbTreeEdit.SplitTickets, ToTimeTicket(ticket))
+	}
 	return &api.Operation_TreeEdit_{TreeEdit: pbTreeEdit}, nil
 }
 

--- a/api/yorkie/v1/resources.pb.go
+++ b/api/yorkie/v1/resources.pb.go
@@ -4146,8 +4146,13 @@ type Operation_TreeEdit struct {
 	RestoreSpans        []*TreeRestoreSpan     `protobuf:"bytes,8,rep,name=restore_spans,json=restoreSpans,proto3" json:"restore_spans,omitempty"` // identity-preserving undo/redo
 	RestoreMode         RestoreMode            `protobuf:"varint,9,opt,name=restore_mode,json=restoreMode,proto3,enum=yorkie.v1.RestoreMode" json:"restore_mode,omitempty"`
 	RetombstoneSpans    []*TreeRestoreSpan     `protobuf:"bytes,10,rep,name=retombstone_spans,json=retombstoneSpans,proto3" json:"retombstone_spans,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// split_tickets carries the tickets the originating replica issued for the
+	// nodes an element split creates, in issue order. Empty for a change
+	// written before this field existed, which replays through the simulation
+	// that reconstructed them from executed_at and the content count.
+	SplitTickets  []*TimeTicket `protobuf:"bytes,11,rep,name=split_tickets,json=splitTickets,proto3" json:"split_tickets,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Operation_TreeEdit) Reset() {
@@ -4246,6 +4251,13 @@ func (x *Operation_TreeEdit) GetRestoreMode() RestoreMode {
 func (x *Operation_TreeEdit) GetRetombstoneSpans() []*TreeRestoreSpan {
 	if x != nil {
 		return x.RetombstoneSpans
+	}
+	return nil
+}
+
+func (x *Operation_TreeEdit) GetSplitTickets() []*TimeTicket {
+	if x != nil {
+		return x.SplitTickets
 	}
 	return nil
 }
@@ -5016,7 +5028,7 @@ const file_yorkie_v1_resources_proto_rawDesc = "" +
 	"\x06vector\x18\x01 \x03(\v2$.yorkie.v1.VersionVector.VectorEntryR\x06vector\x1a9\n" +
 	"\vVectorEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\x03R\x05value:\x028\x01\"\xed#\n" +
+	"\x05value\x18\x02 \x01(\x03R\x05value:\x028\x01\"\xa9$\n" +
 	"\tOperation\x12,\n" +
 	"\x03set\x18\x01 \x01(\v2\x18.yorkie.v1.Operation.SetH\x00R\x03set\x12,\n" +
 	"\x03add\x18\x02 \x01(\v2\x18.yorkie.v1.Operation.AddH\x00R\x03add\x12/\n" +
@@ -5098,7 +5110,7 @@ const file_yorkie_v1_resources_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\v2\x1c.yorkie.v1.JSONElementSimpleR\x05value\x126\n" +
 	"\vexecuted_at\x18\x03 \x01(\v2\x15.yorkie.v1.TimeTicketR\n" +
 	"executedAt\x12\x14\n" +
-	"\x05actor\x18\x04 \x01(\tR\x05actor\x1a\xb6\x05\n" +
+	"\x05actor\x18\x04 \x01(\tR\x05actor\x1a\xf2\x05\n" +
 	"\bTreeEdit\x12A\n" +
 	"\x11parent_created_at\x18\x01 \x01(\v2\x15.yorkie.v1.TimeTicketR\x0fparentCreatedAt\x12&\n" +
 	"\x04from\x18\x02 \x01(\v2\x12.yorkie.v1.TreePosR\x04from\x12\"\n" +
@@ -5112,7 +5124,8 @@ const file_yorkie_v1_resources_proto_rawDesc = "" +
 	"\rrestore_spans\x18\b \x03(\v2\x1a.yorkie.v1.TreeRestoreSpanR\frestoreSpans\x129\n" +
 	"\frestore_mode\x18\t \x01(\x0e2\x16.yorkie.v1.RestoreModeR\vrestoreMode\x12G\n" +
 	"\x11retombstone_spans\x18\n" +
-	" \x03(\v2\x1a.yorkie.v1.TreeRestoreSpanR\x10retombstoneSpans\x1a]\n" +
+	" \x03(\v2\x1a.yorkie.v1.TreeRestoreSpanR\x10retombstoneSpans\x12:\n" +
+	"\rsplit_tickets\x18\v \x03(\v2\x15.yorkie.v1.TimeTicketR\fsplitTickets\x1a]\n" +
 	"\x18CreatedAtMapByActorEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12+\n" +
 	"\x05value\x18\x02 \x01(\v2\x15.yorkie.v1.TimeTicketR\x05value:\x028\x01\x1a\xe1\x04\n" +
@@ -5755,53 +5768,54 @@ var file_yorkie_v1_resources_proto_depIdxs = []int32{
 	34,  // 145: yorkie.v1.Operation.TreeEdit.restore_spans:type_name -> yorkie.v1.TreeRestoreSpan
 	0,   // 146: yorkie.v1.Operation.TreeEdit.restore_mode:type_name -> yorkie.v1.RestoreMode
 	34,  // 147: yorkie.v1.Operation.TreeEdit.retombstone_spans:type_name -> yorkie.v1.TreeRestoreSpan
-	35,  // 148: yorkie.v1.Operation.TreeStyle.parent_created_at:type_name -> yorkie.v1.TimeTicket
-	21,  // 149: yorkie.v1.Operation.TreeStyle.from:type_name -> yorkie.v1.TreePos
-	21,  // 150: yorkie.v1.Operation.TreeStyle.to:type_name -> yorkie.v1.TreePos
-	62,  // 151: yorkie.v1.Operation.TreeStyle.attributes:type_name -> yorkie.v1.Operation.TreeStyle.AttributesEntry
-	35,  // 152: yorkie.v1.Operation.TreeStyle.executed_at:type_name -> yorkie.v1.TimeTicket
-	63,  // 153: yorkie.v1.Operation.TreeStyle.created_at_map_by_actor:type_name -> yorkie.v1.Operation.TreeStyle.CreatedAtMapByActorEntry
-	35,  // 154: yorkie.v1.Operation.ArraySet.parent_created_at:type_name -> yorkie.v1.TimeTicket
-	35,  // 155: yorkie.v1.Operation.ArraySet.created_at:type_name -> yorkie.v1.TimeTicket
-	11,  // 156: yorkie.v1.Operation.ArraySet.value:type_name -> yorkie.v1.JSONElementSimple
-	35,  // 157: yorkie.v1.Operation.ArraySet.executed_at:type_name -> yorkie.v1.TimeTicket
-	35,  // 158: yorkie.v1.Operation.Edit.CreatedAtMapByActorEntry.value:type_name -> yorkie.v1.TimeTicket
-	35,  // 159: yorkie.v1.Operation.Style.CreatedAtMapByActorEntry.value:type_name -> yorkie.v1.TimeTicket
-	35,  // 160: yorkie.v1.Operation.TreeEdit.CreatedAtMapByActorEntry.value:type_name -> yorkie.v1.TimeTicket
-	35,  // 161: yorkie.v1.Operation.TreeStyle.CreatedAtMapByActorEntry.value:type_name -> yorkie.v1.TimeTicket
-	13,  // 162: yorkie.v1.JSONElement.JSONObject.nodes:type_name -> yorkie.v1.RHTNode
-	35,  // 163: yorkie.v1.JSONElement.JSONObject.created_at:type_name -> yorkie.v1.TimeTicket
-	35,  // 164: yorkie.v1.JSONElement.JSONObject.moved_at:type_name -> yorkie.v1.TimeTicket
-	35,  // 165: yorkie.v1.JSONElement.JSONObject.removed_at:type_name -> yorkie.v1.TimeTicket
-	14,  // 166: yorkie.v1.JSONElement.JSONArray.nodes:type_name -> yorkie.v1.RGANode
-	35,  // 167: yorkie.v1.JSONElement.JSONArray.created_at:type_name -> yorkie.v1.TimeTicket
-	35,  // 168: yorkie.v1.JSONElement.JSONArray.moved_at:type_name -> yorkie.v1.TimeTicket
-	35,  // 169: yorkie.v1.JSONElement.JSONArray.removed_at:type_name -> yorkie.v1.TimeTicket
-	1,   // 170: yorkie.v1.JSONElement.Primitive.type:type_name -> yorkie.v1.ValueType
-	35,  // 171: yorkie.v1.JSONElement.Primitive.created_at:type_name -> yorkie.v1.TimeTicket
-	35,  // 172: yorkie.v1.JSONElement.Primitive.moved_at:type_name -> yorkie.v1.TimeTicket
-	35,  // 173: yorkie.v1.JSONElement.Primitive.removed_at:type_name -> yorkie.v1.TimeTicket
-	16,  // 174: yorkie.v1.JSONElement.Text.nodes:type_name -> yorkie.v1.TextNode
-	35,  // 175: yorkie.v1.JSONElement.Text.created_at:type_name -> yorkie.v1.TimeTicket
-	35,  // 176: yorkie.v1.JSONElement.Text.moved_at:type_name -> yorkie.v1.TimeTicket
-	35,  // 177: yorkie.v1.JSONElement.Text.removed_at:type_name -> yorkie.v1.TimeTicket
-	1,   // 178: yorkie.v1.JSONElement.Counter.type:type_name -> yorkie.v1.ValueType
-	35,  // 179: yorkie.v1.JSONElement.Counter.created_at:type_name -> yorkie.v1.TimeTicket
-	35,  // 180: yorkie.v1.JSONElement.Counter.moved_at:type_name -> yorkie.v1.TimeTicket
-	35,  // 181: yorkie.v1.JSONElement.Counter.removed_at:type_name -> yorkie.v1.TimeTicket
-	18,  // 182: yorkie.v1.JSONElement.Tree.nodes:type_name -> yorkie.v1.TreeNode
-	35,  // 183: yorkie.v1.JSONElement.Tree.created_at:type_name -> yorkie.v1.TimeTicket
-	35,  // 184: yorkie.v1.JSONElement.Tree.moved_at:type_name -> yorkie.v1.TimeTicket
-	35,  // 185: yorkie.v1.JSONElement.Tree.removed_at:type_name -> yorkie.v1.TimeTicket
-	15,  // 186: yorkie.v1.TextNode.AttributesEntry.value:type_name -> yorkie.v1.NodeAttr
-	15,  // 187: yorkie.v1.TreeNode.AttributesEntry.value:type_name -> yorkie.v1.NodeAttr
-	29,  // 188: yorkie.v1.DocumentSummary.PresencesEntry.value:type_name -> yorkie.v1.Presence
-	15,  // 189: yorkie.v1.TreeRestoreSpan.AttributesEntry.value:type_name -> yorkie.v1.NodeAttr
-	190, // [190:190] is the sub-list for method output_type
-	190, // [190:190] is the sub-list for method input_type
-	190, // [190:190] is the sub-list for extension type_name
-	190, // [190:190] is the sub-list for extension extendee
-	0,   // [0:190] is the sub-list for field type_name
+	35,  // 148: yorkie.v1.Operation.TreeEdit.split_tickets:type_name -> yorkie.v1.TimeTicket
+	35,  // 149: yorkie.v1.Operation.TreeStyle.parent_created_at:type_name -> yorkie.v1.TimeTicket
+	21,  // 150: yorkie.v1.Operation.TreeStyle.from:type_name -> yorkie.v1.TreePos
+	21,  // 151: yorkie.v1.Operation.TreeStyle.to:type_name -> yorkie.v1.TreePos
+	62,  // 152: yorkie.v1.Operation.TreeStyle.attributes:type_name -> yorkie.v1.Operation.TreeStyle.AttributesEntry
+	35,  // 153: yorkie.v1.Operation.TreeStyle.executed_at:type_name -> yorkie.v1.TimeTicket
+	63,  // 154: yorkie.v1.Operation.TreeStyle.created_at_map_by_actor:type_name -> yorkie.v1.Operation.TreeStyle.CreatedAtMapByActorEntry
+	35,  // 155: yorkie.v1.Operation.ArraySet.parent_created_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 156: yorkie.v1.Operation.ArraySet.created_at:type_name -> yorkie.v1.TimeTicket
+	11,  // 157: yorkie.v1.Operation.ArraySet.value:type_name -> yorkie.v1.JSONElementSimple
+	35,  // 158: yorkie.v1.Operation.ArraySet.executed_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 159: yorkie.v1.Operation.Edit.CreatedAtMapByActorEntry.value:type_name -> yorkie.v1.TimeTicket
+	35,  // 160: yorkie.v1.Operation.Style.CreatedAtMapByActorEntry.value:type_name -> yorkie.v1.TimeTicket
+	35,  // 161: yorkie.v1.Operation.TreeEdit.CreatedAtMapByActorEntry.value:type_name -> yorkie.v1.TimeTicket
+	35,  // 162: yorkie.v1.Operation.TreeStyle.CreatedAtMapByActorEntry.value:type_name -> yorkie.v1.TimeTicket
+	13,  // 163: yorkie.v1.JSONElement.JSONObject.nodes:type_name -> yorkie.v1.RHTNode
+	35,  // 164: yorkie.v1.JSONElement.JSONObject.created_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 165: yorkie.v1.JSONElement.JSONObject.moved_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 166: yorkie.v1.JSONElement.JSONObject.removed_at:type_name -> yorkie.v1.TimeTicket
+	14,  // 167: yorkie.v1.JSONElement.JSONArray.nodes:type_name -> yorkie.v1.RGANode
+	35,  // 168: yorkie.v1.JSONElement.JSONArray.created_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 169: yorkie.v1.JSONElement.JSONArray.moved_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 170: yorkie.v1.JSONElement.JSONArray.removed_at:type_name -> yorkie.v1.TimeTicket
+	1,   // 171: yorkie.v1.JSONElement.Primitive.type:type_name -> yorkie.v1.ValueType
+	35,  // 172: yorkie.v1.JSONElement.Primitive.created_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 173: yorkie.v1.JSONElement.Primitive.moved_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 174: yorkie.v1.JSONElement.Primitive.removed_at:type_name -> yorkie.v1.TimeTicket
+	16,  // 175: yorkie.v1.JSONElement.Text.nodes:type_name -> yorkie.v1.TextNode
+	35,  // 176: yorkie.v1.JSONElement.Text.created_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 177: yorkie.v1.JSONElement.Text.moved_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 178: yorkie.v1.JSONElement.Text.removed_at:type_name -> yorkie.v1.TimeTicket
+	1,   // 179: yorkie.v1.JSONElement.Counter.type:type_name -> yorkie.v1.ValueType
+	35,  // 180: yorkie.v1.JSONElement.Counter.created_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 181: yorkie.v1.JSONElement.Counter.moved_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 182: yorkie.v1.JSONElement.Counter.removed_at:type_name -> yorkie.v1.TimeTicket
+	18,  // 183: yorkie.v1.JSONElement.Tree.nodes:type_name -> yorkie.v1.TreeNode
+	35,  // 184: yorkie.v1.JSONElement.Tree.created_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 185: yorkie.v1.JSONElement.Tree.moved_at:type_name -> yorkie.v1.TimeTicket
+	35,  // 186: yorkie.v1.JSONElement.Tree.removed_at:type_name -> yorkie.v1.TimeTicket
+	15,  // 187: yorkie.v1.TextNode.AttributesEntry.value:type_name -> yorkie.v1.NodeAttr
+	15,  // 188: yorkie.v1.TreeNode.AttributesEntry.value:type_name -> yorkie.v1.NodeAttr
+	29,  // 189: yorkie.v1.DocumentSummary.PresencesEntry.value:type_name -> yorkie.v1.Presence
+	15,  // 190: yorkie.v1.TreeRestoreSpan.AttributesEntry.value:type_name -> yorkie.v1.NodeAttr
+	191, // [191:191] is the sub-list for method output_type
+	191, // [191:191] is the sub-list for method input_type
+	191, // [191:191] is the sub-list for extension type_name
+	191, // [191:191] is the sub-list for extension extendee
+	0,   // [0:191] is the sub-list for field type_name
 }
 
 func init() { file_yorkie_v1_resources_proto_init() }

--- a/api/yorkie/v1/resources.proto
+++ b/api/yorkie/v1/resources.proto
@@ -135,6 +135,11 @@ message Operation {
     repeated TreeRestoreSpan restore_spans = 8; // identity-preserving undo/redo
     RestoreMode restore_mode = 9;
     repeated TreeRestoreSpan retombstone_spans = 10;
+    // split_tickets carries the tickets the originating replica issued for the
+    // nodes an element split creates, in issue order. Empty for a change
+    // written before this field existed, which replays through the simulation
+    // that reconstructed them from executed_at and the content count.
+    repeated TimeTicket split_tickets = 11;
   }
   message TreeStyle {
     TimeTicket parent_created_at = 1;

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -23,6 +23,7 @@ New design documents should be based on [TEMPLATE.md](TEMPLATE.md).
 - [Garbage Collection for Text Type](gc-for-text-type.md): Garbage collection for text type CRDT
 - [GC Registration on Set Conflict](gc-registration-on-set-conflict.md): Fix missing GC registration when new element loses LWW conflict
 - [Tree](tree.md): Tree data structure for tree-based rich text editor
+- [Identity of Inserted Tree Content](tree-content-identity.md): One ticket per inserted node, and what still lets two nodes share an ID
 - [Concurrent Merge and Split](concurrent-merge-split.md): Fix convergence bugs in concurrent tree merge/split operations
 - [Counter Dedup](counter-dedup.md): Counter dedup mode using HyperLogLog for high-volume idempotent counting
 - [Array Move Convergence](array-move-convergence.md): Fix convergence bugs in concurrent array move operations

--- a/docs/design/tree-content-identity.md
+++ b/docs/design/tree-content-identity.md
@@ -1,0 +1,119 @@
+# Identity of Inserted Tree Content
+
+## Problem
+
+Every Tree position anchors by `TreeNodeID`, so an ID must name a single node
+([tree](tree.md#one-node-per-treenodeid)). Two nodes under one ID make every
+position anchored there ambiguous, which is what left a production document
+unopenable.
+
+Undo by copy is the known source. There is a second one, and it needs no undo
+at all: an edit that inserts several nodes at once gave them all the same ID.
+
+```go
+// pkg/document/json/tree.go, before
+ticket := t.context.IssueTimeTicket()
+for _, content := range contents {
+    node = crdt.NewTreeNode(crdt.NewTreeNodeID(ticket, 0), content.Type, attributes, content.Value)
+    for _, child := range content.Children {
+        buildDescendants(t.context, child, node)  // one ticket per descendant
+    }
+}
+```
+
+One ticket was issued for the edit and reused for every top-level content,
+while descendants each took their own. `EditBulk` with two paragraphs
+therefore produced two `<p>` nodes under one ID. The JS SDK issues a ticket per
+content and never had this.
+
+It is one of the reasons `dropDuplicateContents` exempts content from the
+edit's own change: with a legitimate edit able to mint a collision, the rule
+cannot be applied without dropping a node the user just inserted. The other
+reason, the simulated split delimiters, is still live — see below.
+
+### Goals
+
+- Every node an edit inserts gets its own identity.
+- Documents already stored replay to exactly the state they have now.
+
+### Non-Goals
+
+- The simulated split delimiters, the source this does not remove — see below.
+- Undo by copy, the third source — see [undo-redo](undo-redo.md).
+- Removing duplicates already stored in documents.
+
+## Design
+
+Each top-level content takes its own ticket. The first keeps the ticket the
+edit already issued, so a single-content edit — every edit made through `Edit`
+rather than `EditBulk` — assigns exactly the IDs it always did:
+
+```go
+nodeTicket := ticket
+if i > 0 {
+    nodeTicket = t.context.IssueTimeTicket()
+}
+```
+
+### What this does not fix
+
+Content nodes carry their IDs on the wire, so a replica applies the IDs the
+originator chose. Only the tickets an *element split* consumes are recomputed,
+by simulating the originator's allocation:
+
+```go
+delimiter := e.executedAt.Delimiter()
+if contents != nil {
+    delimiter += uint32(len(contents))
+}
+```
+
+That simulation is still wrong, and it is still a live source of duplicate IDs.
+It advances by the number of top-level contents while the originator also spends
+a ticket per descendant, and the two SDKs do not even agree on what `executedAt`
+means: Go publishes it *after* issuing the content tickets, the JS SDK *before*.
+Two tree edits in one change reproduce it today:
+
+```go
+r.GetTree("t").Edit(2, 2, &json.TreeNode{Type: "text", Value: "q"}, 1)
+r.GetTree("t").Edit(1, 1, &json.TreeNode{Type: "text", Value: "z"}, 0)
+// → 2:3:...:0 names two nodes
+```
+
+Fixing it means either aligning the two conventions or carrying the split
+tickets in the operation, both of which change the wire and need a compatibility
+window. That is the next piece of work, not this one; see
+[tree](tree.md#one-node-per-treenodeid), which lists it as a remaining source.
+
+Because that source is still live, `dropDuplicateContents` keeps exempting
+content from the edit's own change. The exemption is load-bearing for current
+traffic, not only for replaying old histories: without it, an edit whose split
+ticket lands on its own content would have that content dropped.
+
+The same mismatch also separates a Go client's two views of its own document.
+`Document.Update` mutates the clone through the json proxies, with the tickets
+actually issued, and then executes the change on the root through the
+simulation. For an edit with contents and `splitLevel > 0` the two disagree, so
+a later edit anchored at a split product can fail against the root while the
+clone has already accepted it.
+
+## Risks and Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| Newly assigned IDs differ from before for bulk edits | Only for `EditBulk` with more than one content, which is where the IDs collided. Single-content edits are unchanged, including every `Edit` |
+| Stored histories replay differently | They do not: content IDs travel on the wire, so replay uses the IDs the change already carries |
+| The remaining source, the split simulation, is read as fixed | It is not, and the section above says so with a reproduction. `tree.md` keeps listing it among the sources |
+
+## Alternatives Considered
+
+| Alternative | Why not |
+|-------------|---------|
+| Carry the split tickets in the operation | The right fix for the simulation, and the next piece of work. It changes the wire on both repos and needs a compatibility window, which is more than this change — removing the bulk-content source — should carry |
+| Issue a fresh ticket for every content including the first | Cleaner to read, but it shifts the IDs of every single-content edit — the common case — for no benefit |
+| Remove the same-change exemption now | The simulation can still land a split ticket on an edit's own content, so the exemption is what keeps that content from being dropped. It also protects the replay of changes written before this fix |
+
+## See Also
+
+- [tree](tree.md) — the rules that keep an ID naming a single node
+- [undo-redo](undo-redo.md) — undo by copy, the other source of duplicate IDs

--- a/pkg/document/json/tree.go
+++ b/pkg/document/json/tree.go
@@ -388,17 +388,27 @@ func (t *Tree) edit(fromPos, toPos *crdt.TreePos, contents []*TreeNode, splitLev
 
 			nodes = append(nodes, crdt.NewTreeNode(crdt.NewTreeNodeID(ticket, 0), index.TextNodeType, nil, value))
 		} else {
-			for _, content := range contents {
+			for i, content := range contents {
+				// Each node needs its own identity: positions anchor by id, and
+				// two nodes under one id make every position anchored there
+				// ambiguous. The first content keeps the ticket issued above so
+				// that a single-content edit — every edit made through Edit,
+				// rather than EditBulk — assigns the ids it always has.
+				nodeTicket := ticket
+				if i > 0 {
+					nodeTicket = t.context.IssueTimeTicket()
+				}
+
 				var attributes *crdt.RHT
 				if content.Attributes != nil {
 					attributes = crdt.NewRHT()
 					for key, val := range content.Attributes {
-						attributes.Set(key, val, ticket)
+						attributes.Set(key, val, nodeTicket)
 					}
 				}
 				var node *crdt.TreeNode
 
-				node = crdt.NewTreeNode(crdt.NewTreeNodeID(ticket, 0), content.Type, attributes, content.Value)
+				node = crdt.NewTreeNode(crdt.NewTreeNodeID(nodeTicket, 0), content.Type, attributes, content.Value)
 
 				for _, child := range content.Children {
 					if err := buildDescendants(t.context, child, node); err != nil {

--- a/pkg/document/json/tree.go
+++ b/pkg/document/json/tree.go
@@ -436,13 +436,24 @@ func (t *Tree) edit(fromPos, toPos *crdt.TreePos, contents []*TreeNode, splitLev
 	}
 
 	ticket = t.context.LastTimeTicket()
+	// Splitting an element creates nodes that need tickets. Record the ones
+	// issued so the operation can carry them: every other replica then uses
+	// them instead of reconstructing them from the operation, which it cannot
+	// do correctly once content has descendants. See
+	// docs/design/tree-content-identity.md.
+	var splitTickets []*time.Ticket
+	issueSplitTicket := func() *time.Ticket {
+		issued := t.context.IssueTimeTicket()
+		splitTickets = append(splitTickets, issued)
+		return issued
+	}
 	pairs, diff, err := t.Tree.Edit(
 		fromPos,
 		toPos,
 		clones,
 		splitLevel,
 		ticket,
-		t.context.IssueTimeTicket,
+		issueSplitTicket,
 		nil,
 	)
 	if err != nil {
@@ -456,14 +467,16 @@ func (t *Tree) edit(fromPos, toPos *crdt.TreePos, contents []*TreeNode, splitLev
 
 	t.context.Acc(diff)
 
-	t.context.Push(operations.NewTreeEdit(
+	edit := operations.NewTreeEdit(
 		t.CreatedAt(),
 		fromPos,
 		toPos,
 		nodes,
 		splitLevel,
 		ticket,
-	))
+	)
+	edit.SetSplitTickets(splitTickets)
+	t.context.Push(edit)
 
 	return true
 }

--- a/pkg/document/operations/tree_edit.go
+++ b/pkg/document/operations/tree_edit.go
@@ -52,6 +52,14 @@ type TreeEdit struct {
 	restoreSpans     []*crdt.TreeRestoreSpan
 	restoreMode      crdt.RestoreMode
 	retombstoneSpans []*crdt.TreeRestoreSpan
+
+	// splitTickets carries the tickets the originating replica issued for the
+	// nodes an element split creates, in issue order. A replica applying the
+	// operation consumes them instead of reconstructing them, so neither side
+	// depends on the other's allocation staying in step. Empty for a change
+	// written before the field existed, which falls back to the simulation
+	// that reconstructed them from executedAt and the content count.
+	splitTickets []*time.Ticket
 }
 
 // NewTreeEdit creates a new instance of TreeEdit.
@@ -182,19 +190,29 @@ func (e *TreeEdit) Execute(root *crdt.Root, versionVector time.VersionVector) er
 			contents,
 			e.splitLevel,
 			e.executedAt,
-			/**
-			 * TODO(sejongk): When splitting element nodes, a new nodeID is assigned with a different timeTicket.
-			 * In the same change context, the timeTickets share the same lamport and actorID but have different delimiters,
-			 * incremented by one for each.
-			 * Therefore, it is possible to simulate later timeTickets using `editedAt` and the length of `contents`.
-			 * This logic might be unclear; consider refactoring for multi-level concurrent editing in the Tree implementation.
-			 */
+			// Splitting an element creates nodes that need tickets. The
+			// originating replica issued them and carries them here, so this
+			// hands them back in the same order.
+			//
+			// A change written before the field existed carries none, and falls
+			// back to reconstructing them from executedAt and the number of
+			// top-level contents. That reconstruction is wrong whenever content
+			// has descendants — each of those consumed a ticket too — which is
+			// why the tickets are carried now; see
+			// docs/design/tree-content-identity.md.
 			func() func() *time.Ticket {
+				issued := 0
 				delimiter := e.executedAt.Delimiter()
 				if contents != nil {
 					delimiter += uint32(len(contents))
 				}
 				return func() *time.Ticket {
+					if issued < len(e.splitTickets) {
+						ticket := e.splitTickets[issued]
+						issued++
+						return ticket
+					}
+
 					delimiter++
 					return time.NewTicket(
 						e.executedAt.Lamport(),
@@ -249,6 +267,19 @@ func (e *TreeEdit) Contents() []*crdt.TreeNode {
 // SplitLevel returns the level of the split.
 func (e *TreeEdit) SplitLevel() int {
 	return e.splitLevel
+}
+
+// SplitTickets returns the tickets issued for the nodes an element split
+// created, in issue order. Empty when the operation predates the field.
+func (e *TreeEdit) SplitTickets() []*time.Ticket {
+	return e.splitTickets
+}
+
+// SetSplitTickets records the tickets issued for the nodes an element split
+// created. The originating replica calls this after executing the edit, so
+// every other replica can use them instead of reconstructing them.
+func (e *TreeEdit) SetSplitTickets(tickets []*time.Ticket) {
+	e.splitTickets = tickets
 }
 
 // ExecutedAt returns execution time of this operation.

--- a/pkg/document/tree_content_identity_test.go
+++ b/pkg/document/tree_content_identity_test.go
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package document_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/pkg/document"
+	"github.com/yorkie-team/yorkie/pkg/document/crdt"
+	"github.com/yorkie-team/yorkie/pkg/document/json"
+	"github.com/yorkie-team/yorkie/pkg/document/presence"
+	"github.com/yorkie-team/yorkie/pkg/document/time"
+)
+
+// Every position anchors by TreeNodeID, so an ID must name a single node.
+// See docs/design/tree-content-identity.md.
+
+// treeNodeIDs returns every node id in the tree under key "t", sorted.
+func treeNodeIDs(t *testing.T, root *crdt.Object) []string {
+	t.Helper()
+
+	tree, ok := root.Get("t").(*crdt.Tree)
+	assert.True(t, ok)
+
+	var ids []string
+	for _, node := range tree.Nodes() {
+		ids = append(ids, node.IDString())
+	}
+	sort.Strings(ids)
+
+	return ids
+}
+
+// duplicatedTreeIDs returns the ids that name more than one node.
+func duplicatedTreeIDs(ids []string) []string {
+	seen := map[string]int{}
+	var dupes []string
+	for _, id := range ids {
+		seen[id]++
+		if seen[id] == 2 {
+			dupes = append(dupes, id)
+		}
+	}
+	return dupes
+}
+
+// newTreeDoc returns a document holding <r><p>ab</p></r> under key "t".
+func newTreeDoc(t *testing.T, hexActor string) *document.Document {
+	t.Helper()
+
+	doc := document.New("doc")
+	actor, err := time.ActorIDFromHex(hexActor)
+	assert.NoError(t, err)
+	doc.SetActor(actor)
+
+	assert.NoError(t, doc.Update(func(r *json.Object, p *presence.Presence) error {
+		r.SetNewTree("t", json.TreeNode{
+			Type: "r",
+			Children: []json.TreeNode{{
+				Type:     "p",
+				Children: []json.TreeNode{{Type: "text", Value: "ab"}},
+			}},
+		})
+		return nil
+	}))
+
+	return doc
+}
+
+// TestBulkContentsGetDistinctIDs verifies that an edit inserting several nodes
+// at once gives each of them its own identity. They are separate nodes in the
+// document, and a position anchored at an id that names two of them resolves
+// differently on different replicas.
+func TestBulkContentsGetDistinctIDs(t *testing.T) {
+	doc := newTreeDoc(t, "000000000000000000000001")
+
+	assert.NoError(t, doc.Update(func(r *json.Object, p *presence.Presence) error {
+		r.GetTree("t").EditBulkByPath([]int{1}, []int{1}, []*json.TreeNode{{
+			Type:     "p",
+			Children: []json.TreeNode{{Type: "text", Value: "x"}},
+		}, {
+			Type:     "p",
+			Children: []json.TreeNode{{Type: "text", Value: "y"}},
+		}}, 0)
+		return nil
+	}))
+
+	ids := treeNodeIDs(t, doc.RootObject())
+	assert.Empty(t, duplicatedTreeIDs(ids), "each inserted node needs its own id, got %v", ids)
+}
+
+// TestSingleContentEditKeepsItsIDs pins the compatibility this change rests
+// on. The first content keeps the ticket the edit already issued, so an edit
+// through Edit — as opposed to EditBulk — assigns the ids it always did, and a
+// stored history replays to the state its snapshot holds. Issuing a fresh
+// ticket for every content would shift these.
+func TestSingleContentEditKeepsItsIDs(t *testing.T) {
+	doc := newTreeDoc(t, "000000000000000000000001")
+
+	assert.NoError(t, doc.Update(func(r *json.Object, p *presence.Presence) error {
+		r.GetTree("t").Edit(2, 2, &json.TreeNode{
+			Type:     "p",
+			Children: []json.TreeNode{{Type: "text", Value: "x"}},
+		}, 0)
+		return nil
+	}))
+
+	assert.Equal(t, []string{
+		"1:1:AAAAAAAAAAAAAAAB:0",
+		"1:2:AAAAAAAAAAAAAAAB:0",
+		"1:3:AAAAAAAAAAAAAAAB:0",
+		"1:3:AAAAAAAAAAAAAAAB:1",
+		"2:1:AAAAAAAAAAAAAAAB:0",
+		"2:2:AAAAAAAAAAAAAAAB:0",
+	}, treeNodeIDs(t, doc.RootObject()))
+}
+
+// TestOriginatorAndReplicaAgree compares what the replica that issued the
+// tickets built against what a replica applying the same change builds. The
+// originator's own tree is the one Update executed the change on; its clone,
+// which the json proxies mutated with the tickets actually issued, is compared
+// too — an edit that splits is where the two allocations can drift apart.
+func TestOriginatorAndReplicaAgree(t *testing.T) {
+	origin := newTreeDoc(t, "000000000000000000000001")
+
+	assert.NoError(t, origin.Update(func(r *json.Object, p *presence.Presence) error {
+		r.GetTree("t").EditBulkByPath([]int{0, 1}, []int{0, 1}, []*json.TreeNode{{
+			Type:     "p",
+			Children: []json.TreeNode{{Type: "text", Value: "x"}},
+		}, {
+			Type:     "p",
+			Children: []json.TreeNode{{Type: "text", Value: "y"}},
+		}}, 0)
+		return nil
+	}))
+
+	pack := origin.CreateChangePack()
+
+	replica := document.New("doc")
+	actorB, err := time.ActorIDFromHex("000000000000000000000002")
+	assert.NoError(t, err)
+	replica.SetActor(actorB)
+	pack.VersionVector.Set(replica.ActorID(), replica.VersionVector().VersionOf(replica.ActorID()))
+	assert.NoError(t, replica.ApplyChangePack(pack))
+
+	assert.Equal(t, origin.Root().GetTree("t").ToXML(), replica.Root().GetTree("t").ToXML())
+	assert.Equal(t, treeNodeIDs(t, origin.RootObject()), treeNodeIDs(t, replica.RootObject()),
+		"a replica must give the inserted nodes the ids the originator issued")
+}
+
+// TestSplitTicketCollidesWithContent is the source this change does NOT
+// remove, kept as its reproduction. The tickets an element split consumes are
+// simulated from the operation rather than carried in it, and the simulation
+// advances by the number of top-level contents while the originator also
+// spends one per descendant — so a split ticket can land on an id the edit's
+// own content already holds. Fixing it changes the wire; see
+// docs/design/tree-content-identity.md.
+func TestSplitTicketCollidesWithContent(t *testing.T) {
+	t.Skip("known issue: split tickets are simulated, not carried; see docs/design/tree-content-identity.md")
+
+	doc := newTreeDoc(t, "000000000000000000000001")
+
+	assert.NoError(t, doc.Update(func(r *json.Object, p *presence.Presence) error {
+		r.GetTree("t").Edit(2, 2, &json.TreeNode{Type: "text", Value: "q"}, 1)
+		r.GetTree("t").Edit(1, 1, &json.TreeNode{Type: "text", Value: "z"}, 0)
+		return nil
+	}))
+
+	ids := treeNodeIDs(t, doc.RootObject())
+	assert.Empty(t, duplicatedTreeIDs(ids), "a split ticket must not land on the edit's own content, got %v", ids)
+}

--- a/pkg/document/tree_content_identity_test.go
+++ b/pkg/document/tree_content_identity_test.go
@@ -32,6 +32,9 @@ import (
 // Every position anchors by TreeNodeID, so an ID must name a single node.
 // See docs/design/tree-content-identity.md.
 
+// textNodeType is the node type a tree uses for text.
+const textNodeType = "text"
+
 // treeNodeIDs returns every node id in the tree under key "t", sorted.
 func treeNodeIDs(t *testing.T, root *crdt.Object) []string {
 	t.Helper()
@@ -75,7 +78,7 @@ func newTreeDoc(t *testing.T, hexActor string) *document.Document {
 			Type: "r",
 			Children: []json.TreeNode{{
 				Type:     "p",
-				Children: []json.TreeNode{{Type: "text", Value: "ab"}},
+				Children: []json.TreeNode{{Type: textNodeType, Value: "ab"}},
 			}},
 		})
 		return nil
@@ -94,10 +97,10 @@ func TestBulkContentsGetDistinctIDs(t *testing.T) {
 	assert.NoError(t, doc.Update(func(r *json.Object, p *presence.Presence) error {
 		r.GetTree("t").EditBulkByPath([]int{1}, []int{1}, []*json.TreeNode{{
 			Type:     "p",
-			Children: []json.TreeNode{{Type: "text", Value: "x"}},
+			Children: []json.TreeNode{{Type: textNodeType, Value: "x"}},
 		}, {
 			Type:     "p",
-			Children: []json.TreeNode{{Type: "text", Value: "y"}},
+			Children: []json.TreeNode{{Type: textNodeType, Value: "y"}},
 		}}, 0)
 		return nil
 	}))
@@ -117,7 +120,7 @@ func TestSingleContentEditKeepsItsIDs(t *testing.T) {
 	assert.NoError(t, doc.Update(func(r *json.Object, p *presence.Presence) error {
 		r.GetTree("t").Edit(2, 2, &json.TreeNode{
 			Type:     "p",
-			Children: []json.TreeNode{{Type: "text", Value: "x"}},
+			Children: []json.TreeNode{{Type: textNodeType, Value: "x"}},
 		}, 0)
 		return nil
 	}))
@@ -143,10 +146,10 @@ func TestOriginatorAndReplicaAgree(t *testing.T) {
 	assert.NoError(t, origin.Update(func(r *json.Object, p *presence.Presence) error {
 		r.GetTree("t").EditBulkByPath([]int{0, 1}, []int{0, 1}, []*json.TreeNode{{
 			Type:     "p",
-			Children: []json.TreeNode{{Type: "text", Value: "x"}},
+			Children: []json.TreeNode{{Type: textNodeType, Value: "x"}},
 		}, {
 			Type:     "p",
-			Children: []json.TreeNode{{Type: "text", Value: "y"}},
+			Children: []json.TreeNode{{Type: textNodeType, Value: "y"}},
 		}}, 0)
 		return nil
 	}))
@@ -174,8 +177,8 @@ func TestSplitTicketDoesNotCollideWithContent(t *testing.T) {
 	doc := newTreeDoc(t, "000000000000000000000001")
 
 	assert.NoError(t, doc.Update(func(r *json.Object, p *presence.Presence) error {
-		r.GetTree("t").Edit(2, 2, &json.TreeNode{Type: "text", Value: "q"}, 1)
-		r.GetTree("t").Edit(1, 1, &json.TreeNode{Type: "text", Value: "z"}, 0)
+		r.GetTree("t").Edit(2, 2, &json.TreeNode{Type: textNodeType, Value: "q"}, 1)
+		r.GetTree("t").Edit(1, 1, &json.TreeNode{Type: textNodeType, Value: "z"}, 0)
 		return nil
 	}))
 

--- a/pkg/document/tree_content_identity_test.go
+++ b/pkg/document/tree_content_identity_test.go
@@ -165,16 +165,12 @@ func TestOriginatorAndReplicaAgree(t *testing.T) {
 		"a replica must give the inserted nodes the ids the originator issued")
 }
 
-// TestSplitTicketCollidesWithContent is the source this change does NOT
-// remove, kept as its reproduction. The tickets an element split consumes are
-// simulated from the operation rather than carried in it, and the simulation
-// advances by the number of top-level contents while the originator also
-// spends one per descendant — so a split ticket can land on an id the edit's
-// own content already holds. Fixing it changes the wire; see
-// docs/design/tree-content-identity.md.
-func TestSplitTicketCollidesWithContent(t *testing.T) {
-	t.Skip("known issue: split tickets are simulated, not carried; see docs/design/tree-content-identity.md")
-
+// TestSplitTicketDoesNotCollideWithContent covers the tickets an element split
+// consumes. They are carried by the operation rather than reconstructed from
+// it, because a reconstruction advancing by the number of top-level contents
+// cannot account for the ticket each descendant also took — so a split ticket
+// used to land on an id the edit's own content already held.
+func TestSplitTicketDoesNotCollideWithContent(t *testing.T) {
 	doc := newTreeDoc(t, "000000000000000000000001")
 
 	assert.NoError(t, doc.Update(func(r *json.Object, p *presence.Presence) error {


### PR DESCRIPTION
## Summary

Every Tree position anchors by `TreeNodeID`, so an ID must name a single node. Two nodes under one ID is the ambiguity that left a production document unopenable ([#1927](https://github.com/yorkie-team/yorkie/pull/1927)). That PR made the tree survive duplicates; it did not stop them being created.

This removes one of the sources, and it needs no undo, no concurrency and no GC — ordinary editing reaches it:

```go
ticket := t.context.IssueTimeTicket()
for _, content := range contents {
    node = crdt.NewTreeNode(crdt.NewTreeNodeID(ticket, 0), ...)   // every content, one ticket
    for _, child := range content.Children {
        buildDescendants(t.context, child, node)                  // descendants take their own
    }
}
```

`EditBulk` with two paragraphs produced two `<p>` nodes under one ID. The JS SDK issues a ticket per content and never had this.

Each content now takes its own ticket. The first keeps the one the edit already issued, so a single-content edit — every edit through `Edit`, as opposed to `EditBulk` — assigns exactly the IDs it always did. That matters beyond taste: content IDs travel on the wire, so stored histories replay unchanged, and a test pins those exact IDs.

## The second source: split tickets

The tickets an element split consumes were reconstructed by every replica from `executed_at` and the number of top-level contents:

```go
delimiter := e.executedAt.Delimiter()
if contents != nil {
    delimiter += uint32(len(contents))
}
```

That reconstruction cannot be right. Content nodes take a ticket each, descendants included, so it under-counts as soon as content has children — and the two SDKs do not even agree on what `executed_at` means, Go publishing it *after* the content tickets and the JS SDK *before*. A split ticket could therefore land on an ID the edit's own content already held. Two tree edits in one change reproduced it:

```go
r.GetTree("t").Edit(2, 2, &json.TreeNode{Type: "text", Value: "q"}, 1)
r.GetTree("t").Edit(1, 1, &json.TreeNode{Type: "text", Value: "z"}, 0)
// → 2:3:...:0 named two nodes
```

The operation now carries the tickets the originating replica issued (`repeated TimeTicket split_tickets = 11`), and a replica hands them back in order. Neither side computes anything, so there is no formula for the two to agree on — the contract that broke here was that agreement, and this removes it rather than correcting it. A change written before the field exists carries none and falls back to the reconstruction, so stored histories replay to the state they hold now.

The client side lands with this: [yorkie-js-sdk#1319](https://github.com/yorkie-team/yorkie-js-sdk/pull/1319).

## Test plan

- `TestBulkContentsGetDistinctIDs` — fails on `main` (`Should be empty, but was [2:1:…:0]`), passes here.
- `TestSingleContentEditKeepsItsIDs` — pins the exact IDs a single-content edit assigns; fails if the first content also takes a fresh ticket.
- `TestOriginatorAndReplicaAgree` — the replica applying the change assigns the IDs the originator did.
- `TestSplitTicketDoesNotCollideWithContent` — the reproduction above; it fails without the carried tickets.
- `go test ./...`, `make test` (integration), `make lint` — all green.
- Instrumented `putNode` to report every ID collision: none across the unit suite or the integration suite. Before this branch it reported them on ordinary bulk edits and on the split case above.
- Replayed three production datasets offline (the document from the incident, its full history, and the other reported document): all apply cleanly, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented identity collisions when inserting multiple top-level tree elements at once.
  * Preserved existing identities for single-element edits.
  * Improved consistency between the originating document and replicas.
  * Prevented conflicts between inserted content and split nodes during tree operations.
  * Maintained compatibility when replaying older operations.

* **Documentation**
  * Added design documentation explaining tree-content identity behavior, known limitations, risks, and compatibility considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->