### PR TITLE
Release v0.7.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and Yorkie adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
-## [v0.7.19-rc] - 2026-08-31
+## [v0.7.19] - 2026-09-03
 
 ### Added
 
 - Serve long-retention project-stats windows via decoupled HLL summaries by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1961
+
+### Fixed
+
+- Make YSON parser string-aware to avoid corrupting values by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1967
 
 ## [v0.7.18] - 2026-08-31
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-YORKIE_VERSION := 0.7.19-rc
+YORKIE_VERSION := 0.7.19
 
 GO_PROJECT = github.com/yorkie-team/yorkie
 

--- a/api/docs/yorkie.base.yaml
+++ b/api/docs/yorkie.base.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Yorkie
   description: "Yorkie is an open source document store for building collaborative editing applications."
-  version: v0.7.19-rc
+  version: v0.7.19
 servers:
   - url: https://api.yorkie.dev
     description: Production server

--- a/api/docs/yorkie/v1/admin.openapi.yaml
+++ b/api/docs/yorkie/v1/admin.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.19-rc
+  version: v0.7.19
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/api/docs/yorkie/v1/resources.openapi.yaml
+++ b/api/docs/yorkie/v1/resources.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.19-rc
+  version: v0.7.19
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/api/docs/yorkie/v1/yorkie.openapi.yaml
+++ b/api/docs/yorkie/v1/yorkie.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.19-rc
+  version: v0.7.19
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/build/charts/yorkie-analytics/Chart.yaml
+++ b/build/charts/yorkie-analytics/Chart.yaml
@@ -11,8 +11,8 @@ maintainers:
 
 sources:
   - https://github.com/yorkie-team/yorkie
-version: 0.7.17
-appVersion: "0.7.17"
+version: 0.7.19
+appVersion: "0.7.19"
 kubeVersion: ">=1.24.0-0"
 
 keywords:

--- a/build/charts/yorkie-cluster/Chart.yaml
+++ b/build/charts/yorkie-cluster/Chart.yaml
@@ -9,8 +9,8 @@ maintainers:
 
 sources:
   - https://github.com/yorkie-team/yorkie
-version: 0.7.19-rc
-appVersion: "0.7.19-rc"
+version: 0.7.19
+appVersion: "0.7.19"
 kubeVersion: ">=1.28.0-0"
 
 dependencies:


### PR DESCRIPTION
## Summary

Promote `v0.7.19-rc` to the final `v0.7.19`.

Scope since `v0.7.18` (production changes only; the rc release commit is excluded):

### Added
- Serve long-retention project-stats windows via decoupled HLL summaries (#1961)

### Fixed
- Make YSON parser string-aware to avoid corrupting values (#1967)

## Version bumps
- `Makefile`: `0.7.19-rc` → `0.7.19`
- `build/charts/yorkie-cluster/Chart.yaml`: version/appVersion → `0.7.19`
- `build/charts/yorkie-analytics/Chart.yaml`: `0.7.17` → `0.7.19` — #1961 changed
  its StarRocks configmap template (decoupled HLL summary tables) without moving
  `Chart.yaml`, so this release aligns the chart with the change per the
  separate-track rule.
- `api/docs/yorkie.base.yaml` + the three `api/docs/yorkie/v1/*.openapi.yaml`: → `v0.7.19`
- `CHANGELOG.md`: consolidate the `v0.7.19-rc` entry into `v0.7.19` and add #1967

`yorkie-monitoring` chart left at `0.7.7` (untouched); `cluster.openapi.yaml`
untouched — both separate tracks.

## Test plan
- Version-only release PR; CI is the source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Promoted version 0.7.19 from release candidate to stable release across builds, deployment charts, and API documentation.
  * Updated the analytics chart to version 0.7.19.
* **Documentation**
  * Added changelog entries for decoupled long-retention project-statistics summaries and improved handling of strings in YSON parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->