### PR TITLE
test: add fuzz test for yson.Unmarshal

### DIFF
--- a/pkg/document/yson/yson.go
+++ b/pkg/document/yson/yson.go
@@ -261,9 +261,19 @@ func (n *TreeNode) Marshal() string {
 func Unmarshal(data string, elem Element) error {
 	processedData := preprocessTypeValues(data)
 
-	// Parse the processed JSON data
+	// Parse the processed JSON data. UseNumber keeps numeric lexemes as
+	// json.Number so that integer typed values can be validated exactly
+	// instead of being coerced through float64 (which truncates fractional
+	// values, wraps out-of-range values, and loses precision beyond 2^53).
 	var raw interface{}
-	if err := gojson.Unmarshal([]byte(processedData), &raw); err != nil {
+	dec := gojson.NewDecoder(strings.NewReader(processedData))
+	dec.UseNumber()
+	if err := dec.Decode(&raw); err != nil {
+		return fmt.Errorf("unmarshal JSON: %w", ErrInvalidYSON)
+	}
+	// Reject trailing data after the top-level value; json.Decoder tolerates
+	// it whereas json.Unmarshal did not.
+	if dec.More() {
 		return fmt.Errorf("unmarshal JSON: %w", ErrInvalidYSON)
 	}
 
@@ -343,6 +353,23 @@ func Unmarshal(data string, elem Element) error {
 	return nil
 }
 
+// parseIntValue decodes a numeric YSON value into an integer of the given bit
+// size (32 or 64). Because the JSON is decoded with UseNumber, the value is a
+// json.Number and is parsed with strconv.ParseInt so that fractional or
+// out-of-range values are rejected with ErrInvalidYSON instead of being
+// silently truncated, wrapped, or rounded through float64.
+func parseIntValue(v interface{}, bitSize int) (int64, error) {
+	n, ok := v.(gojson.Number)
+	if !ok {
+		return 0, ErrInvalidYSON
+	}
+	i, err := strconv.ParseInt(n.String(), 10, bitSize)
+	if err != nil {
+		return 0, ErrInvalidYSON
+	}
+	return i, nil
+}
+
 func parseTypedValue(raw map[string]interface{}) (interface{}, error) {
 	t, ok := raw["type"].(string)
 	if !ok {
@@ -351,17 +378,17 @@ func parseTypedValue(raw map[string]interface{}) (interface{}, error) {
 
 	switch t {
 	case counterTypeInt:
-		v, ok := raw["value"].(float64)
-		if !ok {
-			return nil, fmt.Errorf("parse int value: %w", ErrInvalidYSON)
+		v, err := parseIntValue(raw["value"], 32)
+		if err != nil {
+			return nil, fmt.Errorf("parse int value: %w", err)
 		}
 		return int32(v), nil
 	case counterTypeLong:
-		v, ok := raw["value"].(float64)
-		if !ok {
-			return nil, fmt.Errorf("parse long value: %w", ErrInvalidYSON)
+		v, err := parseIntValue(raw["value"], 64)
+		if err != nil {
+			return nil, fmt.Errorf("parse long value: %w", err)
 		}
-		return int64(v), nil
+		return v, nil
 	case "BinData":
 		s, ok := raw["value"].(string)
 		if !ok {
@@ -432,10 +459,29 @@ func parseObject(raw map[string]interface{}) (Object, error) {
 
 			obj[k] = val
 		default:
-			obj[k] = v
+			val, err := parsePlainValue(v)
+			if err != nil {
+				return nil, err
+			}
+			obj[k] = val
 		}
 	}
 	return obj, nil
+}
+
+// parsePlainValue normalizes a non-typed decoded value. Numbers decoded with
+// UseNumber arrive as json.Number; untyped (non-integer-typed) numbers are
+// converted to float64 to preserve the previous parsing behavior for plain
+// JSON numbers.
+func parsePlainValue(v interface{}) (interface{}, error) {
+	if n, ok := v.(gojson.Number); ok {
+		f, err := n.Float64()
+		if err != nil {
+			return nil, fmt.Errorf("parse number: %w", ErrInvalidYSON)
+		}
+		return f, nil
+	}
+	return v, nil
 }
 
 // Helper functions to parse specific types
@@ -464,7 +510,11 @@ func parseArray(raw []interface{}) (Array, error) {
 			}
 			arr = append(arr, val)
 		default:
-			arr = append(arr, v)
+			val, err := parsePlainValue(v)
+			if err != nil {
+				return nil, err
+			}
+			arr = append(arr, val)
 		}
 	}
 	return arr, nil
@@ -476,19 +526,19 @@ func parseCounter(raw map[string]interface{}) (Counter, error) {
 		if t, ok := value["type"].(string); ok {
 			switch t {
 			case counterTypeInt:
-				v, ok := value["value"].(float64)
-				if !ok {
-					return Counter{}, fmt.Errorf("parse counter value: %w", ErrInvalidYSON)
+				v, err := parseIntValue(value["value"], 32)
+				if err != nil {
+					return Counter{}, fmt.Errorf("parse counter value: %w", err)
 				}
 				counter.Type = crdt.IntegerCnt
 				counter.Value = int32(v)
 			case counterTypeLong:
-				v, ok := value["value"].(float64)
-				if !ok {
-					return Counter{}, fmt.Errorf("parse counter value: %w", ErrInvalidYSON)
+				v, err := parseIntValue(value["value"], 64)
+				if err != nil {
+					return Counter{}, fmt.Errorf("parse counter value: %w", err)
 				}
 				counter.Type = crdt.LongCnt
-				counter.Value = int64(v)
+				counter.Value = v
 			default:
 				return Counter{}, fmt.Errorf("parse counter type: %w", ErrUnsupported)
 			}
@@ -518,9 +568,9 @@ func parseDedupCounter(raw map[string]interface{}) (Counter, error) {
 
 	switch counterType {
 	case counterTypeInt:
-		v, ok := raw["value"].(float64)
-		if !ok {
-			return Counter{}, fmt.Errorf("parse dedup counter value: %w", ErrInvalidYSON)
+		v, err := parseIntValue(raw["value"], 32)
+		if err != nil {
+			return Counter{}, fmt.Errorf("parse dedup counter value: %w", err)
 		}
 		return Counter{
 			Type:      crdt.IntegerDedupCnt,

--- a/pkg/document/yson/yson.go
+++ b/pkg/document/yson/yson.go
@@ -351,18 +351,34 @@ func parseTypedValue(raw map[string]interface{}) (interface{}, error) {
 
 	switch t {
 	case counterTypeInt:
-		return int32(raw["value"].(float64)), nil
+		v, ok := raw["value"].(float64)
+		if !ok {
+			return nil, fmt.Errorf("parse int value: %w", ErrInvalidYSON)
+		}
+		return int32(v), nil
 	case counterTypeLong:
-		return int64(raw["value"].(float64)), nil
+		v, ok := raw["value"].(float64)
+		if !ok {
+			return nil, fmt.Errorf("parse long value: %w", ErrInvalidYSON)
+		}
+		return int64(v), nil
 	case "BinData":
-		val, err := base64.StdEncoding.DecodeString(raw["value"].(string))
+		s, ok := raw["value"].(string)
+		if !ok {
+			return nil, fmt.Errorf("parse BinData: %w", ErrInvalidYSON)
+		}
+		val, err := base64.StdEncoding.DecodeString(s)
 		if err != nil {
 			return nil, fmt.Errorf("parse BinData: %w", ErrInvalidYSON)
 		}
 
 		return val, nil
 	case "Date":
-		val, err := time.Parse(time.RFC3339Nano, raw["value"].(string))
+		s, ok := raw["value"].(string)
+		if !ok {
+			return nil, fmt.Errorf("parse date: %w", ErrInvalidYSON)
+		}
+		val, err := time.Parse(time.RFC3339Nano, s)
 		if err != nil {
 			return nil, fmt.Errorf("parse date: %w", ErrInvalidYSON)
 		}
@@ -460,11 +476,19 @@ func parseCounter(raw map[string]interface{}) (Counter, error) {
 		if t, ok := value["type"].(string); ok {
 			switch t {
 			case counterTypeInt:
+				v, ok := value["value"].(float64)
+				if !ok {
+					return Counter{}, fmt.Errorf("parse counter value: %w", ErrInvalidYSON)
+				}
 				counter.Type = crdt.IntegerCnt
-				counter.Value = int32(value["value"].(float64))
+				counter.Value = int32(v)
 			case counterTypeLong:
+				v, ok := value["value"].(float64)
+				if !ok {
+					return Counter{}, fmt.Errorf("parse counter value: %w", ErrInvalidYSON)
+				}
 				counter.Type = crdt.LongCnt
-				counter.Value = int64(value["value"].(float64))
+				counter.Value = int64(v)
 			default:
 				return Counter{}, fmt.Errorf("parse counter type: %w", ErrUnsupported)
 			}
@@ -512,7 +536,10 @@ func parseText(raw []interface{}) (Text, error) {
 	var text Text
 
 	for _, node := range raw {
-		n := node.(map[string]interface{})
+		n, ok := node.(map[string]interface{})
+		if !ok {
+			return text, fmt.Errorf("parse text node: %w", ErrInvalidYSON)
+		}
 		textNode := TextNode{}
 
 		if val, ok := n["val"].(string); !ok {
@@ -524,7 +551,11 @@ func parseText(raw []interface{}) (Text, error) {
 		if attrs, ok := n["attrs"].(map[string]interface{}); ok {
 			textNode.Attributes = make(map[string]string)
 			for k, v := range attrs {
-				textNode.Attributes[k] = v.(string)
+				s, ok := v.(string)
+				if !ok {
+					return text, fmt.Errorf("parse text attribute: %w", ErrInvalidYSON)
+				}
+				textNode.Attributes[k] = s
 			}
 		}
 
@@ -557,13 +588,21 @@ func parseTreeNode(raw map[string]interface{}) (TreeNode, error) {
 	if attrs, ok := raw["attrs"].(map[string]interface{}); ok {
 		node.Attributes = make(map[string]string)
 		for k, v := range attrs {
-			node.Attributes[k] = v.(string)
+			s, ok := v.(string)
+			if !ok {
+				return TreeNode{}, fmt.Errorf("parse tree node attribute: %w", ErrInvalidYSON)
+			}
+			node.Attributes[k] = s
 		}
 	}
 
 	if children, ok := raw["children"].([]interface{}); ok {
 		for _, child := range children {
-			childNode, err := parseTreeNode(child.(map[string]interface{}))
+			childRaw, ok := child.(map[string]interface{})
+			if !ok {
+				return TreeNode{}, fmt.Errorf("parse tree node child: %w", ErrInvalidYSON)
+			}
+			childNode, err := parseTreeNode(childRaw)
 			if err != nil {
 				return TreeNode{}, err
 			}

--- a/pkg/document/yson/yson.go
+++ b/pkg/document/yson/yson.go
@@ -598,7 +598,11 @@ func parseText(raw []interface{}) (Text, error) {
 			textNode.Value = val
 		}
 
-		if attrs, ok := n["attrs"].(map[string]interface{}); ok {
+		if attrsVal, present := n["attrs"]; present {
+			attrs, ok := attrsVal.(map[string]interface{})
+			if !ok {
+				return text, fmt.Errorf("parse text attribute: %w", ErrInvalidYSON)
+			}
 			textNode.Attributes = make(map[string]string)
 			for k, v := range attrs {
 				s, ok := v.(string)
@@ -635,7 +639,11 @@ func parseTreeNode(raw map[string]interface{}) (TreeNode, error) {
 		node.Value = value
 	}
 
-	if attrs, ok := raw["attrs"].(map[string]interface{}); ok {
+	if attrsVal, present := raw["attrs"]; present {
+		attrs, ok := attrsVal.(map[string]interface{})
+		if !ok {
+			return TreeNode{}, fmt.Errorf("parse tree node attribute: %w", ErrInvalidYSON)
+		}
 		node.Attributes = make(map[string]string)
 		for k, v := range attrs {
 			s, ok := v.(string)
@@ -646,7 +654,11 @@ func parseTreeNode(raw map[string]interface{}) (TreeNode, error) {
 		}
 	}
 
-	if children, ok := raw["children"].([]interface{}); ok {
+	if childrenVal, present := raw["children"]; present {
+		children, ok := childrenVal.([]interface{})
+		if !ok {
+			return TreeNode{}, fmt.Errorf("parse tree node children: %w", ErrInvalidYSON)
+		}
 		for _, child := range children {
 			childRaw, ok := child.(map[string]interface{})
 			if !ok {

--- a/pkg/document/yson/yson.go
+++ b/pkg/document/yson/yson.go
@@ -23,6 +23,7 @@ import (
 	"encoding/base64"
 	gojson "encoding/json"
 	"fmt"
+	"io"
 	"regexp"
 	"sort"
 	"strconv"
@@ -271,9 +272,11 @@ func Unmarshal(data string, elem Element) error {
 	if err := dec.Decode(&raw); err != nil {
 		return fmt.Errorf("unmarshal JSON: %w", ErrInvalidYSON)
 	}
-	// Reject trailing data after the top-level value; json.Decoder tolerates
-	// it whereas json.Unmarshal did not.
-	if dec.More() {
+	// Reject any trailing data after the top-level value. json.Decoder
+	// tolerates trailing bytes whereas json.Unmarshal did not, and dec.More()
+	// alone misses stray closing tokens such as "]" or "}". Require the stream
+	// to be at EOF after the single top-level value.
+	if err := dec.Decode(new(interface{})); err != io.EOF {
 		return fmt.Errorf("unmarshal JSON: %w", ErrInvalidYSON)
 	}
 

--- a/pkg/document/yson/yson_test.go
+++ b/pkg/document/yson/yson_test.go
@@ -635,6 +635,36 @@ func TestYSONMarshal(t *testing.T) {
 				targetType:  &yson.Counter{},
 				expectedErr: "invalid YSON",
 			},
+			{
+				name:        "text node attrs wrong type",
+				input:       `Text([{"val":"hi","attrs":"nope"}])`,
+				targetType:  &yson.Text{},
+				expectedErr: "invalid YSON",
+			},
+			{
+				name:        "text node attrs number",
+				input:       `Text([{"val":"hi","attrs":1}])`,
+				targetType:  &yson.Text{},
+				expectedErr: "invalid YSON",
+			},
+			{
+				name:        "tree node attrs wrong type",
+				input:       `Tree({"type":"p","attrs":"nope","children":[]})`,
+				targetType:  &yson.Tree{},
+				expectedErr: "invalid YSON",
+			},
+			{
+				name:        "tree node children wrong type",
+				input:       `Tree({"type":"p","children":{"not":"an array"}})`,
+				targetType:  &yson.Tree{},
+				expectedErr: "invalid YSON",
+			},
+			{
+				name:        "tree node children string",
+				input:       `Tree({"type":"p","children":"nope"})`,
+				targetType:  &yson.Tree{},
+				expectedErr: "invalid YSON",
+			},
 		}
 
 		for _, tc := range testCases {

--- a/pkg/document/yson/yson_test.go
+++ b/pkg/document/yson/yson_test.go
@@ -665,6 +665,30 @@ func TestYSONMarshal(t *testing.T) {
 				targetType:  &yson.Tree{},
 				expectedErr: "invalid YSON",
 			},
+			{
+				name:        "trailing closing bracket",
+				input:       `{"a":1}]`,
+				targetType:  &yson.Object{},
+				expectedErr: "invalid YSON",
+			},
+			{
+				name:        "trailing closing brace",
+				input:       `{"a":1}}`,
+				targetType:  &yson.Object{},
+				expectedErr: "invalid YSON",
+			},
+			{
+				name:        "trailing second value",
+				input:       `{"a":1} 42`,
+				targetType:  &yson.Object{},
+				expectedErr: "invalid YSON",
+			},
+			{
+				name:        "trailing second object",
+				input:       `[1,2]{"b":2}`,
+				targetType:  &yson.Array{},
+				expectedErr: "invalid YSON",
+			},
 		}
 
 		for _, tc := range testCases {

--- a/pkg/document/yson/yson_test.go
+++ b/pkg/document/yson/yson_test.go
@@ -19,6 +19,7 @@ package yson_test
 import (
 	"encoding/base64"
 	"fmt"
+	"math"
 	"testing"
 	gotime "time"
 
@@ -400,6 +401,18 @@ func TestYSONMarshal(t *testing.T) {
 		assert.Equal(t, expected, actual)
 	})
 
+	t.Run("large long value precision test", func(t *testing.T) {
+		// 9007199254740993 (2^53 + 1) and math.MaxInt64 are not exactly
+		// representable as float64, so they must be parsed from the lexeme.
+		arr := yson.Array{}
+		assert.NoError(t, yson.Unmarshal(`[Long(9007199254740993),Long(9223372036854775807)]`, &arr))
+		assert.Equal(t, yson.Array{int64(9007199254740993), int64(math.MaxInt64)}, arr)
+
+		counter := yson.Counter{}
+		assert.NoError(t, yson.Unmarshal(`Counter(Long(9223372036854775807))`, &counter))
+		assert.Equal(t, int64(math.MaxInt64), counter.Value)
+	})
+
 	t.Run("dedup counter marshal test", func(t *testing.T) {
 		// Create a 16384-byte register array with known values
 		registers := make([]byte, 16384)
@@ -572,6 +585,54 @@ func TestYSONMarshal(t *testing.T) {
 				name:        "missing required field in text node",
 				input:       `Text([{"attrs":{"bold":"true"}}])`,
 				targetType:  &yson.Text{},
+				expectedErr: "invalid YSON",
+			},
+			{
+				name:        "fractional Int typed value",
+				input:       `[Int(1.5)]`,
+				targetType:  &yson.Array{},
+				expectedErr: "invalid YSON",
+			},
+			{
+				name:        "out-of-range Int typed value",
+				input:       `[Int(2147483648)]`,
+				targetType:  &yson.Array{},
+				expectedErr: "invalid YSON",
+			},
+			{
+				name:        "fractional Long typed value",
+				input:       `[Long(1.5)]`,
+				targetType:  &yson.Array{},
+				expectedErr: "invalid YSON",
+			},
+			{
+				name:        "out-of-range Long typed value",
+				input:       `[Long(9223372036854775808)]`,
+				targetType:  &yson.Array{},
+				expectedErr: "invalid YSON",
+			},
+			{
+				name:        "fractional counter Int value",
+				input:       `Counter(Int(1.5))`,
+				targetType:  &yson.Counter{},
+				expectedErr: "invalid YSON",
+			},
+			{
+				name:        "out-of-range counter Int value",
+				input:       `Counter(Int(2147483648))`,
+				targetType:  &yson.Counter{},
+				expectedErr: "invalid YSON",
+			},
+			{
+				name:        "fractional dedup counter value",
+				input:       `DedupCounter(Int(1.5),"AQ==")`,
+				targetType:  &yson.Counter{},
+				expectedErr: "invalid YSON",
+			},
+			{
+				name:        "out-of-range dedup counter value",
+				input:       `DedupCounter(Int(2147483648),"AQ==")`,
+				targetType:  &yson.Counter{},
 				expectedErr: "invalid YSON",
 			},
 		}

--- a/test/fuzz/fuzz_test.go
+++ b/test/fuzz/fuzz_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/yorkie-team/yorkie/pkg/document/json"
 	"github.com/yorkie-team/yorkie/pkg/document/presence"
 	"github.com/yorkie-team/yorkie/pkg/document/time"
+	"github.com/yorkie-team/yorkie/pkg/document/yson"
 	"github.com/yorkie-team/yorkie/pkg/key"
 	"github.com/yorkie-team/yorkie/test/helper"
 )
@@ -156,6 +157,34 @@ func FuzzParseKeyPath(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, str string) {
 		_, _ = channel.ParseKeyPath(key.Key(str))
+	})
+}
+
+func FuzzYSONUnmarshal(f *testing.F) {
+	// typeSelector chooses which YSON Element type the data is decoded into.
+	f.Add(byte(0), `{"key":"value"}`)                    // Object
+	f.Add(byte(1), `[1,2,3]`)                            // Array
+	f.Add(byte(2), `{"value":{"type":"root"}}`)          // Tree
+	f.Add(byte(3), `{"value":[{"val":"hello"}]}`)        // Text
+	f.Add(byte(4), `{"value":{"type":"Int","value":1}}`) // Counter
+	f.Add(byte(0), "")
+	f.Add(byte(0), `{"n":Int(1),"c":Counter(Int(1))}`) // YSON constructor syntax
+
+	f.Fuzz(func(t *testing.T, typeSelector byte, data string) {
+		var elem yson.Element
+		switch typeSelector % 5 {
+		case 0:
+			elem = &yson.Object{}
+		case 1:
+			elem = &yson.Array{}
+		case 2:
+			elem = &yson.Tree{}
+		case 3:
+			elem = &yson.Text{}
+		case 4:
+			elem = &yson.Counter{}
+		}
+		_ = yson.Unmarshal(data, elem)
 	})
 }
 

--- a/test/fuzz/fuzz_test.go
+++ b/test/fuzz/fuzz_test.go
@@ -172,6 +172,9 @@ func FuzzYSONUnmarshal(f *testing.F) {
 	f.Add(byte(1), `[Int(1.5),Int(2147483648)]`)           // fractional / out-of-range Int
 	f.Add(byte(1), `[Long(9223372036854775808)]`)          // out-of-range Long
 	f.Add(byte(4), `DedupCounter(Int(2147483648),"AQ==")`) // out-of-range dedup counter
+	f.Add(byte(3), `Text([{"val":"hi","attrs":"nope"}])`)  // text attrs wrong type
+	f.Add(byte(2), `Tree({"type":"p","attrs":1})`)         // tree attrs wrong type
+	f.Add(byte(2), `Tree({"type":"p","children":"nope"})`) // tree children wrong type
 
 	f.Fuzz(func(t *testing.T, typeSelector byte, data string) {
 		var elem yson.Element

--- a/test/fuzz/fuzz_test.go
+++ b/test/fuzz/fuzz_test.go
@@ -175,6 +175,9 @@ func FuzzYSONUnmarshal(f *testing.F) {
 	f.Add(byte(3), `Text([{"val":"hi","attrs":"nope"}])`)  // text attrs wrong type
 	f.Add(byte(2), `Tree({"type":"p","attrs":1})`)         // tree attrs wrong type
 	f.Add(byte(2), `Tree({"type":"p","children":"nope"})`) // tree children wrong type
+	f.Add(byte(0), `{"a":1}]`)                             // trailing closing bracket
+	f.Add(byte(0), `{"a":1} 42`)                           // trailing second value
+	f.Add(byte(1), `[1,2]{"b":2}`)                         // trailing second object
 
 	f.Fuzz(func(t *testing.T, typeSelector byte, data string) {
 		var elem yson.Element

--- a/test/fuzz/fuzz_test.go
+++ b/test/fuzz/fuzz_test.go
@@ -168,7 +168,10 @@ func FuzzYSONUnmarshal(f *testing.F) {
 	f.Add(byte(3), `{"value":[{"val":"hello"}]}`)        // Text
 	f.Add(byte(4), `{"value":{"type":"Int","value":1}}`) // Counter
 	f.Add(byte(0), "")
-	f.Add(byte(0), `{"n":Int(1),"c":Counter(Int(1))}`) // YSON constructor syntax
+	f.Add(byte(0), `{"n":Int(1),"c":Counter(Int(1))}`)     // YSON constructor syntax
+	f.Add(byte(1), `[Int(1.5),Int(2147483648)]`)           // fractional / out-of-range Int
+	f.Add(byte(1), `[Long(9223372036854775808)]`)          // out-of-range Long
+	f.Add(byte(4), `DedupCounter(Int(2147483648),"AQ==")`) // out-of-range dedup counter
 
 	f.Fuzz(func(t *testing.T, typeSelector byte, data string) {
 		var elem yson.Element

--- a/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/array_int_fractional
+++ b/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/array_int_fractional
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x01')
+string("[Int(1.5)]")

--- a/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/array_int_out_of_range
+++ b/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/array_int_out_of_range
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x01')
+string("[Int(2147483648)]")

--- a/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/array_long_out_of_range
+++ b/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/array_long_out_of_range
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x01')
+string("[Long(9223372036854775808)]")

--- a/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/counter_int_fractional
+++ b/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/counter_int_fractional
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x04')
+string("Counter(Int(1.5))")

--- a/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/counter_nil_inner_value
+++ b/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/counter_nil_inner_value
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x04')
+string("{\"value\":{\"type\":\"Int\"}}")

--- a/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/dedup_counter_out_of_range
+++ b/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/dedup_counter_out_of_range
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x04')
+string("DedupCounter(Int(2147483648),\"AQ==\")")

--- a/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/object_bindata_non_string
+++ b/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/object_bindata_non_string
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x00')
+string("{\"b\":{\"type\":\"BinData\",\"value\":1}}")

--- a/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/object_date_non_string
+++ b/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/object_date_non_string
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x00')
+string("{\"d\":{\"type\":\"Date\",\"value\":1}}")

--- a/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/object_typed_int_nil_value
+++ b/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/object_typed_int_nil_value
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x00')
+string("{\"c\":{\"type\":\"Int\"}}")

--- a/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/text_attrs_wrong_type
+++ b/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/text_attrs_wrong_type
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x03')
+string("Text([{\"val\":\"hi\",\"attrs\":\"nope\"}])")

--- a/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/text_non_map_node
+++ b/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/text_non_map_node
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x03')
+string("{\"value\":[1]}")

--- a/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/text_non_string_attr
+++ b/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/text_non_string_attr
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x03')
+string("{\"value\":[{\"val\":\"a\",\"attrs\":{\"b\":1}}]}")

--- a/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/trailing_close_brace
+++ b/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/trailing_close_brace
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x00')
+string("{\"a\":1}}")

--- a/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/trailing_close_bracket
+++ b/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/trailing_close_bracket
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x00')
+string("{\"a\":1}]")

--- a/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/trailing_second_value
+++ b/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/trailing_second_value
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x01')
+string("[1,2]{\"b\":2}")

--- a/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/tree_attrs_wrong_type
+++ b/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/tree_attrs_wrong_type
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x02')
+string("Tree({\"type\":\"p\",\"attrs\":\"nope\",\"children\":[]})")

--- a/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/tree_children_wrong_type
+++ b/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/tree_children_wrong_type
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x02')
+string("Tree({\"type\":\"p\",\"children\":{\"not\":\"array\"}})")

--- a/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/tree_non_map_child
+++ b/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/tree_non_map_child
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x02')
+string("{\"value\":{\"type\":\"root\",\"children\":[1]}}")

--- a/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/tree_non_string_attr
+++ b/test/fuzz/testdata/fuzz/FuzzYSONUnmarshal/tree_non_string_attr
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x02')
+string("{\"value\":{\"type\":\"root\",\"attrs\":{\"a\":1}}}")


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `FuzzYSONUnmarshal`, a fuzz target for `yson.Unmarshal` (the YSON decoder), and hardens the parser against the panics it surfaces.

`yson.Unmarshal` parses **client-supplied strings** on the server: `AdminService.CreateDocument` / `UpdateDocument` decode `req.Msg.InitialRoot` / `req.Msg.Root` (`server/rpc/admin_server.go`), and `server/revisions` decodes stored snapshots. The parser contained several **unchecked type assertions** on `encoding/json`-decoded values, so a malformed-but-JSON-valid YSON payload could panic the decode path — a robustness/DoS risk that unit tests (well-formed input only) don't cover. Fixed cases:

- `parseTypedValue`: `Int`/`Long` `value.(float64)`, `BinData`/`Date` `value.(string)`
- `parseCounter`: nested `Int`/`Long` `value.(float64)`
- `parseText`: `node.(map[string]interface{})` and attribute `v.(string)`
- `parseTreeNode`: attribute `v.(string)` and `child.(map[string]interface{})`

Each is converted to a comma-ok assertion returning `ErrInvalidYSON`. A seed corpus of the crashers is committed as a regression gate. This continues the umbrella work in #1890/#1892/#1900/#1912/#1920/#1923; the previously listed candidate targets are now all covered, so this adds the next uncovered untrusted-input decoder.

Verification:

```
# discovers the panics on the original code, passes after the fix
go test -tags fuzz -run '^$' -fuzz FuzzYSONUnmarshal -fuzztime 40s ./test/fuzz/
# 1.7M+ execs, no crashes

# seed corpus (regression gate)
go test -tags fuzz -run FuzzYSONUnmarshal ./test/fuzz/   # ok

go test ./pkg/document/yson/...                          # ok
golangci-lint run --build-tags fuzz ./test/fuzz/... ./pkg/document/yson/...  # 0 issues
```

**Which issue(s) this PR fixes**:

Fixes #1944

**Special notes for your reviewer**:

Sub-issue of the fuzz umbrella #1858. Per @ggyuchive's guidance this PR contains a single self-contained fuzz target and does **not** touch the CI-workflow piece (corpus-in-CI / nightly continuous fuzzing), which still needs team alignment via Discord.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation**:

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved YSON decoding to safely reject malformed, trailing, or incorrectly typed data with clear errors.
  - Added exact 32-bit and 64-bit integer validation, including fractional and out-of-range values.
  - Added validation for binary, date, text, attribute, and tree data.
  - Preserved precision when decoding large integer values.

- **Tests**
  - Added fuzz testing and regression coverage for invalid structures, types, and numeric values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->