### PR TITLE
Recover style ranges collapsed by a merge at the from anchor

### DIFF
--- a/docs/design/concurrent-merge-split.md
+++ b/docs/design/concurrent-merge-split.md
@@ -489,12 +489,52 @@ carries the same provenance under either merge-then-split or
 split-then-merge application order and is judged identically by the
 filter.
 
+**From-side recovery (Fix 23).** A range *start* anchored after a moved
+child is the mirror image: the merge moves the anchor child behind the
+interlopers, so on the applying replica the resolved range collapses
+(start past end) and the traversal misses nodes the styling client
+covered — the writer keeps a one-sided attribute entry. A skip filter
+cannot compensate (the traversal covers nothing), so
+`reversedFromAnchorRecovery` re-anchors the traversal start just after
+the last live sibling before the merge-source tombstone, but only when
+the same §9.4 shape holds for the *from* position **and** the resolved
+range actually collapsed; an ordered range that moved with the merge is
+left untouched. The recovered traversal styles only nodes the interloper
+predicate positively identifies (stamp-free children between the
+tombstone and the moved children); version-vector checks keep inserts
+unknown to the styler unstyled. For `RemoveStyle` this materializes the
+removal tombstone on both replicas — it must be recorded even for a
+missing key, because it arbitrates a concurrent `SetAttr` with an
+earlier ticket.
+
 **Known limitations** (tracked as follow-ups):
 
-- A range *start* anchored after a moved child shrinks the traversal
-  on the applying replica instead of growing it (the interlopers sit
-  before the start), which a skip filter cannot compensate; likewise
-  an edit-only divergence independent of styling.
+- An edit-only divergence independent of styling (concurrent unwrap
+  versus merge-delete of the same paragraph) remains open.
+- Within a collapsed from-side range, any *stamped* node fails open in
+  the other direction: a merge-moved element child at or after the
+  original from anchor (probe shape `<p>c<b/></p>`), an insert declared
+  inside the merged-away parent, or a child moved into the target by an
+  *earlier* merge the styler knew (and styled inside its range) all
+  carry a merge stamp, so the recovery cannot tell them from moved
+  content before the anchor and skips them — the writer styles them,
+  the applying replica does not. The pre-fix behavior styled nothing at
+  all there, so the recovery strictly narrows the divergence but does
+  not close this part.
+- A merge into a *sibling* (not the common parent) pulls the from
+  anchor inside that sibling, whose End token newly enters the range
+  and is styled on the merged replica only; the guard's direct-child
+  shape restriction deliberately excludes this shape (reproduces at
+  base, before Fix 23).
+- A range *end* whose left sibling is the merge-source tombstone under
+  a surviving parent resolves past the merge target's End token on the
+  applying replica and styles the target itself one-sidedly
+  (PBT counterexample: `RemoveStyle(6,8)` against `Edit(1,5)`).
+- The recovery inherits the guard's direct-child shape restriction, so
+  a from-anchor collapsed by a *chained* merge (declared parent's
+  tombstone left under an intermediate source) gets no recovery and
+  keeps the pre-fix behavior of styling nothing on the applying
+  replica.
 - A node moved into the target by an *earlier, different* merge that
   the styler knew (and therefore saw outside its range) also fails
   open and is styled on the applying replica — the pre-§9.4 behavior;
@@ -593,3 +633,4 @@ For traceability from git history (commit messages reference Fix N).
 | Fix 20 | §6.3 | Flatten chained merge (P→Q→R) for redirect + snapshot consistency |
 | Fix 21 | §9.3 | Style range boundary right after merge-source tombstone |
 | Fix 22 | §9.4 | Intended-parent stamp + interloper filter at moved anchors |
+| Fix 23 | §9.4 | From-side recovery for style ranges collapsed by a merge |

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -1,5 +1,5 @@
 ---
-updated: 2026-08-17
+updated: 2026-08-22
 ---
 
 # Tasks Index
@@ -20,6 +20,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| Tree: recover style ranges collapsed by a merge at the from anchor (2026-08-22) | [20260822-tree-style-from-side-anchor-todo.md](./active/20260822-tree-style-from-side-anchor-todo.md) | [20260822-tree-style-from-side-anchor-lessons.md](./active/20260822-tree-style-from-side-anchor-lessons.md) |
 | DocSize: a snapshot rebuild over-credits one ticket per tombstone (2026-08-17) | [20260817-docsize-snapshot-rebuild-drift-todo.md](./active/20260817-docsize-snapshot-rebuild-drift-todo.md) | [20260817-docsize-snapshot-rebuild-drift-lessons.md](./active/20260817-docsize-snapshot-rebuild-drift-lessons.md) |
 | DocSize: port the container-removal accounting fix to the JS SDK (2026-08-17) | [20260817-docsize-js-sdk-parity-todo.md](./active/20260817-docsize-js-sdk-parity-todo.md) | [20260817-docsize-js-sdk-parity-lessons.md](./active/20260817-docsize-js-sdk-parity-lessons.md) |
 | Tree Style: a combined reverse's removal half is dropped on execute (2026-08-16) | [20260816-tree-style-combined-reverse-dropped-todo.md](./active/20260816-tree-style-combined-reverse-dropped-todo.md) | [20260816-tree-style-combined-reverse-dropped-lessons.md](./active/20260816-tree-style-combined-reverse-dropped-lessons.md) |

