### PR TITLE
Read project stats from daily HLL materialized views

### DIFF
--- a/build/charts/yorkie-analytics/Chart.yaml
+++ b/build/charts/yorkie-analytics/Chart.yaml
@@ -11,8 +11,8 @@ maintainers:
 
 sources:
   - https://github.com/yorkie-team/yorkie
-version: 0.6.45
-appVersion: "0.6.45"
+version: 0.7.17
+appVersion: "0.7.17"
 kubeVersion: ">=1.24.0-0"
 
 keywords:

--- a/build/charts/yorkie-analytics/templates/starrocks/configmap.yaml
+++ b/build/charts/yorkie-analytics/templates/starrocks/configmap.yaml
@@ -78,6 +78,51 @@ data:
     );
 
 
+  init-create-mv.sql: |
+    USE yorkie;
+
+    -- Synchronous materialized views holding one HLL sketch per (project, day).
+    -- StarRocks maintains them at ingest time and rewrites the dashboard's
+    -- APPROX_COUNT_DISTINCT queries onto them, so GetProjectStats reads a few
+    -- summary rows instead of full-scanning the event tables. The rewrite only
+    -- happens when the query filters on DATE(timestamp), which is why the
+    -- warehouse queries in server/backend/warehouse/starrocks.go use that
+    -- expression. See docs/design/project-stats-warehouse-mv.md.
+    --
+    -- Only the client view carries event_type, because its query filters on it.
+    -- The others omit it so that GROUP BY DATE(timestamp) maps to a clean key
+    -- prefix.
+
+    CREATE MATERIALIZED VIEW mv_user_hll_daily AS
+        SELECT project_id, DATE(timestamp) AS dt,
+               HLL_UNION(HLL_HASH(user_id)) AS user_hll
+        FROM user_events
+        GROUP BY project_id, DATE(timestamp);
+
+    CREATE MATERIALIZED VIEW mv_document_hll_daily AS
+        SELECT project_id, DATE(timestamp) AS dt,
+               HLL_UNION(HLL_HASH(document_key)) AS document_hll
+        FROM document_events
+        GROUP BY project_id, DATE(timestamp);
+
+    CREATE MATERIALIZED VIEW mv_channel_hll_daily AS
+        SELECT project_id, DATE(timestamp) AS dt,
+               HLL_UNION(HLL_HASH(channel_key)) AS channel_hll
+        FROM channel_events
+        GROUP BY project_id, DATE(timestamp);
+
+    CREATE MATERIALIZED VIEW mv_session_hll_daily_ch AS
+        SELECT project_id, DATE(timestamp) AS dt, channel_key,
+               HLL_UNION(HLL_HASH(session_id)) AS session_hll
+        FROM session_events
+        GROUP BY project_id, DATE(timestamp), channel_key;
+
+    CREATE MATERIALIZED VIEW mv_client_hll_daily AS
+        SELECT project_id, event_type, DATE(timestamp) AS dt,
+               HLL_UNION(HLL_HASH(client_id)) AS client_hll
+        FROM client_events
+        GROUP BY project_id, event_type, DATE(timestamp);
+
   init-create-routine-load.sql: |
     CREATE ROUTINE LOAD yorkie.user_events ON user_events
     PROPERTIES
@@ -170,6 +215,32 @@ data:
     mysql -h $STARROCKS_MYSQL_HOST -P 9030 -u root -e 'show tables from yorkie\G' | grep 'Tables_in_yorkie: session_events' || echo -e 'session_events table not found'
     mysql -h $STARROCKS_MYSQL_HOST -P 9030 -u root -e 'show tables from yorkie\G' | grep 'Tables_in_yorkie: client_events' || echo -e 'client_events table not found'
 
