### PR TITLE
Serve long-retention project-stats windows via decoupled HLL summaries

### DIFF
--- a/build/charts/yorkie-analytics/templates/starrocks/configmap.yaml
+++ b/build/charts/yorkie-analytics/templates/starrocks/configmap.yaml
@@ -123,6 +123,47 @@ data:
         FROM client_events
         GROUP BY project_id, event_type, DATE(timestamp);
 
+  init-create-summary.sql: |
+    USE yorkie;
+
+    -- Decoupled daily HLL summary tables that outlive the base event tables, so
+    -- long-retention dashboard windows survive raw-event TTL. Independent
+    -- AGGREGATE KEY tables (not base-bound rollups); filled by the summary
+    -- CronJob and read by the dual-read path in
+    -- server/backend/warehouse/starrocks.go. AGGREGATE KEY + HLL_UNION makes
+    -- inserts idempotent; partition_live_number retains ~15 months.
+    -- See docs/design/project-stats-long-retention.md.
+
+    CREATE TABLE IF NOT EXISTS sum_user_hll_daily (
+        project_id VARCHAR(64), dt DATE, user_hll HLL HLL_UNION
+    ) ENGINE = OLAP AGGREGATE KEY(project_id, dt)
+    PARTITION BY date_trunc('day', dt) DISTRIBUTED BY HASH(project_id)
+    PROPERTIES ("replication_num" = "1", "partition_live_number" = "465");
+
+    CREATE TABLE IF NOT EXISTS sum_document_hll_daily (
+        project_id VARCHAR(64), dt DATE, document_hll HLL HLL_UNION
+    ) ENGINE = OLAP AGGREGATE KEY(project_id, dt)
+    PARTITION BY date_trunc('day', dt) DISTRIBUTED BY HASH(project_id)
+    PROPERTIES ("replication_num" = "1", "partition_live_number" = "465");
+
+    CREATE TABLE IF NOT EXISTS sum_channel_hll_daily (
+        project_id VARCHAR(64), dt DATE, channel_hll HLL HLL_UNION
+    ) ENGINE = OLAP AGGREGATE KEY(project_id, dt)
+    PARTITION BY date_trunc('day', dt) DISTRIBUTED BY HASH(project_id)
+    PROPERTIES ("replication_num" = "1", "partition_live_number" = "465");
+
+    CREATE TABLE IF NOT EXISTS sum_session_hll_daily_ch (
+        project_id VARCHAR(64), dt DATE, channel_key VARCHAR(128), session_hll HLL HLL_UNION
+    ) ENGINE = OLAP AGGREGATE KEY(project_id, dt, channel_key)
+    PARTITION BY date_trunc('day', dt) DISTRIBUTED BY HASH(project_id)
+    PROPERTIES ("replication_num" = "1", "partition_live_number" = "465");
+
+    CREATE TABLE IF NOT EXISTS sum_client_hll_daily (
+        project_id VARCHAR(64), event_type VARCHAR(32), dt DATE, client_hll HLL HLL_UNION
+    ) ENGINE = OLAP AGGREGATE KEY(project_id, event_type, dt)
+    PARTITION BY date_trunc('day', dt) DISTRIBUTED BY HASH(project_id)
+    PROPERTIES ("replication_num" = "1", "partition_live_number" = "465");
+
   init-create-routine-load.sql: |
     CREATE ROUTINE LOAD yorkie.user_events ON user_events
     PROPERTIES
@@ -243,6 +284,13 @@ data:
       done
       [ $attempt -lt 60 ] && echo -e "$index is ready on $table"
     done
+
+    echo -e 'Creating decoupled daily HLL summary tables'
+    if mysql -h $STARROCKS_MYSQL_HOST -P 9030 -u root < /etc/config/init-create-summary.sql; then
+      echo -e 'Successfully created summary tables'
+    else
+      echo -e 'Summary tables may already exist, continuing...'
+    fi
 
     sleep 5s
     echo -e 'Creating routine load'

--- a/build/docker/analytics/docker-compose.yml
+++ b/build/docker/analytics/docker-compose.yml
@@ -107,6 +107,8 @@ services:
     volumes:
       - ./init-create-table.sql:/init-create-table.sql
       - ./init-create-mv.sql:/init-create-mv.sql
+      - ./init-create-summary.sql:/init-create-summary.sql
+      - ./init-backfill-summary.sql:/init-backfill-summary.sql
       - ./init-create-routine-load.sql:/init-create-routine-load.sql
       - ./init-starrocks-database.sh:/init-starrocks-database.sh
     entrypoint: ["/bin/bash"]

--- a/build/docker/analytics/init-backfill-summary.sql
+++ b/build/docker/analytics/init-backfill-summary.sql
@@ -9,27 +9,31 @@ USE yorkie;
 -- rather than all at once; each is a single base full scan. See
 -- docs/design/project-stats-long-retention.md and the MV migration playbook.
 
+-- HLL_HASH is per-row; grouping into the HLL_UNION column requires the
+-- HLL_UNION aggregate around it (a bare HLL_HASH under GROUP BY is rejected as
+-- "must be an aggregate expression"). This matches the mv_*_hll_daily DDL.
+
 INSERT INTO sum_user_hll_daily
-SELECT project_id, DATE(timestamp), HLL_HASH(user_id)
+SELECT project_id, DATE(timestamp), HLL_UNION(HLL_HASH(user_id))
 FROM user_events
 GROUP BY project_id, DATE(timestamp);
 
 INSERT INTO sum_document_hll_daily
-SELECT project_id, DATE(timestamp), HLL_HASH(document_key)
+SELECT project_id, DATE(timestamp), HLL_UNION(HLL_HASH(document_key))
 FROM document_events
 GROUP BY project_id, DATE(timestamp);
 
 INSERT INTO sum_channel_hll_daily
-SELECT project_id, DATE(timestamp), HLL_HASH(channel_key)
+SELECT project_id, DATE(timestamp), HLL_UNION(HLL_HASH(channel_key))
 FROM channel_events
 GROUP BY project_id, DATE(timestamp);
 
 INSERT INTO sum_session_hll_daily_ch
-SELECT project_id, DATE(timestamp), channel_key, HLL_HASH(session_id)
+SELECT project_id, DATE(timestamp), channel_key, HLL_UNION(HLL_HASH(session_id))
 FROM session_events
 GROUP BY project_id, DATE(timestamp), channel_key;
 
 INSERT INTO sum_client_hll_daily
-SELECT project_id, event_type, DATE(timestamp), HLL_HASH(client_id)
+SELECT project_id, event_type, DATE(timestamp), HLL_UNION(HLL_HASH(client_id))
 FROM client_events
 GROUP BY project_id, event_type, DATE(timestamp);

--- a/build/docker/analytics/init-backfill-summary.sql
+++ b/build/docker/analytics/init-backfill-summary.sql
@@ -1,0 +1,35 @@
+USE yorkie;
+
+-- One-time backfill of the decoupled daily HLL summaries from the full base
+-- history. Idempotent: AGGREGATE KEY + HLL_UNION merges re-inserted days, so
+-- this can be re-run safely. The scheduled daily job repeats the same SELECT
+-- for a trailing lookback window (see the devops repo's summary CronJob).
+--
+-- On large clusters run these per table in a low-ingest window (session last)
+-- rather than all at once; each is a single base full scan. See
+-- docs/design/project-stats-long-retention.md and the MV migration playbook.
+
+INSERT INTO sum_user_hll_daily
+SELECT project_id, DATE(timestamp), HLL_HASH(user_id)
+FROM user_events
+GROUP BY project_id, DATE(timestamp);
+
+INSERT INTO sum_document_hll_daily
+SELECT project_id, DATE(timestamp), HLL_HASH(document_key)
+FROM document_events
+GROUP BY project_id, DATE(timestamp);
+
+INSERT INTO sum_channel_hll_daily
+SELECT project_id, DATE(timestamp), HLL_HASH(channel_key)
+FROM channel_events
+GROUP BY project_id, DATE(timestamp);
+
+INSERT INTO sum_session_hll_daily_ch
+SELECT project_id, DATE(timestamp), channel_key, HLL_HASH(session_id)
+FROM session_events
+GROUP BY project_id, DATE(timestamp), channel_key;
+
+INSERT INTO sum_client_hll_daily
+SELECT project_id, event_type, DATE(timestamp), HLL_HASH(client_id)
+FROM client_events
+GROUP BY project_id, event_type, DATE(timestamp);

--- a/build/docker/analytics/init-create-summary.sql
+++ b/build/docker/analytics/init-create-summary.sql
@@ -1,0 +1,67 @@
+USE yorkie;
+
+-- Decoupled daily HLL summary tables. Unlike the synchronous materialized views
+-- in init-create-mv.sql (which are rollup indexes physically bound to the base
+-- event tables and share their lifetime), these are independent AGGREGATE KEY
+-- tables. They are filled by a scheduled idempotent job and survive base-table
+-- partition drops, so long-retention dashboard windows keep working after
+-- raw-event TTL is enabled. The dual-read path in
+-- server/backend/warehouse/starrocks.go reads them for [from, today) and the
+-- base rollups for today. See docs/design/project-stats-long-retention.md.
+--
+-- AGGREGATE KEY + HLL_UNION makes re-inserting a day idempotent (the sketch
+-- merges). partition_live_number retains ~15 months (12-month product window +
+-- buffer). Only the client table carries event_type and only the session table
+-- carries channel_key, mirroring init-create-mv.sql.
+
+CREATE TABLE IF NOT EXISTS sum_user_hll_daily (
+    project_id VARCHAR(64),
+    dt         DATE,
+    user_hll   HLL HLL_UNION
+) ENGINE = OLAP
+AGGREGATE KEY(project_id, dt)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(project_id)
+PROPERTIES ("replication_num" = "1", "partition_live_number" = "465");
+
+CREATE TABLE IF NOT EXISTS sum_document_hll_daily (
+    project_id   VARCHAR(64),
+    dt           DATE,
+    document_hll HLL HLL_UNION
+) ENGINE = OLAP
+AGGREGATE KEY(project_id, dt)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(project_id)
+PROPERTIES ("replication_num" = "1", "partition_live_number" = "465");
+
+CREATE TABLE IF NOT EXISTS sum_channel_hll_daily (
+    project_id  VARCHAR(64),
+    dt          DATE,
+    channel_hll HLL HLL_UNION
+) ENGINE = OLAP
+AGGREGATE KEY(project_id, dt)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(project_id)
+PROPERTIES ("replication_num" = "1", "partition_live_number" = "465");
+
+CREATE TABLE IF NOT EXISTS sum_session_hll_daily_ch (
+    project_id  VARCHAR(64),
+    dt          DATE,
+    channel_key VARCHAR(128),
+    session_hll HLL HLL_UNION
+) ENGINE = OLAP
+AGGREGATE KEY(project_id, dt, channel_key)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(project_id)
+PROPERTIES ("replication_num" = "1", "partition_live_number" = "465");
+
+CREATE TABLE IF NOT EXISTS sum_client_hll_daily (
+    project_id VARCHAR(64),
+    event_type VARCHAR(32),
+    dt         DATE,
+    client_hll HLL HLL_UNION
+) ENGINE = OLAP
+AGGREGATE KEY(project_id, event_type, dt)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(project_id)
+PROPERTIES ("replication_num" = "1", "partition_live_number" = "465");

--- a/build/docker/analytics/init-create-summary.sql
+++ b/build/docker/analytics/init-create-summary.sql
@@ -13,6 +13,11 @@ USE yorkie;
 -- merges). partition_live_number retains ~15 months (12-month product window +
 -- buffer). Only the client table carries event_type and only the session table
 -- carries channel_key, mirroring init-create-mv.sql.