--- a/docs/tasks/active/20260822-tree-style-from-side-anchor-lessons.md
+++ b/docs/tasks/active/20260822-tree-style-from-side-anchor-lessons.md
@@ -1,0 +1,52 @@
+# Lessons: from-side style range recovery
+
+**Created**: 2026-08-22
+
+## A skip filter and a recovery are mirror images, not variations
+
+The end-side fix (§9.4, Fix 22) works because the applying replica
+covers *too much*: filtering nodes out of an over-wide traversal is
+safe. The from-side shape inverts the error direction — the traversal
+covers *nothing* — so no predicate over visited tokens can help; the
+traversal itself must be re-anchored. Recognizing which direction a
+range-resolution bug errs in tells you immediately whether the fix is
+a filter (subtractive) or a recovery (additive), and additive fixes
+need a stricter trigger: here the recovery only activates when the
+same merged-anchor shape holds for the from position *and* the
+resolved range actually collapsed. Without the collapse check, a range
+whose both anchors moved with the merge would be widened onto nodes
+the styler never covered — probed explicitly by the ordered-range
+control test before the trigger was final.
+
+## A removal tombstone for a missing key is load-bearing
+
+The obvious "simpler fix" — make `RemoveAttr` on a missing key a no-op
+so neither replica materializes the container — breaks a different
+concurrency: a concurrent `SetAttr` with an earlier ticket must lose
+to the removal by LWW, which requires the removal to be recorded even
+when the key does not exist yet. So convergence here means both
+replicas carry the removal entry, not neither. This also invalidated
+the issue's suggested oracle (`Attrs` empty on both): the converged
+state is entry/entry, pinned as such in the regression test.
+
+## Fixed-lamport unit contexts cannot express "unknown" by lamport
+
+The unit `ChangeContext` issues all tickets under one lamport, so a
+version-vector entry for the shared actor makes every local ticket
+"known" and the §9.4 guard never activates. Simulating an unknown
+concurrent merge in a unit test requires issuing the merge ticket
+under a *different actor* absent from the styler's vector, not a
+smaller lamport. The integration-level repro caught what the first
+unit attempt could not.
+
+## PBT confirms a fix by moving, not by passing
+
+As in every previous cycle, the pinned-seed PBT run does not go green
+after the fix — the shrinker slides to the nearest surviving
+counterexample (here: a to-side variant where the range end's left
+sibling is the moved merge-source tombstone, plus the known edit-only
+divergence). The verification signal is that the *reported* shape no
+longer minimizes, and that the new counterexamples reproduce on main
+before the change (checked with `git stash` on the JS side). Treating
+"PBT still fails" as fix failure would deadlock the loop; treating it
+as success without the stash check would hide regressions.

--- a/docs/tasks/active/20260822-tree-style-from-side-anchor-lessons.md
+++ b/docs/tasks/active/20260822-tree-style-from-side-anchor-lessons.md
@@ -39,6 +39,25 @@ under a *different actor* absent from the styler's vector, not a
 smaller lamport. The integration-level repro caught what the first
 unit attempt could not.
 
+## A per-replica shape check is not a convergence check
+
+The first version of the regression test asserted, for each replica
+independently, that the surviving `<p>` holds exactly one removed
+`bold` entry. That is a shape assertion, and it passes even when the
+two entries carry different identities or removal tickets — precisely
+the internal divergence class the issue reports, since Marshal already
+cannot see it. A convergence test has to compare the replicas against
+*each other*: the entries are now rendered as sorted descriptors
+carrying key, value, `updatedAt` and the removal flag, and the two
+lists are compared directly. The per-replica assertions stay, because
+"identical on both replicas" alone would also be satisfied by both
+being empty.
+
+The same review pass replaced the remaining `assert` calls guarding a
+dereference with `require`. `assert` does not stop the test, so a
+missing survivor or attribute container panicked on the next line
+instead of reporting the failure that had just been detected.
+
 ## PBT confirms a fix by moving, not by passing
 
 As in every previous cycle, the pinned-seed PBT run does not go green

