### PR TITLE
fix(crdt): anchor Array.Add on position identity to fix snapshot divergence

### DIFF
--- a/pkg/document/crdt/array_move_snapshot_test.go
+++ b/pkg/document/crdt/array_move_snapshot_test.go
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package crdt_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yorkie-team/yorkie/pkg/document/crdt"
+	"github.com/yorkie-team/yorkie/test/helper"
+)
+
+// TestArrayMoveThenAddSnapshotStable is the minimal deterministic regression
+// for yorkie#1948: when the last element of an array was moved into its slot,
+// appending more elements and then rebuilding the array through Add (which is
+// how DeepCopy and snapshot restore reconstruct the list) must preserve order.
+//
+// Before the fix, RGATreeList.Add anchored on the last node's ELEMENT createdAt
+// instead of its POSITION createdAt. For a moved last element those differ, and
+// the element createdAt resolves to the element's now-dead original position
+// node, so each Add landed before the previous one — reversing the appended
+// run. This surfaced as a passive replica diverging after a snapshot restore.
+func TestArrayMoveThenAddSnapshotStable(t *testing.T) {
+	root := helper.TestRoot()
+	ctx := helper.TextChangeContext(root)
+
+	list := crdt.NewRGATreeList()
+
+	add := func(v int) {
+		p, err := crdt.NewPrimitive(v, ctx.IssueTimeTicket())
+		require.NoError(t, err)
+		require.NoError(t, list.Add(p))
+	}
+
+	// Build [14,15].
+	p14, err := crdt.NewPrimitive(14, ctx.IssueTimeTicket())
+	require.NoError(t, err)
+	require.NoError(t, list.Add(p14))
+	p15, err := crdt.NewPrimitive(15, ctx.IssueTimeTicket())
+	require.NoError(t, err)
+	pos14, err := list.PosCreatedAt(p14.CreatedAt())
+	require.NoError(t, err)
+	require.NoError(t, list.InsertAfter(pos14, p15, ctx.IssueTimeTicket()))
+	assert.Equal(t, "[14,15]", list.Marshal())
+
+	// Move 14 after 15, then move 15 after 14 (net order [14,15], two moves that
+	// leave two dead position nodes and a moved last element).
+	pos15, err := list.PosCreatedAt(p15.CreatedAt())
+	require.NoError(t, err)
+	_, err = list.MoveAfter(pos15, p14.CreatedAt(), ctx.IssueTimeTicket())
+	require.NoError(t, err)
+	pos14b, err := list.PosCreatedAt(p14.CreatedAt())
+	require.NoError(t, err)
+	_, err = list.MoveAfter(pos14b, p15.CreatedAt(), ctx.IssueTimeTicket())
+	require.NoError(t, err)
+	assert.Equal(t, "[14,15]", list.Marshal())
+
+	// Append 26 and 66 after the moved last element.
+	add(26)
+	add(66)
+	arr := crdt.NewArray(list, ctx.IssueTimeTicket())
+	assert.Equal(t, "[14,15,26,66]", arr.Marshal())
+
+	// DeepCopy rebuilds the list through Add — it must not reorder.
+	cp, err := arr.DeepCopy()
+	require.NoError(t, err)
+	assert.Equal(t, "[14,15,26,66]", cp.Marshal(),
+		"DeepCopy of a moved-then-appended array must preserve order (yorkie#1948)")
+}

--- a/pkg/document/crdt/rga_tree_list.go
+++ b/pkg/document/crdt/rga_tree_list.go
@@ -241,8 +241,17 @@ func (a *RGATreeList) Marshal() string {
 }
 
 // Add adds the given element at the last.
+//
+// The anchor must be the last node's POSITION identity (LastCreatedAt), not its
+// element identity (last.CreatedAt). When the last element was moved here, its
+// element createdAt maps in nodeMapByCreatedAt to the element's now-dead
+// original position node, so anchoring on element identity would insert after
+// that stale dead slot instead of the tail — and the forward-skip in
+// insertAfter would then place each successive Add before the previous one,
+// reversing the appended run (yorkie#1948, seen only via snapshot restore and
+// DeepCopy, which rebuild the list through Add).
 func (a *RGATreeList) Add(elem Element) error {
-	return a.InsertAfter(a.last.CreatedAt(), elem, nil)
+	return a.InsertAfter(a.LastCreatedAt(), elem, nil)
 }
 
 // AddDeadPosition appends a dead position node during snapshot restoration.