+--
+-- This file is the source of truth for the summary DDL. The deployed clusters
+-- carry the same statements in the analytics chart's init ConfigMap
+-- (build/charts/yorkie-analytics/templates/starrocks/configmap.yaml); keep the
+-- two in sync when changing a column, key, or partition_live_number.
 
 CREATE TABLE IF NOT EXISTS sum_user_hll_daily (
     project_id VARCHAR(64),

--- a/build/docker/analytics/init-starrocks-database.sh
+++ b/build/docker/analytics/init-starrocks-database.sh
@@ -55,6 +55,22 @@ for mv in "${mvs[@]}"; do
   [ $attempt -lt 60 ] && echo -e "$index is ready on $table"
 done
 
+
+echo -e 'Creating decoupled daily HLL summary tables'
+if mysql -h starrocks-fe -P 9030 -u root < /init-create-summary.sql; then
+  echo -e 'Successfully created summary tables'
+else
+  echo -e 'Summary tables may already exist, continuing...'
+fi
+
+# Seed the summaries from whatever base history exists. Idempotent (AGGREGATE
+# KEY + HLL_UNION), so a re-run merges rather than duplicates. In production the
+# scheduled summary CronJob keeps these fresh; locally this one-shot backfill is
+# enough to exercise the dual-read path with SummaryEnabled.
+echo -e 'Backfilling summary tables from base history'
+mysql -h starrocks-fe -P 9030 -u root < /init-backfill-summary.sql \
+  || echo -e 'Could not run the summary backfill, continuing...'
+
 sleep 5s
 echo -e 'Creating routine load'
 if mysql -h starrocks-fe -P 9030 -u root < /init-create-routine-load.sql 2>/dev/null; then

--- a/build/docker/analytics/init-starrocks-database.sh
+++ b/build/docker/analytics/init-starrocks-database.sh
@@ -67,6 +67,11 @@ fi
 # KEY + HLL_UNION), so a re-run merges rather than duplicates. In production the
 # scheduled summary CronJob keeps these fresh; locally this one-shot backfill is
 # enough to exercise the dual-read path with SummaryEnabled.
+#
+# NOTE: on a fresh local stack the base tables are empty, so this backfill is a
+# no-op and dual-read history stays empty until events have been ingested. To
+# see historical points, ingest some events and re-run this backfill by hand
+# (mysql ... < init-backfill-summary.sql) — not a missing-data bug.
 echo -e 'Backfilling summary tables from base history'
 mysql -h starrocks-fe -P 9030 -u root < /init-backfill-summary.sql \
   || echo -e 'Could not run the summary backfill, continuing...'

--- a/cmd/yorkie/server.go
+++ b/cmd/yorkie/server.go
@@ -93,7 +93,8 @@ var (
 	kafkaSessionEventsTopic  string
 	kafkaWriteTimeout        time.Duration
 
-	starRocksDSN string
+	starRocksDSN            string
+	starRocksSummaryEnabled bool
 
 	conf = server.NewConfig()
 )
@@ -165,7 +166,8 @@ func newServerCmd() *cobra.Command {
 
 			if starRocksDSN != "" {
 				conf.StarRocks = &warehouse.Config{
-					DSN: starRocksDSN,
+					DSN:            starRocksDSN,
+					SummaryEnabled: starRocksSummaryEnabled,
 				}
 			}
 
@@ -586,6 +588,13 @@ func init() {
 		"starrocks-dsn",
 		"",
 		"StarRocks DSN for the analytics",
+	)
+	cmd.Flags().BoolVar(
+		&starRocksSummaryEnabled,
+		"starrocks-summary-enabled",
+		false,
+		"Serve project-stats history from the decoupled daily HLL summary tables "+
+			"(dual read). Enable only after the summary tables are backfilled and validated.",
 	)
 	cmd.Flags().DurationVar(
 		&channelSessionTTL,

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -52,6 +52,7 @@ New design documents should be based on [TEMPLATE.md](TEMPLATE.md).
 - [Allowed Origins Wildcard](allowed-origins-wildcard.md): Wildcard pattern matching for project `AllowedOrigins` CORS check
 - [Project Stats Cache](project-stats-cache.md): Asynchronously refreshed cache for `ClientsCount` and `DocumentsCount` to keep `GetProjectStats` fast at large scale
 - [Project Stats Warehouse Materialized Views](project-stats-warehouse-mv.md): Daily HLL rollups that make the warehouse-backed `GetProjectStats` metrics independent of event volume
+- [Project Stats Long-Retention Windows](project-stats-long-retention.md): Decoupled daily HLL summary tables and a dual read that serve up-to-12-month windows after raw-event TTL is enabled
 - [Per-Project Channel Session TTL](per-project-channel-session-ttl.md): Per-project override for `ChannelSessionTTL` to tune the presence-count "feels occupied" effect
 
 ## Maintaining the Document

--- a/docs/design/project-stats-long-retention.md
+++ b/docs/design/project-stats-long-retention.md
@@ -61,6 +61,15 @@ StarRocks 3.3.9:
   `partition_ttl_number`; drop an old base partition; `REFRESH ... WITH SYNC
   MODE`; the MV loses that partition.
 
+The TTL knobs also point the wrong way. `partition_ttl` / `partition_ttl_number`
+retain only the *most recent* N partitions, and StarRocks documents that outdated
+MV partitions "will not be involved in the query plan, and the query will be
+executed on the base tables to guarantee the consistency of data"
+([partitioned MV docs][smv]). That is the opposite of what long retention needs —
+the MV holding *fewer* days than the base and deferring the rest to a base that,
+once purged, has nothing left to give back. An async MV is structurally a
+hot-data optimization, not a long-retention store.
+
 So the summary cannot be anything StarRocks maintains as a dependent of the base
 table. It has to be a plain table the base cannot reach.
 
@@ -94,6 +103,11 @@ PROPERTIES (
 `sum_session_hll_daily_ch` adds `channel_key` to the key, so it serves both the
 sessions metric and peak sessions per channel. `sum_client_hll_daily` adds
 `event_type`, matching the MV that carries it.
+
+This is the pattern StarRocks recommends directly: for HLL distinct counts, "when
+the data volume is large, it is better to create a corresponding rollup table for
+high frequency HLL queries" ([HLL docs][hll]). The summary table is that rollup,
+kept independent so it can also outlive the base.
 
 Two properties do the work:
 
@@ -266,6 +280,7 @@ retention, and by then the summary has been serving and validated.
 | Backfill full-scans the billion-row tables | Staged per table, `session_events` in a low-ingest window; cost is the one-time base scan (~80ns/row), as measured for the MV builds. |
 | Enabling raw TTL before the summary is trusted would lose history irrecoverably | TTL is step 6, gated on steps 1–5; validation in step 3 runs while both paths overlap. |
 | Expression partitioning, `partition_live_number`, and the HLL functions need a recent StarRocks | Verify the engine clears the version floor per environment before creating the tables (deployed clusters run 3.3.x). |
+| Raw-TTL enforcement may not drop partitions as expected on 3.3.x | `partition_live_number` has had drop bugs ([#39341][p39341]); the cleaner `partition_retention_condition` (Common Partition Expression TTL) is native-table-only from v3.5, past the deployed 3.3.x. Use dynamic partitioning / `partition_live_number` and confirm old partitions actually drop before relying on TTL for the storage saving. |
 
 ## Design Decisions
 
@@ -283,7 +298,8 @@ retention, and by then the summary has been serving and validated.
 
 | Alternative | Why not |
 |-------------|---------|
-| Asynchronous MV with its own TTL | Retention does not decouple — a dropped base partition drops the MV partition on the next refresh (measured on 3.3.9). |
+| Asynchronous MV with its own TTL | Retention does not decouple — a dropped base partition drops the MV partition on the next refresh (measured on 3.3.9), and its `partition_ttl` retains the *most recent* N partitions while routing older queries back to the base, the opposite of long retention. |
+| Archive raw events to an external store (S3/Parquet + a lakehouse table), as Grab does for Spark observability | Works for raw retention but adds an external store and a cross-system read on the historical path. The HLL summary is orders of magnitude smaller than raw, so long retention fits inside StarRocks with no external tier and no join across systems. |
 | Retain raw events for 12 months, no summary | Storage on a billion-row table for a full year is the cost this design exists to avoid. |
 | Summary table but keep automatic rewrite from `APPROX_COUNT_DISTINCT` | Rewrite targets the base's own rollup, which dies with the base. Serving a separate-lifetime table requires naming it and unioning by hand. |
 | StarRocks native `SUBMIT TASK ... SCHEDULE` for ingest | Runs inside the cluster with no run history or alerting; a silent failure stops the summary without a signal. |
@@ -294,3 +310,19 @@ retention, and by then the summary has been serving and validated.
 ## Tasks
 
 Track execution plans in `docs/tasks/active/` as separate task documents.
+
+## References
+
+- [Use HLL for approximate count distinct][hll] — the `HLL_UNION` column,
+  `HLL_HASH` on insert, `HLL_UNION_AGG` on read, and the rollup-table
+  recommendation this design follows.
+- [Create a partitioned materialized view][smv] — async MV `partition_ttl`
+  semantics and base-table fallback for outdated partitions.
+- [Building a Spark observability product with StarRocks][grab] — a production
+  short-hot-retention + external long-history precedent, contrasted above.
+- StarRocks [#39341][p39341] — `partition_live_number` drop bug.
+
+[hll]: https://docs.starrocks.io/docs/using_starrocks/distinct_values/Using_HLL/
+[smv]: https://docs.starrocks.io/docs/using_starrocks/async_mv/use_cases/create_partitioned_materialized_view/
+[grab]: https://engineering.grab.com/building-a-spark-observability
+[p39341]: https://github.com/StarRocks/starrocks/issues/39341

--- a/docs/design/project-stats-long-retention.md
+++ b/docs/design/project-stats-long-retention.md
@@ -200,10 +200,18 @@ boundary would over-count; this design never does.
 `sum_session_hll_daily_ch` for the history and from the base for today, then take
 the daily `MAX` (series) or the window `MAX` (total).
 
-**Fallback.** If the summary table is absent, every read falls back to the base
-scan the MV design already defines — correct, slower, lossless — so a cluster
-that has not created the summaries keeps working. This mirrors the MV design's
-fallback philosophy.
+**Fallback.** The fallback is the `SummaryEnabled` flag, which gates the whole
+dual read and defaults off. A cluster that has not created the summaries leaves
+it off and runs the base-scan path unchanged — byte-identical to today. The flag
+is turned on per environment only after the summary tables exist and are
+validated (see Deployment sequencing), so the base path is always the safe
+default. Unlike the MV design's rewrite — which falls back to a base scan
+per query automatically — this dual read names the summary table directly, so a
+misconfiguration (flag on, table missing) surfaces as a loud read error rather
+than a silent slow path; that is deliberate, since the flag is only ever enabled
+behind the validation gate. An automatic per-query fallback (catch a
+missing-table error, retry the retained base query) is a reserved hardening if a
+cluster ever needs the flag on before every summary exists.
 
 This is the one place the design reverses a decision from
 [project-stats-warehouse-mv](project-stats-warehouse-mv.md): that design kept the
@@ -260,7 +268,8 @@ fallback. Per environment:
    here is the proof the union math is right, because the two paths overlap
    completely before TTL.
 4. Enable the daily ingest CronJob; observe a few days of runs.
-5. Deploy the server with the dual-read path (summary-absent → base fallback).
+5. Deploy the server and turn on `SummaryEnabled` (the flag defaults off, so the
+   deploy itself changes nothing until it is flipped, and only after step 3/4).
 6. Only now recreate the base tables partitioned and enable the 90-day TTL,
    per-table, TTL last.
 

--- a/docs/design/project-stats-long-retention.md
+++ b/docs/design/project-stats-long-retention.md
@@ -204,14 +204,24 @@ the daily `MAX` (series) or the window `MAX` (total).
 dual read and defaults off. A cluster that has not created the summaries leaves
 it off and runs the base-scan path unchanged — byte-identical to today. The flag
 is turned on per environment only after the summary tables exist and are
-validated (see Deployment sequencing), so the base path is always the safe
-default. Unlike the MV design's rewrite — which falls back to a base scan
-per query automatically — this dual read names the summary table directly, so a
-misconfiguration (flag on, table missing) surfaces as a loud read error rather
-than a silent slow path; that is deliberate, since the flag is only ever enabled
-behind the validation gate. An automatic per-query fallback (catch a
-missing-table error, retry the retained base query) is a reserved hardening if a
-cluster ever needs the flag on before every summary exists.
+validated (see Deployment sequencing). Unlike the MV design's rewrite — which
+falls back to a base scan per query automatically — this dual read names the
+summary table directly, so a misconfiguration (flag on, table missing) surfaces
+as a loud read error rather than a silent slow path; that is deliberate, since
+the flag is only ever enabled behind the validation gate. An automatic per-query
+fallback (catch a missing-table error, retry the retained base query) is a
+reserved hardening if a cluster ever needs the flag on before every summary
+exists.
+
+**The flag-off path is only a lossless default before raw TTL.** It is
+byte-identical and complete only while the base still holds the full history —
+i.e. before step 6 enables the 90-day TTL. Once the base is trimmed to 90 days,
+turning `SummaryEnabled` off no longer reproduces the long windows: a 3-/12-month
+read then silently returns the last 90 days without erroring. So disabling the
+flag is a valid rollback only up to the TTL step; after it, rollback means
+repairing or backfilling the summaries (or temporarily restoring raw retention),
+not just flipping the flag. This is the other reason TTL is sequenced last and
+gated on the summary being trusted.
 
 This is the one place the design reverses a decision from
 [project-stats-warehouse-mv](project-stats-warehouse-mv.md): that design kept the

--- a/docs/design/project-stats-long-retention.md
+++ b/docs/design/project-stats-long-retention.md
@@ -1,0 +1,296 @@
+---
+title: project-stats-long-retention
+target-version: 0.7.18
+---
+
+# Project Stats Long-Retention Windows
+
+## Problem
+
+[Project Stats Warehouse MV](project-stats-warehouse-mv.md) put the six
+warehouse-backed metrics — active users, documents, clients, channels, sessions,
+and peak sessions per channel — on synchronous HLL materialized views
+(`mv_*_hll_daily`). A synchronous view is a rollup index physically part of its
+base table: it shares the base partitions and the base lifetime. StarRocks
+rewrites the `DATE(timestamp)` queries onto it at read time, so nothing in Go
+reads the view directly.
+
+That design left event retention as an explicit Non-Goal, and its Risks section
+flagged what happens when retention arrives. The event tables carry no
+`PARTITION BY` and no TTL today, so nothing is purged and every metric window is
+served from the full history. The dashboard renders windows up to 12 months.
+
+Retaining raw events for 12 months is expensive — the largest event table is
+already past a billion rows — while the daily HLL summary is orders of magnitude
+smaller (a billion `session_events` rows roll up to a few million daily sketch
+rows, most tables to a few thousand). The moment event retention is added
+(partition the base tables by day, drop old partitions), a synchronous rollup
+loses those days with its base, and any window longer than the base retention —
+the 3- and 12-month views — breaks.
+
+**The daily summary has to outlive the base table.**
+
+### Goals
+
+- Serve windows up to 12 months after raw-event TTL is enabled, with latency
+  driven by the number of days in the window, not the number of events.
+- Keep the numbers identical to what the MV path returns today.
+- Bound raw-event storage to a short retention while retaining daily summaries
+  for the full product window.
+
+### Non-Goals
+
+- Exact distinct counts. HLL error (~0.2–1.7%) was accepted in v0.7.15.
+- Changing the metric set, the API, or the `MetricPoint` shape.
+- Per-project or viewer-chosen local-day boundaries. Days stay UTC, as in the
+  MV design; the reserved ingest-time-local-date path there still applies.
+
+## What doesn't work: an asynchronous MV
+
+The obvious idea is a StarRocks asynchronous materialized view — a separate table
+with its own partitioning and TTL and automatic query rewrite. Tested on
+StarRocks 3.3.9:
+
+- Auto query-rewrite works well, even rewriting raw-timestamp predicates onto
+  the MV.
+- Retention does **not** decouple. A partitioned async MV tracks its base
+  partitions: when a base partition is dropped, the next refresh (manual `SYNC`
+  or triggered by ingest) drops the corresponding MV partition too. The async MV
+  cannot keep a day whose base partition was purged.
+- Minimal repro: partitioned base + partitioned async MV with
+  `partition_ttl_number`; drop an old base partition; `REFRESH ... WITH SYNC
+  MODE`; the MV loses that partition.
+
+So the summary cannot be anything StarRocks maintains as a dependent of the base
+table. It has to be a plain table the base cannot reach.
+
+## Design: decoupled daily summary + dual read
+
+Keep the synchronous MVs for the fresh path. Add an independent per-metric
+summary table with its own long TTL, fill it with a scheduled idempotent job,
+and split every read at *today*: history from the summary, today from the MV.
+
+### Summary tables
+
+One `AGGREGATE KEY` table per event table, mirroring the five MVs, each holding a
+day-grained `HLL_UNION` sketch:
+
+```sql
+CREATE TABLE sum_user_hll_daily (
+    project_id VARCHAR(64),
+    dt         DATE,
+    user_hll   HLL HLL_UNION
+) ENGINE = OLAP
+AGGREGATE KEY(project_id, dt)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(project_id)
+PROPERTIES (
+    "replication_num"       = "1",
+    "partition_live_number" = "465"   -- ~15 months
+);
+```
+
+`sum_document_hll_daily` and `sum_channel_hll_daily` follow the same shape.
+`sum_session_hll_daily_ch` adds `channel_key` to the key, so it serves both the
+sessions metric and peak sessions per channel. `sum_client_hll_daily` adds
+`event_type`, matching the MV that carries it.
+
+Two properties do the work:
+
+- **A plain table, not a base-tracking view.** Nothing links it to the base
+  partitions, so a base partition drop cannot touch it. This is the whole point
+  the async MV could not deliver.
+- **`AGGREGATE KEY` + `HLL_UNION` makes inserts idempotent.** Re-inserting a day
+  merges its sketch into the existing one instead of duplicating it, so the
+  ingest job can reprocess a day safely.
+
+Retention is 15 months — the 12-month product window plus a buffer — via
+`partition_live_number` on the daily partitions.
+
+### Daily ingest job
+
+A scheduled, idempotent insert per metric, reprocessing a 7-day lookback so late
+ingestion and retries are covered:
+
+```sql
+INSERT INTO sum_user_hll_daily
+SELECT project_id, DATE(timestamp) AS dt, HLL_HASH(user_id)
+FROM user_events
+WHERE DATE(timestamp) >= <today-7> AND DATE(timestamp) < <today>
+GROUP BY project_id, DATE(timestamp);
+```
+
+`HLL_UNION` on the target column merges the re-inserted days; the 7-day window is
+safe to repeat every run. A one-time backfill over the full base history seeds
+the table before the job takes over.
+
+The job runs as a **Kubernetes CronJob** — a `starrocks/fe-ubuntu` container
+running the idempotent SQL through the MySQL client, the same image and access
+path the MV migration Jobs already use — not a StarRocks native `SUBMIT TASK`.
+The reasons: retries, run history, alerting, and deployment ownership are native
+to a CronJob and to the existing analytics ops tooling, whereas a native task
+fails silently inside the cluster. The manifests live beside the MV migration in
+the analytics deployment (`build/charts/yorkie-analytics/.../starrocks/`), with
+`concurrencyPolicy: Forbid` and history limits.
+
+### Read path (dual read)
+
+Split the requested window at **today** (UTC). The summary and the base never
+overlap by day — summary serves `[from, today)`, the MV serves
+`[today, tomorrow)` — so their union is exact with no double counting.
+
+**Series** metrics (`GetActiveUsers`, …) are per-day and independent, so no
+cross-day work is needed. Read the historical days from the summary and today
+from the base, then concatenate:
+
+```sql
+-- history, from the summary
+SELECT dt, HLL_CARDINALITY(HLL_UNION_AGG(user_hll)) AS v
+FROM sum_user_hll_daily
+WHERE project_id = '%s' AND dt >= '%s' AND dt < '%s'   -- [from, today)
+GROUP BY dt ORDER BY dt;
+-- today, from the base (existing MV rewrite path, unchanged)
+```
+
+**Totals** (`GetActiveUsersCount`, …) are a distinct over the whole window, so
+the fresh day and the history must be **unioned, never summed** — a subject
+active in both halves must count once. The union happens in the engine, over a
+`UNION ALL` of the summary sketches and today's base rows, with cardinality taken
+exactly once:
+
+```sql
+SELECT HLL_CARDINALITY(HLL_UNION_AGG(sketch)) FROM (
+    SELECT user_hll AS sketch FROM sum_user_hll_daily
+     WHERE project_id = '%s' AND dt >= '%s' AND dt < '%s'          -- [from, today)
+    UNION ALL
+    SELECT HLL_HASH(user_id) AS sketch FROM user_events
+     WHERE project_id = '%s'
+       AND timestamp >= '%s' AND timestamp < '%s'                  -- [today, tomorrow), raw bounds prune partitions
+       AND DATE(timestamp) >= '%s' AND DATE(timestamp) < '%s'      -- and DATE() keeps the fresh day exact
+) t;
+```
+
+`HLL_UNION_AGG` accepts both a stored `HLL` column and the per-row `HLL_HASH(...)`
+output, so the two halves compose losslessly. Adding two cardinalities across the
+boundary would over-count; this design never does.
+
+**Peak sessions** needs no boundary union: it is `MAX` over independent
+`(day, channel)` distinct counts. Read per-`(dt, channel)` cardinality from
+`sum_session_hll_daily_ch` for the history and from the base for today, then take
+the daily `MAX` (series) or the window `MAX` (total).
+
+**Fallback.** If the summary table is absent, every read falls back to the base
+scan the MV design already defines — correct, slower, lossless — so a cluster
+that has not created the summaries keeps working. This mirrors the MV design's
+fallback philosophy.
+
+This is the one place the design reverses a decision from
+[project-stats-warehouse-mv](project-stats-warehouse-mv.md): that design kept the
+warehouse schema out of the Go server and let the rewrite union the sketches.
+Automatic rewrite cannot span two tables with different lifetimes, so the
+long-retention read has to name the summary table and write the `HLL_UNION_AGG`
+by hand. The fallback is what keeps that from hard-coding the schema into every
+cluster.
+
+### Base partitioning and TTL
+
+The read path and summary are correct with the base tables exactly as they are
+today; partitioning and TTL are what make the summary *necessary* and what
+realise the storage saving. They come last.
+
+The event tables are `DUPLICATE KEY / DISTRIBUTED BY RANDOM BUCKETS 16 /
+replication_num = 1`, with no `PARTITION BY`. StarRocks cannot add partitioning
+to an existing table with `ALTER`, so each table is recreated with expression
+partitioning and reloaded:
+
+```sql
+CREATE TABLE user_events_p ( ... same columns ... ) ENGINE = OLAP
+DUPLICATE KEY(project_id, user_id, timestamp)
+PARTITION BY date_trunc('day', timestamp)
+DISTRIBUTED BY RANDOM BUCKETS 16
+PROPERTIES ("replication_num" = "1", "partition_live_number" = "90");  -- 90-day raw TTL
+```
+
+The routine load binds to the base table by name, so the swap follows the
+`session_events` redistribution playbook: `PAUSE ROUTINE LOAD`, `INSERT INTO
+..._p SELECT`, `ALTER TABLE ... RENAME` to swap, `RESUME ROUTINE LOAD`. On the
+billion-row tables this is done in a low-ingest window with replica status
+watched — `replication_num = 1` has a tablet-quorum-stall history. TTL is
+enabled last, only after the summary is backfilled and validated.
+
+**Partition pruning under `DATE()`.** The MV design warned that wrapping
+`timestamp` in `DATE()` can lose partition pruning once the base is partitioned.
+The fresh-day total query above therefore carries **both** predicates: raw
+`timestamp` bounds so the partitioned base prunes to a single day, and
+`DATE(timestamp)` bounds so the fresh half stays exact and the MV rewrite still
+matches. `EXPLAIN` must confirm the fresh query prunes to one partition on the
+deployed StarRocks version.
+
+### Deployment sequencing
+
+Each step is lossless and reversible; the base scan is always a correct
+fallback. Per environment:
+
+1. Create the summary tables (empty, partitioned, 15-month TTL).
+2. Backfill from the base — staged per table, `session_events` last and in a
+   low-ingest window, as with the MV builds. Idempotent.
+3. **Validate**: while the base still holds full history, the dual-read result
+   must equal the MV-only result for a set of projects and windows. Equality
+   here is the proof the union math is right, because the two paths overlap
+   completely before TTL.
+4. Enable the daily ingest CronJob; observe a few days of runs.
+5. Deploy the server with the dual-read path (summary-absent → base fallback).
+6. Only now recreate the base tables partitioned and enable the 90-day TTL,
+   per-table, TTL last.
+
+Steps 1–5 change nothing a user sees; step 6 is the one that shortens raw
+retention, and by then the summary has been serving and validated.
+
+### Verification
+
+- Dual-read total equals the MV-only total for windows inside current retention
+  (step 3).
+- `ScanRows` in the FE audit log stays small for the six metrics.
+- After TTL: a 12-month window still returns a full series, and its values match
+  the summary rather than collapsing to the 90-day base.
+
+## Risks and Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| Adding cardinalities across the today boundary over-counts a subject active in both halves | Union sketches with `HLL_UNION_AGG`, take cardinality once. Summary `[from, today)` and base `[today, tomorrow)` split on the day, so there is no overlap to double count. |
+| `DATE(timestamp)` loses partition pruning once the base is partitioned, so the fresh-day scan reads every partition | Carry raw `timestamp` bounds alongside `DATE(timestamp)` on the fresh half; confirm single-partition pruning with `EXPLAIN` on the deployed version. |
+| Repartitioning a live billion-row table (session) risks stalled ingest and quorum loss under `replication_num = 1` | New table + `INSERT SELECT` + rename swap under `PAUSE`/`RESUME ROUTINE LOAD`, in a low-ingest window, watching `ADMIN SHOW REPLICA STATUS`. Same playbook as the `session_events` redistribution. |
+| The ingest job misses a day or late events land after it runs | 7-day lookback reprocess every run; `HLL_UNION` makes repeats idempotent. CronJob history and alerting surface a failed run. |
+| Summary drifts from the base over time | Periodic reconciliation comparing an overlap day's summary against a base recount; the 7-day lookback self-heals recent drift. |
+| Backfill full-scans the billion-row tables | Staged per table, `session_events` in a low-ingest window; cost is the one-time base scan (~80ns/row), as measured for the MV builds. |
+| Enabling raw TTL before the summary is trusted would lose history irrecoverably | TTL is step 6, gated on steps 1–5; validation in step 3 runs while both paths overlap. |
+| Expression partitioning, `partition_live_number`, and the HLL functions need a recent StarRocks | Verify the engine clears the version floor per environment before creating the tables (deployed clusters run 3.3.x). |
+
+## Design Decisions
+
+| Decision | Reason |
+|----------|--------|
+| An independent aggregate-key table, not an async MV | Only a table with no link to the base survives base partition drops; the async MV provably re-tracks and drops the same partition. |
+| Kubernetes CronJob, not StarRocks `SUBMIT TASK` | Retries, run history, alerting, and ownership are native to the CronJob and the existing analytics ops tooling; a native task fails silently. |
+| Hand-written `HLL_UNION_AGG` in the Go read path | Reverses the MV design's "no schema in the server", but automatic rewrite cannot union two tables with different lifetimes. The base-scan fallback keeps clusters without the summary correct. |
+| 90-day raw retention, 15-month summary | 90 days keeps the quarter view answerable from the base fallback; 15 months is the 12-month product window plus buffer. |
+| Split at today; union across the boundary | The fresh day stays exact from the base, history comes from the summary, and the union avoids the double count a sum would introduce. |
+| 7-day ingest lookback | Covers late ingestion and retries without a reconciliation job; `HLL_UNION` makes the repeat free of side effects. |
+| UTC day buckets | Unchanged from the MV design; a local-day boundary is still the reserved ingest-time-date path there. |
+
+## Alternatives Considered
+
+| Alternative | Why not |
+|-------------|---------|
+| Asynchronous MV with its own TTL | Retention does not decouple — a dropped base partition drops the MV partition on the next refresh (measured on 3.3.9). |
+| Retain raw events for 12 months, no summary | Storage on a billion-row table for a full year is the cost this design exists to avoid. |
+| Summary table but keep automatic rewrite from `APPROX_COUNT_DISTINCT` | Rewrite targets the base's own rollup, which dies with the base. Serving a separate-lifetime table requires naming it and unioning by hand. |
+| StarRocks native `SUBMIT TASK ... SCHEDULE` for ingest | Runs inside the cluster with no run history or alerting; a silent failure stops the summary without a signal. |
+| Union the sketches in Go instead of SQL | HLL sketches cannot be merged outside the engine; the union must be a `HLL_UNION_AGG` in the query. |
+| Cache the 12-month totals in MongoDB, as `stats_clients_count` does | A second staleness budget for a value that is not a small scalar and that the summary already produces cheaply. |
+| Longer raw retention instead of a summary | Directly defeats the storage goal; the summary is what lets raw retention be short. |
+
+## Tasks
+
+Track execution plans in `docs/tasks/active/` as separate task documents.

--- a/docs/design/project-stats-long-retention.md
+++ b/docs/design/project-stats-long-retention.md
@@ -128,15 +128,17 @@ ingestion and retries are covered:
 
 ```sql
 INSERT INTO sum_user_hll_daily
-SELECT project_id, DATE(timestamp) AS dt, HLL_HASH(user_id)
+SELECT project_id, DATE(timestamp) AS dt, HLL_UNION(HLL_HASH(user_id))
 FROM user_events
 WHERE DATE(timestamp) >= <today-7> AND DATE(timestamp) < <today>
 GROUP BY project_id, DATE(timestamp);
 ```
 
-`HLL_UNION` on the target column merges the re-inserted days; the 7-day window is
-safe to repeat every run. A one-time backfill over the full base history seeds
-the table before the job takes over.
+The `GROUP BY` needs `HLL_UNION` around `HLL_HASH` — a bare `HLL_HASH` under a
+`GROUP BY` is rejected as "must be an aggregate expression", the same shape the
+`mv_*_hll_daily` DDL uses. `HLL_UNION` on the target column then merges the
+re-inserted days, so the 7-day window is safe to repeat every run. A one-time
+backfill over the full base history seeds the table before the job takes over.
 
 The job runs as a **Kubernetes CronJob** — a `starrocks/fe-ubuntu` container
 running the idempotent SQL through the MySQL client, the same image and access
@@ -159,12 +161,17 @@ from the base, then concatenate:
 
 ```sql
 -- history, from the summary
-SELECT dt, HLL_CARDINALITY(HLL_UNION_AGG(user_hll)) AS v
+SELECT dt, HLL_UNION_AGG(user_hll) AS v
 FROM sum_user_hll_daily
 WHERE project_id = '%s' AND dt >= '%s' AND dt < '%s'   -- [from, today)
 GROUP BY dt ORDER BY dt;
 -- today, from the base (existing MV rewrite path, unchanged)
 ```
+
+`HLL_UNION_AGG` already returns the merged cardinality (a bigint), so it is not
+wrapped in `HLL_CARDINALITY` — doing so reads the count back as an HLL and yields
+zero. Use `HLL_UNION_AGG(col)` to count, or `HLL_RAW_AGG(col)` / `HLL_UNION(col)`
+when a merged sketch is needed.
 
 **Totals** (`GetActiveUsersCount`, …) are a distinct over the whole window, so
 the fresh day and the history must be **unioned, never summed** — a subject
@@ -173,7 +180,7 @@ active in both halves must count once. The union happens in the engine, over a
 exactly once:
 
 ```sql
-SELECT HLL_CARDINALITY(HLL_UNION_AGG(sketch)) FROM (
+SELECT HLL_UNION_AGG(sketch) FROM (
     SELECT user_hll AS sketch FROM sum_user_hll_daily
      WHERE project_id = '%s' AND dt >= '%s' AND dt < '%s'          -- [from, today)
     UNION ALL

--- a/docs/tasks/active/20260831-project-stats-long-retention-lessons.md
+++ b/docs/tasks/active/20260831-project-stats-long-retention-lessons.md
@@ -25,6 +25,34 @@ Fixed from the review:
 - Documented that the local backfill is a no-op on an empty stack, and marked
   `init-create-summary.sql` as the source of truth mirrored to the chart.
 
+## Local StarRocks rehearsal caught two HLL bugs the tests could not
+
+Golden-string tests and a code reviewer both passed the query SQL, because
+neither can execute StarRocks. A throwaway rehearsal — `allin1-ubuntu:3.3.9`
+container, five synthetic days with a subject active in both the past and today,
+backfill, then dual-read vs. base-only for all six metrics — found two real bugs:
+
+1. **`HLL_UNION_AGG` already returns the cardinality (a bigint).** The builders
+   wrapped it as `HLL_CARDINALITY(HLL_UNION_AGG(sketch))`, i.e.
+   `HLL_CARDINALITY(bigint)`, which reads back as **0**. Every summary-served day
+   returned 0 while the base-served "today" was correct — a silent
+   half-wrong result, not an error. Fix: `HLL_UNION_AGG(col)` to count;
+   `HLL_RAW_AGG(col)` / `HLL_UNION(col)` when a merged sketch is needed. The
+   tell was `HLL_SERIALIZE(HLL_UNION_AGG(...))` erroring with
+   "signature: hll_serialize(bigint)".
+2. **Grouped ingest needs `HLL_UNION(HLL_HASH(col))`, not bare `HLL_HASH(col)`.**
+   `INSERT INTO sum_* SELECT ..., HLL_HASH(col) ... GROUP BY` is rejected with
+   "must be an aggregate expression or appear in GROUP BY". The MV DDL already
+   used the `HLL_UNION(HLL_HASH(...))` form; the backfill/refresh SQL had dropped
+   the `HLL_UNION`.
+
+After both fixes, dual-read equalled base-only for every metric (users 3,
+documents 3, channels 2, clients 2, sessions 5, peak 2), and the union-once
+property held: a user and a session active on both a past day and today counted
+once in the totals (3/5, not 4/6). Lesson: a warehouse query with no cluster in
+CI must be rehearsed against a real engine with representative data before it is
+trusted — string assertions prove shape, not semantics.
+
 ## Known limitation: today boundary is per-call
 
 `todayUTC()` reads `time.Now()` inside each of the 12 metric methods, so a

--- a/docs/tasks/active/20260831-project-stats-long-retention-lessons.md
+++ b/docs/tasks/active/20260831-project-stats-long-retention-lessons.md
@@ -1,0 +1,9 @@
+**Created**: 2026-08-31
+
+# Project Stats Long-Retention Windows — Lessons
+
+Captured during implementation and cluster rehearsal. See the plan in
+`20260831-project-stats-long-retention-todo.md` and the design in
+`docs/design/project-stats-long-retention.md`.
+
+(To be filled in as tasks complete.)

--- a/docs/tasks/active/20260831-project-stats-long-retention-lessons.md
+++ b/docs/tasks/active/20260831-project-stats-long-retention-lessons.md
@@ -53,12 +53,25 @@ once in the totals (3/5, not 4/6). Lesson: a warehouse query with no cluster in
 CI must be rehearsed against a real engine with representative data before it is
 trusted — string assertions prove shape, not semantics.
 
-## Known limitation: today boundary is per-call
+## Known limitation: today boundary is per-call, and refresh can lag it
 
 `todayUTC()` reads `time.Now()` inside each of the 12 metric methods, so a
 dashboard render that crosses midnight UTC mid-render can split two metrics at
-different `today` boundaries. Blast radius is one day of one metric served from
-base vs. summary — self-healing and within HLL error, and the design already
-treats the boundary as fuzzy. Threading a single per-request `today` through the
-`Warehouse` interface was judged not worth the interface churn. Revisit if
-strict intra-render consistency is ever required.
+different `today` boundaries — one day of one metric served from base vs. summary.
+
+The sharper case is **refresh lag at the boundary**, not just intra-render skew.
+The instant the UTC day rolls to D+1, every read now expects the just-closed day
+D to come from the summary (`[from, today)` includes D) — but the daily refresh
+runs later (01:30 UTC) and only then does its 7-day lookback populate D. Between
+00:00 and that run, D is read from a summary that has no D row yet, so that day
+reads **zero/undercount** — and a missing day is not covered by HLL error; it is
+recovered only when the refresh lands. It self-heals within that window and the
+lookback keeps re-filling, but it is a real freshness gap.
+
+Mitigations, in increasing cost: document it and add a freshness monitor on the
+newest summary partition (chosen for now); or split at `today - 1` so the
+just-closed day is always served fresh from the base until the summary is known
+to hold it (one extra partition-pruned day of base scan, no interface change);
+or capture one `today` per request and thread it through the `Warehouse`
+interface (removes the intra-render skew too, at the cost of interface churn).
+Revisit if the boundary undercount becomes visible in the dashboard.

--- a/docs/tasks/active/20260831-project-stats-long-retention-lessons.md
+++ b/docs/tasks/active/20260831-project-stats-long-retention-lessons.md
@@ -53,6 +53,20 @@ once in the totals (3/5, not 4/6). Lesson: a warehouse query with no cluster in
 CI must be rehearsed against a real engine with representative data before it is
 trusted — string assertions prove shape, not semantics.
 
+A second pass closed the remaining gap: the SQL rehearsal ran the *builder
+output* by hand, but not the Go methods that execute and scan it. Added
+`e2e_rehearsal_test.go` (build tag `starrocksrehearsal`, `SR_DSN` env, skips in
+CI) that drives all twelve `Warehouse` methods with `SummaryEnabled` off vs on
+against a live seeded StarRocks. It passed on 3.3.9 — confirming the full
+dial → build → execute → `queryMetrics`/`queryCount` scan path, including the
+`HLL_UNION_AGG` bigint scanning into the `int32`/`NullInt64` result and the DATE
+column parsing. Run it during a rehearsal with:
+
+```sh
+SR_DSN='root:@tcp(127.0.0.1:9931)/yorkie' \
+  go test -tags starrocksrehearsal ./server/backend/warehouse/ -run TestE2E -v
+```
+
 ## Known limitation: today boundary is per-call, and refresh can lag it
 
 `todayUTC()` reads `time.Now()` inside each of the 12 metric methods, so a

--- a/docs/tasks/active/20260831-project-stats-long-retention-lessons.md
+++ b/docs/tasks/active/20260831-project-stats-long-retention-lessons.md
@@ -6,4 +6,31 @@ Captured during implementation and cluster rehearsal. See the plan in
 `20260831-project-stats-long-retention-todo.md` and the design in
 `docs/design/project-stats-long-retention.md`.
 
-(To be filled in as tasks complete.)
+## Code review (self-review before push)
+
+A reviewer subagent over the branch found no Critical issues. The correctness
+core held up: union-once totals, boundary-safe peak (MAX over independent
+per-day-per-channel buckets, no cross-boundary union), distinct-across-channels
+sessions via `HLL_UNION_AGG` over the channel-keyed summary, a byte-identical
+flag-off path, and a deliberate empty-window guard (`!hist.Empty || fresh.Empty`).
+
+Fixed from the review:
+- **`SummaryEnabled` was unreachable from the `--starrocks-dsn` flag path** — the
+  CLI built `warehouse.Config{DSN: ...}` and never set the flag, so a
+  flag-configured deployment could never turn dual-read on. Added a
+  `--starrocks-summary-enabled` bool flag and YAML tags on `warehouse.Config`
+  so both the flag and config-file paths can flip it.
+- Added golden tests for `seriesQuery` straddling and the sessions-total
+  cross-channel union (the two invariants the design leans on).
+- Documented that the local backfill is a no-op on an empty stack, and marked
+  `init-create-summary.sql` as the source of truth mirrored to the chart.
+
+## Known limitation: today boundary is per-call
+
+`todayUTC()` reads `time.Now()` inside each of the 12 metric methods, so a
+dashboard render that crosses midnight UTC mid-render can split two metrics at
+different `today` boundaries. Blast radius is one day of one metric served from
+base vs. summary — self-healing and within HLL error, and the design already
+treats the boundary as fuzzy. Threading a single per-request `today` through the
+`Warehouse` interface was judged not worth the interface churn. Revisit if
+strict intra-render consistency is ever required.

--- a/docs/tasks/active/20260831-project-stats-long-retention-todo.md
+++ b/docs/tasks/active/20260831-project-stats-long-retention-todo.md
@@ -1,0 +1,417 @@
+**Created**: 2026-08-31
+
+# Project Stats Long-Retention Windows Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Serve project-stats windows up to 12 months after raw-event TTL is
+enabled, by reading a decoupled daily HLL summary for history and the fresh MV
+for today.
+
+**Architecture:** Independent per-metric `AGGREGATE KEY` summary tables in
+StarRocks, filled by an idempotent daily job, read by splitting each window at
+today (history from the summary, today from the existing MV, unioned with
+`HLL_UNION` for totals). A `SummaryEnabled` config flag ships the read path dark;
+it is flipped on only after backfill and validation. Base partitioning + 90-day
+TTL is a separate operational migration, gated on validation.
+
+**Tech Stack:** Go (`server/backend/warehouse`), StarRocks SQL (HLL, aggregate
+tables, expression partitioning), Kubernetes CronJob (internal devops repo).
+
+**Spec:** `docs/design/project-stats-long-retention.md`
+
+## Global Constraints
+
+- Apache 2.0 license header on every new Go file.
+- Package comment on every package; follow the Uber Go Style Guide.
+- StarRocks has no prepared statements — queries are built with `fmt.Sprintf`
+  and `//nolint:gosec`, exactly as the existing methods do. Dates format as
+  `2006-01-02`.
+- Day boundaries are UTC, matching the MV design. "today" = `time.Now().UTC()`
+  truncated to the day.
+- Numbers must stay identical to the MV path for windows inside current
+  retention — HLL sketches are unioned, never summed.
+- StarRocks is NOT in the Go test harness (`project_stats_test.go` passes a nil
+  warehouse → `DummyWarehouse`). Go tests cover pure logic and query strings;
+  real StarRocks behavior is verified by cluster rehearsal (Task 8), as the MV
+  task did.
+- Code PR scope excludes the base repartitioning/TTL migration (Task 7 is a
+  runbook, executed separately after validation).
+
+## File Structure
+
+- `build/docker/analytics/init-create-summary.sql` — 5 summary table DDLs (local stack).
+- `build/docker/analytics/init-backfill-summary.sql` — one-time backfill INSERTs.
+- `build/charts/yorkie-analytics/templates/starrocks/configmap.yaml` — same DDL for deployed clusters (mirror of the MV configmap).
+- `server/backend/warehouse/window.go` — pure window-split helper (`splitWindow`).
+- `server/backend/warehouse/window_test.go` — unit tests for `splitWindow`.
+- `server/backend/warehouse/metrics.go` — per-metric descriptor table (base table, id column, summary table, hll column, extra predicate).
+- `server/backend/warehouse/starrocks.go` — rewrite the 12 methods to dual-read via the descriptor + helper; add `SummaryEnabled`.
+- `server/backend/warehouse/starrocks_query_test.go` — golden-string tests for the built queries (no DB).
+- `server/backend/warehouse/warehouse.go` — add `SummaryEnabled bool` to `Config`.
+- Internal devops repo `k8s/apps/yorkie-analytics/starrocks/summary/` — ingest CronJob + configmap + backfill Job (Task 6), mirroring `starrocks/mv/`.
+
+---
+
+### Task 1: Summary table DDL
+
+**Files:**
+- Create: `build/docker/analytics/init-create-summary.sql`
+- Modify: `build/docker/analytics/docker-compose.yml` (mount/run the new SQL after tables, before/after MV — order-independent, it reads base only at backfill)
+- Modify: `build/charts/yorkie-analytics/templates/starrocks/configmap.yaml` (add the same DDL under a new key)
+
+**Interfaces:**
+- Produces: tables `sum_user_hll_daily(project_id, dt, user_hll)`,
+  `sum_document_hll_daily(project_id, dt, document_hll)`,
+  `sum_channel_hll_daily(project_id, dt, channel_hll)`,
+  `sum_session_hll_daily_ch(project_id, dt, channel_key, session_hll)`,
+  `sum_client_hll_daily(project_id, event_type, dt, client_hll)`. All
+  `AGGREGATE KEY`, `HLL_UNION` sketch column, `PARTITION BY date_trunc('day', dt)`,
+  `partition_live_number = 465`.
+
+- [ ] **Step 1: Write the DDL** mirroring `init-create-mv.sql` metric-for-metric, e.g.:
+
+```sql
+USE yorkie;
+
+-- Decoupled daily HLL summaries that outlive the base event tables so
+-- long-retention dashboard windows survive raw-event TTL. Filled by the
+-- daily ingest job; read by the dual-read path in
+-- server/backend/warehouse/starrocks.go. See
+-- docs/design/project-stats-long-retention.md.
+
+CREATE TABLE IF NOT EXISTS sum_user_hll_daily (
+    project_id VARCHAR(64),
+    dt         DATE,
+    user_hll   HLL HLL_UNION
+) ENGINE = OLAP
+AGGREGATE KEY(project_id, dt)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(project_id)
+PROPERTIES ("replication_num" = "1", "partition_live_number" = "465");
+
+-- document, channel identical shape; session adds channel_key; client adds event_type:
+
+CREATE TABLE IF NOT EXISTS sum_session_hll_daily_ch (
+    project_id  VARCHAR(64),
+    dt          DATE,
+    channel_key VARCHAR(128),
+    session_hll HLL HLL_UNION
+) ENGINE = OLAP
+AGGREGATE KEY(project_id, dt, channel_key)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(project_id)
+PROPERTIES ("replication_num" = "1", "partition_live_number" = "465");
+
+CREATE TABLE IF NOT EXISTS sum_client_hll_daily (
+    project_id VARCHAR(64),
+    event_type VARCHAR(32),
+    dt         DATE,
+    client_hll HLL HLL_UNION
+) ENGINE = OLAP
+AGGREGATE KEY(project_id, event_type, dt)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(project_id)
+PROPERTIES ("replication_num" = "1", "partition_live_number" = "465");
+```
+
+- [ ] **Step 2: Bring up the local analytics stack** and confirm the tables exist.
+
+Run: `docker compose -f build/docker/analytics/docker-compose.yml up --build -d`
+then `mysql -h127.0.0.1 -P9030 -uroot -e "SHOW TABLES FROM yorkie LIKE 'sum_%'"`
+Expected: 5 `sum_*` tables. (Local stack must run StarRocks ≥3.1 for
+`date_trunc` expression partitioning — bump the pinned image if it is 2.5.x.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add build/docker/analytics/init-create-summary.sql build/docker/analytics/docker-compose.yml build/charts/yorkie-analytics/templates/starrocks/configmap.yaml
+git commit -m "Add decoupled daily HLL summary tables for project stats"
+```
+
+---
+
+### Task 2: Window-split helper (pure, TDD)
+
+**Files:**
+- Create: `server/backend/warehouse/window.go`
+- Test: `server/backend/warehouse/window_test.go`
+
+**Interfaces:**
+- Produces:
+  ```go
+  // dayRange is a half-open [start, end) UTC day range; Empty when start >= end.
+  type dayRange struct { Start, End time.Time; Empty bool }
+  // splitWindow splits [from, to) at the UTC day `today` into a historical
+  // range served by the summary and a fresh range served by the base rollup.
+  func splitWindow(from, to, today time.Time) (hist, fresh dayRange)
+  ```
+  `hist = [from, min(to, today))`, `fresh = [max(from, today), to)`; each Empty
+  when its start >= end.
+
+- [ ] **Step 1: Write failing tests**
+
+```go
+func TestSplitWindow(t *testing.T) {
+    day := func(s string) time.Time { d, _ := time.Parse("2006-01-02", s); return d }
+    today := day("2026-08-31")
+    cases := []struct{ name, from, to string; histEmpty, freshEmpty bool; hEnd, fStart string }{
+        {"entirely past", "2026-08-01", "2026-08-31", false, true, "2026-08-31", ""},
+        {"entirely today", "2026-08-31", "2026-09-01", true, false, "", "2026-08-31"},
+        {"straddling", "2026-08-01", "2026-09-01", false, false, "2026-08-31", "2026-08-31"},
+        {"empty input", "2026-08-31", "2026-08-31", true, true, "", ""},
+    }
+    for _, c := range cases {
+        t.Run(c.name, func(t *testing.T) {
+            hist, fresh := splitWindow(day(c.from), day(c.to), today)
+            assert.Equal(t, c.histEmpty, hist.Empty)
+            assert.Equal(t, c.freshEmpty, fresh.Empty)
+            if !hist.Empty { assert.Equal(t, day(c.hEnd), hist.End) }
+            if !fresh.Empty { assert.Equal(t, day(c.fStart), fresh.Start) }
+        })
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./server/backend/warehouse/ -run TestSplitWindow -v`
+Expected: FAIL (`splitWindow` undefined).
+
+- [ ] **Step 3: Implement `splitWindow`** in `window.go` (license header + package comment).
+
+```go
+func splitWindow(from, to, today time.Time) (hist, fresh dayRange) {
+    hEnd := to
+    if today.Before(hEnd) { hEnd = today }
+    hist = dayRange{Start: from, End: hEnd, Empty: !from.Before(hEnd)}
+
+    fStart := from
+    if today.After(fStart) { fStart = today }
+    fresh = dayRange{Start: fStart, End: to, Empty: !fStart.Before(to)}
+    return hist, fresh
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `go test ./server/backend/warehouse/ -run TestSplitWindow -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/backend/warehouse/window.go server/backend/warehouse/window_test.go
+git commit -m "Add UTC day window-split helper for dual-read project stats"
+```
+
+---
+
+### Task 3: Per-metric descriptor + SummaryEnabled config
+
+**Files:**
+- Create: `server/backend/warehouse/metrics.go`
+- Modify: `server/backend/warehouse/warehouse.go` (add `SummaryEnabled bool` to `Config`)
+
+**Interfaces:**
+- Produces:
+  ```go
+  // metricDesc describes one warehouse metric's base and summary shapes.
+  type metricDesc struct {
+      baseTable   string // e.g. "user_events"
+      idColumn    string // e.g. "user_id"
+      summaryTable string // e.g. "sum_user_hll_daily"
+      hllColumn   string // e.g. "user_hll"
+      byChannel   bool   // session: group/read per channel_key
+      eventType   string // non-empty only for clients ("client-activated")
+  }
+  var (
+      descUser, descDocument, descClient, descChannel, descSession metricDesc
+  )
+  ```
+  `StarRocks.summaryEnabled` read from `Config.SummaryEnabled`.
+
+- [ ] **Step 1: Write the descriptors and wire the flag.** Add `SummaryEnabled`
+  to `Config`, set `r.conf` already carries it; expose `func (r *StarRocks)
+  summaryEnabled() bool { return r.conf.SummaryEnabled }`.
+
+- [ ] **Step 2: Build** to confirm it compiles.
+
+Run: `go build ./server/backend/warehouse/`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/backend/warehouse/metrics.go server/backend/warehouse/warehouse.go
+git commit -m "Add per-metric descriptors and SummaryEnabled warehouse flag"
+```
+
+---
+
+### Task 4: Dual-read query builders (golden-string TDD)
+
+**Files:**
+- Modify: `server/backend/warehouse/starrocks.go`
+- Test: `server/backend/warehouse/starrocks_query_test.go`
+
+**Interfaces:**
+- Consumes: `metricDesc`, `splitWindow`, `dayRange`.
+- Produces (unexported, pure string builders — the DB call stays in the public methods):
+  ```go
+  // seriesQuery builds the per-day series query for [from,to) at today.
+  func seriesQuery(d metricDesc, id types.ID, from, to, today time.Time, summary bool) string
+  // totalQuery builds the whole-window distinct total, unioning summary + fresh.
+  func totalQuery(d metricDesc, id types.ID, from, to, today time.Time, summary bool) string
+  // peakSeriesQuery / peakTotalQuery for GetPeakSessionsPerChannel[Count].
+  ```
+  When `summary` is false, the builders return exactly today's base-only SQL
+  (byte-identical to the current queries) so the flag-off path is unchanged.
+
+- [ ] **Step 1: Write failing golden tests** asserting the built SQL for each
+  branch. Example for the total, straddling window, summary on:
+
+```go
+func TestTotalQuery_Straddling_Summary(t *testing.T) {
+    day := func(s string) time.Time { d, _ := time.Parse("2006-01-02", s); return d }
+    got := totalQuery(descUser, types.ID("p1"), day("2026-08-01"), day("2026-09-01"), day("2026-08-31"), true)
+    assert.Contains(t, got, "HLL_CARDINALITY(HLL_UNION_AGG(sketch))")
+    assert.Contains(t, got, "SELECT user_hll AS sketch FROM sum_user_hll_daily")
+    assert.Contains(t, got, "dt >= '2026-08-01' AND dt < '2026-08-31'")
+    assert.Contains(t, got, "UNION ALL")
+    assert.Contains(t, got, "HLL_HASH(user_id) AS sketch FROM user_events")
+    assert.Contains(t, got, "timestamp >= '2026-08-31' AND timestamp < '2026-09-01'")   // partition pruning
+    assert.Contains(t, got, "DATE(timestamp) >= '2026-08-31' AND DATE(timestamp) < '2026-09-01'") // MV-exact fresh
+}
+
+func TestTotalQuery_SummaryOff_MatchesBase(t *testing.T) {
+    day := func(s string) time.Time { d, _ := time.Parse("2006-01-02", s); return d }
+    got := totalQuery(descUser, types.ID("p1"), day("2026-08-01"), day("2026-09-01"), day("2026-08-31"), false)
+    assert.Contains(t, got, "APPROX_COUNT_DISTINCT(user_id)")
+    assert.NotContains(t, got, "sum_user_hll_daily")
+}
+```
+
+Add analogous tests for `seriesQuery` (hist rows from summary + today from base,
+concatenated), the client `event_type` predicate, and `peakTotalQuery` (per
+`(dt, channel)` cardinality then `MAX`, no cross-boundary union).
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `go test ./server/backend/warehouse/ -run Query -v`
+Expected: FAIL (builders undefined).
+
+- [ ] **Step 3: Implement the builders** in `starrocks.go`, using `splitWindow`.
+  Totals union `dayRange` halves with `HLL_UNION_AGG` per the spec's read-path
+  SQL; the fresh half carries both raw-`timestamp` and `DATE(timestamp)` bounds.
+  Series concatenates summary rows and today's base row. Peak reads per
+  `(dt, channel)` and takes `MAX`. Summary-off returns the current SQL verbatim.
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `go test ./server/backend/warehouse/ -run Query -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/backend/warehouse/starrocks.go server/backend/warehouse/starrocks_query_test.go
+git commit -m "Build dual-read project-stats queries splitting at today"
+```
+
+---
+
+### Task 5: Wire the 12 methods through the builders + fallback
+
+**Files:**
+- Modify: `server/backend/warehouse/starrocks.go`
+
+**Interfaces:**
+- Consumes: the builders from Task 4.
+- Produces: the 12 `Warehouse` methods unchanged in signature; each now calls
+  its builder with `today = time.Now().UTC().Truncate(24h)` and
+  `summary = r.summaryEnabled()`. Behavior with the flag off is identical to
+  today.
+
+- [ ] **Step 1: Replace each method body** to delegate to the builder + existing
+  `queryMetrics`/`queryCount`. Keep the `//nolint:gosec` and NOTE comment.
+
+- [ ] **Step 2: Run the warehouse unit tests + lint**
+
+Run: `go test ./server/backend/warehouse/... && make lint`
+Expected: PASS, lint clean.
+
+- [ ] **Step 3: Run the full unit suite** (no DB) to confirm nothing else broke.
+
+Run: `go test ./...`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/backend/warehouse/starrocks.go
+git commit -m "Route project-stats reads through the dual-read builders"
+```
+
+---
+
+### Task 6: Ingest CronJob + backfill (internal devops repo)
+
+**Files (internal `media-tool-dev/devops` repo):**
+- Create: `k8s/apps/yorkie-analytics/starrocks/summary/configmap.yaml` — the daily idempotent INSERT SQL (7-day lookback) per metric.
+- Create: `k8s/apps/yorkie-analytics/starrocks/summary/cronjob.yaml` — `starrocks/fe-ubuntu` mysql client running the SQL; `concurrencyPolicy: Forbid`, history limits, `ttlSecondsAfterFinished`.
+- Create: `k8s/apps/yorkie-analytics/starrocks/summary/backfill-job.yaml` — one-time full-history backfill, staged per table for prod (session last, low-ingest window), mirroring `starrocks/mv/prod/`.
+- Create: `k8s/apps/yorkie-analytics/starrocks/summary/README.md` — apply/verify/rollback, mirroring `starrocks/mv/README.md`.
+
+**Interfaces:**
+- Consumes: the summary tables from Task 1 (must exist first).
+- Produces: a running daily job filling `sum_*` tables. Backfill SQL example:
+  ```sql
+  INSERT INTO sum_user_hll_daily
+  SELECT project_id, DATE(timestamp), HLL_HASH(user_id)
+  FROM user_events
+  GROUP BY project_id, DATE(timestamp);
+  ```
+  Daily SQL is the same with `WHERE DATE(timestamp) >= DATE_SUB(CURDATE(), 7) AND DATE(timestamp) < CURDATE()`.
+
+- [ ] **Step 1: Write the configmap SQL** for all 5 metrics (daily + backfill variants).
+- [ ] **Step 2: Write the CronJob and backfill Job** modeled on `starrocks/mv/job.yaml` and `tools/housekeeping-trend/cronjob.yaml`.
+- [ ] **Step 3: Write the README** (apply order: tables → backfill → validate → enable CronJob).
+- [ ] **Step 4: Commit in the devops repo** (English, per that repo's rules).
+
+Note: no CI here; correctness is verified by the rehearsal in Task 8.
+
+---
+
+### Task 7: Base partitioning + 90-day TTL (runbook — separate migration)
+
+**Not part of the code PR.** A StarRocks migration executed after Task 8 validation,
+following the `session_events` redistribution playbook.
+
+- [ ] Create partitioned twins: `<t>_p` with `PARTITION BY date_trunc('day', timestamp)`, `partition_live_number = 90`.
+- [ ] Per table, low-ingest window: `PAUSE ROUTINE LOAD` → `INSERT INTO <t>_p SELECT *` → `ALTER TABLE ... RENAME` swap → recreate routine load on the new table → `RESUME`. `session_events` last, watching `ADMIN SHOW REPLICA STATUS` (replication_num=1).
+- [ ] `EXPLAIN` a fresh-day total: confirm it prunes to one partition with the raw-`timestamp` bound present.
+- [ ] Confirm old partitions actually drop (3.3.x `partition_live_number` — verify against StarRocks #39341) before relying on TTL.
+- [ ] Only after summary validation is green: enable the 90-day TTL.
+
+---
+
+### Task 8: Cluster rehearsal + validation
+
+**Not TDD-able** (StarRocks not in CI). Rehearse against the local stack, then dev, then prod.
+
+- [ ] Backfill locally; run the 12 dashboard queries with `SummaryEnabled=true` and again with the flag off; assert **identical results** for windows fully inside current retention (this proves the union math).
+- [ ] `EXPLAIN` + `fe.audit.log` `ScanRows` small for the six metrics on the summary path.
+- [ ] Flip `SummaryEnabled` on only after backfill + the equality check pass.
+- [ ] After Task 7 TTL: confirm a 12-month window still returns a full series matching the summary, not collapsing to the 90-day base.
+- [ ] Capture findings in `docs/tasks/active/20260831-project-stats-long-retention-lessons.md`.
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: summary tables (T1), ingest+lookback (T6), dual-read split/union/fallback (T2–T5), base partition+TTL (T7), sequencing/validation (T8). All spec sections mapped.
+- `SummaryEnabled` off = byte-identical current SQL, so the code PR is safe to merge before any cluster work — matching the spec's "ships dark, flip after validation".
+- Peak sessions deliberately needs no cross-boundary union (MAX of independent per-day-per-channel cardinalities) — encoded in T4.

--- a/docs/tasks/active/20260831-project-stats-long-retention-todo.md
+++ b/docs/tasks/active/20260831-project-stats-long-retention-todo.md
@@ -277,7 +277,7 @@ git commit -m "Add per-metric descriptors and SummaryEnabled warehouse flag"
 func TestTotalQuery_Straddling_Summary(t *testing.T) {
     day := func(s string) time.Time { d, _ := time.Parse("2006-01-02", s); return d }
     got := totalQuery(descUser, types.ID("p1"), day("2026-08-01"), day("2026-09-01"), day("2026-08-31"), true)
-    assert.Contains(t, got, "HLL_CARDINALITY(HLL_UNION_AGG(sketch))")
+    assert.Contains(t, got, "HLL_UNION_AGG(sketch)")
     assert.Contains(t, got, "SELECT user_hll AS sketch FROM sum_user_hll_daily")
     assert.Contains(t, got, "dt >= '2026-08-01' AND dt < '2026-08-31'")
     assert.Contains(t, got, "UNION ALL")
@@ -370,11 +370,15 @@ git commit -m "Route project-stats reads through the dual-read builders"
 - Produces: a running daily job filling `sum_*` tables. Backfill SQL example:
   ```sql
   INSERT INTO sum_user_hll_daily
-  SELECT project_id, DATE(timestamp), HLL_HASH(user_id)
+  SELECT project_id, DATE(timestamp), HLL_UNION(HLL_HASH(user_id))
   FROM user_events
   GROUP BY project_id, DATE(timestamp);
   ```
-  Daily SQL is the same with `WHERE DATE(timestamp) >= DATE_SUB(CURDATE(), 7) AND DATE(timestamp) < CURDATE()`.
+  The `GROUP BY` requires `HLL_UNION(HLL_HASH(...))`; a bare `HLL_HASH` is
+  rejected as "must be an aggregate expression". The daily SQL is the same with
+  a trailing 7-day UTC window — use `DATE(UTC_TIMESTAMP())` (not `CURDATE()`,
+  which StarRocks evaluates in the session `time_zone`, default `Asia/Shanghai`):
+  `WHERE DATE(timestamp) >= DATE_SUB(DATE(UTC_TIMESTAMP()), INTERVAL 7 DAY) AND DATE(timestamp) < DATE(UTC_TIMESTAMP())`.
 
 - [ ] **Step 1: Write the configmap SQL** for all 5 metrics (daily + backfill variants).
 - [ ] **Step 2: Write the CronJob and backfill Job** modeled on `starrocks/mv/job.yaml` and `tools/housekeeping-trend/cronjob.yaml`.

--- a/server/backend/warehouse/e2e_rehearsal_test.go
+++ b/server/backend/warehouse/e2e_rehearsal_test.go
@@ -1,0 +1,102 @@
+//go:build starrocksrehearsal
+
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package warehouse
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yorkie-team/yorkie/api/types"
+)
+
+// TestE2EDualReadAgainstStarRocks exercises the real StarRocks read path — dial,
+// build, execute, scan — for every metric with SummaryEnabled off vs on, against
+// a live StarRocks seeded by scratchpad/rehearsal.sql. It is gated behind the
+// `starrocksrehearsal` build tag and a SR_DSN env var, so it never runs in CI
+// (StarRocks is not in the harness); run it by hand during a rehearsal:
+//
+//	SR_DSN='root:@tcp(127.0.0.1:9931)/yorkie' \
+//	  go test -tags starrocksrehearsal ./server/backend/warehouse/ -run TestE2E -v
+func TestE2EDualReadAgainstStarRocks(t *testing.T) {
+	dsn := os.Getenv("SR_DSN")
+	if dsn == "" {
+		t.Skip("set SR_DSN to run the StarRocks e2e rehearsal")
+	}
+
+	off, err := Ensure(&Config{DSN: dsn, SummaryEnabled: false})
+	require.NoError(t, err)
+	defer func() { _ = off.Close() }()
+	on, err := Ensure(&Config{DSN: dsn, SummaryEnabled: true})
+	require.NoError(t, err)
+	defer func() { _ = on.Close() }()
+
+	ctx := context.Background()
+	id := types.ID("p1")
+	from := time.Date(2026, 8, 28, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+
+	counts := []struct {
+		name string
+		fn   func(Warehouse) (int, error)
+		want int
+	}{
+		{"users", func(w Warehouse) (int, error) { return w.GetActiveUsersCount(ctx, id, from, to) }, 3},
+		{"documents", func(w Warehouse) (int, error) { return w.GetActiveDocumentsCount(ctx, id, from, to) }, 3},
+		{"channels", func(w Warehouse) (int, error) { return w.GetActiveChannelsCount(ctx, id, from, to) }, 2},
+		{"clients", func(w Warehouse) (int, error) { return w.GetActiveClientsCount(ctx, id, from, to) }, 2},
+		{"sessions", func(w Warehouse) (int, error) { return w.GetSessionsCount(ctx, id, from, to) }, 5},
+		{"peak", func(w Warehouse) (int, error) { return w.GetPeakSessionsPerChannelCount(ctx, id, from, to) }, 2},
+	}
+	for _, c := range counts {
+		t.Run("count_"+c.name, func(t *testing.T) {
+			gotOff, err := c.fn(off)
+			require.NoError(t, err)
+			gotOn, err := c.fn(on)
+			require.NoError(t, err)
+			assert.Equal(t, c.want, gotOff, "base-only ground truth")
+			assert.Equal(t, gotOff, gotOn, "dual-read must equal base-only")
+		})
+	}
+
+	series := []struct {
+		name string
+		fn   func(Warehouse) ([]types.MetricPoint, error)
+	}{
+		{"users", func(w Warehouse) ([]types.MetricPoint, error) { return w.GetActiveUsers(ctx, id, from, to) }},
+		{"documents", func(w Warehouse) ([]types.MetricPoint, error) { return w.GetActiveDocuments(ctx, id, from, to) }},
+		{"channels", func(w Warehouse) ([]types.MetricPoint, error) { return w.GetActiveChannels(ctx, id, from, to) }},
+		{"clients", func(w Warehouse) ([]types.MetricPoint, error) { return w.GetActiveClients(ctx, id, from, to) }},
+		{"sessions", func(w Warehouse) ([]types.MetricPoint, error) { return w.GetSessions(ctx, id, from, to) }},
+		{"peak", func(w Warehouse) ([]types.MetricPoint, error) { return w.GetPeakSessionsPerChannel(ctx, id, from, to) }},
+	}
+	for _, s := range series {
+		t.Run("series_"+s.name, func(t *testing.T) {
+			gotOff, err := s.fn(off)
+			require.NoError(t, err)
+			gotOn, err := s.fn(on)
+			require.NoError(t, err)
+			assert.Equal(t, gotOff, gotOn, "dual-read series must equal base-only series")
+		})
+	}
+}

--- a/server/backend/warehouse/metrics.go
+++ b/server/backend/warehouse/metrics.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package warehouse
+
+import "github.com/yorkie-team/yorkie/api/types/events"
+
+// metricDesc describes one warehouse metric's base and summary shapes so the
+// dual-read query builders can be shared across the six metrics. Each metric
+// counts distinct idColumn per (project, day) over baseTable, and the daily
+// summary lives in summaryTable with an HLL_UNION column named hllColumn.
+type metricDesc struct {
+	// baseTable is the raw event table, e.g. "user_events".
+	baseTable string
+	// idColumn is the identifier counted distinct, e.g. "user_id".
+	idColumn string
+	// summaryTable is the decoupled daily HLL summary, e.g. "sum_user_hll_daily".
+	summaryTable string
+	// hllColumn is the HLL_UNION sketch column in summaryTable, e.g. "user_hll".
+	hllColumn string
+	// byChannel is true for the session metric, which groups by channel_key so
+	// one table serves both sessions and peak sessions per channel.
+	byChannel bool
+	// eventType, when non-empty, filters the base query and keys the summary,
+	// used only by the client metric ("client-activated").
+	eventType string
+}
+
+var (
+	descUser = metricDesc{
+		baseTable:    "user_events",
+		idColumn:     "user_id",
+		summaryTable: "sum_user_hll_daily",
+		hllColumn:    "user_hll",
+	}
+	descDocument = metricDesc{
+		baseTable:    "document_events",
+		idColumn:     "document_key",
+		summaryTable: "sum_document_hll_daily",
+		hllColumn:    "document_hll",
+	}
+	descChannel = metricDesc{
+		baseTable:    "channel_events",
+		idColumn:     "channel_key",
+		summaryTable: "sum_channel_hll_daily",
+		hllColumn:    "channel_hll",
+	}
+	descClient = metricDesc{
+		baseTable:    "client_events",
+		idColumn:     "client_id",
+		summaryTable: "sum_client_hll_daily",
+		hllColumn:    "client_hll",
+		eventType:    string(events.ClientActivatedEvent),
+	}
+	descSession = metricDesc{
+		baseTable:    "session_events",
+		idColumn:     "session_id",
+		summaryTable: "sum_session_hll_daily_ch",
+		hllColumn:    "session_hll",
+		byChannel:    true,
+	}
+)

--- a/server/backend/warehouse/query.go
+++ b/server/backend/warehouse/query.go
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package warehouse
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/yorkie-team/yorkie/api/types"
+)
+
+// The dual-read query builders split the requested window at the UTC day today:
+// the historical part [from, today) is served by the decoupled daily HLL
+// summary tables, and the fresh part [today, to) by the base rollups. Totals
+// union the two halves' sketches with HLL_UNION_AGG and take cardinality once,
+// so a subject active in both halves counts once. These builders run only when
+// SummaryEnabled is true; the flag-off path keeps the base-only queries in
+// starrocks.go unchanged. See docs/design/project-stats-long-retention.md.
+
+// dayFmt formats a time as the StarRocks date literal used throughout.
+func dayFmt(t time.Time) string {
+	return t.Format("2006-01-02")
+}
+
+// summaryEventTypePred returns the summary-table event_type predicate for the
+// client metric, or an empty string for the others.
+func (d metricDesc) summaryEventTypePred() string {
+	if d.eventType == "" {
+		return ""
+	}
+	return fmt.Sprintf(" AND event_type = '%s'", d.eventType)
+}
+
+// basePred returns the fresh-half base-table predicate: raw timestamp bounds so
+// a partitioned base prunes to today, plus DATE(timestamp) bounds so the MV
+// rewrite still matches, plus the optional event_type filter.
+func (d metricDesc) basePred(id types.ID, fresh dayRange) string {
+	start, end := dayFmt(fresh.Start), dayFmt(fresh.End)
+	pred := fmt.Sprintf(
+		"project_id = '%s' AND timestamp >= '%s' AND timestamp < '%s' "+
+			"AND DATE(timestamp) >= '%s' AND DATE(timestamp) < '%s'",
+		id.String(), start, end, start, end,
+	)
+	if d.eventType != "" {
+		pred += fmt.Sprintf(" AND event_type = '%s'", d.eventType)
+	}
+	return pred
+}
+
+// join wraps the non-empty parts in UNION ALL. When every part is empty it
+// returns the first part, whose empty range yields no rows.
+func join(parts []string) string {
+	nonEmpty := parts[:0:0]
+	for _, p := range parts {
+		if p != "" {
+			nonEmpty = append(nonEmpty, p)
+		}
+	}
+	if len(nonEmpty) == 0 {
+		return parts[0]
+	}
+	return strings.Join(nonEmpty, "\nUNION ALL\n")
+}
+
+// seriesQuery builds the per-day series for a simple distinct-count metric
+// (users, documents, channels, sessions) as a dual read.
+func (d metricDesc) seriesQuery(id types.ID, from, to, today time.Time) string {
+	hist, fresh := splitWindow(from, to, today)
+
+	var histSQL, freshSQL string
+	if !hist.Empty || fresh.Empty {
+		histSQL = fmt.Sprintf(
+			"SELECT dt AS event_date, HLL_CARDINALITY(HLL_UNION_AGG(%s)) AS metric_value "+
+				"FROM %s WHERE project_id = '%s' AND dt >= '%s' AND dt < '%s'%s GROUP BY dt",
+			d.hllColumn, d.summaryTable, id.String(),
+			dayFmt(from), dayFmt(hist.End), d.summaryEventTypePred(),
+		)
+	}
+	if !fresh.Empty {
+		freshSQL = fmt.Sprintf(
+			"SELECT DATE(timestamp) AS event_date, APPROX_COUNT_DISTINCT(%s) AS metric_value "+
+				"FROM %s WHERE %s GROUP BY DATE(timestamp)",
+			d.idColumn, d.baseTable, d.basePred(id, fresh),
+		)
+	}
+
+	//nolint:gosec
+	return fmt.Sprintf(
+		"SELECT event_date, metric_value FROM (\n%s\n) t ORDER BY event_date ASC;",
+		join([]string{histSQL, freshSQL}),
+	)
+}
+
+// totalQuery builds the whole-window distinct total as a dual read, unioning
+// the summary sketches with the fresh half's per-row sketches and taking
+// cardinality exactly once.
+func (d metricDesc) totalQuery(id types.ID, from, to, today time.Time) string {
+	hist, fresh := splitWindow(from, to, today)
+
+	var histSQL, freshSQL string
+	if !hist.Empty || fresh.Empty {
+		histSQL = fmt.Sprintf(
+			"SELECT %s AS sketch FROM %s WHERE project_id = '%s' AND dt >= '%s' AND dt < '%s'%s",
+			d.hllColumn, d.summaryTable, id.String(),
+			dayFmt(from), dayFmt(hist.End), d.summaryEventTypePred(),
+		)
+	}
+	if !fresh.Empty {
+		freshSQL = fmt.Sprintf(
+			"SELECT HLL_HASH(%s) AS sketch FROM %s WHERE %s",
+			d.idColumn, d.baseTable, d.basePred(id, fresh),
+		)
+	}
+
+	//nolint:gosec
+	return fmt.Sprintf(
+		"SELECT HLL_CARDINALITY(HLL_UNION_AGG(sketch)) FROM (\n%s\n) t;",
+		join([]string{histSQL, freshSQL}),
+	)
+}
+
+// peakSeriesQuery builds the per-day peak-sessions-per-channel series as a dual
+// read: the daily peak is MAX over channels of the per-channel distinct
+// sessions, which needs no cross-boundary union because each day is independent.
+func peakSeriesQuery(id types.ID, from, to, today time.Time) string {
+	hist, fresh := splitWindow(from, to, today)
+	d := descSession
+
+	var histSQL, freshSQL string
+	if !hist.Empty || fresh.Empty {
+		histSQL = fmt.Sprintf(
+			"SELECT event_date, MAX(session_count) AS metric_value FROM ("+
+				"SELECT dt AS event_date, channel_key, HLL_CARDINALITY(HLL_UNION_AGG(session_hll)) AS session_count "+
+				"FROM %s WHERE project_id = '%s' AND dt >= '%s' AND dt < '%s' GROUP BY dt, channel_key"+
+				") hc GROUP BY event_date",
+			d.summaryTable, id.String(), dayFmt(from), dayFmt(hist.End),
+		)
+	}
+	if !fresh.Empty {
+		freshSQL = fmt.Sprintf(
+			"SELECT event_date, MAX(session_count) AS metric_value FROM ("+
+				"SELECT DATE(timestamp) AS event_date, channel_key, APPROX_COUNT_DISTINCT(session_id) AS session_count "+
+				"FROM %s WHERE %s GROUP BY DATE(timestamp), channel_key"+
+				") fc GROUP BY event_date",
+			d.baseTable, d.basePred(id, fresh),
+		)
+	}
+
+	//nolint:gosec
+	return fmt.Sprintf(
+		"SELECT event_date, metric_value FROM (\n%s\n) t ORDER BY event_date ASC;",
+		join([]string{histSQL, freshSQL}),
+	)
+}
+
+// peakTotalQuery builds the whole-window peak sessions per channel: the single
+// highest per-(day, channel) distinct-session count. It is a MAX over
+// independent buckets, so no cross-boundary sketch union is needed.
+func peakTotalQuery(id types.ID, from, to, today time.Time) string {
+	hist, fresh := splitWindow(from, to, today)
+	d := descSession
+
+	var histSQL, freshSQL string
+	if !hist.Empty || fresh.Empty {
+		histSQL = fmt.Sprintf(
+			"SELECT HLL_CARDINALITY(HLL_UNION_AGG(session_hll)) AS session_count "+
+				"FROM %s WHERE project_id = '%s' AND dt >= '%s' AND dt < '%s' GROUP BY dt, channel_key",
+			d.summaryTable, id.String(), dayFmt(from), dayFmt(hist.End),
+		)
+	}
+	if !fresh.Empty {
+		freshSQL = fmt.Sprintf(
+			"SELECT APPROX_COUNT_DISTINCT(session_id) AS session_count "+
+				"FROM %s WHERE %s GROUP BY DATE(timestamp), channel_key",
+			d.baseTable, d.basePred(id, fresh),
+		)
+	}
+
+	//nolint:gosec
+	return fmt.Sprintf(
+		"SELECT MAX(session_count) FROM (\n%s\n) t;",
+		join([]string{histSQL, freshSQL}),
+	)
+}

--- a/server/backend/warehouse/query.go
+++ b/server/backend/warehouse/query.go
@@ -27,10 +27,12 @@ import (
 // The dual-read query builders split the requested window at the UTC day today:
 // the historical part [from, today) is served by the decoupled daily HLL
 // summary tables, and the fresh part [today, to) by the base rollups. Totals
-// union the two halves' sketches with HLL_UNION_AGG and take cardinality once,
-// so a subject active in both halves counts once. These builders run only when
-// SummaryEnabled is true; the flag-off path keeps the base-only queries in
-// starrocks.go unchanged. See docs/design/project-stats-long-retention.md.
+// union the two halves' sketches and count once with HLL_UNION_AGG, so a
+// subject active in both halves counts once. Note HLL_UNION_AGG already returns
+// the merged cardinality (a bigint), so it is not wrapped in HLL_CARDINALITY.
+// These builders run only when SummaryEnabled is true; the flag-off path keeps
+// the base-only queries in starrocks.go unchanged.
+// See docs/design/project-stats-long-retention.md.
 
 // dayFmt formats a time as the StarRocks date literal used throughout.
 func dayFmt(t time.Time) string {
@@ -85,7 +87,7 @@ func (d metricDesc) seriesQuery(id types.ID, from, to, today time.Time) string {
 	var histSQL, freshSQL string
 	if !hist.Empty || fresh.Empty {
 		histSQL = fmt.Sprintf(
-			"SELECT dt AS event_date, HLL_CARDINALITY(HLL_UNION_AGG(%s)) AS metric_value "+
+			"SELECT dt AS event_date, HLL_UNION_AGG(%s) AS metric_value "+
 				"FROM %s WHERE project_id = '%s' AND dt >= '%s' AND dt < '%s'%s GROUP BY dt",
 			d.hllColumn, d.summaryTable, id.String(),
 			dayFmt(from), dayFmt(hist.End), d.summaryEventTypePred(),
@@ -129,7 +131,7 @@ func (d metricDesc) totalQuery(id types.ID, from, to, today time.Time) string {
 
 	//nolint:gosec
 	return fmt.Sprintf(
-		"SELECT HLL_CARDINALITY(HLL_UNION_AGG(sketch)) FROM (\n%s\n) t;",
+		"SELECT HLL_UNION_AGG(sketch) FROM (\n%s\n) t;",
 		join([]string{histSQL, freshSQL}),
 	)
 }
@@ -145,7 +147,7 @@ func peakSeriesQuery(id types.ID, from, to, today time.Time) string {
 	if !hist.Empty || fresh.Empty {
 		histSQL = fmt.Sprintf(
 			"SELECT event_date, MAX(session_count) AS metric_value FROM ("+
-				"SELECT dt AS event_date, channel_key, HLL_CARDINALITY(HLL_UNION_AGG(session_hll)) AS session_count "+
+				"SELECT dt AS event_date, channel_key, HLL_UNION_AGG(session_hll) AS session_count "+
 				"FROM %s WHERE project_id = '%s' AND dt >= '%s' AND dt < '%s' GROUP BY dt, channel_key"+
 				") hc GROUP BY event_date",
 			d.summaryTable, id.String(), dayFmt(from), dayFmt(hist.End),
@@ -178,7 +180,7 @@ func peakTotalQuery(id types.ID, from, to, today time.Time) string {
 	var histSQL, freshSQL string
 	if !hist.Empty || fresh.Empty {
 		histSQL = fmt.Sprintf(
-			"SELECT HLL_CARDINALITY(HLL_UNION_AGG(session_hll)) AS session_count "+
+			"SELECT HLL_UNION_AGG(session_hll) AS session_count "+
 				"FROM %s WHERE project_id = '%s' AND dt >= '%s' AND dt < '%s' GROUP BY dt, channel_key",
 			d.summaryTable, id.String(), dayFmt(from), dayFmt(hist.End),
 		)

--- a/server/backend/warehouse/query.go
+++ b/server/backend/warehouse/query.go
@@ -34,9 +34,11 @@ import (
 // the base-only queries in starrocks.go unchanged.
 // See docs/design/project-stats-long-retention.md.
 
-// dayFmt formats a time as the StarRocks date literal used throughout.
+// dayFmt formats a time as the StarRocks date literal used throughout. It
+// normalizes to UTC first so the summary-path literals line up with the UTC day
+// boundary from todayUTC, even when from/to arrive in the server's local zone.
 func dayFmt(t time.Time) string {
-	return t.Format("2006-01-02")
+	return t.UTC().Format("2006-01-02")
 }
 
 // summaryEventTypePred returns the summary-table event_type predicate for the

--- a/server/backend/warehouse/starrocks.go
+++ b/server/backend/warehouse/starrocks.go
@@ -56,6 +56,17 @@ func (r *StarRocks) dial(dsn string) error {
 	return nil
 }
 
+// summaryEnabled reports whether the dual-read summary path is turned on.
+func (r *StarRocks) summaryEnabled() bool {
+	return r.conf != nil && r.conf.SummaryEnabled
+}
+
+// todayUTC returns the start of the current day in UTC, the boundary the
+// dual-read path splits the requested window on.
+func todayUTC() time.Time {
+	return time.Now().UTC().Truncate(24 * time.Hour)
+}
+
 // GetActiveUsers returns the number of active users in the given time range.
 func (r *StarRocks) GetActiveUsers(
 	ctx context.Context,
@@ -84,6 +95,10 @@ func (r *StarRocks) GetActiveUsers(
 	ORDER BY 
 	    event_date ASC;
 	`, id.String(), from.Format("2006-01-02"), to.Format("2006-01-02"))
+
+	if r.summaryEnabled() {
+		query = descUser.seriesQuery(id, from, to, todayUTC())
+	}
 
 	metrics, err := r.queryMetrics(ctx, query)
 	if err != nil {
@@ -115,6 +130,10 @@ func (r *StarRocks) GetActiveUsersCount(
 		AND DATE(timestamp) >= '%s'
 		AND DATE(timestamp) < '%s';
 	`, id.String(), from.Format("2006-01-02"), to.Format("2006-01-02"))
+
+	if r.summaryEnabled() {
+		query = descUser.totalQuery(id, from, to, todayUTC())
+	}
 
 	count, err := r.queryCount(ctx, query)
 	if err != nil {
@@ -152,6 +171,10 @@ func (r *StarRocks) GetActiveDocuments(
 	    event_date ASC;
 	`, id.String(), from.Format("2006-01-02"), to.Format("2006-01-02"))
 
+	if r.summaryEnabled() {
+		query = descDocument.seriesQuery(id, from, to, todayUTC())
+	}
+
 	metrics, err := r.queryMetrics(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("get active documents: %w", err)
@@ -182,6 +205,10 @@ func (r *StarRocks) GetActiveDocumentsCount(
 		AND DATE(timestamp) >= '%s'
 		AND DATE(timestamp) < '%s';
 	`, id.String(), from.Format("2006-01-02"), to.Format("2006-01-02"))
+
+	if r.summaryEnabled() {
+		query = descDocument.totalQuery(id, from, to, todayUTC())
+	}
 
 	count, err := r.queryCount(ctx, query)
 	if err != nil {
@@ -220,6 +247,10 @@ func (r *StarRocks) GetActiveClients(
 	    event_date ASC;
 	`, id.String(), events.ClientActivatedEvent, from.Format("2006-01-02"), to.Format("2006-01-02"))
 
+	if r.summaryEnabled() {
+		query = descClient.seriesQuery(id, from, to, todayUTC())
+	}
+
 	metrics, err := r.queryMetrics(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("get active clients: %w", err)
@@ -251,6 +282,10 @@ func (r *StarRocks) GetActiveClientsCount(
 		AND DATE(timestamp) >= '%s'
 		AND DATE(timestamp) < '%s';
 	`, id.String(), events.ClientActivatedEvent, from.Format("2006-01-02"), to.Format("2006-01-02"))
+
+	if r.summaryEnabled() {
+		query = descClient.totalQuery(id, from, to, todayUTC())
+	}
 
 	count, err := r.queryCount(ctx, query)
 	if err != nil {
@@ -288,6 +323,10 @@ func (r *StarRocks) GetActiveChannels(
 	    event_date ASC;
 	`, id.String(), from.Format("2006-01-02"), to.Format("2006-01-02"))
 
+	if r.summaryEnabled() {
+		query = descChannel.seriesQuery(id, from, to, todayUTC())
+	}
+
 	metrics, err := r.queryMetrics(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("get active channels: %w", err)
@@ -318,6 +357,10 @@ func (r *StarRocks) GetActiveChannelsCount(
 		AND DATE(timestamp) >= '%s'
 		AND DATE(timestamp) < '%s';
 	`, id.String(), from.Format("2006-01-02"), to.Format("2006-01-02"))
+
+	if r.summaryEnabled() {
+		query = descChannel.totalQuery(id, from, to, todayUTC())
+	}
 
 	count, err := r.queryCount(ctx, query)
 	if err != nil {
@@ -355,6 +398,10 @@ func (r *StarRocks) GetSessions(
 	    event_date ASC;
 	`, id.String(), from.Format("2006-01-02"), to.Format("2006-01-02"))
 
+	if r.summaryEnabled() {
+		query = descSession.seriesQuery(id, from, to, todayUTC())
+	}
+
 	metrics, err := r.queryMetrics(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("get sessions: %w", err)
@@ -385,6 +432,10 @@ func (r *StarRocks) GetSessionsCount(
 		AND DATE(timestamp) >= '%s'
 		AND DATE(timestamp) < '%s';
 	`, id.String(), from.Format("2006-01-02"), to.Format("2006-01-02"))
+
+	if r.summaryEnabled() {
+		query = descSession.totalQuery(id, from, to, todayUTC())
+	}
 
 	count, err := r.queryCount(ctx, query)
 	if err != nil {
@@ -430,6 +481,10 @@ func (r *StarRocks) GetPeakSessionsPerChannel(
 	    event_date ASC;
 	`, id.String(), from.Format("2006-01-02"), to.Format("2006-01-02"))
 
+	if r.summaryEnabled() {
+		query = peakSeriesQuery(id, from, to, todayUTC())
+	}
+
 	metrics, err := r.queryMetrics(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("get peak sessions per channel: %w", err)
@@ -468,6 +523,10 @@ func (r *StarRocks) GetPeakSessionsPerChannelCount(
 	        event_date, channel_key
 	) AS channel_sessions;
 	`, id.String(), from.Format("2006-01-02"), to.Format("2006-01-02"))
+
+	if r.summaryEnabled() {
+		query = peakTotalQuery(id, from, to, todayUTC())
+	}
 
 	count, err := r.queryCount(ctx, query)
 	if err != nil {

--- a/server/backend/warehouse/starrocks_query_test.go
+++ b/server/backend/warehouse/starrocks_query_test.go
@@ -40,7 +40,7 @@ func day(s string) time.Time {
 func TestTotalQueryStraddlingSummary(t *testing.T) {
 	got := norm(descUser.totalQuery(types.ID("p1"), day("2026-08-01"), day("2026-09-01"), day("2026-08-31")))
 
-	assert.Contains(t, got, "SELECT HLL_CARDINALITY(HLL_UNION_AGG(sketch)) FROM")
+	assert.Contains(t, got, "SELECT HLL_UNION_AGG(sketch) FROM")
 	assert.Contains(t, got, "SELECT user_hll AS sketch FROM sum_user_hll_daily "+
 		"WHERE project_id = 'p1' AND dt >= '2026-08-01' AND dt < '2026-08-31'")
 	assert.Contains(t, got, "UNION ALL")
@@ -52,7 +52,7 @@ func TestTotalQueryStraddlingSummary(t *testing.T) {
 func TestSeriesQueryEntirelyPastSummaryOnly(t *testing.T) {
 	got := norm(descDocument.seriesQuery(types.ID("p1"), day("2026-08-01"), day("2026-08-31"), day("2026-08-31")))
 
-	assert.Contains(t, got, "SELECT dt AS event_date, HLL_CARDINALITY(HLL_UNION_AGG(document_hll)) AS metric_value "+
+	assert.Contains(t, got, "SELECT dt AS event_date, HLL_UNION_AGG(document_hll) AS metric_value "+
 		"FROM sum_document_hll_daily WHERE project_id = 'p1' AND dt >= '2026-08-01' AND dt < '2026-08-31' GROUP BY dt")
 	assert.Contains(t, got, "ORDER BY event_date ASC")
 	assert.NotContains(t, got, "UNION ALL")
@@ -82,7 +82,7 @@ func TestPeakTotalQueryIsMaxNoBoundaryUnion(t *testing.T) {
 	got := norm(peakTotalQuery(types.ID("p1"), day("2026-08-01"), day("2026-09-01"), day("2026-08-31")))
 
 	assert.Contains(t, got, "SELECT MAX(session_count) FROM")
-	assert.Contains(t, got, "HLL_CARDINALITY(HLL_UNION_AGG(session_hll)) AS session_count "+
+	assert.Contains(t, got, "HLL_UNION_AGG(session_hll) AS session_count "+
 		"FROM sum_session_hll_daily_ch WHERE project_id = 'p1' AND dt >= '2026-08-01' AND dt < '2026-08-31' "+
 		"GROUP BY dt, channel_key")
 	assert.Contains(t, got, "APPROX_COUNT_DISTINCT(session_id) AS session_count FROM session_events")
@@ -106,7 +106,7 @@ func TestSeriesQueryStraddlingConcatenatesHalves(t *testing.T) {
 	got := norm(descUser.seriesQuery(types.ID("p1"), day("2026-08-01"), day("2026-09-01"), day("2026-08-31")))
 
 	// history from the summary, per day
-	assert.Contains(t, got, "SELECT dt AS event_date, HLL_CARDINALITY(HLL_UNION_AGG(user_hll)) AS metric_value "+
+	assert.Contains(t, got, "SELECT dt AS event_date, HLL_UNION_AGG(user_hll) AS metric_value "+
 		"FROM sum_user_hll_daily WHERE project_id = 'p1' AND dt >= '2026-08-01' AND dt < '2026-08-31' GROUP BY dt")
 	// today from the base, per day
 	assert.Contains(t, got, "SELECT DATE(timestamp) AS event_date, APPROX_COUNT_DISTINCT(user_id) AS metric_value "+
@@ -122,7 +122,7 @@ func TestSessionTotalUnionsAcrossChannels(t *testing.T) {
 
 	// distinct sessions across the whole window: union every channel-day sketch,
 	// cardinality once. The summary half must NOT filter or group by channel_key.
-	assert.Contains(t, got, "SELECT HLL_CARDINALITY(HLL_UNION_AGG(sketch)) FROM")
+	assert.Contains(t, got, "SELECT HLL_UNION_AGG(sketch) FROM")
 	assert.Contains(t, got, "SELECT session_hll AS sketch FROM sum_session_hll_daily_ch "+
 		"WHERE project_id = 'p1' AND dt >= '2026-08-01' AND dt < '2026-08-31'")
 	assert.Contains(t, got, "SELECT HLL_HASH(session_id) AS sketch FROM session_events")

--- a/server/backend/warehouse/starrocks_query_test.go
+++ b/server/backend/warehouse/starrocks_query_test.go
@@ -102,6 +102,33 @@ func TestPeakSeriesQueryStraddling(t *testing.T) {
 	assert.Contains(t, got, "ORDER BY event_date ASC")
 }
 
+func TestSeriesQueryStraddlingConcatenatesHalves(t *testing.T) {
+	got := norm(descUser.seriesQuery(types.ID("p1"), day("2026-08-01"), day("2026-09-01"), day("2026-08-31")))
+
+	// history from the summary, per day
+	assert.Contains(t, got, "SELECT dt AS event_date, HLL_CARDINALITY(HLL_UNION_AGG(user_hll)) AS metric_value "+
+		"FROM sum_user_hll_daily WHERE project_id = 'p1' AND dt >= '2026-08-01' AND dt < '2026-08-31' GROUP BY dt")
+	// today from the base, per day
+	assert.Contains(t, got, "SELECT DATE(timestamp) AS event_date, APPROX_COUNT_DISTINCT(user_id) AS metric_value "+
+		"FROM user_events")
+	assert.Contains(t, got, "timestamp >= '2026-08-31' AND timestamp < '2026-09-01'")
+	assert.Contains(t, got, "GROUP BY DATE(timestamp)")
+	assert.Contains(t, got, "UNION ALL")
+	assert.Contains(t, got, "ORDER BY event_date ASC")
+}
+
+func TestSessionTotalUnionsAcrossChannels(t *testing.T) {
+	got := norm(descSession.totalQuery(types.ID("p1"), day("2026-08-01"), day("2026-09-01"), day("2026-08-31")))
+
+	// distinct sessions across the whole window: union every channel-day sketch,
+	// cardinality once. The summary half must NOT filter or group by channel_key.
+	assert.Contains(t, got, "SELECT HLL_CARDINALITY(HLL_UNION_AGG(sketch)) FROM")
+	assert.Contains(t, got, "SELECT session_hll AS sketch FROM sum_session_hll_daily_ch "+
+		"WHERE project_id = 'p1' AND dt >= '2026-08-01' AND dt < '2026-08-31'")
+	assert.Contains(t, got, "SELECT HLL_HASH(session_id) AS sketch FROM session_events")
+	assert.NotContains(t, got, "channel_key")
+}
+
 func TestTotalQueryEmptyWindowNoUnion(t *testing.T) {
 	got := norm(descUser.totalQuery(types.ID("p1"), day("2026-08-31"), day("2026-08-31"), day("2026-08-31")))
 

--- a/server/backend/warehouse/starrocks_query_test.go
+++ b/server/backend/warehouse/starrocks_query_test.go
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package warehouse
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/api/types"
+)
+
+// norm collapses all runs of whitespace to single spaces so assertions do not
+// depend on the query's formatting.
+func norm(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+func day(s string) time.Time {
+	d, _ := time.Parse("2006-01-02", s)
+	return d
+}
+
+func TestTotalQueryStraddlingSummary(t *testing.T) {
+	got := norm(descUser.totalQuery(types.ID("p1"), day("2026-08-01"), day("2026-09-01"), day("2026-08-31")))
+
+	assert.Contains(t, got, "SELECT HLL_CARDINALITY(HLL_UNION_AGG(sketch)) FROM")
+	assert.Contains(t, got, "SELECT user_hll AS sketch FROM sum_user_hll_daily "+
+		"WHERE project_id = 'p1' AND dt >= '2026-08-01' AND dt < '2026-08-31'")
+	assert.Contains(t, got, "UNION ALL")
+	assert.Contains(t, got, "SELECT HLL_HASH(user_id) AS sketch FROM user_events "+
+		"WHERE project_id = 'p1' AND timestamp >= '2026-08-31' AND timestamp < '2026-09-01' "+
+		"AND DATE(timestamp) >= '2026-08-31' AND DATE(timestamp) < '2026-09-01'")
+}
+
+func TestSeriesQueryEntirelyPastSummaryOnly(t *testing.T) {
+	got := norm(descDocument.seriesQuery(types.ID("p1"), day("2026-08-01"), day("2026-08-31"), day("2026-08-31")))
+
+	assert.Contains(t, got, "SELECT dt AS event_date, HLL_CARDINALITY(HLL_UNION_AGG(document_hll)) AS metric_value "+
+		"FROM sum_document_hll_daily WHERE project_id = 'p1' AND dt >= '2026-08-01' AND dt < '2026-08-31' GROUP BY dt")
+	assert.Contains(t, got, "ORDER BY event_date ASC")
+	assert.NotContains(t, got, "UNION ALL")
+	assert.NotContains(t, got, "document_events")
+}
+
+func TestSeriesQueryEntirelyTodayBaseOnly(t *testing.T) {
+	got := norm(descUser.seriesQuery(types.ID("p1"), day("2026-08-31"), day("2026-09-01"), day("2026-08-31")))
+
+	assert.Contains(t, got, "APPROX_COUNT_DISTINCT(user_id) AS metric_value FROM user_events")
+	assert.NotContains(t, got, "sum_user_hll_daily")
+	assert.NotContains(t, got, "UNION ALL")
+}
+
+func TestTotalQueryClientCarriesEventType(t *testing.T) {
+	got := norm(descClient.totalQuery(types.ID("p1"), day("2026-08-01"), day("2026-09-01"), day("2026-08-31")))
+
+	// summary half keyed by event_type
+	assert.Contains(t, got, "SELECT client_hll AS sketch FROM sum_client_hll_daily "+
+		"WHERE project_id = 'p1' AND dt >= '2026-08-01' AND dt < '2026-08-31' AND event_type = 'client-activated'")
+	// fresh half filters event_type too
+	assert.Contains(t, got, "HLL_HASH(client_id) AS sketch FROM client_events")
+	assert.Contains(t, got, "AND event_type = 'client-activated'")
+}
+
+func TestPeakTotalQueryIsMaxNoBoundaryUnion(t *testing.T) {
+	got := norm(peakTotalQuery(types.ID("p1"), day("2026-08-01"), day("2026-09-01"), day("2026-08-31")))
+
+	assert.Contains(t, got, "SELECT MAX(session_count) FROM")
+	assert.Contains(t, got, "HLL_CARDINALITY(HLL_UNION_AGG(session_hll)) AS session_count "+
+		"FROM sum_session_hll_daily_ch WHERE project_id = 'p1' AND dt >= '2026-08-01' AND dt < '2026-08-31' "+
+		"GROUP BY dt, channel_key")
+	assert.Contains(t, got, "APPROX_COUNT_DISTINCT(session_id) AS session_count FROM session_events")
+	assert.Contains(t, got, "GROUP BY DATE(timestamp), channel_key")
+	// peak never unions sketches across the today boundary
+	assert.NotContains(t, got, "HLL_UNION_AGG(sketch)")
+}
+
+func TestPeakSeriesQueryStraddling(t *testing.T) {
+	got := norm(peakSeriesQuery(types.ID("p1"), day("2026-08-01"), day("2026-09-01"), day("2026-08-31")))
+
+	assert.Contains(t, got, "SELECT event_date, metric_value FROM")
+	assert.Contains(t, got, "MAX(session_count) AS metric_value")
+	assert.Contains(t, got, "sum_session_hll_daily_ch")
+	assert.Contains(t, got, "UNION ALL")
+	assert.Contains(t, got, "session_events")
+	assert.Contains(t, got, "ORDER BY event_date ASC")
+}
+
+func TestTotalQueryEmptyWindowNoUnion(t *testing.T) {
+	got := norm(descUser.totalQuery(types.ID("p1"), day("2026-08-31"), day("2026-08-31"), day("2026-08-31")))
+
+	// from == to: a single summary select over an empty range, no UNION ALL, no panic
+	assert.Contains(t, got, "sum_user_hll_daily")
+	assert.NotContains(t, got, "UNION ALL")
+}

--- a/server/backend/warehouse/warehouse.go
+++ b/server/backend/warehouse/warehouse.go
@@ -27,6 +27,13 @@ import (
 // Config is the configuration for StarRocks.
 type Config struct {
 	DSN string
+
+	// SummaryEnabled turns on the dual-read path that serves history from the
+	// decoupled daily HLL summary tables and today from the base rollups. When
+	// false, reads use the base rollups over the whole window, byte-identical to
+	// the pre-summary behavior. It is flipped on only after the summary tables
+	// are backfilled and validated. See docs/design/project-stats-long-retention.md.
+	SummaryEnabled bool
 }
 
 // Warehouse represents the warehouse interface.

--- a/server/backend/warehouse/warehouse.go
+++ b/server/backend/warehouse/warehouse.go
@@ -26,14 +26,14 @@ import (
 
 // Config is the configuration for StarRocks.
 type Config struct {
-	DSN string
+	DSN string `yaml:"DSN"`
 
 	// SummaryEnabled turns on the dual-read path that serves history from the
 	// decoupled daily HLL summary tables and today from the base rollups. When
 	// false, reads use the base rollups over the whole window, byte-identical to
 	// the pre-summary behavior. It is flipped on only after the summary tables
 	// are backfilled and validated. See docs/design/project-stats-long-retention.md.
-	SummaryEnabled bool
+	SummaryEnabled bool `yaml:"SummaryEnabled"`
 }
 
 // Warehouse represents the warehouse interface.

--- a/server/backend/warehouse/window.go
+++ b/server/backend/warehouse/window.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package warehouse
+
+import "time"
+
+// dayRange is a half-open [Start, End) UTC day range. Empty is true when the
+// range covers no day, i.e. Start >= End.
+type dayRange struct {
+	Start time.Time
+	End   time.Time
+	Empty bool
+}
+
+// splitWindow splits the requested window [from, to) at the UTC day boundary
+// today into two half-open ranges: a historical range served by the daily
+// summary and a fresh range served by the base rollup. The two never overlap
+// by day, so their union is exact.
+//
+// hist  = [from, min(to, today))
+// fresh = [max(from, today), to)
+//
+// Either range may be Empty: a window entirely in the past has an empty fresh
+// range, and a window entirely within today has an empty historical range.
+func splitWindow(from, to, today time.Time) (hist, fresh dayRange) {
+	hEnd := to
+	if today.Before(hEnd) {
+		hEnd = today
+	}
+	hist = dayRange{Start: from, End: hEnd, Empty: !from.Before(hEnd)}
+
+	fStart := from
+	if today.After(fStart) {
+		fStart = today
+	}
+	fresh = dayRange{Start: fStart, End: to, Empty: !fStart.Before(to)}
+
+	return hist, fresh
+}

--- a/server/backend/warehouse/window_test.go
+++ b/server/backend/warehouse/window_test.go
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package warehouse
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitWindow(t *testing.T) {
+	day := func(s string) time.Time {
+		d, err := time.Parse("2006-01-02", s)
+		assert.NoError(t, err)
+		return d
+	}
+	today := day("2026-08-31")
+
+	cases := []struct {
+		name       string
+		from, to   string
+		histEmpty  bool
+		freshEmpty bool
+		hEnd       string
+		fStart     string
+	}{
+		{"entirely past", "2026-08-01", "2026-08-31", false, true, "2026-08-31", ""},
+		{"entirely today", "2026-08-31", "2026-09-01", true, false, "", "2026-08-31"},
+		{"straddling", "2026-08-01", "2026-09-01", false, false, "2026-08-31", "2026-08-31"},
+		{"empty input", "2026-08-31", "2026-08-31", true, true, "", ""},
+		{"future window", "2026-09-01", "2026-09-05", true, false, "", "2026-09-01"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			hist, fresh := splitWindow(day(c.from), day(c.to), today)
+			assert.Equal(t, c.histEmpty, hist.Empty, "hist.Empty")
+			assert.Equal(t, c.freshEmpty, fresh.Empty, "fresh.Empty")
+			if !hist.Empty {
+				assert.Equal(t, day(c.from), hist.Start, "hist.Start")
+				assert.Equal(t, day(c.hEnd), hist.End, "hist.End")
+			}
+			if !fresh.Empty {
+				assert.Equal(t, day(c.fStart), fresh.Start, "fresh.Start")
+				assert.Equal(t, day(c.to), fresh.End, "fresh.End")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Serve project-stats dashboard windows up to 12 months **after raw-event TTL is enabled**. The synchronous HLL materialized views from #1939 are rollup indexes physically bound to the base event tables, so once event retention drops old base partitions, any window longer than base retention (the 3-/12-month views) breaks. An async MV cannot decouple — its `partition_ttl` retains only the most recent N partitions and routes older queries back to a base that has been purged.

This adds a **decoupled daily HLL summary + dual read**:

- **Independent `AGGREGATE KEY` summary tables** (`sum_*_hll_daily`) that outlive the base tables (`build/docker/analytics/init-create-summary.sql`, chart init ConfigMap). Filled by an idempotent backfill + a daily refresh job.
- **Dual read** (`server/backend/warehouse/`): split each window at today (UTC) — history from the summary, today from the base rollup — unioning the two halves' sketches with `HLL_UNION_AGG` (never summing), so a subject active in both halves counts once. Peak-sessions is `MAX` over independent per-(day,channel) buckets, no cross-boundary union.
- **`--starrocks-summary-enabled` flag (default off)**. Flag-off keeps the existing base-only SQL byte-identical, so this is safe to merge dark and flip on only after backfill + validation.

Design: `docs/design/project-stats-long-retention.md`. Plan/lessons: `docs/tasks/active/20260831-project-stats-long-retention-*`.

The ingest CronJob + backfill Job live in the analytics deploy repo. Base-table daily partitioning + the 90-day raw TTL is a separate operational migration, gated on summary validation (out of this PR).

## Test plan

- `go test ./server/backend/warehouse/` — unit tests for the UTC window split and golden-string tests for every dual-read builder (totals, series, peak, client `event_type`, sessions cross-channel, empty window). `golangci-lint` clean.
- **Local StarRocks 3.3.9 rehearsal** (allin1, synthetic multi-day data with a subject active on both a past day and today): dual-read equals base-only for all six metrics (users 3, documents 3, channels 2, clients 2, sessions 5, peak 2) and the union-once property holds (3/5, not 4/6). This caught two real bugs string tests could not — `HLL_UNION_AGG` already returns cardinality (dropped the erroneous `HLL_CARDINALITY` wrapper), and grouped ingest needs `HLL_UNION(HLL_HASH(...))`.
- Flag defaults off → no behavior change until explicitly enabled per environment.

Relates to the event-retention risk called out in #1939.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retaining and querying project statistics across longer historical windows, including up to 12 months.
  * Added optional summary-based analytics reads while preserving existing behavior when disabled.
  * Added daily summaries for users, documents, channels, sessions, and clients.
  * Added automatic summary creation and historical backfill during analytics database initialization.

* **Documentation**
  * Added design and implementation guidance for long-retention project statistics.

* **Tests**
  * Added coverage for historical, current-day, boundary, and metric-specific analytics queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->