--- a/docs/tasks/active/20260822-tree-style-from-side-anchor-todo.md
+++ b/docs/tasks/active/20260822-tree-style-from-side-anchor-todo.md
@@ -1,0 +1,57 @@
+# Tree: recover style ranges collapsed by a merge at the from anchor
+
+**Created**: 2026-08-22
+
+Fixes #1942 (yorkie-team/yorkie-js-sdk#1324). The from-side variant
+documented as a §9.4 known limitation: a style range start anchored
+after a merge-moved child collapses on the applying replica, which then
+misses the nodes the styling client covered.
+
+## Problem
+
+Initial `<r><p>ab</p><p>cd</p></r>`. Concurrently:
+- A: `Edit(8, 8, <p/>)`, then `RemoveStyle(6, 9, ["bold"])` — the range
+  starts after `c` and ends inside A's own insert, so A's local
+  application touches the insert
+- B: `Edit(0, 5)` — merge across the paragraphs
+
+On B the moved `cd` resolves behind the insert, so the resolved range
+collapses (start past end) and the traversal styles nothing. Only the
+writer carries the removal entry; `Marshal` hides the empty container,
+but the asymmetric RHT state round-trips through snapshots. In the JS
+SDK the same state is visible as a one-sided `attributes: {}`.
+
+## Plan
+
+- [x] Reproduce with failing complex tests (RED): style variant,
+      RemoveStyle variant with the internal-state pin, ordered-range
+      control
+- [x] `reversedFromAnchorRecovery`: reuse the §9.4 shape detection for
+      the *from* position; when the resolved range actually collapsed,
+      re-anchor the traversal start after the last live sibling before
+      the merge-source tombstone
+- [x] Style only nodes the interloper predicate positively identifies;
+      fail open (skip) for stamped or merge-moved nodes
+- [x] Unit tests pinning the recovery and the ordered-range no-op
+- [x] gocyclo relief: extract `stylePrevAttrs` and
+      `styleClientLamportAt` (shared by Style/RemoveStyle)
+- [x] Design doc: §9.4 from-side recovery (Fix 23), rewritten known
+      limitations
+- [x] Verify: unit, integration `TestTree*`, complex
+      `TestTreeConcurrency*`, golangci-lint, gofmt
+- [x] Triage remaining PBT counterexamples against main: a to-side
+      variant (`RemoveStyle(6,8)` vs `Edit(1,5)`, styles the merge
+      target one-sidedly) and the edit-only unwrap-vs-merge-delete
+      divergence both reproduce on main before this change
+- [x] Self review (multi-agent, both repos): confirmed the residual
+      stamped-node shapes (moved element children, earlier-known-merge
+      children) and the sibling-merge End-token shape all reproduce at
+      base; recorded them in §9.4 and applied the cleanup findings
+      (guard returns its derivations, recovery gate folded into the
+      shared skip predicate)
+
+## Out of scope
+
+- The edit-only divergence (concurrent unwrap vs merge-delete) and the
+  to-side moved-tombstone variant: pre-existing on main, documented in
+  §9.4 known limitations, next report/fix cycle.

--- a/docs/tasks/archive/README.md
+++ b/docs/tasks/archive/README.md
@@ -1,5 +1,5 @@
 ---