+
+    echo -e 'Creating materialized views'
+    # A synchronous materialized view has no working IF NOT EXISTS guard: the
+    # clause parses but still errors once the view exists. This hook re-runs on
+    # every upgrade, so --force is what keeps a second run from failing.
+    mysql -h $STARROCKS_MYSQL_HOST -P 9030 -u root --force < /etc/config/init-create-mv.sql \
+      || echo -e 'Could not run the materialized view script, continuing...'
+
+    echo -e 'Checking materialized views'
+    # The rollup build runs asynchronously, so the index only shows up in `desc
+    # ... all` once it finishes. Poll instead of checking straight after CREATE.
+    mvs=(user_events:mv_user_hll_daily document_events:mv_document_hll_daily channel_events:mv_channel_hll_daily session_events:mv_session_hll_daily_ch client_events:mv_client_hll_daily)
+    for mv in ${mvs[@]}; do
+      table=${mv%%:*}
+      index=${mv##*:}
+      attempt=0
+      until mysql -h $STARROCKS_MYSQL_HOST -P 9030 -u root -e "desc yorkie.$table all\G" 2>/dev/null | grep -q "IndexName: $index"; do
+        attempt=$((attempt + 1))
+        if [ $attempt -ge 30 ]; then
+          echo -e "$index not found on $table"
+          break
+        fi
+        sleep 2s
+      done
+      [ $attempt -lt 30 ] && echo -e "$index is ready on $table"
+    done
 
     sleep 5s
     echo -e 'Creating routine load'

--- a/build/charts/yorkie-analytics/templates/starrocks/configmap.yaml
+++ b/build/charts/yorkie-analytics/templates/starrocks/configmap.yaml
@@ -14,15 +14,15 @@ data:
     USE yorkie;
 
     CREATE TABLE IF NOT EXISTS user_events (
-        user_id VARCHAR(64),
-        timestamp DATETIME, 
-        event_type VARCHAR(32),
         project_id VARCHAR(64),
+        user_id VARCHAR(64),
+        timestamp DATETIME,
+        event_type VARCHAR(32),
         user_agent VARCHAR(32)
-    ) ENGINE = OLAP  
-    DUPLICATE KEY(user_id)  
-    DISTRIBUTED BY HASH(user_id) BUCKETS 10
-    PROPERTIES (  
+    ) ENGINE = OLAP
+    DUPLICATE KEY(project_id, user_id, timestamp)
+    DISTRIBUTED BY HASH(project_id) BUCKETS 16
+    PROPERTIES (
         "replication_num" = "1"
     );
 

--- a/build/charts/yorkie-analytics/templates/starrocks/configmap.yaml
+++ b/build/charts/yorkie-analytics/templates/starrocks/configmap.yaml
@@ -224,8 +224,10 @@ data:
       || echo -e 'Could not run the materialized view script, continuing...'
 
     echo -e 'Checking materialized views'
-    # The rollup build runs asynchronously, so the index only shows up in `desc
-    # ... all` once it finishes. Poll instead of checking straight after CREATE.
+    # The rollup build runs asynchronously and the index only shows up in `desc
+    # ... all` once it finishes, so poll rather than checking straight after the
+    # CREATE. A view that never shows up is not fatal: the queries fall back to
+    # scanning the base table, which is slower but still correct.
     mvs=(user_events:mv_user_hll_daily document_events:mv_document_hll_daily channel_events:mv_channel_hll_daily session_events:mv_session_hll_daily_ch client_events:mv_client_hll_daily)
     for mv in ${mvs[@]}; do
       table=${mv%%:*}
@@ -233,13 +235,13 @@ data:
       attempt=0
       until mysql -h $STARROCKS_MYSQL_HOST -P 9030 -u root -e "desc yorkie.$table all\G" 2>/dev/null | grep -q "IndexName: $index"; do
         attempt=$((attempt + 1))
-        if [ $attempt -ge 30 ]; then
-          echo -e "$index not found on $table"
+        if [ $attempt -ge 60 ]; then
+          echo -e "$index is not ready on $table yet; it may still be building"
           break
         fi
         sleep 2s
       done
-      [ $attempt -lt 30 ] && echo -e "$index is ready on $table"
+      [ $attempt -lt 60 ] && echo -e "$index is ready on $table"
     done
 
     sleep 5s

--- a/build/docker/analytics/README.md
+++ b/build/docker/analytics/README.md
@@ -29,8 +29,12 @@ docker compose -f build/docker/analytics/docker-compose.yml down
 The files used are as follows:
 
 - docker-compose.yml: Defines the StarRocks and Kafka services
-- init-user-events-db.sql: Creates the Yorkie database and tables
-- init-routine-load.sql: Sets up Kafka routine load jobs
+- init-create-table.sql: Creates the Yorkie database and tables
+- init-create-mv.sql: Creates the daily HLL materialized views the project stats
+  queries are rewritten onto
+- init-create-routine-load.sql: Sets up Kafka routine load jobs
+- init-kafka-topics.sh: Creates the Kafka topics
+- init-starrocks-database.sh: Runs the SQL files above and reports what was created
 
 Key services:
 
@@ -44,6 +48,7 @@ The initialization services will:
 - Start the StarRocks FE/BE nodes
 - Create the required Kafka topics
 - Initialize the StarRocks database and tables
+- Create the daily HLL materialized views on the event tables
 - Configure the routine load from Kafka to StarRocks
 
 > Table creation fails with `No alive nodes` when the host disk is more than 85%

--- a/build/docker/analytics/README.md
+++ b/build/docker/analytics/README.md
@@ -46,6 +46,11 @@ The initialization services will:
 - Initialize the StarRocks database and tables
 - Configure the routine load from Kafka to StarRocks
 
+> Table creation fails with `No alive nodes` when the host disk is more than 85%
+> full: StarRocks drops a backend out of the tablet allocation candidates at that
+> point, even though `SHOW BACKENDS` still reports it alive. Free up disk space
+> rather than raising the watermark.
+
 ## For Setup Kafka Cluster Mode
 
 To set up Kafka in cluster mode, refer to the [Docker Hub Apache Kafka](https://hub.docker.com/r/apache/kafka) for detailed instructions on setting up Kafka in cluster mode using Docker Compose.

--- a/build/docker/analytics/README.md
+++ b/build/docker/analytics/README.md
@@ -51,6 +51,10 @@ The initialization services will:
 - Create the daily HLL materialized views on the event tables
 - Configure the routine load from Kafka to StarRocks
 
+Creating the materialized views is best effort: initialization logs whether each
+one became ready and carries on either way. Without a view, the project stats
+queries fall back to scanning the base table — slower, but still correct.
+
 > Table creation fails with `No alive nodes` when the host disk is more than 85%
 > full: StarRocks drops a backend out of the tablet allocation candidates at that
 > point, even though `SHOW BACKENDS` still reports it alive. Free up disk space

--- a/build/docker/analytics/docker-compose.yml
+++ b/build/docker/analytics/docker-compose.yml
@@ -106,6 +106,7 @@ services:
         condition: service_completed_successfully
     volumes:
       - ./init-create-table.sql:/init-create-table.sql
+      - ./init-create-mv.sql:/init-create-mv.sql
       - ./init-create-routine-load.sql:/init-create-routine-load.sql
       - ./init-starrocks-database.sh:/init-starrocks-database.sh
     entrypoint: ["/bin/bash"]

--- a/build/docker/analytics/docker-compose.yml
+++ b/build/docker/analytics/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   starrocks-fe:
-    image: starrocks/fe-ubuntu:2.5.4
+    image: starrocks/fe-ubuntu:3.3.9
     hostname: starrocks-fe
     container_name: starrocks-fe
     user: root
@@ -20,7 +20,7 @@ services:
       - ./starrocks/fe/log:/opt/starrocks/fe/log
 
   starrocks-be:
-    image: starrocks/be-ubuntu:2.5.4
+    image: starrocks/be-ubuntu:3.3.9
     hostname: starrocks-be
     container_name: starrocks-be
     user: root
@@ -94,7 +94,7 @@ services:
       - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=kafka:9092
 
   init-starrocks-database:
-    image: starrocks/fe-ubuntu:2.5.4
+    image: starrocks/fe-ubuntu:3.3.9
     depends_on:
       starrocks-fe:
         condition: service_healthy

--- a/build/docker/analytics/init-create-mv.sql
+++ b/build/docker/analytics/init-create-mv.sql
@@ -1,0 +1,42 @@
+USE yorkie;
+
+-- Synchronous materialized views holding one HLL sketch per (project, day).
+-- StarRocks maintains them at ingest time and rewrites the dashboard's
+-- APPROX_COUNT_DISTINCT queries onto them, so GetProjectStats reads a few
+-- summary rows instead of full-scanning the event tables. The rewrite only
+-- happens when the query filters on DATE(timestamp), which is why the warehouse
+-- queries in server/backend/warehouse/starrocks.go use that expression.
+-- See docs/design/project-stats-warehouse-mv.md.
+--
+-- Only the client view carries event_type, because its query filters on it. The
+-- others omit it so that GROUP BY DATE(timestamp) maps to a clean key prefix.
+
+CREATE MATERIALIZED VIEW mv_user_hll_daily AS
+    SELECT project_id, DATE(timestamp) AS dt,
+           HLL_UNION(HLL_HASH(user_id)) AS user_hll
+    FROM user_events
+    GROUP BY project_id, DATE(timestamp);
+
+CREATE MATERIALIZED VIEW mv_document_hll_daily AS
+    SELECT project_id, DATE(timestamp) AS dt,
+           HLL_UNION(HLL_HASH(document_key)) AS document_hll
+    FROM document_events
+    GROUP BY project_id, DATE(timestamp);
+
+CREATE MATERIALIZED VIEW mv_channel_hll_daily AS
+    SELECT project_id, DATE(timestamp) AS dt,
+           HLL_UNION(HLL_HASH(channel_key)) AS channel_hll
+    FROM channel_events
+    GROUP BY project_id, DATE(timestamp);
+
+CREATE MATERIALIZED VIEW mv_session_hll_daily_ch AS
+    SELECT project_id, DATE(timestamp) AS dt, channel_key,
+           HLL_UNION(HLL_HASH(session_id)) AS session_hll
+    FROM session_events
+    GROUP BY project_id, DATE(timestamp), channel_key;
+
+CREATE MATERIALIZED VIEW mv_client_hll_daily AS
+    SELECT project_id, event_type, DATE(timestamp) AS dt,
+           HLL_UNION(HLL_HASH(client_id)) AS client_hll
+    FROM client_events
+    GROUP BY project_id, event_type, DATE(timestamp);

--- a/build/docker/analytics/init-create-table.sql
+++ b/build/docker/analytics/init-create-table.sql
@@ -3,15 +3,15 @@ CREATE DATABASE IF NOT EXISTS yorkie;
 USE yorkie;
 
 CREATE TABLE IF NOT EXISTS user_events (
-    user_id VARCHAR(64),
-    timestamp DATETIME, 
-    event_type VARCHAR(32),
     project_id VARCHAR(64),
+    user_id VARCHAR(64),
+    timestamp DATETIME,
+    event_type VARCHAR(32),
     user_agent VARCHAR(32)
-) ENGINE = OLAP  
-DUPLICATE KEY(user_id)  
-DISTRIBUTED BY HASH(user_id) BUCKETS 10
-PROPERTIES (  
+) ENGINE = OLAP
+DUPLICATE KEY(project_id, user_id, timestamp)
+DISTRIBUTED BY HASH(project_id) BUCKETS 16
+PROPERTIES (
     "replication_num" = "1"
 );
 

--- a/build/docker/analytics/init-starrocks-database.sh
+++ b/build/docker/analytics/init-starrocks-database.sh
@@ -27,6 +27,32 @@ mysql -h starrocks-fe -P 9030 -u root -e 'show tables from yorkie\G' | grep 'Tab
 mysql -h starrocks-fe -P 9030 -u root -e 'show tables from yorkie\G' | grep 'Tables_in_yorkie: client_events' || echo -e 'client_events table not found'
 
 
+echo -e 'Creating materialized views'
+# A synchronous materialized view has no working IF NOT EXISTS guard: the clause
+# parses but still errors once the view exists. --force is what keeps a re-run
+# of this script from failing.
+mysql -h starrocks-fe -P 9030 -u root --force < /init-create-mv.sql \
+  || echo -e 'Could not run the materialized view script, continuing...'
+
+echo -e 'Checking materialized views'
+# The rollup build runs asynchronously, so the index only shows up in `desc ...
+# all` once it finishes. Poll instead of checking straight after the CREATE.
+mvs=(user_events:mv_user_hll_daily document_events:mv_document_hll_daily channel_events:mv_channel_hll_daily session_events:mv_session_hll_daily_ch client_events:mv_client_hll_daily)
+for mv in "${mvs[@]}"; do
+  table=${mv%%:*}
+  index=${mv##*:}
+  attempt=0
+  until mysql -h starrocks-fe -P 9030 -u root -e "desc yorkie.$table all\G" 2>/dev/null | grep -q "IndexName: $index"; do
+    attempt=$((attempt + 1))
+    if [ $attempt -ge 30 ]; then
+      echo -e "$index not found on $table"
+      break
+    fi
+    sleep 2s
+  done
+  [ $attempt -lt 30 ] && echo -e "$index is ready on $table"
+done
+
 sleep 5s
 echo -e 'Creating routine load'
 if mysql -h starrocks-fe -P 9030 -u root < /init-create-routine-load.sql 2>/dev/null; then

--- a/build/docker/analytics/init-starrocks-database.sh
+++ b/build/docker/analytics/init-starrocks-database.sh
@@ -35,8 +35,10 @@ mysql -h starrocks-fe -P 9030 -u root --force < /init-create-mv.sql \
   || echo -e 'Could not run the materialized view script, continuing...'
 
 echo -e 'Checking materialized views'
-# The rollup build runs asynchronously, so the index only shows up in `desc ...
-# all` once it finishes. Poll instead of checking straight after the CREATE.
+# The rollup build runs asynchronously and the index only shows up in `desc ...
+# all` once it finishes, so poll rather than checking straight after the CREATE.
+# A view that never shows up is not fatal: the queries fall back to scanning the
+# base table, which is slower but still correct.
 mvs=(user_events:mv_user_hll_daily document_events:mv_document_hll_daily channel_events:mv_channel_hll_daily session_events:mv_session_hll_daily_ch client_events:mv_client_hll_daily)
 for mv in "${mvs[@]}"; do
   table=${mv%%:*}
@@ -44,13 +46,13 @@ for mv in "${mvs[@]}"; do
   attempt=0
   until mysql -h starrocks-fe -P 9030 -u root -e "desc yorkie.$table all\G" 2>/dev/null | grep -q "IndexName: $index"; do
     attempt=$((attempt + 1))
-    if [ $attempt -ge 30 ]; then
-      echo -e "$index not found on $table"
+    if [ $attempt -ge 60 ]; then
+      echo -e "$index is not ready on $table yet; it may still be building"
       break
     fi
     sleep 2s
   done
-  [ $attempt -lt 30 ] && echo -e "$index is ready on $table"
+  [ $attempt -lt 60 ] && echo -e "$index is ready on $table"
 done
 
 sleep 5s

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -51,6 +51,7 @@ New design documents should be based on [TEMPLATE.md](TEMPLATE.md).
 - [Snapshot Overflow](snapshot-overflow.md): Handling Yorkie snapshots that exceed MongoDB's 16MB BSON limit
 - [Allowed Origins Wildcard](allowed-origins-wildcard.md): Wildcard pattern matching for project `AllowedOrigins` CORS check
 - [Project Stats Cache](project-stats-cache.md): Asynchronously refreshed cache for `ClientsCount` and `DocumentsCount` to keep `GetProjectStats` fast at large scale
+- [Project Stats Warehouse Materialized Views](project-stats-warehouse-mv.md): Daily HLL rollups that make the warehouse-backed `GetProjectStats` metrics independent of event volume
 - [Per-Project Channel Session TTL](per-project-channel-session-ttl.md): Per-project override for `ChannelSessionTTL` to tune the presence-count "feels occupied" effect
 
 ## Maintaining the Document

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -45,7 +45,7 @@ New design documents should be based on [TEMPLATE.md](TEMPLATE.md).
 - [Housekeeping](housekeeping.md): Background tasks for cleaning up documents and tombstones
 - [Document Epoch](document-epoch.md): Epoch-based detection and recovery for clients stale after compaction
 - [Fine-grained Document Locking](fine-grained-document-locking.md): Fine-grained document locking for high concurrency
-- [OLAP Stack for MAU Tracking](olap-stack.md): OLAP stack for Monthly Active Users (MAU) tracking
+- [OLAP Stack for MAU Tracking](olap-stack.md): Kafka and StarRocks pipeline behind the warehouse-backed project stats, starting from Monthly Active Users (MAU) tracking
 - [Cluster Service Authentication](cluster-service-auth.md): Shared secret authentication for inter-node cluster RPCs
 - [MCP Server](mcp.md): Model Context Protocol server integration for AI assistants
 - [Snapshot Overflow](snapshot-overflow.md): Handling Yorkie snapshots that exceed MongoDB's 16MB BSON limit

--- a/docs/design/olap-stack.md
+++ b/docs/design/olap-stack.md
@@ -9,6 +9,8 @@ target-version: 0.6.1
 
 To accurately measure Monthly Active Users (MAU) for the Yorkie Project, we propose introducing an OLAP stack. This stack will leverage Kafka for event streaming and StarRocks for efficient OLAP query processing. The implementation will enable real-time data aggregation and analytics, providing valuable insights into user activity trends.
 
+> MAU was the first consumer, not the last. The stack now carries five event families — user, document, client, channel and session — each with its own Kafka topic and StarRocks table, and they feed the six warehouse-backed metrics the dashboard renders through `GetProjectStats`. The sections below describe the original design; where a detail has since changed, it says so.
+
 ## Goals
 
 - Implement a scalable OLAP stack to measure MAU effectively.
@@ -46,14 +48,16 @@ const client = new yorkie.Client("https://api.yorkie.dev", {
 #### **Data Flow**
 
 1. Yorkie clients generate events(e.g., client activation, document edits).
-2. Events are streamed via Kafka.
-3. StarRocks processes and aggregates event data with Routine Load jobs.
-4. Precomputed MAU statistics are available for querying.
+2. Events are streamed via Kafka, one topic per event family.
+3. StarRocks ingests each topic into its own table with a Routine Load job.
+4. The dashboard queries those tables through `GetProjectStats`.
+
+Step 4 reads the raw event tables, so its cost grows with event volume. Since 0.7.17 each table also carries a synchronous materialized view holding one HLL sketch per `(project, day)`, and StarRocks rewrites the dashboard's queries onto it — see [Project Stats Warehouse Materialized Views](project-stats-warehouse-mv.md).
 
 ### Risks and Mitigation
 
-- **High Data Volume**: Implement partitioning and indexing strategies in StarRocks.
-- **Security Concerns**: Store only hashed UserIDs to protect user privacy.
+- **High Data Volume**: Implement partitioning and indexing strategies in StarRocks. In practice the answer was pre-aggregation rather than partitioning: the event tables are still unpartitioned, and the read cost was removed with daily HLL rollups instead ([Project Stats Warehouse Materialized Views](project-stats-warehouse-mv.md)).
+- **Security Concerns**: Store only hashed UserIDs to protect user privacy. Not implemented — consistent with the non-goal above, `user_events.user_id` holds the identifier the client supplies in its metadata, unhashed.
 - **Scalability**: Use Kafka’s distributed architecture to handle high throughput.
 
 By implementing this OLAP stack, Yorkie will gain a powerful analytics framework to track MAU efficiently and support data-driven decision-making for user activity trends.

--- a/docs/design/project-stats-cache.md
+++ b/docs/design/project-stats-cache.md
@@ -34,7 +34,9 @@ index entry.
   cluster nodes, has no DB scan, and reflects currently-connected state.
   Caching it would obscure live behavior without saving meaningful work.
 - Caching warehouse-backed stats (`ActiveUsers`, `Sessions`, etc.). The
-  warehouse (StarRocks) is already OLAP-optimized.
+  warehouse (StarRocks) is already OLAP-optimized. (This holds only up to a
+  point — see [Project Stats Warehouse Materialized Views](project-stats-warehouse-mv.md),
+  which pre-aggregates those queries inside StarRocks instead of caching them.)
 - Fixing the upstream growth that produced 83M activated clients. Tracked
   separately as housekeeping efficiency work.
 

--- a/docs/design/project-stats-warehouse-mv.md
+++ b/docs/design/project-stats-warehouse-mv.md
@@ -1,0 +1,201 @@
+---
+title: project-stats-warehouse-mv
+target-version: 0.7.17
+---
+
+# Project Stats Warehouse Materialized Views
+
+## Problem
+
+`GetProjectStats` renders six warehouse-backed metrics — active users, active
+documents, active clients, active channels, sessions, and peak sessions per
+channel — each as a daily series plus a total. That is 12 queries against the
+event tables in `server/backend/warehouse/starrocks.go`, and every one of them
+is a distinct count over a whole event table.
+
+[Project Stats Cache](project-stats-cache.md) fixed the MongoDB half of the same
+endpoint and explicitly left the warehouse alone, on the grounds that StarRocks
+"is already OLAP-optimized". That holds only up to a point. Running the 12
+queries concurrently with `APPROX_COUNT_DISTINCT` instead of exact distinct
+(v0.7.15) is a constant-factor win: each request still full-scans its base
+table, so cost stays O(rows). For a project with more than 100M events in the
+window a single approximate distinct is still multi-second, and the peak
+sessions per channel query alone runs past the dashboard's 3s budget.
+
+The durable fix is to stop reading raw events on the request path.
+
+### Goals
+
+- Make the warehouse reads volume-independent: latency driven by the number of
+  days in the window, not the number of events in it.
+- Keep the numbers identical to what `APPROX_COUNT_DISTINCT` already returns.
+- Require no new refresh job, no new table to keep in sync, and no change to the
+  `Warehouse` interface.
+
+### Non-Goals
+
+- Exact distinct counts. HLL error (~0.2–1.7%) was already accepted in v0.7.15.
+- Event retention. Purging old events interacts with this design (see Risks) but
+  no purge exists today.
+- Caching warehouse results in MongoDB the way `stats_clients_count` is cached.
+  Pre-aggregation inside the warehouse is cheaper and never goes stale.
+
+## Design
+
+Store one HLL sketch per `(project, day[, channel])` and let StarRocks maintain
+it at ingest time. StarRocks calls this a **synchronous materialized view**: a
+rollup index on the base table, updated as part of the write, with no refresh
+job and no rebuild. The dashboard query then reads a handful of summary rows and
+unions the daily sketches.
+
+The critical property is that nothing in the Go code reads the view directly.
+StarRocks rewrites the existing query onto the rollup, so the sketch union
+happens inside the engine. There is no hand-written `HLL_UNION_AGG`.
+
+### Rewrite conditions
+
+StarRocks only rewrites a query onto the view when all three hold:
+
+1. The aggregate is HLL-based — `APPROX_COUNT_DISTINCT`, already true.
+2. The date predicate and grouping use **`DATE(timestamp)`**, matching the
+   expression the view is grouped by.
+3. The view exists on that base table.
+
+Condition 2 is the code change. The predicate moves from `timestamp` to
+`DATE(timestamp)` in all 12 queries:
+
+```go
+// before: predicate on the raw timestamp -> no rewrite, base full scan
+//   WHERE project_id = '%s' AND timestamp >= '%s' AND timestamp < '%s'
+// after: predicate on DATE(timestamp) -> rewritten onto the rollup
+//   WHERE project_id = '%s' AND DATE(timestamp) >= '%s' AND DATE(timestamp) < '%s'
+```
+
+`from` and `to` are already formatted as dates, so day-boundary semantics are
+unchanged. Miss condition 2 and the query silently falls back to a base full
+scan — correct results, no error, no log line. That silence is why the
+expression is worth a comment at the call site.
+
+### The views
+
+A synchronous view inherits the base table's distribution and replication, so it
+takes no `buckets` or `replication_num` clause. They live in
+`build/charts/yorkie-analytics/.../starrocks/configmap.yaml` (deployed clusters)
+and `build/docker/analytics/init-create-mv.sql` (local stack):
+
+```sql
+CREATE MATERIALIZED VIEW mv_user_hll_daily AS
+    SELECT project_id, DATE(timestamp) AS dt,
+           HLL_UNION(HLL_HASH(user_id)) AS user_hll
+    FROM user_events
+    GROUP BY project_id, DATE(timestamp);
+```
+
+`mv_document_hll_daily` and `mv_channel_hll_daily` follow the same shape.
+`mv_session_hll_daily_ch` additionally groups by `channel_key`, which lets one
+view serve both the sessions metric and peak sessions per channel.
+`mv_client_hll_daily` is the only one that carries `event_type`, because its
+query filters on `event_type = 'client-activated'`; the other four omit it so
+that `GROUP BY DATE(timestamp)` maps to a clean key prefix.
+
+The column aliases are cosmetic. StarRocks renames the view's columns to
+`mv_dt`, `mv_hll_union_user_id`, and so on — nothing can reference them by name,
+which is another way of saying the rewrite is the only interface.
+
+### Base table alignment
+
+Four event tables key and distribute on `project_id`. `user_events` did not: it
+was `DUPLICATE KEY(user_id)` / `DISTRIBUTED BY HASH(user_id) BUCKETS 10`, so a
+per-project query could not prune anything. Measured on 200k synthetic rows
+across 50 projects, querying one project:
+
+| layout | rewritten query | fallback (no view) |
+|---|---|---|
+| `DUPLICATE KEY(user_id)` | 60 rows scanned | 200,000 rows scanned |
+| `DUPLICATE KEY(project_id, user_id, timestamp)` | 6 rows scanned | 4,000 rows scanned |
+
+Both return the same value. The view helps either way, but the misaligned layout
+scans ten times more summary rows, and its fallback path reads every project's
+events instead of one project's. `user_events` is therefore redefined to match
+the other four.
+
+`CREATE TABLE IF NOT EXISTS` does not alter an existing table, so this only
+takes effect on new installs. Existing clusters keep the old layout until
+someone migrates them — create the table under a new name, `INSERT INTO ...
+SELECT`, then swap with `ALTER TABLE ... RENAME`. Nothing breaks in the
+meantime; the queries stay correct and still hit the view.
+
+### Deployment sequencing
+
+Views without the code change mean no rewrite — harmless. The code change
+without the views means the base-scan fallback, which is correct but not
+automatically as fast as before: wrapping the column in `DATE()` can cost
+partition pruning if the base table is partitioned on `timestamp`. The event
+tables carry no `PARTITION BY` today, and measurement confirms the fallback
+scans exactly the same rows as the raw predicate, so the order is not load
+bearing on the current schema. It becomes load bearing the day the tables are
+partitioned. Safe order per environment:
+
+1. Create and build the views (a one-time base full scan, ~80ns/row).
+2. Confirm ingest-time maintenance.
+3. Deploy the server with the `DATE(timestamp)` predicate.
+4. Confirm `ScanRows` in the FE audit log is small for the six metrics.
+
+### Verification
+
+`EXPLAIN` naming the rollup index tells you the plan picked the view;
+`ScanRows` in `fe.audit.log` tells you the base table was actually skipped. Both
+are worth checking, because a plan can read the rollup with
+`PREAGGREGATION: OFF` — the peak sessions query does exactly that, since the
+outer `MAX` sits over a derived aggregate — and still avoid the base scan.
+
+Measured on the public cluster (StarRocks 3.3.9), before and after creating the
+views, with every value identical across the two runs:
+
+| metric | rows scanned before | after |
+|---|---|---|
+| active users | 26,047 | 1,422 |
+| active documents | 23,781 | 199 |
+| active clients | 33,533 | 195 |
+| active channels | 66 | 3 |
+| sessions | 82 | 33 |
+| peak sessions per channel | 82 | 33 |
+
+Events ingested after the views were built are reflected without any rebuild.
+
+### Risks and Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| A base `DELETE` on `timestamp` fails with error 5509 while a view is attached, because `timestamp` is not a column of the view | No retention purge exists today. When one is added: delete on a column the view carries (`project_id` works and stays consistent), partition the base tables and drop partitions, or drop the views, purge, and recreate them. The rebuild is a single base scan. |
+| The 5509 check only fires when the table holds rows | Never validate a purge against an empty table — it will pass and teach you the wrong thing. |
+| Rewrite silently stops if someone rewrites the predicate back to a raw `timestamp` | Comment at the call site in `starrocks.go`; `ScanRows` in the FE audit log is the check. |
+| Aggregate rollups produce frequent small writes under continuous ingest, and compaction on the internal cluster has deadlocked before | Summary volume is tiny next to the base table, and the compaction score stayed at zero on the public cluster — but public ingest is a trickle, so this has to be re-measured under production ingest before rollout there. |
+| Expressions in synchronous views need StarRocks 3.1 or newer | The chart pins `3.3-latest` and the local stack pins 3.3.9. Check the version before creating the views in any other environment. |
+| The init hook re-runs on every chart upgrade and `CREATE MATERIALIZED VIEW IF NOT EXISTS` still errors when the view exists | The init script runs the view DDL with `mysql --force` and then polls `desc <table> all` for each index. |
+
+### Design Decisions
+
+| Decision | Reason |
+|----------|--------|
+| Synchronous view rather than an asynchronous one | Maintained at ingest time, so there is no refresh interval to tune and no staleness window. An async view would reintroduce exactly the freshness question the MongoDB cache had to answer. |
+| Let the rewrite union the sketches, instead of querying the view directly | The only Go change is the predicate. Reading the view by name would hard-code the schema into the server and break every cluster that has not created it. |
+| One view per event table, keyed on `(project_id, day)` | Matches how the dashboard slices the data. Days are the finest granularity the API exposes. |
+| `event_type` in the client view only | Its query is the only one that filters on `event_type`. Adding the column elsewhere would push `dt` out of the key prefix for no gain. |
+| Channel key in the session view | One view serves both the sessions metric and peak sessions per channel, instead of two views over the same table. |
+| Realign `user_events` in the DDL, without an automatic migration | New installs get the good layout at no cost. Rewriting a live event table is a separate operation with its own risk, and the old layout still works. |
+
+## Alternatives Considered
+
+| Alternative | Why not |
+|-------------|---------|
+| A manually maintained daily rollup table | Needs a scheduled job, a backfill, and reconciliation after gaps. The synchronous view gets the same result from the ingest path already in place. |
+| An asynchronous materialized view with a refresh interval | Adds a staleness window and a refresh job, in exchange for flexibility this query shape does not need. |
+| Hand-written `HLL_UNION_AGG` over a sketch table in Go | Puts the warehouse schema in the server. Any cluster without the table breaks, instead of falling back to a correct base scan. |
+| Cache the warehouse results in MongoDB, as `stats_clients_count` does | A second staleness budget for numbers the warehouse can produce fresh in tens of milliseconds. |
+| Partition the event tables by day and rely on partition pruning alone | Helps the scan, but the request still counts distinct values over every event in the window. Pruning and pre-aggregation are complementary; pre-aggregation is what removes the O(rows) term. |
+| Raise the dashboard timeout | Moves the failure rather than removing it. |
+
+## Tasks
+
+Track execution plans in `docs/tasks/active/` as separate task documents.

--- a/docs/design/project-stats-warehouse-mv.md
+++ b/docs/design/project-stats-warehouse-mv.md
@@ -10,8 +10,9 @@ target-version: 0.7.17
 `GetProjectStats` renders six warehouse-backed metrics — active users, active
 documents, active clients, active channels, sessions, and peak sessions per
 channel — each as a daily series plus a total. That is 12 queries against the
-event tables in `server/backend/warehouse/starrocks.go`, and every one of them
-is a distinct count over a whole event table.
+event tables the [OLAP stack](olap-stack.md) fills, issued from
+`server/backend/warehouse/starrocks.go`, and every one of them is a distinct
+count over a whole event table.
 
 [Project Stats Cache](project-stats-cache.md) fixed the MongoDB half of the same
 endpoint and explicitly left the warehouse alone, on the grounds that StarRocks

--- a/docs/design/project-stats-warehouse-mv.md
+++ b/docs/design/project-stats-warehouse-mv.md
@@ -126,6 +126,47 @@ someone migrates them — create the table under a new name, `INSERT INTO ...
 SELECT`, then swap with `ALTER TABLE ... RENAME`. Nothing breaks in the
 meantime; the queries stay correct and still hit the view.
 
+### Day boundaries
+
+The views bucket by `DATE(timestamp)`, and that day is a **UTC** day. The server
+writes event timestamps with `time.Now()` from a container running on UTC, and a
+StarRocks `DATETIME` is timezone-naive — it stores the wall clock it was given
+and converts nothing on read, so `DATE()` simply truncates. A chart point
+labelled `2026-08-18` therefore covers 09:00 KST that day to 09:00 KST the next.
+
+This is not new: the pre-view queries grouped by the same expression, so the
+numbers are unchanged. What is new is that the view **freezes the boundary at
+ingest**. The bucket is materialized, so it cannot be reinterpreted later by
+changing a session variable or wrapping the column at query time.
+
+Two measurements shape what a locale-aware version would cost:
+
+- A finer view does not serve a coarser query. An hourly rollup
+  (`date_trunc('hour', timestamp)`) answers hourly queries from 96 summary rows
+  but sends the daily query to a 31,616-row base scan. HLL sketches compose
+  losslessly, so 24 hourly sketches *are* a day mathematically — the optimizer
+  just does not make that leap. Matching is on the expression, not its meaning.
+- A converted day is materializable.
+  `DATE(CONVERT_TZ(timestamp,'UTC','Asia/Seoul'))` is accepted in a synchronous
+  view, and a KST-day query then reads 22 rows instead of the base table, with
+  values identical to an exact count over the same window.
+
+So each day boundary needs its own view, and every view on a table is written on
+every load. **The decision is to keep UTC buckets** and let the dashboard say so,
+rather than double the ingest cost for a requirement nobody has raised.
+
+If per-project local days are needed later, the cheaper path is to stop deriving
+the day in the warehouse: have the server compute the project's local date when
+it emits the event, carry it as a column, and key the view on that. One view,
+any per-project timezone, no `CONVERT_TZ`. It fixes the boundary at write time,
+so changing a project's timezone would not restate its history.
+
+A viewer-chosen timezone is a different problem and this design does not reach
+it. That needs sketches finer than the finest boundary — hourly, or 15 minutes
+to cover offsets like +05:30 and +05:45 — unioned per request with
+`HLL_UNION_AGG`, which means a view the server can name and query. The automatic
+rewrite would be given up in the process.
+
 ### Deployment sequencing
 
 Views without the code change mean no rewrite — harmless. The code change
@@ -174,6 +215,7 @@ Events ingested after the views were built are reflected without any rebuild.
 | Aggregate rollups produce frequent small writes under continuous ingest, and compaction on the internal cluster has deadlocked before | Summary volume is tiny next to the base table, and the compaction score stayed at zero on the public cluster — but public ingest is a trickle, so this has to be re-measured under production ingest before rollout there. |
 | Expressions in synchronous views need StarRocks 3.1 or newer | The chart pins `3.3-latest` and the local stack pins 3.3.9. Check the version before creating the views in any other environment. |
 | The init hook re-runs on every chart upgrade and `CREATE MATERIALIZED VIEW IF NOT EXISTS` still errors when the view exists | The init script runs the view DDL with `mysql --force` and then polls `desc <table> all` for each index. |
+| The event tables hold UTC, but StarRocks defaults its `time_zone` to `Asia/Shanghai`, so anything written against `NOW()` is eight hours off the data | These queries pass explicit date strings from Go and never ask the server what time it is. Ad-hoc queries should not: either set the FE `time_zone` to UTC or use `UTC_TIMESTAMP()`. |
 
 ### Design Decisions
 
@@ -185,6 +227,7 @@ Events ingested after the views were built are reflected without any rebuild.
 | `event_type` in the client view only | Its query is the only one that filters on `event_type`. Adding the column elsewhere would push `dt` out of the key prefix for no gain. |
 | Channel key in the session view | One view serves both the sessions metric and peak sessions per channel, instead of two views over the same table. |
 | Realign `user_events` in the DDL, without an automatic migration | New installs get the good layout at no cost. Rewriting a live event table is a separate operation with its own risk, and the old layout still works. |
+| UTC day buckets, with an ingest-time local date as the reserved path | Every additional day boundary is another view written on every load. Nobody has asked for local days yet, and if they do, computing the date at write time costs one column instead of one view per timezone. |
 
 ## Alternatives Considered
 
@@ -196,6 +239,8 @@ Events ingested after the views were built are reflected without any rebuild.
 | Cache the warehouse results in MongoDB, as `stats_clients_count` does | A second staleness budget for numbers the warehouse can produce fresh in tens of milliseconds. |
 | Partition the event tables by day and rely on partition pruning alone | Helps the scan, but the request still counts distinct values over every event in the window. Pruning and pre-aggregation are complementary; pre-aggregation is what removes the O(rows) term. |
 | Raise the dashboard timeout | Moves the failure rather than removing it. |
+| One view per supported timezone, keyed on `DATE(CONVERT_TZ(...))` | It works — a converted day materializes and rewrites correctly — but each view is written on every load, so the ingest cost scales with the number of locales supported. Reserved for the day a specific market needs it. |
+| One hourly view, composed into whichever local day is asked for | The rewrite matches the grouping expression, not its meaning, so an hourly view leaves daily queries on a base scan. Composing sketches per request means querying a view by name, which a synchronous view does not allow. |
 
 ## Tasks
 

--- a/server/backend/warehouse/starrocks.go
+++ b/server/backend/warehouse/starrocks.go
@@ -30,6 +30,12 @@ import (
 )
 
 // StarRocks is a warehouse that stores data in StarRocks.
+//
+// NOTE(hackerwins): The queries below filter on DATE(timestamp) instead of the
+// raw timestamp. StarRocks rewrites an APPROX_COUNT_DISTINCT query onto a
+// synchronous materialized view grouped by DATE(timestamp) only when the query
+// uses the same expression in its predicate. With a raw timestamp predicate the
+// query silently falls back to a full scan of the base event table.
 type StarRocks struct {
 	conf   *Config
 	driver *sql.DB
@@ -71,8 +77,8 @@ func (r *StarRocks) GetActiveUsers(
 	    user_events
 	WHERE
 		project_id = '%s'
-		AND timestamp >= '%s'
-		AND timestamp < '%s'
+		AND DATE(timestamp) >= '%s'
+		AND DATE(timestamp) < '%s'
 	GROUP BY 
 	    event_date
 	ORDER BY 
@@ -106,8 +112,8 @@ func (r *StarRocks) GetActiveUsersCount(
 	    user_events
 	WHERE
 		project_id = '%s'
-		AND timestamp >= '%s'
-		AND timestamp < '%s';
+		AND DATE(timestamp) >= '%s'
+		AND DATE(timestamp) < '%s';
 	`, id.String(), from.Format("2006-01-02"), to.Format("2006-01-02"))
 
 	count, err := r.queryCount(ctx, query)
@@ -138,8 +144,8 @@ func (r *StarRocks) GetActiveDocuments(
 	    document_events
 	WHERE
 		project_id = '%s'
-		AND timestamp >= '%s'
-		AND timestamp < '%s'
+		AND DATE(timestamp) >= '%s'
+		AND DATE(timestamp) < '%s'
 	GROUP BY 
 	    event_date
 	ORDER BY 
@@ -173,8 +179,8 @@ func (r *StarRocks) GetActiveDocumentsCount(
 		document_events
 	WHERE
 		project_id = '%s'
-		AND timestamp >= '%s'
-		AND timestamp < '%s';
+		AND DATE(timestamp) >= '%s'
+		AND DATE(timestamp) < '%s';
 	`, id.String(), from.Format("2006-01-02"), to.Format("2006-01-02"))
 
 	count, err := r.queryCount(ctx, query)
@@ -206,8 +212,8 @@ func (r *StarRocks) GetActiveClients(
 	WHERE
 		project_id = '%s'
 		AND event_type = '%s'
-		AND timestamp >= '%s'
-		AND timestamp < '%s'
+		AND DATE(timestamp) >= '%s'
+		AND DATE(timestamp) < '%s'
 	GROUP BY
 	    event_date
 	ORDER BY
@@ -242,8 +248,8 @@ func (r *StarRocks) GetActiveClientsCount(
 	WHERE
 		project_id = '%s'
 		AND event_type = '%s'
-		AND timestamp >= '%s'
-		AND timestamp < '%s';
+		AND DATE(timestamp) >= '%s'
+		AND DATE(timestamp) < '%s';
 	`, id.String(), events.ClientActivatedEvent, from.Format("2006-01-02"), to.Format("2006-01-02"))
 
 	count, err := r.queryCount(ctx, query)
@@ -274,8 +280,8 @@ func (r *StarRocks) GetActiveChannels(
 	    channel_events
 	WHERE
 		project_id = '%s'
-		AND timestamp >= '%s'
-		AND timestamp < '%s'
+		AND DATE(timestamp) >= '%s'
+		AND DATE(timestamp) < '%s'
 	GROUP BY 
 	    event_date
 	ORDER BY 
@@ -309,8 +315,8 @@ func (r *StarRocks) GetActiveChannelsCount(
 	    channel_events
 	WHERE
 		project_id = '%s'
-		AND timestamp >= '%s'
-		AND timestamp < '%s';
+		AND DATE(timestamp) >= '%s'
+		AND DATE(timestamp) < '%s';
 	`, id.String(), from.Format("2006-01-02"), to.Format("2006-01-02"))
 
 	count, err := r.queryCount(ctx, query)
@@ -341,8 +347,8 @@ func (r *StarRocks) GetSessions(
 	    session_events
 	WHERE
 		project_id = '%s'
-		AND timestamp >= '%s'
-		AND timestamp < '%s'
+		AND DATE(timestamp) >= '%s'
+		AND DATE(timestamp) < '%s'
 	GROUP BY 
 	    event_date
 	ORDER BY 
@@ -376,8 +382,8 @@ func (r *StarRocks) GetSessionsCount(
 	    session_events
 	WHERE
 		project_id = '%s'
-		AND timestamp >= '%s'
-		AND timestamp < '%s';
+		AND DATE(timestamp) >= '%s'
+		AND DATE(timestamp) < '%s';
 	`, id.String(), from.Format("2006-01-02"), to.Format("2006-01-02"))
 
 	count, err := r.queryCount(ctx, query)
@@ -413,8 +419,8 @@ func (r *StarRocks) GetPeakSessionsPerChannel(
 	        session_events
 	    WHERE
 	        project_id = '%s'
-	        AND timestamp >= '%s'
-	        AND timestamp < '%s'
+	        AND DATE(timestamp) >= '%s'
+	        AND DATE(timestamp) < '%s'
 	    GROUP BY 
 	        event_date, channel_key
 	) AS channel_sessions
@@ -456,8 +462,8 @@ func (r *StarRocks) GetPeakSessionsPerChannelCount(
 	        session_events
 	    WHERE
 	        project_id = '%s'
-	        AND timestamp >= '%s'
-	        AND timestamp < '%s'
+	        AND DATE(timestamp) >= '%s'
+	        AND DATE(timestamp) < '%s'
 	    GROUP BY 
 	        event_date, channel_key
 	) AS channel_sessions;


### PR DESCRIPTION
## Summary

`GetProjectStats` issues 12 `APPROX_COUNT_DISTINCT` queries against the event
tables and every one of them full-scans its base table, so read latency grows
with event volume and the dashboard times out on busy projects.

This PR pre-aggregates one HLL sketch per `(project, day)` in a StarRocks
**synchronous materialized view** — maintained at ingest time, no refresh job —
and lets StarRocks rewrite the existing queries onto it. The rewrite only
happens when the query's date predicate uses the same `DATE(timestamp)`
expression the view is grouped by, which is the server-side change. Nothing
reads the view by name, so a cluster without the views still gets correct
results from a base scan.

Design: [`docs/design/project-stats-warehouse-mv.md`](https://github.com/yorkie-team/yorkie/blob/enhance/starrocks-mv-date-predicate/docs/design/project-stats-warehouse-mv.md).

Commits, in order:

1. **Query predicate** — all 12 queries filter on `DATE(timestamp)`. `from`/`to`
   are already date-formatted, so day-boundary semantics are unchanged.
2. **Local stack to StarRocks 3.3.9** — expressions in synchronous views need
   3.1+; the compose stack pinned 2.5.4. The chart already tracks 3.3.
3. **The five views** — added to the analytics chart (deployed clusters) and to
   the compose stack (local), with the init script creating and verifying them.
4. **`user_events` key alignment** — it keyed and distributed on `user_id` while
   the other four tables use `project_id`, so per-project queries pruned nothing.
5. **Design doc**, plus corrections to `olap-stack.md` where it had drifted
   from the stack it describes.
6. **Chart release 0.7.17**.

Deploying the views takes a `targetRevision` bump for the `yorkie-analytics`
application in `devops`, which still pins `0.6.0`. Views without this code are
inert; this code without the views falls back to a base scan.

## Test plan

- `make lint` — 0 issues. `make test` — green with MongoDB up.
- **Public cluster** (StarRocks 3.3.9): created the five views (built in ~16s)
  and re-ran all six metrics.

  | metric | rows scanned before | after | value |
  |---|---|---|---|
  | active users | 26,047 | 1,422 | 177 = 177 |
  | active documents | 23,781 | 199 | 608 = 608 |
  | active clients | 33,533 | 195 | 17,828 = 17,828 |
  | active channels | 66 | 3 | 27 = 27 |
  | sessions | 82 | 33 | 82 = 82 |
  | peak sessions/channel | 82 | 33 | 11 = 11 |

  `EXPLAIN` shows all six plans reading the rollup index. Events ingested after
  the build were reflected with no rebuild (17,828 → 17,831 on both the
  rewritten and the base query), and the rewritten query still scanned 194 rows
  against 33,536 base rows.

- **Purge interaction**: in a throwaway database, `DELETE ... WHERE timestamp <
  ...` with a view attached fails with `ERROR 5509` — but only once the table
  holds rows; on an empty table it succeeds. Deleting on a column the view
  carries works and stays consistent, as does dropping the view, purging, and
  recreating it. No retention purge exists today.

- **Local stack**: brought up on 3.3.9 from scratch, init creates the tables,
  all five views report ready, routine loads run. A re-run is clean: `--force`
  carries past the "already exists" errors and the views still verify.

- **`user_events` layout**, 200k synthetic rows over 50 projects, one project
  queried: old layout scanned 60 rows via the view and 200,000 on the fallback;
  aligned layout scanned 6 and 4,000, same value.

## Not settled here

- Compaction under production ingest. The public cluster's compaction score
  stayed at 0, but its ingest is a trickle — this needs re-measuring on the
  internal cluster before the views are created there.
- Existing clusters keep the old `user_events` layout; migrating them is a
  separate operation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added daily materialized views to improve project statistics query performance in StarRocks.
  * Added automatic setup and readiness checks for analytics materialized views.
  * Improved analytics table distribution for project-based queries.
  * Updated StarRocks components to version 3.3.9.

* **Bug Fixes**
  * Improved warehouse metric reporting with date-based filtering.
  * Preserved base-table query fallback when materialized views are unavailable.

* **Documentation**
  * Added guidance on materialized-view setup, query rewriting, verification, and disk-space requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

