### PR TITLE
Release v0.7.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and Yorkie adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## [v0.7.18] - 2026-08-31
+
+### Fixed
+
+- Anchor Array.Add on the last node's position identity by @lemon0333 in https://github.com/yorkie-team/yorkie/pull/1958
+- Recover style ranges collapsed by a merge at the from anchor by @Nahee-Park in https://github.com/yorkie-team/yorkie/pull/1954
+- Relink insertion chain when restore recreates a purged fragment by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1953
+- Harden yson.Unmarshal against panics on malformed payloads by @lemon0333 in https://github.com/yorkie-team/yorkie/pull/1945
+- Keep the watch event pump alive while detaching by @lshtar13 in https://github.com/yorkie-team/yorkie/pull/1959
+
 ## [v0.7.17] - 2026-08-18
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-YORKIE_VERSION := 0.7.17
+YORKIE_VERSION := 0.7.18
 
 GO_PROJECT = github.com/yorkie-team/yorkie
 

--- a/api/docs/yorkie.base.yaml
+++ b/api/docs/yorkie.base.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Yorkie
   description: "Yorkie is an open source document store for building collaborative editing applications."
-  version: v0.7.17
+  version: v0.7.18
 servers:
   - url: https://api.yorkie.dev
     description: Production server

--- a/api/docs/yorkie/v1/admin.openapi.yaml
+++ b/api/docs/yorkie/v1/admin.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.17
+  version: v0.7.18
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/api/docs/yorkie/v1/resources.openapi.yaml
+++ b/api/docs/yorkie/v1/resources.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.17
+  version: v0.7.18
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/api/docs/yorkie/v1/yorkie.openapi.yaml
+++ b/api/docs/yorkie/v1/yorkie.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.17
+  version: v0.7.18
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/build/charts/yorkie-cluster/Chart.yaml
+++ b/build/charts/yorkie-cluster/Chart.yaml
@@ -9,8 +9,8 @@ maintainers:
 
 sources:
   - https://github.com/yorkie-team/yorkie
-version: 0.7.17
-appVersion: "0.7.17"
+version: 0.7.18
+appVersion: "0.7.18"
 kubeVersion: ">=1.28.0-0"
 
 dependencies:


### PR DESCRIPTION
## Summary

Bump Yorkie to v0.7.18.

- `Makefile`: `YORKIE_VERSION := 0.7.18`
- `build/charts/yorkie-cluster/Chart.yaml`: version + appVersion → 0.7.18
- `api/docs/yorkie.base.yaml`, `admin`/`yorkie`/`resources` openapi docs → v0.7.18
- `CHANGELOG.md`: v0.7.18 section

`yorkie-analytics` (0.7.17) and `yorkie-monitoring` (0.7.7) charts and
`cluster.openapi.yaml` (v0.7.8) are on separate tracks and unchanged since v0.7.17.

### CHANGELOG (Fixed)

- Anchor Array.Add on the last node's position identity (#1958)
- Recover style ranges collapsed by a merge at the from anchor (#1954)
- Relink insertion chain when restore recreates a purged fragment (#1953)
- Harden `yson.Unmarshal` against panics on malformed payloads (#1945)
- Keep the watch event pump alive while detaching (#1959)

Test-only PRs (#1940, #1946, #1947) and the analytics warehouse DDL change
(#1951, `init-create-table.sql`) are excluded from the server CHANGELOG.

## Test plan

Version-bump + CHANGELOG only; no code change. CI validates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved array insertion anchoring and restoration behavior.
  * Preserved style ranges more reliably after merges.
  * Hardened parsing against malformed payloads to prevent crashes.
  * Kept watch event processing active during detachment.

* **Documentation**
  * Updated the changelog and API documentation for version 0.7.18.

* **Chores**
  * Updated release and deployment metadata to version 0.7.18.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->