-updated: 2026-08-17
+updated: 2026-08-22
 ---
 
 # Tasks Archive

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -2018,15 +2018,15 @@ func (t *Tree) intendedMergeParent(
 func (t *Tree) mergedAnchorInterloperGuard(
 	pos *TreePos,
 	versionVector time.VersionVector,
-) func(*TreeNode) bool {
+) (func(*TreeNode) bool, *TreeNode, *TreeNode) {
 	if len(versionVector) == 0 {
-		return nil
+		return nil, nil, nil
 	}
 	declaredParent, _ := t.ToTreeNodes(pos)
 	if declaredParent == nil || !declaredParent.IsRemoved() ||
 		declaredParent.mergedInto == nil || declaredParent.removedAt == nil ||
 		ticketKnown(versionVector, declaredParent.removedAt) {
-		return nil
+		return nil, nil, nil
 	}
 	target := t.resolveMergeTarget(declaredParent)
 	// Restricted to the shape where the tombstone sits directly under the
@@ -2034,7 +2034,7 @@ func (t *Tree) mergedAnchorInterloperGuard(
 	// the interlopers.
 	if target == declaredParent || declaredParent.Index.Parent == nil ||
 		declaredParent.Index.Parent.Value != target {
-		return nil
+		return nil, nil, nil
 	}
 	// Collect the target's children positioned after the merge-source
 	// tombstone in one pass, so the predicate is O(depth) per node.
@@ -2068,7 +2068,87 @@ func (t *Tree) mergedAnchorInterloperGuard(
 			return false
 		}
 		return afterTombstone[top]
+	}, declaredParent, target
+}
+
+// stylePrevAttrs reports, for each key in attrs in sorted order, the value
+// that key held (or its absence) on the given node, for the reverse Style
+// capture.
+func stylePrevAttrs(node *TreeNode, attrs map[string]string) []PrevAttr {
+	keys := make([]string, 0, len(attrs))
+	for key := range attrs {
+		keys = append(keys, key)
 	}
+	sort.Strings(keys)
+	var prevAttrs []PrevAttr
+	for _, key := range keys {
+		if node.Attrs != nil && node.Attrs.Has(key) {
+			prevAttrs = append(prevAttrs, PrevAttr{Key: key, Value: node.Attrs.Get(key), Existed: true})
+		} else {
+			prevAttrs = append(prevAttrs, PrevAttr{Key: key, Existed: false})
+		}
+	}
+	return prevAttrs
+}
+
+// styleClientLamportAt returns the styling client's lamport for the given
+// actor: MaxLamport for local edits (empty version vector), the vector entry
+// when present, and zero for actors the client had never seen.
+func styleClientLamportAt(versionVector time.VersionVector, actorID time.ActorID) int64 {
+	if len(versionVector) == 0 {
+		// Case 1: local editing from json package
+		return time.MaxLamport
+	}
+	// Case 2: from operation with version vector(After v0.5.7)
+	if lamport, ok := versionVector.Get(actorID); ok {
+		return lamport
+	}
+	return 0
+}
+
+// reversedFromAnchorRecovery prepares the §9.4 from-side counterpart of
+// mergedAnchorInterloperGuard for a style range whose start position was
+// declared inside a parent that a merge unknown to the styling client
+// removed. The resolved range then collapses (start past end) and the
+// traversal misses nodes the styling client covered. The recovery
+// re-anchors the traversal start just after the last live sibling before
+// the merge-source tombstone; the caller must style only nodes the
+// returned predicate positively identifies as interlopers. Stamped nodes
+// in the span stay out of reach and fail open unstyled — see the
+// §9.4 known limitations in docs/design/concurrent-merge-split.md.
+func (t *Tree) reversedFromAnchorRecovery(
+	from *TreePos,
+	fromParent, fromLeft, toParent, toLeft *TreeNode,
+	versionVector time.VersionVector,
+) (*TreeNode, *TreeNode, func(*TreeNode) bool, error) {
+	isInterloper, declaredParent, target := t.mergedAnchorInterloperGuard(from, versionVector)
+	if isInterloper == nil {
+		return nil, nil, nil, nil
+	}
+	// Only a range that actually collapsed needs recovery: when both
+	// anchors moved with the merge, the resolved range stays ordered and
+	// still covers what the styling client covered.
+	fromIdx, err := t.ToIndex(fromParent, fromLeft)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	toIdx, err := t.ToIndex(toParent, toLeft)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if fromIdx <= toIdx {
+		return nil, nil, nil, nil
+	}
+	anchorLeft := target
+	for _, child := range target.Index.Children(true) {
+		if child.Value == declaredParent {
+			break
+		}
+		if !child.Value.IsRemoved() {
+			anchorLeft = child.Value
+		}
+	}
+	return target, anchorLeft, isInterloper, nil
 }
 
 // styleSkipPredicate builds the per-token skip checks shared by Style and
@@ -2077,15 +2157,21 @@ func (t *Tree) mergedAnchorInterloperGuard(
 func (t *Tree) styleSkipPredicate(
 	to *TreePos,
 	versionVector time.VersionVector,
+	recoveredInterloper func(*TreeNode) bool,
 ) func(index.TreeToken[*TreeNode]) bool {
 	isVersionVectorEmpty := len(versionVector) == 0
-	isAnchorInterloper := t.mergedAnchorInterloperGuard(to, versionVector)
+	isAnchorInterloper, _, _ := t.mergedAnchorInterloperGuard(to, versionVector)
 	return func(token index.TreeToken[*TreeNode]) bool {
 		// Skip styling via End token when the node has an unknown
 		// split sibling. The End token is in the range only because
 		// a concurrent split extended the range into the sibling.
 		if token.TokenType == index.End && !isVersionVectorEmpty &&
 			t.hasUnknownSplitSibling(token.Node, versionVector) {
+			return true
+		}
+		// §9.4 from-side: a recovered traversal may only touch nodes the
+		// collapsed range lost, the positively identified interlopers.
+		if recoveredInterloper != nil && !recoveredInterloper(token.Node) {
 			return true
 		}
 		// §9.4: the node is in the range only because an unknown merge
@@ -2618,28 +2704,22 @@ func (t *Tree) Style(
 	}
 
 	isVersionVectorEmpty := len(versionVector) == 0
-	shouldSkipToken := t.styleSkipPredicate(to, versionVector)
+	recoveredParent, recoveredLeft, isRecoveredInterloper, err := t.reversedFromAnchorRecovery(
+		from, fromParent, fromLeft, toParent, toLeft, versionVector)
+	if err != nil {
+		return t.drainPendingGCPairs(), diff, nil, err
+	}
+	if recoveredParent != nil {
+		fromParent, fromLeft = recoveredParent, recoveredLeft
+	}
+	shouldSkipToken := t.styleSkipPredicate(to, versionVector, isRecoveredInterloper)
 
 	var pairs []GCPair
 	var prevAttrs []PrevAttr
 	captured := false
 	if err = t.traverseInPosRange(fromParent, fromLeft, toParent, toLeft, func(token index.TreeToken[*TreeNode], _ bool) {
 		node := token.Node
-		actorID := node.id.CreatedAt.ActorID()
-
-		var clientLamportAtChange int64
-		if isVersionVectorEmpty {
-			// Case 1: local editing from json package
-			clientLamportAtChange = time.MaxLamport
-		} else {
-			// Case 2: from operation with version vector(After v0.5.7)
-			lamport, ok := versionVector.Get(actorID)
-			if ok {
-				clientLamportAtChange = lamport
-			} else {
-				clientLamportAtChange = 0
-			}
-		}
+		clientLamportAtChange := styleClientLamportAt(versionVector, node.id.CreatedAt.ActorID())
 
 		if node.canStyle(editedAt, clientLamportAtChange) && len(attrs) > 0 {
 			if shouldSkipToken(token) {
@@ -2647,18 +2727,7 @@ func (t *Tree) Style(
 			}
 
 			if !captured {
-				keys := make([]string, 0, len(attrs))
-				for key := range attrs {
-					keys = append(keys, key)
-				}
-				sort.Strings(keys)
-				for _, key := range keys {
-					if node.Attrs != nil && node.Attrs.Has(key) {
-						prevAttrs = append(prevAttrs, PrevAttr{Key: key, Value: node.Attrs.Get(key), Existed: true})
-					} else {
-						prevAttrs = append(prevAttrs, PrevAttr{Key: key, Existed: false})
-					}
-				}
+				prevAttrs = stylePrevAttrs(node, attrs)
 				captured = true
 			}
 
@@ -2747,28 +2816,22 @@ func (t *Tree) RemoveStyle(
 	}
 
 	isVersionVectorEmpty := len(versionVector) == 0
-	shouldSkipToken := t.styleSkipPredicate(to, versionVector)
+	recoveredParent, recoveredLeft, isRecoveredInterloper, err := t.reversedFromAnchorRecovery(
+		from, fromParent, fromLeft, toParent, toLeft, versionVector)
+	if err != nil {
+		return t.drainPendingGCPairs(), diff, nil, err
+	}
+	if recoveredParent != nil {
+		fromParent, fromLeft = recoveredParent, recoveredLeft
+	}
+	shouldSkipToken := t.styleSkipPredicate(to, versionVector, isRecoveredInterloper)
 
 	var pairs []GCPair
 	var prevAttrs []PrevAttr
 	captured := false
 	if err = t.traverseInPosRange(fromParent, fromLeft, toParent, toLeft, func(token index.TreeToken[*TreeNode], _ bool) {
 		node := token.Node
-		actorID := node.id.CreatedAt.ActorID()
-
-		var clientLamportAtChange int64
-		if isVersionVectorEmpty {
-			// Case 1: local editing from json package
-			clientLamportAtChange = time.MaxLamport
-		} else {
-			// Case 2: from operation with version vector(After v0.5.7)
-			lamport, ok := versionVector.Get(actorID)
-			if ok {
-				clientLamportAtChange = lamport
-			} else {
-				clientLamportAtChange = 0
-			}
-		}
+		clientLamportAtChange := styleClientLamportAt(versionVector, node.id.CreatedAt.ActorID())
 
 		if node.canStyle(editedAt, clientLamportAtChange) && len(attrs) > 0 {
 			if shouldSkipToken(token) {

--- a/pkg/document/crdt/tree_test.go
+++ b/pkg/document/crdt/tree_test.go
@@ -526,6 +526,97 @@ func TestTreeEdit(t *testing.T) {
 		assert.Equal(t, mergeTicket, content.MergedAt)
 	})
 
+	t.Run("recovers a style range reversed by an unknown merge at the from anchor", func(t *testing.T) {
+		// 01. Create <root><p>ab</p><p>cd</p></root> and insert the
+		// styler's own <p> after the second paragraph.
+		ctx := helper.TextChangeContext(helper.TestRoot())
+		tree := crdt.NewTree(crdt.NewTreeNode(helper.PosT(ctx), "root", nil), helper.TimeT(ctx))
+		_, _, err := tree.EditT(0, 0, []*crdt.TreeNode{crdt.NewTreeNode(helper.PosT(ctx), "p", nil)}, 0,
+			helper.TimeT(ctx), issueTicket(ctx))
+		assert.NoError(t, err)
+		_, _, err = tree.EditT(1, 1, []*crdt.TreeNode{
+			crdt.NewTreeNode(helper.PosT(ctx), "text", nil, "ab"),
+		}, 0, helper.TimeT(ctx), issueTicket(ctx))
+		assert.NoError(t, err)
+		_, _, err = tree.EditT(4, 4, []*crdt.TreeNode{crdt.NewTreeNode(helper.PosT(ctx), "p", nil)}, 0,
+			helper.TimeT(ctx), issueTicket(ctx))
+		assert.NoError(t, err)
+		_, _, err = tree.EditT(5, 5, []*crdt.TreeNode{
+			crdt.NewTreeNode(helper.PosT(ctx), "text", nil, "cd"),
+		}, 0, helper.TimeT(ctx), issueTicket(ctx))
+		assert.NoError(t, err)
+		inserted := crdt.NewTreeNode(helper.PosT(ctx), "p", nil)
+		_, _, err = tree.EditT(8, 8, []*crdt.TreeNode{inserted}, 0, helper.TimeT(ctx), issueTicket(ctx))
+		assert.NoError(t, err)
+
+		// 02. Capture the styler-view range (from after `c`, to inside
+		// the insert) and a version vector that predates the merge.
+		fromPos, err := tree.FindPos(6)
+		assert.NoError(t, err)
+		toPos, err := tree.FindPos(9)
+		assert.NoError(t, err)
+		known := helper.TimeT(ctx)
+		vv := time.VersionVector{known.ActorID(): known.Lamport()}
+
+		// 03. Apply a merge from another actor, outside the styler's
+		// version vector: the moved `cd` resolves after the insert, so
+		// the range collapses. The recovery must still style the insert.
+		otherActor, err := time.ActorIDFromHex("111111111111111111111111")
+		assert.NoError(t, err)
+		mergeTicket := time.NewTicket(known.Lamport()+1, 0, otherActor)
+		_, _, err = tree.EditT(0, 5, nil, 0, mergeTicket, issueTicket(ctx))
+		assert.NoError(t, err)
+		_, _, _, err = tree.Style(fromPos, toPos, map[string]string{"bold": "x"}, helper.TimeT(ctx), vv)
+		assert.NoError(t, err)
+
+		require.NotNil(t, inserted.Attrs)
+		assert.Equal(t, "x", inserted.Attrs.Get("bold"))
+	})
+
+	t.Run("keeps an ordered from-anchor range off the writer insert", func(t *testing.T) {
+		// Same shape, but both anchors sit inside the merged paragraph:
+		// the resolved range moves with the merge and stays ordered, so
+		// the recovery must not widen it onto the insert.
+		ctx := helper.TextChangeContext(helper.TestRoot())
+		tree := crdt.NewTree(crdt.NewTreeNode(helper.PosT(ctx), "root", nil), helper.TimeT(ctx))
+		_, _, err := tree.EditT(0, 0, []*crdt.TreeNode{crdt.NewTreeNode(helper.PosT(ctx), "p", nil)}, 0,
+			helper.TimeT(ctx), issueTicket(ctx))
+		assert.NoError(t, err)
+		_, _, err = tree.EditT(1, 1, []*crdt.TreeNode{
+			crdt.NewTreeNode(helper.PosT(ctx), "text", nil, "ab"),
+		}, 0, helper.TimeT(ctx), issueTicket(ctx))
+		assert.NoError(t, err)
+		_, _, err = tree.EditT(4, 4, []*crdt.TreeNode{crdt.NewTreeNode(helper.PosT(ctx), "p", nil)}, 0,
+			helper.TimeT(ctx), issueTicket(ctx))
+		assert.NoError(t, err)
+		_, _, err = tree.EditT(5, 5, []*crdt.TreeNode{
+			crdt.NewTreeNode(helper.PosT(ctx), "text", nil, "cd"),
+		}, 0, helper.TimeT(ctx), issueTicket(ctx))
+		assert.NoError(t, err)
+		inserted := crdt.NewTreeNode(helper.PosT(ctx), "p", nil)
+		_, _, err = tree.EditT(8, 8, []*crdt.TreeNode{inserted}, 0, helper.TimeT(ctx), issueTicket(ctx))
+		assert.NoError(t, err)
+
+		fromPos, err := tree.FindPos(6)
+		assert.NoError(t, err)
+		toPos, err := tree.FindPos(7)
+		assert.NoError(t, err)
+		known := helper.TimeT(ctx)
+		vv := time.VersionVector{known.ActorID(): known.Lamport()}
+
+		otherActor, err := time.ActorIDFromHex("111111111111111111111111")
+		assert.NoError(t, err)
+		mergeTicket := time.NewTicket(known.Lamport()+1, 0, otherActor)
+		_, _, err = tree.EditT(0, 5, nil, 0, mergeTicket, issueTicket(ctx))
+		assert.NoError(t, err)
+		_, _, _, err = tree.Style(fromPos, toPos, map[string]string{"bold": "x"}, helper.TimeT(ctx), vv)
+		assert.NoError(t, err)
+
+		if inserted.Attrs != nil {
+			assert.Empty(t, inserted.Attrs.Nodes())
+		}
+	})
+
 	t.Run("delete nodes between element nodes in different levels test", func(t *testing.T) {
 		// 01. Create a tree with 2 paragraphs.
 		//       0   1   2 3 4    5    6   7 8 9    10

--- a/test/complex/tree_concurrency_test.go
+++ b/test/complex/tree_concurrency_test.go
@@ -1135,3 +1135,166 @@ func TestTreeConcurrencyRemoveStyleAfterMovedAnchor(t *testing.T) {
 		}
 	}
 }
+
+// TestTreeConcurrencyStyleFromSideMovedAnchor verifies the §9.4 from-side
+// variant (yorkie-team/yorkie#1942): a style range starting after a
+// merge-moved child collapses on the applying replica, which then must
+// recover the writer's own insert sitting between the merge-source
+// tombstone and the moved children.
+func TestTreeConcurrencyStyleFromSideMovedAnchor(t *testing.T) {
+	clients := activeClients(t, 2)
+	c1, c2 := clients[0], clients[1]
+	defer deactivateAndCloseClients(t, clients)
+
+	ctx := context.Background()
+	d1 := document.New(helper.TestKey(t))
+	assert.NoError(t, c1.Attach(ctx, d1))
+	d2 := document.New(helper.TestKey(t))
+	assert.NoError(t, c2.Attach(ctx, d2))
+
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.SetNewTree("t", json.TreeNode{
+			Type: "r",
+			Children: []json.TreeNode{
+				{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "ab"}}},
+				{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "cd"}}},
+			},
+		})
+		return nil
+	}))
+	assert.NoError(t, c1.Sync(ctx))
+	assert.NoError(t, c2.Sync(ctx))
+
+	// d1 inserts an empty <p> after the second paragraph, then styles a
+	// range starting after `c` and ending inside its own insert. d2's
+	// concurrent merge moves `cd` behind the insert, collapsing the range.
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(8, 8, &json.TreeNode{Type: "p", Children: []json.TreeNode{}}, 0)
+		return nil
+	}))
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Style(6, 9, map[string]string{"bold": "x"})
+		return nil
+	}))
+	assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(0, 5, nil, 0)
+		return nil
+	}))
+
+	flag := syncClientsThenCheckEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
+	assert.True(t, flag, "d1: %s\nd2: %s",
+		d1.Root().GetTree("t").ToXML(), d2.Root().GetTree("t").ToXML())
+	assert.Equal(t, `<r><p bold="x"></p>cd</r>`, d1.Root().GetTree("t").ToXML())
+}
+
+// TestTreeConcurrencyRemoveStyleFromSideMovedAnchor verifies the RemoveStyle
+// side of the from-side variant: the removal tombstone that arbitrates a
+// concurrent earlier SetAttr must materialize on both replicas, not only on
+// the writer. Marshal hides empty containers, so the internal attribute
+// state is pinned directly.
+func TestTreeConcurrencyRemoveStyleFromSideMovedAnchor(t *testing.T) {
+	clients := activeClients(t, 2)
+	c1, c2 := clients[0], clients[1]
+	defer deactivateAndCloseClients(t, clients)
+
+	ctx := context.Background()
+	d1 := document.New(helper.TestKey(t))
+	assert.NoError(t, c1.Attach(ctx, d1))
+	d2 := document.New(helper.TestKey(t))
+	assert.NoError(t, c2.Attach(ctx, d2))
+
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.SetNewTree("t", json.TreeNode{
+			Type: "r",
+			Children: []json.TreeNode{
+				{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "ab"}}},
+				{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "cd"}}},
+			},
+		})
+		return nil
+	}))
+	assert.NoError(t, c1.Sync(ctx))
+	assert.NoError(t, c2.Sync(ctx))
+
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(8, 8, &json.TreeNode{Type: "p", Children: []json.TreeNode{}}, 0)
+		return nil
+	}))
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").RemoveStyle(6, 9, []string{"bold"})
+		return nil
+	}))
+	assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(0, 5, nil, 0)
+		return nil
+	}))
+
+	flag := syncClientsThenCheckEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
+	assert.True(t, flag, "d1: %s\nd2: %s",
+		d1.Root().GetTree("t").ToXML(), d2.Root().GetTree("t").ToXML())
+
+	// Both replicas must hold the same removal entry on the surviving <p>.
+	for i, pair := range []clientAndDocPair{{c1, d1}, {c2, d2}} {
+		tree, ok := pair.doc.RootObject().Members()["t"].(*crdt.Tree)
+		assert.True(t, ok)
+		var survivor *crdt.TreeNode
+		for _, child := range tree.Root().Children(true) {
+			if child.Type() == "p" && !child.IsRemoved() {
+				survivor = child
+			}
+		}
+		assert.NotNil(t, survivor, "d%d: live <p> not found", i+1)
+		assert.NotNil(t, survivor.Attrs, "d%d: attribute container missing", i+1)
+		nodes := survivor.Attrs.Nodes()
+		assert.Len(t, nodes, 1, "d%d: removal entry count", i+1)
+		assert.Equal(t, "bold", nodes[0].Key(), "d%d", i+1)
+		assert.True(t, nodes[0].IsRemoved(), "d%d: entry must be a removal", i+1)
+	}
+}
+
+// TestTreeConcurrencyStyleFromSideOrderedRange pins the recovery trigger:
+// when both anchors sit inside the merged paragraph, the resolved range
+// moves with the merge and stays ordered, so the recovery must not widen
+// it onto the writer's insert.
+func TestTreeConcurrencyStyleFromSideOrderedRange(t *testing.T) {
+	clients := activeClients(t, 2)
+	c1, c2 := clients[0], clients[1]
+	defer deactivateAndCloseClients(t, clients)
+
+	ctx := context.Background()
+	d1 := document.New(helper.TestKey(t))
+	assert.NoError(t, c1.Attach(ctx, d1))
+	d2 := document.New(helper.TestKey(t))
+	assert.NoError(t, c2.Attach(ctx, d2))
+
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.SetNewTree("t", json.TreeNode{
+			Type: "r",
+			Children: []json.TreeNode{
+				{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "ab"}}},
+				{Type: "p", Children: []json.TreeNode{{Type: "text", Value: "cd"}}},
+			},
+		})
+		return nil
+	}))
+	assert.NoError(t, c1.Sync(ctx))
+	assert.NoError(t, c2.Sync(ctx))
+
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(8, 8, &json.TreeNode{Type: "p", Children: []json.TreeNode{}}, 0)
+		return nil
+	}))
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Style(6, 7, map[string]string{"bold": "x"})
+		return nil
+	}))
+	assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetTree("t").Edit(0, 5, nil, 0)
+		return nil
+	}))
+
+	flag := syncClientsThenCheckEqual(t, []clientAndDocPair{{c1, d1}, {c2, d2}})
+	assert.True(t, flag, "d1: %s\nd2: %s",
+		d1.Root().GetTree("t").ToXML(), d2.Root().GetTree("t").ToXML())
+	assert.Equal(t, `<r><p></p>cd</r>`, d1.Root().GetTree("t").ToXML())
+}

