### PR TITLE
Release v0.7.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and Yorkie adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## [v0.7.17] - 2026-08-18
+
+### Added
+
+- Port the JS SDK's undo/redo history layer to the Go SDK by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1932
+
+### Changed
+
+- Read project stats from daily HLL materialized views by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1939
+
+### Fixed
+
+- Count a removed container's descendants in the GC total by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1934
+
 ## [v0.7.16] - 2026-08-15
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-YORKIE_VERSION := 0.7.16
+YORKIE_VERSION := 0.7.17
 
 GO_PROJECT = github.com/yorkie-team/yorkie
 

--- a/api/docs/yorkie.base.yaml
+++ b/api/docs/yorkie.base.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Yorkie
   description: "Yorkie is an open source document store for building collaborative editing applications."
-  version: v0.7.16
+  version: v0.7.17
 servers:
   - url: https://api.yorkie.dev
     description: Production server

--- a/api/docs/yorkie/v1/admin.openapi.yaml
+++ b/api/docs/yorkie/v1/admin.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.16
+  version: v0.7.17
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/api/docs/yorkie/v1/resources.openapi.yaml
+++ b/api/docs/yorkie/v1/resources.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.16
+  version: v0.7.17
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/api/docs/yorkie/v1/yorkie.openapi.yaml
+++ b/api/docs/yorkie/v1/yorkie.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.16
+  version: v0.7.17
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/build/charts/yorkie-cluster/Chart.yaml
+++ b/build/charts/yorkie-cluster/Chart.yaml
@@ -9,8 +9,8 @@ maintainers:
 
 sources:
   - https://github.com/yorkie-team/yorkie
-version: 0.7.16
-appVersion: "0.7.16"
+version: 0.7.17
+appVersion: "0.7.17"
 kubeVersion: ">=1.28.0-0"
 
 dependencies:


### PR DESCRIPTION
## Summary

Bumps the server to v0.7.17.

- `Makefile`: `YORKIE_VERSION`
- `build/charts/yorkie-cluster/Chart.yaml`: version, appVersion
- `api/docs/yorkie.base.yaml` and the three `api/docs/yorkie/v1/*.openapi.yaml`
- `CHANGELOG.md`

Left alone on purpose:

- `build/charts/yorkie-analytics/Chart.yaml` is already `0.7.17` — #1939 bumped
  it when it changed the chart, so bumping again here would skip a version.
- `build/charts/yorkie-monitoring/Chart.yaml` stays at `0.7.7`; nothing in this
  range touched it.

## Contents

`v0.7.16..main` is three production commits plus one docs and tooling commit
(#1933), which is excluded from the changelog:

- #1932 — Port the JS SDK's undo/redo history layer to the Go SDK
- #1934 — Count a removed container's descendants in the GC total
- #1939 — Read project stats from daily HLL materialized views

#1939 also ships the daily HLL materialized views in the analytics chart. The
views are already created on the public cluster, so the query change takes
effect there as soon as this deploys; other environments fall back to a base
scan until their views exist.

## Test plan

- `make build` reports `Yorkie Client: 0.7.17`.
- `make lint` — 0 issues.
- `go test ./...` and `make test` — green with MongoDB up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added undo/redo history support to the Go SDK.
  * Added daily project statistics using approximate distinct-user counting.
  * Improved garbage-collection tracking for removed document descendants.
* **Documentation**
  * Updated release notes and API documentation for version 0.7.17.
* **Chores**
  * Updated deployment metadata and chart versions to 0.7.17.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->