### PR TITLE
Distribute event tables by RANDOM to avoid project skew

### DIFF
--- a/build/docker/analytics/init-create-table.sql
+++ b/build/docker/analytics/init-create-table.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS user_events (
     user_agent VARCHAR(32)
 ) ENGINE = OLAP
 DUPLICATE KEY(project_id, user_id, timestamp)
-DISTRIBUTED BY HASH(project_id) BUCKETS 16
+DISTRIBUTED BY RANDOM BUCKETS 16
 PROPERTIES (
     "replication_num" = "1"
 );
@@ -23,7 +23,7 @@ CREATE TABLE IF NOT EXISTS document_events (
     event_type VARCHAR(32)
 ) ENGINE = OLAP  
 DUPLICATE KEY(project_id, document_key, actor_id, timestamp)  
-DISTRIBUTED BY HASH(project_id) BUCKETS 16  
+DISTRIBUTED BY RANDOM BUCKETS 16
 PROPERTIES (  
     "replication_num" = "1"  
 );  
@@ -35,7 +35,7 @@ CREATE TABLE IF NOT EXISTS channel_events (
     event_type VARCHAR(32)
 ) ENGINE = OLAP
 DUPLICATE KEY(project_id, channel_key, timestamp)
-DISTRIBUTED BY HASH(project_id) BUCKETS 16
+DISTRIBUTED BY RANDOM BUCKETS 16
 PROPERTIES (
     "replication_num" = "1"
 );
@@ -61,7 +61,7 @@ CREATE TABLE IF NOT EXISTS client_events (
     event_type VARCHAR(32)
 ) ENGINE = OLAP
 DUPLICATE KEY(project_id, client_id, timestamp)
-DISTRIBUTED BY HASH(project_id) BUCKETS 16
+DISTRIBUTED BY RANDOM BUCKETS 16
 PROPERTIES (
     "replication_num" = "1"
 );

--- a/build/docker/analytics/init-create-table.sql
+++ b/build/docker/analytics/init-create-table.sql
@@ -49,7 +49,7 @@ CREATE TABLE IF NOT EXISTS session_events (
     event_type VARCHAR(32)
 ) ENGINE = OLAP
 DUPLICATE KEY(project_id, session_id, timestamp)
-DISTRIBUTED BY HASH(project_id) BUCKETS 16
+DISTRIBUTED BY RANDOM BUCKETS 16
 PROPERTIES (
     "replication_num" = "1"
 );


### PR DESCRIPTION
## Summary

The five event tables (`user_events`, `document_events`, `channel_events`,
`session_events`, `client_events`) all key and distribute on `project_id`.
When one project dominates the dataset, all of its rows hash into a single
bucket, producing one oversized tablet. That imbalance can make the
synchronous daily-HLL materialized view build unstable at scale and
concentrates compaction load on a single replica.

This changes the distribution to `RANDOM BUCKETS 16` on all five tables so
rows spread evenly across buckets regardless of per-project volume.
Project-level bucket pruning on the base tables is not needed here:
per-project stats are served by the daily-HLL materialized views via query
rewrite, and the base tables are only a correctness fallback.

## Test plan

- `CREATE TABLE IF NOT EXISTS` does not alter an existing table, so existing
  deployments are unaffected — only newly provisioned clusters pick up the
  even distribution.
- Verified on a scaled dataset that the per-project stats queries still
  rewrite onto the `mv_*_hll_daily` materialized views after the change.