--- a/test/complex/tree_concurrency_test.go
+++ b/test/complex/tree_concurrency_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yorkie-team/yorkie/pkg/document"
 	"github.com/yorkie-team/yorkie/pkg/document/crdt"
@@ -1246,7 +1247,7 @@ func TestTreeConcurrencyRemoveStyleFromSideMovedAnchor(t *testing.T) {
 		assert.NotNil(t, survivor, "d%d: live <p> not found", i+1)
 		assert.NotNil(t, survivor.Attrs, "d%d: attribute container missing", i+1)
 		nodes := survivor.Attrs.Nodes()
-		assert.Len(t, nodes, 1, "d%d: removal entry count", i+1)
+		require.Len(t, nodes, 1, "d%d: removal entry count", i+1)
 		assert.Equal(t, "bold", nodes[0].Key(), "d%d", i+1)
 		assert.True(t, nodes[0].IsRemoved(), "d%d: entry must be a removal", i+1)
 	}

--- a/test/complex/tree_concurrency_test.go
+++ b/test/complex/tree_concurrency_test.go
@@ -21,6 +21,7 @@ package complex
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1235,22 +1236,43 @@ func TestTreeConcurrencyRemoveStyleFromSideMovedAnchor(t *testing.T) {
 		d1.Root().GetTree("t").ToXML(), d2.Root().GetTree("t").ToXML())
 
 	// Both replicas must hold the same removal entry on the surviving <p>.