--- a/test/integration/array_property_test.go
+++ b/test/integration/array_property_test.go
@@ -52,22 +52,19 @@ const (
 // read the replica's local length so the randomly picked indices always stay in
 // bounds.
 //
-// NOTE(convergence scope): The generated ops are limited to Add, Insert, Delete
-// and Set, which are the Array operations that converge under arbitrary
-// concurrency. Concurrent Move (MoveBefore/MoveAfterByIndex) is a non-commutative
-// operation that does not yet converge in the general case — a known limitation
-// tracked by #1382 (Operation Reorder/Replay Engine for non-commutative
-// operations). Randomized concurrent moves therefore diverge and are
-// intentionally excluded from this convergence guard; hand-written concurrent
-// move scenarios that are expected to converge already live in array_test.go
-// (TestConcurrentArrayOperations, TestComplicatedArrayConcurrency).
+// NOTE(convergence scope): The generator covers Add, Insert, Delete, Set, and
+// both Move variants (MoveBefore/MoveAfterByIndex). Concurrent Move used to be
+// excluded here because randomized moves diverged (#1948); that divergence was a
+// snapshot/DeepCopy reconstruction bug (Array.Add anchored on element identity
+// instead of position-node identity) and is now fixed, so Move is exercised as a
+// first-class convergence case.
 func applyRandomArrayOps(t *testing.T, doc *document.Document, r *rand.Rand, opCount int) {
 	for range opCount {
 		require.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
 			arr := root.GetArray("arr")
 			length := arr.Len()
 
-			switch r.Intn(4) {
+			switch r.Intn(6) {
 			case 0:
 				// Add: append a value to the end of the array.
 				arr.AddInteger(r.Intn(100))
@@ -89,6 +86,24 @@ func applyRandomArrayOps(t *testing.T, doc *document.Document, r *rand.Rand, opC
 				// Set: replace the element at a random index in place.
 				if length > 0 {
 					arr.SetInteger(r.Intn(length), r.Intn(100))
+				}
+			case 4:
+				// MoveAfterByIndex: relocate an element after another index.
+				if length >= 2 {
+					pi := r.Intn(length)
+					ti := r.Intn(length)
+					if pi != ti {
+						arr.MoveAfterByIndex(pi, ti)
+					}
+				}
+			case 5:
+				// MoveBefore: relocate an element before another element.
+				if length >= 2 {
+					ni := r.Intn(length)
+					ti := r.Intn(length)
+					if ni != ti {
+						arr.MoveBefore(arr.Get(ni).CreatedAt(), arr.Get(ti).CreatedAt())
+					}
 				}
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Concurrent Array `Move` mixed with `Add`/`Insert` left replicas permanently divergent under random concurrency: a passive replica reordered another client's moved-and-appended block (e.g. `[...,14,15,26,66]` vs `[...,66,26,14,15]`).

**Root cause — a reconstruction bug, not a CRDT-ordering bug.**

`RGATreeList.Add` anchored the appended element on the last node's *element* `createdAt` (`a.last.CreatedAt()`) instead of its *position-node* `createdAt`. For an element that was moved into its slot, the two differ, and the element `createdAt` resolves via `nodeMapByCreatedAt` to the element's now-dead *original* position node (dead position nodes are intentionally kept in that map as stable anchors). So the append anchored at that stale dead slot early in the list, and the forward-skip in `insertAfter` then placed each successive `Add` *before* the previous one — reversing the appended run.

The live insert path was never affected: the `json` layer already converts to position identity via `LastCreatedAt()` before issuing operations. The bug surfaced only when the list is rebuilt through `Add`, i.e. **snapshot restore** (`fromJSONArray`) and **`Array.DeepCopy`**. That is exactly why the passive replica in the repro diverged only *after* the server took a snapshot, while every pure operation-replay ordering converges (verified by exhaustively enumerating all interleavings).

**Fix:** anchor `Add` on `LastCreatedAt()` (the last node's position identity). For never-moved elements position-createdAt == element-createdAt, so behavior is unchanged; it only differs for a moved last element.

Scope note: this is a scoped serialization/reconstruction fix. It is **not** the fundamental non-commutative-move redesign discussed in #1382 — the RGA LWW position register (#1762) is otherwise sound here.

**Which issue(s) this PR fixes**:

Fixes #1948

**Special notes for your reviewer**:

Verification:
- New minimal, no-server regression `TestArrayMoveThenAddSnapshotStable` (pure CRDT `DeepCopy`) — fails without the fix, passes with it.
- Re-enabled concurrent `Move` (`MoveBefore` + `MoveAfterByIndex`) in the randomized property test `TestArrayPropertyConvergence`, which had excluded it. Confirmed deterministically green, including an out-of-band stress run at 200 seeds × 12 ops (x2) before restoring CI-friendly counts.
- Existing suites pass: `TestArray`, `TestArrayConcurrency` (49-case table), `TestComplicatedArrayConcurrency`, `TestArraySetByIndex`, plus `go build ./...`, `go vet ./pkg/document/...`, and the `crdt`/`document`/`converter`/`operations` unit tests.
- Additional confidence: a 100-seed randomized 3-client Move fuzz on a real server fails without the fix and passes with it.

**Does this PR introduce a user-facing change?**:

Yes — concurrent Array `Move` now converges across replicas when reconstructed from a snapshot.

```release-note
Fix Array convergence divergence where a moved-then-appended element block was reversed after snapshot restore / DeepCopy (concurrent Move).
```

**Checklist**:

- [x] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where adding items after moving the last array element could reverse the order of newly appended items.
  * Ensured snapshots and copied arrays preserve the correct item order.

* **Tests**
  * Expanded array testing to cover move operations and verify consistent results across reconstruction and concurrent scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->