### PR TITLE
Make YSON parser string-aware to avoid corrupting values

### DIFF
--- a/pkg/document/yson/yson.go
+++ b/pkg/document/yson/yson.go
@@ -764,7 +764,22 @@ func rewriteDedupCounters(data string) string {
 // and rewriting known constructors at token boundaries. It writes the result
 // into b. Malformed input (unbalanced parens, unterminated strings) is copied
 // through best-effort; the surrounding decoder then rejects the invalid JSON.
+// maxConstructorDepth bounds how deeply YSON constructors may nest during
+// preprocessing. Real YSON nests constructors at most two deep (for example
+// Counter(Int(0))); anything past this generous bound is malformed. Bounding
+// the depth keeps preprocessing from recursing without limit on adversarial
+// input such as Int(Int(...Int(0)...)), which would otherwise exhaust the
+// goroutine stack and crash the process instead of returning ErrInvalidYSON.
+const maxConstructorDepth = 100
+
 func scanConstructors(b *strings.Builder, data string) {
+	scanConstructorsAt(b, data, 0)
+}
+
+// scanConstructorsAt is scanConstructors with an explicit nesting depth so that
+// unbounded recursion on pathologically nested input is rejected rather than
+// crashing the process.
+func scanConstructorsAt(b *strings.Builder, data string, depth int) {
 	i := 0
 	for i < len(data) {
 		c := data[i]
@@ -776,6 +791,14 @@ func scanConstructors(b *strings.Builder, data string) {
 		}
 
 		if name, typ, argStart, ok := matchConstructor(data, i); ok {
+			if depth >= maxConstructorDepth {
+				// Too deeply nested: copy the remainder verbatim so the leftover
+				// constructor syntax makes the decoder report invalid YSON,
+				// instead of recursing until the stack is exhausted.
+				b.WriteString(data[i:])
+				return
+			}
+
 			argEnd, found := findMatchingParen(data, argStart)
 			if !found {
 				// Unbalanced parens: copy the rest verbatim so the decoder
@@ -786,7 +809,7 @@ func scanConstructors(b *strings.Builder, data string) {
 
 			inner := strings.TrimSpace(data[argStart:argEnd])
 			b.WriteString(constructorPrefix(name, typ, inner))
-			scanConstructors(b, inner)
+			scanConstructorsAt(b, inner, depth+1)
 			b.WriteByte('}')
 			i = argEnd + 1 // skip past ')'
 			continue

--- a/pkg/document/yson/yson.go
+++ b/pkg/document/yson/yson.go
@@ -679,45 +679,205 @@ func parseTreeNode(raw map[string]interface{}) (TreeNode, error) {
 	return node, nil
 }
 
-// preprocessTypeValues replaces custom types in the YSON string with
-// JSON-compatible formats.
+// ysonConstructor maps a YSON constructor name to its intermediate JSON
+// object type. The scanner rewrites Name(<arg>) into
+// {"type":"<type>","value":<arg>} for these constructors.
+type ysonConstructor struct {
+	name string
+	typ  string
+}
+
+// ysonConstructors lists the value-carrying YSON constructors. Longer names
+// must precede any name that is a prefix of them so a prefix never shadows a
+// longer name (e.g. DedupCounter before Counter). Names are matched only at a
+// token boundary, so this ordering is defensive rather than strictly required.
+var ysonConstructors = []ysonConstructor{
+	{"Counter", "Counter"},
+	{"Text", "Text"},
+	{"Tree", "Tree"},
+	{"Int", "Int"},
+	{"Long", "Long"},
+	{"BinData", "BinData"},
+	{"Date", "Date"},
+}
+
+// preprocessTypeValues rewrites custom YSON constructors into JSON-compatible
+// forms so the result can be decoded with encoding/json.
+//
+// The rewrite is a single left-to-right, string-aware scan. String literals
+// are copied verbatim (honoring \" and \\ escapes) so that brackets, parens,
+// or constructor-like substrings appearing inside string values are never
+// interpreted as structure. Earlier revisions used global strings.ReplaceAll
+// calls (notably ")" → "}"), which silently corrupted such values.
 func preprocessTypeValues(data string) string {
-	// Pre-substitute DedupCounter into complete JSON before general
-	// replacements. The compound structure (Int(...) + bare base64 string)
-	// is incompatible with the global ')' → '}' replacement.
-	data = dedupCounterRe.ReplaceAllString(data,
-		`{"type":"DedupCounter","counterType":"Int","value":$1,"hll":"$2"}`)
+	// DedupCounter is handled first by its precise regex. Its compound shape
+	// (Int(...) plus a bare base64 string argument) does not fit the generic
+	// Name(<arg>) rewrite, and the regex only matches at real DedupCounter
+	// call sites. The scanner then leaves the produced JSON untouched. Prose
+	// containing the literal text DedupCounter(...) inside a string value is
+	// protected because the scanner copies string literals verbatim; the regex
+	// pass may edit such prose, but the subsequent scanner would break on the
+	// same input regardless, and the marshalers never emit it inside strings.
+	data = rewriteDedupCounters(data)
 
-	type replacement struct {
-		oldStr string
-		newStr string
+	var b strings.Builder
+	b.Grow(len(data) + len(data)/4)
+	scanConstructors(&b, data)
+	return b.String()
+}
+
+// rewriteDedupCounters substitutes DedupCounter(Int(N),"b64") occurrences that
+// lie outside string literals with complete intermediate JSON. Occurrences
+// inside string literals are left untouched.
+func rewriteDedupCounters(data string) string {
+	var b strings.Builder
+	b.Grow(len(data))
+	i := 0
+	for i < len(data) {
+		c := data[i]
+		if c == '"' {
+			j := scanStringLiteral(data, i)
+			b.WriteString(data[i:j])
+			i = j
+			continue
+		}
+		// Gate the regex on a cheap prefix check. Only a match anchored at the
+		// current position is used, so without the "DedupCounter(" prefix the
+		// regex cannot contribute; skipping it keeps this pass linear instead of
+		// rescanning the whole suffix at every byte.
+		if strings.HasPrefix(data[i:], "DedupCounter(") {
+			if loc := dedupCounterRe.FindStringSubmatchIndex(data[i:]); loc != nil && loc[0] == 0 {
+				match := data[i : i+loc[1]]
+				b.WriteString(dedupCounterRe.ReplaceAllString(match,
+					`{"type":"DedupCounter","counterType":"Int","value":$1,"hll":"$2"}`))
+				i += loc[1]
+				continue
+			}
+		}
+		b.WriteByte(c)
+		i++
 	}
+	return b.String()
+}
 
-	// Replace custom types with JSON-compatible formats in a specific order
-	replacements := []replacement{
-		// Process empty constructors first
-		{`Text()`, `{"type":"Text","value":[]}`},
-		{`Tree()`, `{"type":"Tree","value":{}}`},
+// scanConstructors walks data left to right, copying string literals verbatim
+// and rewriting known constructors at token boundaries. It writes the result
+// into b. Malformed input (unbalanced parens, unterminated strings) is copied
+// through best-effort; the surrounding decoder then rejects the invalid JSON.
+func scanConstructors(b *strings.Builder, data string) {
+	i := 0
+	for i < len(data) {
+		c := data[i]
+		if c == '"' {
+			j := scanStringLiteral(data, i)
+			b.WriteString(data[i:j])
+			i = j
+			continue
+		}
 
-		// Process constructors with values
-		{`Counter(`, `{"type":"Counter","value":`},
-		{`Text(`, `{"type":"Text","value":`},
-		{`Tree(`, `{"type":"Tree","value":`},
-		{`Int(`, `{"type":"Int","value":`},
-		{`Long(`, `{"type":"Long","value":`},
-		{`BinData("`, `{"type":"BinData","value":"`},
-		{`Date("`, `{"type":"Date","value":"`},
+		if name, typ, argStart, ok := matchConstructor(data, i); ok {
+			argEnd, found := findMatchingParen(data, argStart)
+			if !found {
+				// Unbalanced parens: copy the rest verbatim so the decoder
+				// reports invalid YSON instead of us panicking.
+				b.WriteString(data[i:])
+				return
+			}
 
-		// Finally, handle closing parentheses
-		{`)`, `}`},
+			inner := strings.TrimSpace(data[argStart:argEnd])
+			b.WriteString(constructorPrefix(name, typ, inner))
+			scanConstructors(b, inner)
+			b.WriteByte('}')
+			i = argEnd + 1 // skip past ')'
+			continue
+		}
+
+		b.WriteByte(c)
+		i++
 	}
+}
 
-	// Replace custom types with JSON-compatible formats
-	for _, r := range replacements {
-		data = strings.ReplaceAll(data, r.oldStr, r.newStr)
+// matchConstructor reports whether data at position i begins a known
+// constructor name that is immediately followed by '(' and sits at a token
+// boundary (the preceding char is not an identifier char). On success it
+// returns the name, its intermediate type, and the index just after '('.
+func matchConstructor(data string, i int) (name, typ string, argStart int, ok bool) {
+	if i > 0 && isIdentChar(data[i-1]) {
+		return "", "", 0, false
 	}
+	for _, ctor := range ysonConstructors {
+		end := i + len(ctor.name)
+		if end < len(data) && data[i:end] == ctor.name && data[end] == '(' {
+			return ctor.name, ctor.typ, end + 1, true
+		}
+	}
+	return "", "", 0, false
+}
 
-	return data
+// constructorPrefix returns the JSON prefix emitted before a constructor's
+// processed argument. The closing '}' is written separately by the caller.
+// Empty Text()/Tree() collapse to a fixed empty value so that Text() and
+// Tree() decode as an empty array and object respectively.
+func constructorPrefix(name, typ, inner string) string {
+	if inner == "" {
+		switch name {
+		case "Text":
+			return `{"type":"Text","value":[]`
+		case "Tree":
+			return `{"type":"Tree","value":{}`
+		}
+	}
+	return fmt.Sprintf(`{"type":"%s","value":`, typ)
+}
+
+// findMatchingParen returns the index of the ')' that closes the '(' whose
+// argument starts at argStart, counting nested parens and skipping string
+// literals. found is false if no matching paren exists.
+func findMatchingParen(data string, argStart int) (int, bool) {
+	depth := 1
+	i := argStart
+	for i < len(data) {
+		switch data[i] {
+		case '"':
+			i = scanStringLiteral(data, i)
+			continue
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i, true
+			}
+		}
+		i++
+	}
+	return 0, false
+}
+
+// scanStringLiteral returns the index just past the JSON string literal that
+// starts at the opening quote data[start]. It honors \" and \\ escapes. If the
+// string is unterminated it returns len(data).
+func scanStringLiteral(data string, start int) int {
+	i := start + 1
+	for i < len(data) {
+		switch data[i] {
+		case '\\':
+			i += 2
+			continue
+		case '"':
+			return i + 1
+		}
+		i++
+	}
+	return len(data)
+}
+
+// isIdentChar reports whether c can appear in a YSON constructor identifier.
+func isIdentChar(c byte) bool {
+	return c == '_' ||
+		('a' <= c && c <= 'z') ||
+		('A' <= c && c <= 'Z') ||
+		('0' <= c && c <= '9')
 }
 
 // ParseObject parses a string representation of a YSON object into the

--- a/pkg/document/yson/yson_test.go
+++ b/pkg/document/yson/yson_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"math"
+	"strings"
 	"testing"
 	gotime "time"
 
@@ -882,5 +883,19 @@ func TestYSONStringAwareParsing(t *testing.T) {
 		obj := yson.Object{}
 		assert.Error(t, yson.Unmarshal(`Text([{"val":"unterminated`, &obj))
 		assert.Error(t, yson.Unmarshal(`Counter(Int(10)`, &obj))
+	})
+
+	t.Run("deeply nested constructors are rejected without exhausting the stack", func(t *testing.T) {
+		// Real YSON nests constructors at most two deep (Counter(Int(...))).
+		// A pathological input nesting far past that must return invalid YSON
+		// rather than recursing until the goroutine stack is exhausted, which
+		// would crash the process. The depth is chosen well above the parser's
+		// bound so the preprocessing pass, not a later stage, rejects it.
+		const depth = 100000
+		data := `{"c":` + strings.Repeat("Int(", depth) + "0" +
+			strings.Repeat(")", depth) + "}"
+
+		obj := yson.Object{}
+		assert.Error(t, yson.Unmarshal(data, &obj))
 	})
 }

--- a/pkg/document/yson/yson_test.go
+++ b/pkg/document/yson/yson_test.go
@@ -714,3 +714,173 @@ func TestYSONParse(t *testing.T) {
 		})
 	})
 }
+
+// textOf builds a single-node Text with the given value for round-trip tests.
+func textOf(value string) yson.Text {
+	return yson.Text{Nodes: []yson.TextNode{{Value: value}}}
+}
+
+func TestYSONStringAwareParsing(t *testing.T) {
+	t.Run("text value with closing paren round-trip", func(t *testing.T) {
+		obj := yson.Object{"c": textOf("see figure (1)")}
+		marshalled, err := obj.Marshal()
+		assert.NoError(t, err)
+
+		actual := yson.Object{}
+		assert.NoError(t, yson.Unmarshal(marshalled, &actual))
+		assert.Equal(t, obj, actual)
+	})
+
+	t.Run("text values with structural characters round-trip", func(t *testing.T) {
+		values := []string{
+			"close paren )",
+			"close brace }",
+			"close bracket ]",
+			"open bracket [",
+			"open brace {",
+			"open paren (",
+			"mixed )}]{[( soup",
+		}
+		for _, v := range values {
+			obj := yson.Object{"c": textOf(v)}
+			marshalled, err := obj.Marshal()
+			assert.NoError(t, err)
+
+			actual := yson.Object{}
+			assert.NoError(t, yson.Unmarshal(marshalled, &actual))
+			assert.Equal(t, obj, actual, "value %q", v)
+		}
+	})
+
+	t.Run("text values with constructor-like substrings round-trip", func(t *testing.T) {
+		values := []string{
+			"use Int( here",
+			"use Text( here",
+			"use Tree( here",
+			"use Counter( here",
+			"use Long( here",
+			"use Date( here",
+			"use BinData( here",
+			"use DedupCounter(Int(5),\"x\") here",
+			"Int(42) is a number",
+			"Tree({}) is empty",
+		}
+		for _, v := range values {
+			obj := yson.Object{"c": textOf(v)}
+			marshalled, err := obj.Marshal()
+			assert.NoError(t, err)
+
+			actual := yson.Object{}
+			assert.NoError(t, yson.Unmarshal(marshalled, &actual))
+			assert.Equal(t, obj, actual, "value %q", v)
+		}
+	})
+
+	t.Run("escaped quote adjacent to bracket in string round-trip", func(t *testing.T) {
+		values := []string{
+			`quote before bracket "] here`,
+			`bracket then quote [" here`,
+			`paren then escaped quote (\ okay`,
+			`he said ")" loudly`,
+		}
+		for _, v := range values {
+			obj := yson.Object{"c": textOf(v)}
+			marshalled, err := obj.Marshal()
+			assert.NoError(t, err)
+
+			actual := yson.Object{}
+			assert.NoError(t, yson.Unmarshal(marshalled, &actual))
+			assert.Equal(t, obj, actual, "value %q", v)
+		}
+	})
+
+	t.Run("text and tree in same root with tricky prose round-trip", func(t *testing.T) {
+		obj := yson.Object{
+			"note": textOf("see Int(3) in figure (2]"),
+			"body": yson.Tree{
+				Root: yson.TreeNode{
+					Type: "p",
+					Children: []yson.TreeNode{
+						{Type: "text", Value: "Tree(node) with ) brace }"},
+					},
+				},
+			},
+		}
+		marshalled, err := obj.Marshal()
+		assert.NoError(t, err)
+
+		actual := yson.Object{}
+		assert.NoError(t, yson.Unmarshal(marshalled, &actual))
+		assert.Equal(t, obj, actual)
+	})
+
+	t.Run("hand-written YSON literal with parens in string", func(t *testing.T) {
+		input := `Text([{"val":"see figure (1)"}])`
+		text := yson.Text{}
+		assert.NoError(t, yson.Unmarshal(input, &text))
+		assert.Equal(t, textOf("see figure (1)"), text)
+	})
+
+	t.Run("deeply nested tree past four levels round-trip", func(t *testing.T) {
+		// depth: root > a > b > c > d > text
+		leaf := yson.TreeNode{Type: "text", Value: "deep )"}
+		d := yson.TreeNode{Type: "d", Children: []yson.TreeNode{leaf}}
+		c := yson.TreeNode{Type: "c", Children: []yson.TreeNode{d}}
+		b := yson.TreeNode{Type: "b", Children: []yson.TreeNode{c}}
+		a := yson.TreeNode{Type: "a", Children: []yson.TreeNode{b}}
+		tree := yson.Tree{Root: yson.TreeNode{
+			Type: "root", Children: []yson.TreeNode{a},
+		}}
+
+		marshalled, err := tree.Marshal()
+		assert.NoError(t, err)
+
+		actual := yson.Tree{}
+		assert.NoError(t, yson.Unmarshal(marshalled, &actual))
+		assert.Equal(t, tree, actual)
+	})
+
+	t.Run("counter regressions", func(t *testing.T) {
+		intCounter := yson.Counter{}
+		assert.NoError(t, yson.Unmarshal(`Counter(Int(10))`, &intCounter))
+		assert.Equal(t, crdt.IntegerCnt, intCounter.Type)
+		assert.Equal(t, int32(10), intCounter.Value)
+
+		longCounter := yson.Counter{}
+		assert.NoError(t, yson.Unmarshal(`Counter(Long(100))`, &longCounter))
+		assert.Equal(t, crdt.LongCnt, longCounter.Type)
+		assert.Equal(t, int64(100), longCounter.Value)
+
+		dedup := yson.Counter{}
+		assert.NoError(t, yson.Unmarshal(`DedupCounter(Int(15),"AQIDBA==")`, &dedup))
+		assert.Equal(t, crdt.IntegerDedupCnt, dedup.Type)
+		assert.Equal(t, int32(15), dedup.Value)
+		assert.Equal(t, []byte{1, 2, 3, 4}, dedup.Registers)
+	})
+
+	t.Run("empty text and tree regressions", func(t *testing.T) {
+		text := yson.Text{}
+		assert.NoError(t, yson.Unmarshal(`Text()`, &text))
+		assert.Equal(t, yson.Text{}, text)
+
+		tree := yson.Tree{}
+		assert.NoError(t, yson.Unmarshal(`Tree()`, &tree))
+		assert.Equal(t, yson.Tree{Root: yson.TreeNode{Type: yson.DefaultRootNodeType}}, tree)
+	})
+
+	t.Run("scalar type regressions", func(t *testing.T) {
+		arr := yson.Array{}
+		assert.NoError(t, yson.Unmarshal(
+			`[Int(42),Long(64),Date("2025-01-02T15:04:05.058Z"),BinData("AQID")]`, &arr))
+		assert.Equal(t, int32(42), arr[0])
+		assert.Equal(t, int64(64), arr[1])
+		assert.Equal(t, gotime.Date(2025, 1, 2, 15, 4, 5, 58000000, gotime.UTC), arr[2])
+		assert.Equal(t, []byte{1, 2, 3}, arr[3])
+	})
+
+	t.Run("malformed input returns invalid YSON without panic", func(t *testing.T) {
+		obj := yson.Object{}
+		assert.Error(t, yson.Unmarshal(`Text([{"val":"unterminated`, &obj))
+		assert.Error(t, yson.Unmarshal(`Counter(Int(10)`, &obj))
+	})
+}


### PR DESCRIPTION
## Summary

`preprocessTypeValues` (used by `yson.Unmarshal`) rewrote YSON constructor syntax
into JSON with a `DedupCounter` regex followed by a chain of global
`strings.ReplaceAll` calls — notably a blanket `")" -> "}"` and substring
rewrites such as `"Text(" -> ...`. None of these were string-aware, so any string
**value** containing `)`, `}`, `]`, `[`, or a constructor-like substring (`Int(`,
`Text(`, ...) was silently corrupted.

For example, a `Text` whose prose is `see figure (1)` serializes to
`Text([{"val":"see figure (1)"}])` and round-tripped back through `Unmarshal` as
`see figure (1}` — the `)` inside the string became `}`. `strconv.Quote` on the
marshal side does not (and should not) escape `)`, so this reaches ordinary prose.

Unlike the sibling JS SDK bug, the depth handling here was already correct; only
the string-awareness defect applies. But it is more dangerous: the parser
returns **silently corrupted data** rather than an error, and it runs on
production paths — `server/revisions` (parsing stored snapshots),
`server/rpc/admin_server` (parsing user-supplied roots), and
`cmd/yorkie/document`.

Same class of bug as, and found while investigating, yorkie-team/yorkie#1966
(which is about the JS SDK's `YSON.parse`).

## Approach

Rewrite `preprocessTypeValues` as a single left-to-right, string-aware scan:

- `scanStringLiteral` copies JSON string literals verbatim (honoring `\"` / `\\`),
  so nothing inside a string is ever treated as structure.
- `matchConstructor` matches known constructors only at a token boundary
  (preceding byte is not an identifier char), longest-name-first.
- `findMatchingParen` delimits each argument by paren depth while skipping string
  literals; arguments are processed recursively, so arbitrary Tree depth works.
- Empty `Text()` / `Tree()` collapse to `[]` / `{}`.
- `DedupCounter` keeps its focused regex, now applied only outside string
  literals and gated on a cheap prefix check so the pass stays linear.

The intermediate JSON is byte-identical to the previous implementation on every
input the old code handled correctly. Malformed input (unbalanced parens,
unterminated strings) is copied through and rejected by the decoder as
`ErrInvalidYSON`; no new panics.

## Test plan

Added `TestYSONStringAwareParsing` to `pkg/document/yson/yson_test.go`: the
closing-paren round-trip, structural characters and constructor-like substrings
inside string values, an escaped quote adjacent to a bracket, `Text`+`Tree` in
one root, a deep Tree, counter regressions, empty `Text()`/`Tree()`, scalars,
and malformed-input handling. Existing tests unchanged.

```
go test ./pkg/document/yson/...      # ok
go build ./...                       # clean
golangci-lint run ./pkg/document/yson/...   # 0 issues
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed YSON parsing for text containing parentheses, brackets, braces, escaped quotes, and constructor-like text.
  - Improved handling of deeply nested trees and counter values.
  - Malformed or excessively nested YSON now returns an invalid-input error without causing a crash.

- **Tests**
  - Added coverage for complex text values, mixed text and tree content, nested structures, scalar types, empty values, invalid input, and deeply nested constructors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->