+	// The entries are compared against each other and not merely counted:
+	// two replicas can each hold one removed "bold" entry while those
+	// entries carry different identities or removal tickets, which is the
+	// internal divergence issue #1942 reports and Marshal cannot see.
+	descs := make([][]string, 0, 2)
 	for i, pair := range []clientAndDocPair{{c1, d1}, {c2, d2}} {
 		tree, ok := pair.doc.RootObject().Members()["t"].(*crdt.Tree)
-		assert.True(t, ok)
+		require.True(t, ok, "d%d: tree not found", i+1)
 		var survivor *crdt.TreeNode
 		for _, child := range tree.Root().Children(true) {
 			if child.Type() == "p" && !child.IsRemoved() {
 				survivor = child
 			}
 		}
-		assert.NotNil(t, survivor, "d%d: live <p> not found", i+1)
-		assert.NotNil(t, survivor.Attrs, "d%d: attribute container missing", i+1)
+		require.NotNil(t, survivor, "d%d: live <p> not found", i+1)
+		require.NotNil(t, survivor.Attrs, "d%d: attribute container missing", i+1)
 		nodes := survivor.Attrs.Nodes()
 		require.Len(t, nodes, 1, "d%d: removal entry count", i+1)
 		assert.Equal(t, "bold", nodes[0].Key(), "d%d", i+1)
 		assert.True(t, nodes[0].IsRemoved(), "d%d: entry must be a removal", i+1)
+		descs = append(descs, attrEntryDescs(nodes))
 	}
