### PR TITLE
Release v0.7.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and Yorkie adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## [v0.7.16] - 2026-08-15
+
+### Fixed
+
+- Keep a document loadable when two tree nodes share one ID by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1927
+- Stamp merge-bound inserts and filter style-range interlopers by @Nahee-Park in https://github.com/yorkie-team/yorkie/pull/1928
+- Stop ordinary editing from putting two nodes under one ID by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1929
+
 ## [v0.7.15] - 2026-08-13
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-YORKIE_VERSION := 0.7.15
+YORKIE_VERSION := 0.7.16
 
 GO_PROJECT = github.com/yorkie-team/yorkie
 

--- a/api/docs/yorkie.base.yaml
+++ b/api/docs/yorkie.base.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Yorkie
   description: "Yorkie is an open source document store for building collaborative editing applications."
-  version: v0.7.15
+  version: v0.7.16
 servers:
   - url: https://api.yorkie.dev
     description: Production server

--- a/api/docs/yorkie/v1/admin.openapi.yaml
+++ b/api/docs/yorkie/v1/admin.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.15
+  version: v0.7.16
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/api/docs/yorkie/v1/resources.openapi.yaml
+++ b/api/docs/yorkie/v1/resources.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.15
+  version: v0.7.16
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/api/docs/yorkie/v1/yorkie.openapi.yaml
+++ b/api/docs/yorkie/v1/yorkie.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.15
+  version: v0.7.16
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/build/charts/yorkie-cluster/Chart.yaml
+++ b/build/charts/yorkie-cluster/Chart.yaml
@@ -9,8 +9,8 @@ maintainers:
 
 sources:
   - https://github.com/yorkie-team/yorkie
-version: 0.7.15
-appVersion: "0.7.15"
+version: 0.7.16
+appVersion: "0.7.16"
 kubeVersion: ">=1.28.0-0"
 
 dependencies:


### PR DESCRIPTION
## What

Bump to v0.7.16 across the Makefile, the `yorkie-cluster` chart, and the four
OpenAPI docs that track the release.

Untouched, all on separate version tracks with no change since v0.7.15:
`yorkie-monitoring` chart (`0.7.7`), `yorkie-analytics` chart (`0.6.0`),
`api/docs/yorkie/v1/cluster.openapi.yaml` (`v0.7.8`).

## CHANGELOG

All three commits since v0.7.15 are fixes with production diffs under
`pkg/document`, so nothing is excluded. #1927 and #1928 have large
`docs/design` and `docs/tasks` diffs next to the code — classification follows
the production paths, not the line counts.

- Keep a document loadable when two tree nodes share one ID (#1927)
- Stamp merge-bound inserts and filter style-range interlopers (#1928)
- Stop ordinary editing from putting two nodes under one ID (#1929)

## Test plan

`make build` → `./bin/yorkie version` reports `0.7.16`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of duplicate tree-node IDs during editing.
  * Fixed insert stamping when merging content at boundaries.
  * Corrected style-range filtering behavior.

* **Documentation**
  * Added the v0.7.16 release notes.
  * Updated API documentation to reflect version 0.7.16.

* **Chores**
  * Updated application and deployment package versions to v0.7.16.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->