### PR TITLE
Keep the watch event pump alive while detaching

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -438,10 +438,6 @@ func (c *Client) Detach(ctx context.Context, r attachable.Attachable, opts ...in
 	attachment.syncMu.Lock()
 	defer attachment.syncMu.Unlock()
 
-	if attachment.closeWatchStream != nil {
-		attachment.closeWatchStream()
-	}
-
 	if attachment.Is(attachable.TypeDocument) {
 		d, ok := r.(*document.Document)
 		if !ok {
@@ -455,15 +451,28 @@ func (c *Client) Detach(ctx context.Context, r attachable.Attachable, opts ...in
 			}
 		}
 
-		return c.detachDocument(ctx, d, detachOpts)
+		if err := c.detachDocument(ctx, d, detachOpts); err != nil {
+			return err
+		}
+	} else {
+		p, ok := r.(*channel.Channel)
+		if !ok {
+			return ErrInvalidResource
+		}
+
+		if err := c.detachChannel(ctx, p); err != nil {
+			return err
+		}
 	}
 
-	p, ok := r.(*channel.Channel)
-	if !ok {
-		return ErrInvalidResource
+	// Keep the watch pipeline alive while applying the final ChangePack. Its
+	// event pump is the sole consumer of Document.Events, so stopping it first
+	// can leave ApplyChangePack blocked when the pack emits multiple events.
+	if attachment.closeWatchStream != nil {
+		attachment.closeWatchStream()
 	}
 
-	return c.detachChannel(ctx, p)
+	return nil
 }
 
 // attachDocument attaches the given document to this client. It tells the server that

--- a/client/detach_test.go
+++ b/client/detach_test.go
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yorkie-team/yorkie/api/types"
+	api "github.com/yorkie-team/yorkie/api/yorkie/v1"
+	"github.com/yorkie-team/yorkie/api/yorkie/v1/v1connect"
+	"github.com/yorkie-team/yorkie/pkg/document"
+	"github.com/yorkie-team/yorkie/pkg/key"
+)
+
+type detachTestServer struct {
+	v1connect.UnimplementedYorkieServiceHandler
+
+	detachStarted chan struct{}
+	allowDetach   chan struct{}
+}
+
+func (s *detachTestServer) DetachDocument(
+	ctx context.Context,
+	req *connect.Request[api.DetachDocumentRequest],
+) (*connect.Response[api.DetachDocumentResponse], error) {
+	close(s.detachStarted)
+	select {
+	case <-s.allowDetach:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	pack := req.Msg.ChangePack
+	return connect.NewResponse(&api.DetachDocumentResponse{
+		ChangePack: &api.ChangePack{
+			DocumentKey:   pack.DocumentKey,
+			Checkpoint:    pack.Checkpoint,
+			VersionVector: pack.VersionVector,
+		},
+	}), nil
+}
+
+func TestDetachClosesWatchAfterApplyingChangePack(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	server := &detachTestServer{
+		detachStarted: make(chan struct{}),
+		allowDetach:   make(chan struct{}),
+	}
+	mux := http.NewServeMux()
+	mux.Handle(v1connect.NewYorkieServiceHandler(server))
+	httpServer := httptest.NewServer(mux)
+	defer httpServer.Close()
+
+	cli, err := Dial(httpServer.URL)
+	require.NoError(t, err)
+	cli.status = statusActivated
+
+	doc := document.New(key.Key("detach-watch-order"))
+	doc.SetStatus(document.StatusAttached)
+
+	watchClosed := make(chan struct{})
+	cli.attachments.Set(doc.Key(), &Attachment{
+		resourceID: types.ID("000000000000000000000000"),
+		resource:   doc,
+		closeWatchStream: func() {
+			close(watchClosed)
+		},
+	})
+
+	detachDone := make(chan error, 1)
+	go func() {
+		detachDone <- cli.Detach(ctx, doc)
+	}()
+
+	select {
+	case <-server.detachStarted:
+	case <-ctx.Done():
+		t.Fatal("detach request did not reach the server")
+	}
+	select {
+	case <-watchClosed:
+		t.Fatal("watch stream closed before the final ChangePack was received")
+	default:
+	}
+
+	close(server.allowDetach)
+	select {
+	case err := <-detachDone:
+		require.NoError(t, err)
+	case <-ctx.Done():
+		t.Fatal("detach did not finish")
+	}
+
+	select {
+	case <-watchClosed:
+	default:
+		t.Fatal("watch stream remained open after detaching the document")
+	}
+}

--- a/test/integration/doc_presence_test.go
+++ b/test/integration/doc_presence_test.go
@@ -473,7 +473,7 @@ func TestDocPresence(t *testing.T) {
 				c2.ID().String(): {},
 			},
 		})
-		_, cancel2, err := c2.WatchStream(d2)
+		_, _, err = c2.WatchStream(d2)
 		assert.NoError(t, err)
 		wgEvents.Wait()
 		wgEvents.Add(1)
@@ -502,8 +502,6 @@ func TestDocPresence(t *testing.T) {
 				c2.ID().String(): d2.MyPresence(),
 			},
 		})
-		cancel2()
-
 		assert.NoError(t, c2.Detach(ctx, d2))
 		assert.NoError(t, c1.Sync(ctx, client.WithKey(helper.TestKey(t))))
 

--- a/test/integration/watch_pipeline_test.go
+++ b/test/integration/watch_pipeline_test.go
@@ -77,7 +77,7 @@ func TestWatchEventDeliveryPipeline(t *testing.T) {
 		for i := 0; i < 5; i++ {
 			d2 := document.New(d1.Key())
 			assert.NoError(t, c2.Attach(ctx, d2, client.WithRealtimeSync()))
-			_, cancel2, err := c2.WatchStream(d2)
+			_, _, err := c2.WatchStream(d2)
 			assert.NoError(t, err)
 
 			assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
@@ -86,7 +86,6 @@ func TestWatchEventDeliveryPipeline(t *testing.T) {
 			}))
 			assert.NoError(t, c2.Sync(ctx))
 
-			cancel2()
 			assert.NoError(t, c2.Detach(ctx, d2))
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

`Client.Detach` previously closed the watch stream before applying the final
`DetachDocument` ChangePack. The watch event pump is the sole consumer of
`Document.Events()`, so stopping it first could leave `ApplyChangePack` blocked
when the final pack emitted multiple presence events.

This PR keeps the watch pipeline alive until the detach response has been
applied, then closes it after a successful detach. It also updates integration
tests to let `Detach` own watch teardown and adds a deterministic regression
test for the lifecycle ordering.

**Which issue(s) this PR fixes**:

Fixes #1896

**Special notes for your reviewer**:

The failure was originally observed as a flaky integration-test timeout in
#1895. The new unit test pauses the detach response and verifies that the watch
is still open until the final ChangePack has been received and applied.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation**:

```docs

```

**Checklist**:

- [x] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document detachment to keep watch updates active while the final changes are applied.
  * Ensured the watch stream closes only after detachment completes, preventing missed updates or premature shutdown.

* **Tests**
  * Added coverage verifying watch-stream behavior during document detachment.
  * Updated integration tests to confirm detachment properly ends active watch streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->