+	assert.Equal(t, descs[0], descs[1], "attribute entries diverged")
+}
+
+// attrEntryDescs renders attribute RHT entries as comparable descriptors,
+// carrying the entry identity and removal metadata that Marshal omits. The
+// descriptors are sorted because RHT.Nodes iterates a map.
+func attrEntryDescs(nodes []*crdt.RHTNode) []string {
+	descs := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		descs = append(descs, fmt.Sprintf("%s=%q updatedAt=%s removed=%t",
+			node.Key(), node.Value(), node.UpdatedAt().Key(), node.IsRemoved()))
+	}
+	sort.Strings(descs)
+
+	return descs
 }
 
 // TestTreeConcurrencyStyleFromSideOrderedRange pins the recovery trigger:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

A `Tree.Style`/`Tree.RemoveStyle` whose range starts after a merge-moved child styles nothing on the applying replica. From `<r><p>ab</p><p>cd</p></r>`:

- client A inserts an empty `<p>` at index 8, then calls `RemoveStyle(6, 9)` (from after `c`, to inside the insert)
- client B concurrently removes `[0,5)`, merging the paragraphs

`Marshal` hides the asymmetry (it omits empty attribute containers), but only A's insert carries the removal entry in its attribute RHT, and the state round-trips through snapshots. The JS SDK shows it as a one-sided `attributes: {}`.

