### PR TITLE
Relink insertion chain when restore recreates a purged fragment

### DIFF
--- a/pkg/document/crdt/rga_tree_split.go
+++ b/pkg/document/crdt/rga_tree_split.go
@@ -866,6 +866,22 @@ func (s *RGATreeSplit[V]) restore(
 				prev := s.findRestoreAnchor(
 					span.createdAt, cursor, gapEnd, chainAnchor, fromPos, executedAt)
 				s.InsertAfter(prev, newNode)
+				// InsertAfter only maintains the physical prev/next chain.
+				// Relink the separate insertion chain (insPrev/insNext) too, the
+				// same way splitNode does, so a recreated interior fragment is
+				// not skipped by the surviving same-insertion neighbours.
+				// Otherwise a later edit whose boundary lands on this fragment
+				// resolves through a stale insertion pointer in
+				// findFloorNodePreferToLeft and miscomputes its offset
+				// (yorkie-team/yorkie-js-sdk#1327).
+				if cursor > 0 {
+					if insPrev := s.findPieceCovering(span.createdAt, cursor-1); insPrev != nil {
+						newNode.SetInsPrev(insPrev)
+					}
+				}
+				if insNext := s.findPieceCovering(span.createdAt, gapEnd); insNext != nil {
+					insNext.SetInsPrev(newNode)
+				}
 				recreated = append(recreated, newNode)
 				chainAnchor = newNode
 				cursor = gapEnd

--- a/pkg/document/text_restore_relink_test.go
+++ b/pkg/document/text_restore_relink_test.go
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package document_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/test/helper"
+)
+
+// TestTextRestoreRelink is a regression for yorkie-team/yorkie-js-sdk#1327.
+//
+// restore()'s gap-recreate branch inserts a recreated node with InsertAfter,
+// which only maintains the physical prev/next chain -- not the separate
+// insertion chain (insPrev/insNext). So after a purged interior fragment is
+// recreated on undo, the surviving same-insertion neighbours still point their
+// insertion pointers past the recreated node. A later edit whose boundary
+// lands on that node resolves its offset through the stale insertion chain in
+// findFloorNodePreferToLeft and miscomputes it -- dropping the edit or, as
+// here, erroring because the offset exceeds the resolved node's length.
+func TestTextRestoreRelink(t *testing.T) {
+	t.Run("later boundary edit stays correct after a purged interior fragment is recreated test", func(t *testing.T) {
+		// Single insertion "0123456789": one node, id (t1:0).
+		doc := newTextDoc(t)
+		editText(t, doc, 0, 0, "0123456789")
+		assert.Equal(t, "0123456789", textOf(t, doc, "t").String())
+
+		// Delete the interior "45" (indices [4,6)). The node splits into
+		// (t1:0)"0123" - {t1:4 "45"} - (t1:6)"6789"; the middle is tombstoned.
+		editText(t, doc, 4, 6, "")
+		assert.Equal(t, "01236789", textOf(t, doc, "t").String())
+		assert.Equal(t, 1, doc.GarbageLen())
+
+		// Purge the tombstone so Undo cannot un-tombstone in place and must
+		// recreate the "45" fragment through restore()'s gap branch.
+		assert.Equal(t, 1, doc.GarbageCollect(helper.MaxVersionVector(doc.ActorID())))
+		assert.Equal(t, 0, doc.GarbageLen())
+
+		// Undo recreates (t1:4)"45" via InsertAfter -- the physical chain is
+		// repaired ("0123456789") but the insertion chain around it stays stale.
+		assert.NoError(t, doc.Undo())
+		assert.Equal(t, "0123456789", textOf(t, doc, "t").String())
+
+		// The bug bites here: an edit whose boundary (index 6) sits exactly at
+		// the recreated node's right edge resolves through the stale insertion
+		// chain and miscomputes its offset.
+		editText(t, doc, 6, 6, "X")
+		assert.Equal(t, "012345X6789", textOf(t, doc, "t").String())
+	})
+}


### PR DESCRIPTION
## Summary

Mirrors the fix for yorkie-team/yorkie-js-sdk#1327 on the Go side — the
RGATreeSplit CRDT logic is shared across both SDKs and must stay
behaviourally identical.

`RGATreeSplit.restore()`'s gap-recreate branch recreated a purged interior
fragment with `InsertAfter`, which maintains only the physical `prev`/`next`
chain — not the separate insertion chain (`insPrev`/`insNext`). Sibling
methods (`splitNode`, `deepcopy`, `purge`) keep both chains in sync, but the
restore gap branch did not.

As a result the recreated node was skipped by its surviving same-insertion
neighbours. A **later** edit whose boundary landed on that node resolved its
absolute offset via `findFloorNodePreferToLeft`, which walks `insPrev`. The
walk hit a stale pointer and `findNodeWithSplit` miscomputed the relative
offset — silently dropping the edit or erroring with `offset should be less
than or equal to length`.

### Reproduction

1. `edit(0, 0, "0123456789")` — one node `(t1:0)`
2. `edit(4, 6, "")` — splits into `(t1:0)"0123"`, `{t1:4 "45"}` (tombstone),
   `(t1:6)"6789"`
3. GC purges the tombstone
4. `Undo()` — recreates `(t1:4)"45"` via the gap branch; visible text is
   correct but the insertion chain around it is stale
5. `edit(6, 6, "X")` — boundary at the recreated node resolves through the
   stale chain and panics

### Fix

After `InsertAfter` in the gap branch, relink the insertion chain the same
way `splitNode` does, locating the same-insertion neighbours with
`findPieceCovering` (left neighbour covering `cursor-1`, right neighbour
covering `gapEnd`). Guarded for `cursor == 0` and missing neighbours.

## Test plan

- Added `pkg/document/text_restore_relink_test.go`, which reproduces the bug
  and fails without the fix (panics on `offset should be less than or equal
  to length`), passes with it.
- `go test ./pkg/document/...` ✓
- `make test` (integration, MongoDB up) ✓ — full suite green
- `gofmt` ✓, `go vet` ✓

### Follow-up (non-blocking)

A multi-agent review flagged optional test-hardening for a later PR:
multi-gap-within-one-insertion, `cursor == 0` leftmost fragment, and a
redo-cycle case. The shipped code is correct without them; the added test
pins the exact regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected text restoration after deleted content is recovered, preserving proper insertion order.
  * Text inserted at a restored fragment’s boundary now appears in the expected position.

* **Tests**
  * Added regression coverage for restoring deleted text and inserting content adjacent to it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->