### PR TITLE
test(rpc): add RBAC coverage for UpdateProject admin API

### DIFF
--- a/test/integration/admin_test.go
+++ b/test/integration/admin_test.go
@@ -442,6 +442,57 @@ func TestAdminMember(t *testing.T) {
 		assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
 	})
 
+	t.Run("UpdateProject role-based access control test", func(t *testing.T) {
+		// 01. Create a project (owner is the default admin user).
+		projectName := newSlug("prj")
+		project, err := adminCli.CreateProject(ctx, projectName)
+		assert.NoError(t, err)
+
+		// 02. Invite a user as a member and accept the invite.
+		token, err := adminCli.CreateInvite(
+			ctx,
+			projectName,
+			"member",
+			api.InviteExpireOption_INVITE_EXPIRE_OPTION_SEVEN_DAYS,
+		)
+		assert.NoError(t, err)
+
+		username, password := newUser(t)
+		userCli, err := admin.Dial(defaultServer.RPCAddr(), admin.WithInsecure(true))
+		assert.NoError(t, err)
+		defer func() { userCli.Close() }()
+		_, err = userCli.LogIn(ctx, username, password)
+		assert.NoError(t, err)
+		_, err = userCli.AcceptInvite(ctx, token)
+		assert.NoError(t, err)
+
+		// 03. A member must not be able to update the project config.
+		memberUpdate := newSlug("upd")
+		_, err = userCli.UpdateProject(ctx, project.ID.String(), &types.UpdatableProjectFields{
+			Name: &memberUpdate,
+		})
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+
+		// 04. After promotion to admin, the same user can update the project config.
+		_, err = adminCli.UpdateMemberRole(ctx, projectName, username, "admin")
+		assert.NoError(t, err)
+
+		adminUpdate := newSlug("upd")
+		updated, err := userCli.UpdateProject(ctx, project.ID.String(), &types.UpdatableProjectFields{
+			Name: &adminUpdate,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, adminUpdate, updated.Name)
+
+		// 05. The owner can always update the project config.
+		ownerUpdate := newSlug("upd")
+		updated, err = adminCli.UpdateProject(ctx, project.ID.String(), &types.UpdatableProjectFields{
+			Name: &ownerUpdate,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, ownerUpdate, updated.Name)
+	})
+
 	t.Run("Owner cannot accept their own invite link test", func(t *testing.T) {
 		// 01. Create a project as owner.
 		projectName := newSlug("prj")


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds RBAC integration coverage for the `UpdateProject` Admin API so that the
Owner/Admin/Member permission matrix from yorkie-team/dashboard#272 is verified
for project-config updates.

Role-based authorization for `UpdateProject` already landed in #1628, which added
`authz.CheckPermission(ctx, be, userID, id, database.Admin)` to
`projects.UpdateProject`. However, there was no test asserting that a Member is
actually denied while Owners/Admins are allowed. This PR adds that missing
coverage (rather than duplicating the check):

- A Member receives `CodePermissionDenied` when calling `UpdateProject`.
- After promotion to Admin, the same user can update the config.
- The Owner can always update the config.

**Which issue(s) this PR fixes**:

Part of yorkie-team/dashboard#272 (API side). The UI side is in
yorkie-team/dashboard#309.

**Special notes for your reviewer**:

The test lives in `TestAdminMember` (`test/integration/admin_test.go`) alongside
the other member-management RBAC tests and follows the same invite/accept setup.
Since the enforcement was already present, no production code changes are needed.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying that project configuration updates respect member roles.
  * Confirmed standard members cannot rename projects, while project admins and owners can.
  * Verified successful project updates reflect the new configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->