**Root cause:** the merge moves the anchor child behind the insert, so the resolved range inverts (start past end) and the traversal is empty. The per-node filter from #1916 cannot help: it only skips visited nodes, and nothing is visited.

**Fix:** `reversedFromAnchorRecovery`, the from-side counterpart of that filter. When the range start matches the same merged-anchor shape and the resolved range actually collapsed, it re-anchors the traversal start just after the last live sibling before the merge-source tombstone; the shared skip predicate then styles only nodes positively identified as interlopers, and version-vector checks keep unknown inserts unstyled. An ordered range that moved with the merge is left untouched.

The removal tombstone now materializes on both replicas: even for a missing key it arbitrates a concurrent `SetAttr` with an earlier ticket by LWW. The regression test pins the converged entry/entry state directly, since Marshal alone cannot detect it.

Tests: three complex cases (Style reversal with the converged XML pinned, RemoveStyle with the symmetric-entry pin, ordered-range control) and two unit tests at the CRDT layer. `stylePrevAttrs` and `styleClientLamportAt` are extracted from the duplicated Style/RemoveStyle blocks (gocyclo).

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #1942

**Special notes for your reviewer**:
- The from-side variant documented as a §9.4 known limitation when #1928 landed; the JS SDK diverges identically (yorkie-team/yorkie-js-sdk#1324, mirror PR follows). Found by the Tree PBT for yorkie-team/yorkie-js-sdk#1298.
- Design: `docs/design/concurrent-merge-split.md` §9.4 "From-side recovery (Fix 23)" plus a rewritten known-limitations list; the residual shapes listed there all reproduce on main without this change.
- Verified with the unit, integration `TestTree*`, and complex `TestTreeConcurrency*` lanes plus golangci-lint.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Fix Tree.Style and Tree.RemoveStyle ranges starting after a merge-moved child styling only the writer's replica.
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs
- [Design]: docs/design/concurrent-merge-split.md §9.4 (Fix 23)
```

**Checklist**:

- [x] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved styling and style removal when concurrent paragraph merges move or collapse range anchors.
  - Preserved formatting on affected inserted content without incorrectly expanding ranges.
  - Ensured style removals are recorded consistently, including when attributes are missing.
- **Tests**
  - Added regression coverage for concurrent merge scenarios, range recovery, and synchronized style removal.
- **Documentation**
  - Documented the fix, recovery behavior, testing lessons, and known limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->