### PR TITLE
Add server-side offline-resumable attach (stable actor, resume, epoch)

### DIFF
--- a/api/converter/converter_test.go
+++ b/api/converter/converter_test.go
@@ -232,6 +232,25 @@ func TestConverter(t *testing.T) {
 		assert.ErrorIs(t, err, converter.ErrCheckpointRequired)
 	})
 
+	t.Run("change pack epoch round-trip test", func(t *testing.T) {
+		// The epoch carrier flows both ways: request = client's last-known
+		// epoch, response = the doc's current epoch. Encode/decode must
+		// preserve it so a resumed client can present its persisted epoch.
+		pack := &change.Pack{
+			DocumentKey: "d1",
+			Checkpoint:  change.NewCheckpoint(7, 5),
+			Epoch:       42,
+		}
+
+		pbPack, err := converter.ToChangePack(pack)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(42), pbPack.Epoch)
+
+		got, err := converter.FromChangePack(pbPack)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(42), got.Epoch)
+	})
+
 	t.Run("tree converting test", func(t *testing.T) {
 		root := helper.BuildTreeNode(&json.TreeNode{
 			Type: "r",

--- a/api/converter/from_pb.go
+++ b/api/converter/from_pb.go
@@ -198,6 +198,7 @@ func FromChangePack(pbPack *api.ChangePack) (*change.Pack, error) {
 		Snapshot:      pbPack.Snapshot,
 		IsRemoved:     pbPack.IsRemoved,
 		VersionVector: versionVector,
+		Epoch:         pbPack.Epoch,
 	}
 
 	return pack, nil

--- a/api/converter/to_pb.go
+++ b/api/converter/to_pb.go
@@ -224,6 +224,7 @@ func ToChangePack(pack *change.Pack) (*api.ChangePack, error) {
 		Changes:       pbChanges,
 		Snapshot:      pack.Snapshot,
 		VersionVector: pbVersionVector,
+		Epoch:         pack.Epoch,
 		IsRemoved:     pack.IsRemoved,
 	}, nil
 }

--- a/api/docs/yorkie/v1/resources.openapi.yaml
+++ b/api/docs/yorkie/v1/resources.openapi.yaml
@@ -311,6 +311,13 @@ components:
           description: ""
           title: document_key
           type: string
+        epoch:
+          additionalProperties: false
+          description: ""
+          oneOf:
+          - type: string
+          - type: number
+          title: epoch
         isRemoved:
           additionalProperties: false
           description: ""

--- a/api/docs/yorkie/v1/yorkie.openapi.yaml
+++ b/api/docs/yorkie/v1/yorkie.openapi.yaml
@@ -682,6 +682,14 @@ components:
       additionalProperties: false
       description: ""
       properties:
+        actorId:
+          additionalProperties: false
+          description: |-
+            actor_id is the stable actor derived from the project and client key.
+             Opted-in SDKs stamp it into changes; old SDKs ignore it and keep using
+             client_id as their actor.
+          title: actor_id
+          type: string
         clientId:
           additionalProperties: false
           description: ""

--- a/api/docs/yorkie/v1/yorkie.openapi.yaml
+++ b/api/docs/yorkie/v1/yorkie.openapi.yaml
@@ -936,6 +936,13 @@ components:
           description: ""
           title: document_key
           type: string
+        epoch:
+          additionalProperties: false
+          description: ""
+          oneOf:
+          - type: string
+          - type: number
+          title: epoch
         isRemoved:
           additionalProperties: false
           description: ""

--- a/api/types/actor.go
+++ b/api/types/actor.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package types
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+
+	"github.com/yorkie-team/yorkie/pkg/document/time"
+)
+
+// stableActorTag is the permanent domain-separation tag for the stable actor
+// derivation. Changing it changes every derived actor and orphans every
+// persisted offline document, so bump the version only in an emergency.
+const stableActorTag = "yorkie/stable-actor/v1"
+
+// actorIDSize is the byte length of an actor ID (mirrors time.ActorID).
+const actorIDSize = 12
+
+// DeriveActorID deterministically derives a stable 12-byte actor ID from the
+// given projectID and clientKey. The same inputs always yield the same actor,
+// so two sessions of the same logical client resume the same actor without any
+// coordination, unique index, or upsert.
+//
+// The derivation is SHA256(tag || projectID.Bytes() || clientKey), truncated to
+// the first 12 bytes. projectID is placed first at its fixed 12-byte width so
+// concatenation with the variable-length clientKey is unambiguous and the actor
+// is namespaced per project. clientKey is used byte-for-byte, with no trimming
+// or case normalization.
+//
+// The reserved actor values time.InitialActorID (all-zero) and time.MaxActorID
+// (all-0xFF) are avoided by re-hashing until the result differs from both. The
+// probability of hitting either is negligible; the loop only makes the fallback
+// deterministic.
+func DeriveActorID(projectID ID, clientKey string) ID {
+	// projectID is an ObjectID hex string; decode it to its 12 raw bytes so the
+	// derivation matches the design's byte-level definition. If it is not valid
+	// hex (it always is in practice), fall back to its raw string bytes rather
+	// than panic.
+	projectBytes, err := hex.DecodeString(string(projectID))
+	if err != nil {
+		projectBytes = []byte(projectID)
+	}
+
+	h := sha256.New()
+	h.Write([]byte(stableActorTag))
+	h.Write(projectBytes)
+	h.Write([]byte(clientKey))
+	sum := h.Sum(nil)
+
+	var actor [actorIDSize]byte
+	copy(actor[:], sum[:actorIDSize])
+
+	for actor == time.InitialActorID || actor == time.MaxActorID {
+		next := sha256.New()
+		next.Write([]byte(stableActorTag))
+		next.Write([]byte{0x01})
+		next.Write(sum)
+		sum = next.Sum(nil)
+		copy(actor[:], sum[:actorIDSize])
+	}
+
+	return IDFromBytes(actor[:])
+}

--- a/api/types/actor.go
+++ b/api/types/actor.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The Yorkie Authors. All rights reserved.
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package types
 
 import (
 	"crypto/sha256"
-	"encoding/hex"
 
 	"github.com/yorkie-team/yorkie/pkg/document/time"
 )
@@ -47,11 +46,10 @@ const actorIDSize = 12
 // probability of hitting either is negligible; the loop only makes the fallback
 // deterministic.
 func DeriveActorID(projectID ID, clientKey string) ID {
-	// projectID is an ObjectID hex string; decode it to its 12 raw bytes so the
-	// derivation matches the design's byte-level definition. If it is not valid
-	// hex (it always is in practice), fall back to its raw string bytes rather
-	// than panic.
-	projectBytes, err := hex.DecodeString(string(projectID))
+	// projectID is an ObjectID hex string; use its 12 raw bytes so the
+	// derivation matches the byte-level definition. It is always valid in
+	// practice; on the impossible decode error, fall back to its raw bytes.
+	projectBytes, err := projectID.Bytes()
 	if err != nil {
 		projectBytes = []byte(projectID)
 	}
@@ -65,13 +63,22 @@ func DeriveActorID(projectID ID, clientKey string) ID {
 	var actor [actorIDSize]byte
 	copy(actor[:], sum[:actorIDSize])
 
+	return resolveReserved(actor, sum)
+}
+
+// resolveReserved returns actor as an ID, re-hashing until it differs from the
+// reserved values time.InitialActorID (all-zero) and time.MaxActorID (all-0xFF).
+// seed is the SHA256 sum that produced actor and drives the deterministic
+// re-hash. The probability of hitting a reserved value is ~2^-96; the loop only
+// makes the fallback deterministic.
+func resolveReserved(actor [actorIDSize]byte, seed []byte) ID {
 	for actor == time.InitialActorID || actor == time.MaxActorID {
 		next := sha256.New()
 		next.Write([]byte(stableActorTag))
 		next.Write([]byte{0x01})
-		next.Write(sum)
-		sum = next.Sum(nil)
-		copy(actor[:], sum[:actorIDSize])
+		next.Write(seed)
+		seed = next.Sum(nil)
+		copy(actor[:], seed[:actorIDSize])
 	}
 
 	return IDFromBytes(actor[:])

--- a/api/types/actor_internal_test.go
+++ b/api/types/actor_internal_test.go
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package types
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/pkg/document/time"
+)
+
+// TestResolveReserved exercises the reserved-value guard directly, since a
+// derived actor colliding with a reserved value organically has probability
+// ~2^-96 and cannot be reached through DeriveActorID in a test.
+func TestResolveReserved(t *testing.T) {
+	seed := sha256.Sum256([]byte("seed"))
+
+	t.Run("rehashes away from InitialActorID test", func(t *testing.T) {
+		got := resolveReserved(time.InitialActorID, seed[:])
+		assert.NotEqual(t, IDFromActorID(time.InitialActorID), got)
+		assert.NotEqual(t, IDFromActorID(time.MaxActorID), got)
+	})
+
+	t.Run("rehashes away from MaxActorID test", func(t *testing.T) {
+		got := resolveReserved(time.MaxActorID, seed[:])
+		assert.NotEqual(t, IDFromActorID(time.InitialActorID), got)
+		assert.NotEqual(t, IDFromActorID(time.MaxActorID), got)
+	})
+
+	t.Run("passes through a non-reserved actor test", func(t *testing.T) {
+		actor := [actorIDSize]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
+		assert.Equal(t, IDFromBytes(actor[:]), resolveReserved(actor, seed[:]))
+	})
+}

--- a/api/types/actor_test.go
+++ b/api/types/actor_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The Yorkie Authors. All rights reserved.
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/types/actor_test.go
+++ b/api/types/actor_test.go
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package types_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/api/types"
+	"github.com/yorkie-team/yorkie/pkg/document/time"
+)
+
+func TestDeriveActorID(t *testing.T) {
+	proj := types.ID("000000000000000000000000")
+	other := types.ID("0123456789abcdef01234567")
+
+	t.Run("determinism test", func(t *testing.T) {
+		first := types.DeriveActorID(proj, "alice")
+		second := types.DeriveActorID(proj, "alice")
+		assert.Equal(t, first, second)
+	})
+
+	t.Run("different client key yields different actor test", func(t *testing.T) {
+		alice := types.DeriveActorID(proj, "alice")
+		bob := types.DeriveActorID(proj, "bob")
+		assert.NotEqual(t, alice, bob)
+	})
+
+	t.Run("different project namespaces the actor test", func(t *testing.T) {
+		here := types.DeriveActorID(proj, "alice")
+		there := types.DeriveActorID(other, "alice")
+		assert.NotEqual(t, here, there)
+	})
+
+	t.Run("output is a valid 12-byte actor id test", func(t *testing.T) {
+		actor := types.DeriveActorID(proj, "alice")
+		assert.NoError(t, actor.Validate())
+
+		actorID, err := actor.ToActorID()
+		assert.NoError(t, err)
+		assert.Len(t, actorID.Bytes(), 12)
+	})
+
+	t.Run("never equals reserved values test", func(t *testing.T) {
+		initial := types.IDFromActorID(time.InitialActorID)
+		max := types.IDFromActorID(time.MaxActorID)
+
+		// Sweep a range of keys to exercise the reserved-value guard path; none
+		// of the derived actors may collide with the two reserved values.
+		for _, key := range []string{"", "alice", "bob", "carol", "dave", "eve"} {
+			actor := types.DeriveActorID(proj, key)
+			assert.NotEqual(t, initial, actor)
+			assert.NotEqual(t, max, actor)
+		}
+	})
+
+	t.Run("pinned test vectors test", func(t *testing.T) {
+		// Pinned outputs of the permanent "yorkie/stable-actor/v1" derivation.
+		// A change here means the algorithm changed and every persisted offline
+		// document is orphaned, so these must not drift silently.
+		assert.Equal(t, types.ID("c2c36be133e39f90dc17d198"), types.DeriveActorID(proj, "alice"))
+		assert.Equal(t, types.ID("06631cb05238779c0597f815"), types.DeriveActorID(proj, "bob"))
+		assert.Equal(t, types.ID("479dc734ba367130cd706e15"), types.DeriveActorID(other, "alice"))
+	})
+}

--- a/api/yorkie/v1/resources.pb.go
+++ b/api/yorkie/v1/resources.pb.go
@@ -394,6 +394,7 @@ type ChangePack struct {
 	MinSyncedTicket *TimeTicket            `protobuf:"bytes,5,opt,name=min_synced_ticket,json=minSyncedTicket,proto3" json:"min_synced_ticket,omitempty"` // deprecated
 	IsRemoved       bool                   `protobuf:"varint,6,opt,name=is_removed,json=isRemoved,proto3" json:"is_removed,omitempty"`
 	VersionVector   *VersionVector         `protobuf:"bytes,7,opt,name=version_vector,json=versionVector,proto3" json:"version_vector,omitempty"`
+	Epoch           int64                  `protobuf:"varint,8,opt,name=epoch,proto3" json:"epoch,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -475,6 +476,13 @@ func (x *ChangePack) GetVersionVector() *VersionVector {
 		return x.VersionVector
 	}
 	return nil
+}
+
+func (x *ChangePack) GetEpoch() int64 {
+	if x != nil {
+		return x.Epoch
+	}
+	return 0
 }
 
 type Change struct {
@@ -4996,7 +5004,7 @@ const file_yorkie_v1_resources_proto_rawDesc = "" +
 	"\tpresences\x18\x02 \x03(\v2\".yorkie.v1.Snapshot.PresencesEntryR\tpresences\x1aQ\n" +
 	"\x0ePresencesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12)\n" +
-	"\x05value\x18\x02 \x01(\v2\x13.yorkie.v1.PresenceR\x05value:\x028\x01\"\xd2\x02\n" +
+	"\x05value\x18\x02 \x01(\v2\x13.yorkie.v1.PresenceR\x05value:\x028\x01\"\xe8\x02\n" +
 	"\n" +
 	"ChangePack\x12!\n" +
 	"\fdocument_key\x18\x01 \x01(\tR\vdocumentKey\x125\n" +
@@ -5008,7 +5016,8 @@ const file_yorkie_v1_resources_proto_rawDesc = "" +
 	"\x11min_synced_ticket\x18\x05 \x01(\v2\x15.yorkie.v1.TimeTicketR\x0fminSyncedTicket\x12\x1d\n" +
 	"\n" +
 	"is_removed\x18\x06 \x01(\bR\tisRemoved\x12?\n" +
-	"\x0eversion_vector\x18\a \x01(\v2\x18.yorkie.v1.VersionVectorR\rversionVector\"\xc1\x01\n" +
+	"\x0eversion_vector\x18\a \x01(\v2\x18.yorkie.v1.VersionVectorR\rversionVector\x12\x14\n" +
+	"\x05epoch\x18\b \x01(\x03R\x05epoch\"\xc1\x01\n" +
 	"\x06Change\x12#\n" +
 	"\x02id\x18\x01 \x01(\v2\x13.yorkie.v1.ChangeIDR\x02id\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x124\n" +

--- a/api/yorkie/v1/resources.proto
+++ b/api/yorkie/v1/resources.proto
@@ -47,6 +47,7 @@ message ChangePack {
   TimeTicket min_synced_ticket = 5; // deprecated
   bool is_removed = 6;
   VersionVector version_vector = 7;
+  int64 epoch = 8;
 }
 
 message Change {

--- a/api/yorkie/v1/yorkie.pb.go
+++ b/api/yorkie/v1/yorkie.pb.go
@@ -89,8 +89,12 @@ func (x *ActivateClientRequest) GetMetadata() map[string]string {
 }
 
 type ActivateClientResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	ClientId      string                 `protobuf:"bytes,1,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	ClientId string                 `protobuf:"bytes,1,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
+	// actor_id is the stable actor derived from the project and client key.
+	// Opted-in SDKs stamp it into changes; old SDKs ignore it and keep using
+	// client_id as their actor.
+	ActorId       string `protobuf:"bytes,2,opt,name=actor_id,json=actorId,proto3" json:"actor_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -128,6 +132,13 @@ func (*ActivateClientResponse) Descriptor() ([]byte, []int) {
 func (x *ActivateClientResponse) GetClientId() string {
 	if x != nil {
 		return x.ClientId
+	}
+	return ""
+}
+
+func (x *ActivateClientResponse) GetActorId() string {
+	if x != nil {
+		return x.ActorId
 	}
 	return ""
 }
@@ -2813,9 +2824,10 @@ const file_yorkie_v1_yorkie_proto_rawDesc = "" +
 	"\bmetadata\x18\x02 \x03(\v2..yorkie.v1.ActivateClientRequest.MetadataEntryR\bmetadata\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"5\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"P\n" +
 	"\x16ActivateClientResponse\x12\x1b\n" +
-	"\tclient_id\x18\x01 \x01(\tR\bclientId\"X\n" +
+	"\tclient_id\x18\x01 \x01(\tR\bclientId\x12\x19\n" +
+	"\bactor_id\x18\x02 \x01(\tR\aactorId\"X\n" +
 	"\x17DeactivateClientRequest\x12\x1b\n" +
 	"\tclient_id\x18\x01 \x01(\tR\bclientId\x12 \n" +
 	"\vsynchronous\x18\x02 \x01(\bR\vsynchronous\"\x1a\n" +

--- a/api/yorkie/v1/yorkie.proto
+++ b/api/yorkie/v1/yorkie.proto
@@ -58,6 +58,10 @@ message ActivateClientRequest {
 
 message ActivateClientResponse {
   string client_id = 1;
+  // actor_id is the stable actor derived from the project and client key.
+  // Opted-in SDKs stamp it into changes; old SDKs ignore it and keep using
+  // client_id as their actor.
+  string actor_id = 2;
 }
 
 message DeactivateClientRequest {

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -44,6 +44,7 @@ New design documents should be based on [TEMPLATE.md](TEMPLATE.md).
 - [PubSub](pub-sub.md): Client-side event sharing with gRPC server-side stream and PubSub pattern
 - [Housekeeping](housekeeping.md): Background tasks for cleaning up documents and tombstones
 - [Document Epoch](document-epoch.md): Epoch-based detection and recovery for clients stale after compaction
+- [Offline-Resumable Attach](offline-resumable-attach.md): Stable actor decoupled from the per-session client row plus a resumable checkpoint, so a client's locally-persisted un-pushed changes replay after a reload
 - [Fine-grained Document Locking](fine-grained-document-locking.md): Fine-grained document locking for high concurrency
 - [OLAP Stack for MAU Tracking](olap-stack.md): Kafka and StarRocks pipeline behind the warehouse-backed project stats, starting from Monthly Active Users (MAU) tracking
 - [Cluster Service Authentication](cluster-service-auth.md): Shared secret authentication for inter-node cluster RPCs

--- a/docs/design/offline-resumable-attach.md
+++ b/docs/design/offline-resumable-attach.md
@@ -197,7 +197,7 @@ An actor is exactly **12 bytes** (`time.ActorID [12]byte`; `types.ID` is its
 lowercase-hex form). The derivation is server-authoritative — the SDK receives
 the result and stamps it verbatim, so it never recomputes the hash:
 
-```
+```text
 DeriveActorID(projectID types.ID, clientKey string) time.ActorID:
     tag = "yorkie/stable-actor/v1"                  // domain tag, permanent
     h   = SHA256(tag || projectID.Bytes()/*12B*/ || []byte(clientKey))
@@ -362,7 +362,7 @@ interim behavior), so this is safe to ship server-first.
 
 ### Data flow
 
-```
+```text
 attach(docKey, ChangePack{ Checkpoint: presentedCkpt, Epoch: presentedEpoch, changes })
   └─ ActivateClient already ran → new per-session _id + StableActorID  [Seam 1]
   └─ AttachDocument seeds ClientDocInfo (Case A is unreachable, not implemented):

--- a/docs/design/offline-resumable-attach.md
+++ b/docs/design/offline-resumable-attach.md
@@ -91,10 +91,12 @@ to reuse the actor purely on the client. Both were evaluated and rejected:
 
 Instead, **decouple a stable actor identity from the per-session session
 identity**. The change localizes to two seams. The hard invariant tying them
-together: *the actor stamped into persisted changes must equal the key used for
-pull dedup, VV, min-VV, and GC.* Both are `ClientInfo.ID` today; move **both**
-to the stable actor together — never one without the other, or GC advances past
-un-synced tombstones.
+together: *the actor stamped into persisted changes must be recognized as the
+same client's own by the predicate that keys pull dedup, VV liveness, min-VV,
+and GC.* Because old and new SDKs stamp different actors, the recognition is
+**compare-both** (`IsOwnActor`: session id OR stable actor), applied to dedup and
+VV liveness together — never dedup without VV, or GC advances past un-synced
+tombstones.
 
 #### Seam 1 — actor identity on the wire
 
@@ -116,18 +118,32 @@ un-synced tombstones.
   *stable actor* (fed only to `doc.setActor`), with a nil-guard fallback to
   `clientId`-as-actor against old servers.
 
-#### Seam 2 — dedup and VV liveness
+#### Seam 2 — dedup and VV liveness (COMPARE-BOTH)
 
-Switch these from `clientInfo.ID` to the stable actor:
+A change carries whatever actor the client stamped into it. Old SDKs stamp the
+per-session `clientInfo.ID`; new SDKs stamp `clientInfo.StableActorID`. The
+server cannot know which SDK sent a given change, so it must recognize a
+change (or a VV entry) as "this client's own" if its actor equals **either**
+identity. Do **not** hard-switch these sites from `clientInfo.ID` to the stable
+actor — that would break old SDKs mid-transition. Instead compare against both.
 
-| Site | Role |
-|------|------|
-| `pushpull.go:568` (`clientInfo.ID == pulledChange.ActorID`) | Self-echo dedup — **the single most important switch** |
-| `pushpull.go:163` | Pubsub publisher actor |
-| `pushpull.go:377` | `DisableGC` VV truncation key |
-| `clients.go:90` | Cluster `DetachDocument` actor |
-| `client_info.go:354/360` | `VersionVectorInfo.ClientID` construction |
-| `memory/database.go:2260-2296`, `mongo/client.go:2374-2475` | VV upsert, min-VV, delete-on-detach, vector cache |
+The predicate lives on `ClientInfo`:
+
+```go
+func (i *ClientInfo) IsOwnActor(actorID types.ID) bool {
+    return i.ID == actorID || (i.StableActorID != "" && i.StableActorID == actorID)
+}
+```
+
+The empty-`StableActorID` guard is load-bearing: rows written before the stable
+actor existed leave it empty, and an empty value must never match.
+
+| Site | Role | Decision |
+|------|------|----------|
+| `pushpull.go` `pullChangeInfos` dedup (`clientInfo.ID == pulledChange.ActorID`) | Self-echo dedup — **the single most important switch** | `clientInfo.IsOwnActor(pulledChange.ActorID)` |
+| `pushpull.go` `DisableGC` VV truncation key | Size-1 VV keyed on the client's own actor so its lamport clock advances | `clientInfo.OwnActorID()` (StableActorID when present, else session id) |
+| `pushpull.go` pubsub publisher actor | DocChanged event author for self-echo filtering | **stays** on `clientInfo.ID` (see below) |
+| `client_info.go` `VersionVectorInfo.ClientID`; `memory/database.go`, `mongo/client.go` VV upsert / delete-on-detach / vector cache | VV **row identity** | **stays** on `clientInfo.ID` (see VV keying below) |
 
 Sites that **stay** on the session `_id`: all `IDFromActorID` RPC row lookups;
 `ActivateClient` minting a fresh `_id`; housekeeping row reaping; checkpoint
@@ -135,7 +151,45 @@ ownership in `ClientDocInfo` (scoped per session on purpose — see below);
 analytics counting (Q4). Snapshot authoring uses `InitialActorID`, unaffected.
 
 A client that does not supply a stable identity keeps today's behavior: a random
-actor per session.
+actor per session. With compare-both, its changes stamp the session id, which is
+still recognized as its own — no regression, byte-identical behavior.
+
+##### VV keying: row identity stays on the session id
+
+`VersionVectorInfo.ClientID` remains the per-session `clientInfo.ID` — it is the
+**row identity** for upsert and delete-on-detach, not a min-VV/GC key. The actor
+that matters for min-VV and GC lives **inside** the stored
+`VersionVectorInfo.VersionVector` map, keyed by whatever actor the client
+stamped into its changes (its StableActorID for a new SDK). That map is built
+from the client-supplied `reqPack.VersionVector`, so no server-side re-keying is
+needed. `MinVersionVector` iterates the entries **inside** each stored vector; it
+never reads `ClientID`. On detach, the row is deleted by `client_id =
+clientInfo.ID`, which removes the whole vector — including its stable-actor entry
+— so that client stops holding tombstones alive and GC can advance. This is
+GC-safe precisely because dedup now uses compare-both: the actor stamped into a
+change is recognized as the same client's own by the predicate that governs
+dedup, while its VV contribution is dropped atomically with the row on detach.
+
+##### Pubsub publisher stays on the session id
+
+The DocChanged publisher stays on `clientInfo.ID`. `Watch` subscribes with the
+wire `clientId` (the session id), and the pubsub self-echo filter drops events
+whose `Actor` equals the subscriber. Keying the publisher on the stable actor
+would leak the client's own event back to itself. Even if it did, that self-echo
+would be re-caught by the compare-both dedup on the next pull (no double-apply),
+but avoiding the wasted round trip is why the publisher keys on the session id.
+
+##### Version-vector transition staleness (accepted)
+
+During a rolling deploy, a long-lived attached doc can briefly hold a client's
+VV entry under its **old session actor** (written by a pre-Phase-1 session)
+alongside new entries under the stable actor. These stale session-actor entries
+linger until the client detaches (which deletes its VV row) or overwrites them
+on the next sync. Min-VV floors an actor missing from any presented vector at
+`0`, so a lingering stale entry can only hold GC **back** (conservative), never
+advance it past un-synced tombstones. This transient staleness is **accepted**;
+no data migration is required because VV rows are deleted on detach and new
+writes use the client-supplied vector.
 
 #### Stable actor derivation
 
@@ -245,7 +299,7 @@ attach(docKey, sessionId, resumeIntent?, lastCheckpoint?)
   └─ pull-before-trust: epoch/serverSeq behind → snapshot re-anchor [Q2 tiers]
   └─ client pushes pending changes from the (preserved) clientSeq
        └─ validateClientSeqContinuity guards continuity (loud on mismatch)
-  └─ dedup/VV/min-VV keyed on StableActorID                         [Seam 2]
+  └─ dedup/VV/min-VV recognize own actor via compare-both           [Seam 2]
 ```
 
 ### Analytics invariants (Q4)
@@ -279,7 +333,7 @@ docs attached across the upgrade.
 
 | Risk | Mitigation |
 |------|------------|
-| Seam 2 must move dedup **and** VV keying together; moving only one lets min-VV compare mismatched key spaces → GC past un-synced tombstones (data loss) | Treat "change actor == dedup/VV/GC key" as a hard invariant; switch all Seam-2 sites in one change; land behind an opt-in path so default behavior is byte-identical |
+| Seam 2 must move dedup **and** VV keying together; moving only one lets min-VV compare mismatched key spaces → GC past un-synced tombstones (data loss) | Treat "change actor recognized as own == dedup/VV/GC key" as a hard invariant; use compare-both (`IsOwnActor`) at dedup while VV rows delete atomically on detach; default behavior is byte-identical because the session id still matches |
 | Housekeeping (`FindDeactivateCandidates`, `housekeeping.go`) reaps a client idle past `ClientDeactivateThreshold`; a later return must revive under the same stable actor | Deterministic derivation reproduces the actor regardless of row lifecycle; revive reconciles via pull-before-trust |
 | A resumed checkpoint is behind `serverSeq` after compaction/purge | Pull-before-trust re-anchors via the three-tier contract before accepting pushes; never trust the stored `serverSeq` |
 | Tier 3 (`DocInfo` purged) has no server signal — attach silently mints a new empty doc | Closed only on the client: persist `docID`/`epoch` and raise a data-loss event on mismatch. Future server hardening: expose a distinguishable "purged" signal |

--- a/docs/design/offline-resumable-attach.md
+++ b/docs/design/offline-resumable-attach.md
@@ -1,0 +1,325 @@
+---
+title: offline-resumable-attach
+target-version: unreleased
+---
+
+# Offline-Resumable Attach
+
+## Problem
+
+A client (e.g. Wafflebase) that edits while offline keeps its un-pushed
+changes only in the SDK's in-memory `Document`. Closing or reloading the tab
+loses that work. To make local persistence possible, the SDK needs to store a
+document and its pending changes on disk and, on the next session, push them to
+the server. Today the server prevents this in two independent ways.
+
+**1. The actor is not stable across sessions.** `ClientInfo.ID` *is* the
+actorID (both are 12-byte ObjectIDs; the server converts with
+`types.IDFromActorID` / `cli.ID.ToActorID()` throughout). `ActivateClient`
+mints a fresh `_id` on every call:
+
+```go
+// server/backend/database/mongo/client.go (ActivateClient)
+// server/backend/database/memory/database.go (ActivateClient)
+info := &database.ClientInfo{ ID: types.NewID(), Key: key, ... }
+// InsertOne — no upsert, no reuse by key
+```
+
+Every position ticket embedded in a stored change (`fromPos`, `toPos`,
+`parentCreatedAt`, element `createdAt`) carries the old actorID. Replaying those
+changes under a new actor requires rewriting them — and that rewrite is
+unsound (see [Why not rebase](#alternatives-considered) and the SDK-side
+companion doc). A stable actorID makes replay correct **by construction**,
+requiring zero ticket rewriting.
+
+**2. Re-attach resets the checkpoint to zero.** Even with a stable actor,
+`DetachDocument` (`server/backend/database/client_info.go`) and `TryAttaching`
+reset `ClientSeq`/`ServerSeq` to `0`. On the next attach the server's checkpoint
+is `0`, but the restored local changes start at, say, `clientSeq = 6`.
+`pushpull` then rejects them: `validateClientSeqContinuity` expects the incoming
+`clientSeq` to be exactly `checkpoint.ClientSeq + 1`. The un-pushed work is
+refused.
+
+The equation `actorID == clientID == checkpoint owner` is baked into the
+protocol. Local persistence breaks it, so this is a protocol change, not a
+documentation gap.
+
+### Goals
+
+- The same logical client resumes the **same actorID** across activate cycles,
+  so locally-stored changes replay without ticket rewriting.
+- On re-attach, a client can **resume its last checkpoint** instead of starting
+  from `0`, so its persisted un-pushed changes push cleanly.
+- No regression for existing clients that do not opt in (they still get a fresh
+  actor per session).
+- Keep the CRDT protocol sound: no change to how elements are keyed, ordered, or
+  deduplicated.
+
+### Non-Goals
+
+- Client-side storage, serialization, and the restore flow — covered in the
+  yorkie-js-sdk companion doc `offline-local-persistence.md`.
+- Concurrent multi-tab editing under one identity. A single stable identity
+  shared by two live tabs collapses to one checkpoint and corrupts `clientSeq`;
+  this is bounded by a single-active-session lease on the SDK side, not solved
+  here.
+- Server-authored snapshots or any change to GC/compaction cadence.
+
+## Design
+
+Two additions, both opt-in and both keeping per-session client rows intact.
+
+### 1. Stable actor, decoupled from the per-session client row
+
+Do **not** make `ActivateClient` idempotent per `clientKey`, and do **not** try
+to reuse the actor purely on the client. Both were evaluated and rejected:
+
+- **Upsert-by-`clientKey`** (reuse `ClientInfo.ID`): `ColClients` is sharded on
+  `[project_id, _id]` (`indexes.go`); a unique index on `{project_id, key}`
+  cannot be enforced without a shard-key prefix, so upsert-by-key is racy on any
+  sharded deployment and its enabling index fails to build against existing
+  duplicate rows.
+- **Pure client-side reuse** (SDK persists its actor and stamps it via
+  `doc.setActor` after a fresh activation): the server persists a change's actor
+  straight from the wire (`change_info.go:72` reads `c.ID().ActorID()`, decoded
+  in `from_pb.go:249`) and **never validates it against `clientInfo.ID`**, so a
+  divergent push is *silently accepted* — then breaks three server invariants
+  (self-echo dedup, VV/GC keying, checkpoint continuity; see
+  [Alternatives](#alternatives-considered)). Making it correct requires the exact
+  same server changes as the decoupled field below, so client-side-only reuse
+  buys nothing and corrupts state in the meantime.
+
+Instead, **decouple a stable actor identity from the per-session session
+identity**. The change localizes to two seams. The hard invariant tying them
+together: *the actor stamped into persisted changes must equal the key used for
+pull dedup, VV, min-VV, and GC.* Both are `ClientInfo.ID` today; move **both**
+to the stable actor together — never one without the other, or GC advances past
+un-synced tombstones.
+
+#### Seam 1 — actor identity on the wire
+
+- `ClientInfo.ID` stays a fresh per-session ObjectID. It remains the **session
+  id** used for every RPC row lookup (`types.IDFromActorID(actorID)` →
+  `ClientRefKey` in `yorkie_server.go`, ~21 sites) and the shard key. Do **not**
+  feed the stable actor into those lookups.
+- Add a stable `StableActorID` field to `ClientInfo` (`client_info.go`), derived
+  deterministically as `StableActorID = DeriveActorID(project_id, clientKey)` at
+  `ActivateClient` (see [Stable actor derivation](#stable-actor-derivation)).
+  Deterministic derivation means two concurrent activations for the same key
+  compute the same actor with **no** unique index and **no** upsert. It is a plain
+  field, never a Mongo `_id`, so it carries **no** unique index — the same key
+  across sessions legitimately shares one actor.
+- Return it **additively** in `ActivateClientResponse` (`api/yorkie/v1/yorkie.proto`;
+  the request already carries `client_key`). Old SDKs ignore the new field and
+  keep using `client_id` as their actor (status quo). The SDK splits `this.id`
+  (`client.ts:547`) into a *session id* (wire `clientId`, all RPCs) and a
+  *stable actor* (fed only to `doc.setActor`), with a nil-guard fallback to
+  `clientId`-as-actor against old servers.
+
+#### Seam 2 — dedup and VV liveness
+
+Switch these from `clientInfo.ID` to the stable actor:
+
+| Site | Role |
+|------|------|
+| `pushpull.go:568` (`clientInfo.ID == pulledChange.ActorID`) | Self-echo dedup — **the single most important switch** |
+| `pushpull.go:163` | Pubsub publisher actor |
+| `pushpull.go:377` | `DisableGC` VV truncation key |
+| `clients.go:90` | Cluster `DetachDocument` actor |
+| `client_info.go:354/360` | `VersionVectorInfo.ClientID` construction |
+| `memory/database.go:2260-2296`, `mongo/client.go:2374-2475` | VV upsert, min-VV, delete-on-detach, vector cache |
+
+Sites that **stay** on the session `_id`: all `IDFromActorID` RPC row lookups;
+`ActivateClient` minting a fresh `_id`; housekeeping row reaping; checkpoint
+ownership in `ClientDocInfo` (scoped per session on purpose — see below);
+analytics counting (Q4). Snapshot authoring uses `InitialActorID`, unaffected.
+
+A client that does not supply a stable identity keeps today's behavior: a random
+actor per session.
+
+#### Stable actor derivation
+
+An actor is exactly **12 bytes** (`time.ActorID [12]byte`; `types.ID` is its
+lowercase-hex form). The derivation is server-authoritative — the SDK receives
+the result and stamps it verbatim, so it never recomputes the hash:
+
+```
+DeriveActorID(projectID types.ID, clientKey string) time.ActorID:
+    tag = "yorkie/stable-actor/v1"                  // domain tag, permanent
+    h   = SHA256(tag || projectID.Bytes()/*12B*/ || []byte(clientKey))
+    a   = h[0:12]
+    for a == time.InitialActorID || a == time.MaxActorID:   // reserved-value guard
+        h = SHA256(tag || 0x01 || h); a = h[0:12]
+    return time.ActorIDFromBytes(a)                 // → .String() = lowercase 24-hex
+```
+
+Design points:
+
+- **Plain SHA256, not HMAC.** `clientKey` is already the client's own credential;
+  forging another client's actor requires knowing that client's key regardless, so
+  a server secret adds little. It would also have to be stable and shared across
+  every node forever (rotation breaks all actors) — an operational liability the
+  plain hash avoids. Determinism is then free: identical on every node, restart,
+  and offline.
+- **`projectID` first, fixed 12-byte width**, so concatenation with the
+  variable-length `clientKey` is unambiguous; including it namespaces the actor
+  per project.
+- **Reserved-value guard.** Hitting all-zero (`InitialActorID` / system client) or
+  all-`0xFF` (`MaxActorID`) has probability ≈ 2·2⁻⁹⁶; the loop makes the fallback
+  deterministic anyway.
+- **`clientKey` is used byte-for-byte** — no trimming or case normalization, or
+  two encodings would derive different actors. Apps already must send a
+  byte-identical key each session for a stable identity.
+- **The `v1` tag is permanent.** Changing the algorithm changes every actor and
+  orphans every persisted offline document; bump the version only in an emergency.
+
+Collision profile: 96 uniform bits. Per-project birthday collision for N distinct
+keys ≈ N²/2⁹⁷ (~6×10⁻¹² at N = 10⁹) — the **same** profile the system already
+accepts for random 12-byte ObjectID actors, so derivation is no worse. There is no
+DB uniqueness check (there cannot be), so a collision would be silent; the 96-bit
+width is the mitigation.
+
+Encoding matches existing actors exactly (lowercase hex via `.String()`), so the
+derived actor slots into the current comparison path unchanged. (Note a
+pre-existing cross-runtime detail, unrelated to this change: Go compares actors by
+raw bytes while the JS SDK compares by `localeCompare` on the hex string; identical
+lowercase-hex encoding keeps them in agreement, as it already does for random
+actors.)
+
+### 2. Resumable checkpoint on attach
+
+A stable actor alone does not enable replay: on attach, `ClientDocInfo`
+checkpoint starts at `0` while the restored local changes continue the actor's
+`clientSeq` lineage. Two mechanisms close this, both reusing existing machinery.
+
+#### Conditional checkpoint reset (Q3)
+
+Make the reset-to-`0` conditional at exactly two owned sites; leave
+`validateClientSeqContinuity` (`pushpull.go:205`) as the loud safety net.
+
+1. `ClientInfo.AttachDocument` (`client_info.go:154-159`): **preserve** existing
+   `ServerSeq`/`ClientSeq` when the same stable-actor row already holds a
+   `ClientDocInfo` for `docID` in `Attached`/`Attaching` status (crash/reload
+   resume); otherwise zero as today. Thread an explicit **resume-intent flag**
+   (or `change.Checkpoint`) into the pure-struct method rather than reading
+   global state, to keep it testable.
+2. Both `TryAttaching` impls (`memory/database.go:1064-1068`,
+   `mongo/client.go:1112-1113`): stop clobbering `server_seq`/`client_seq` on the
+   `attached→attaching` transition, letting `AttachDocument` be the sole owner.
+
+Do **not** touch `DetachDocument`/`RemoveDocument` resets — a genuine detach must
+restart `clientSeq` at `1`. The current `IsAlreadyDetached` guard
+(`clients.go:160-163`) blocks re-attach today, so the resume path is opened
+deliberately via the resume-intent flag, not by relaxing the guard.
+
+#### Pull-before-trust reconciliation (Q2)
+
+Never trust the presented `serverSeq` blindly. Reuse the **epoch +
+snapshot-threshold + `FindClosestSnapshotInfo` empty-fallback** machinery (see
+`document-epoch.md`) as a three-tier contract — do **not** build a parallel path:
+
+- **Tier 1** — same epoch, `serverSeq` behind, rows intact: normal `PushPull`
+  auto-ships a snapshot re-anchor via `preparePack → pullSnapshot`
+  (`pushpull.go:447/470`) when `(initialServerSeq − client.ServerSeq) ≥
+  snapshotThreshold`.
+- **Tier 2** — epoch advanced by force-compaction, or GC'd past the client
+  `serverSeq`: warm `PushPull` returns `ErrEpochMismatch` (`pushpull.go:88/431`);
+  on re-attach the checkpoint resets to `0` with the current epoch, and
+  `FindClosestSnapshotInfo` returns an empty snapshot at seq `0`, so re-anchor
+  always succeeds while the `DocInfo` row survives. Reuse `ErrEpochMismatch` as
+  the "re-anchor by re-attach" signal — do not invent a new one.
+- **Tier 3** — unrecoverable (`DocInfo` purged): there is **no server signal**;
+  attach silently mints a fresh empty doc via `FindOrCreateDocInfo`. This is
+  closable only on the client (persist `docID`/`epoch` with the offline
+  snapshot; raise a data-loss event on re-attach when the returned `docID`
+  differs or `serverSeq` regressed to `0` against a non-empty local snapshot).
+
+### Data flow
+
+```
+attach(docKey, sessionId, resumeIntent?, lastCheckpoint?)
+  └─ server resolves StableActorID = derive(project_id, clientKey)  [Seam 1]
+  └─ AttachDocument: resumeIntent && existing ClientDocInfo[docKey] Attached/Attaching
+       ? preserve ClientSeq/ServerSeq                               [Q3]
+       : checkpoint = 0 (fresh)
+  └─ pull-before-trust: epoch/serverSeq behind → snapshot re-anchor [Q2 tiers]
+  └─ client pushes pending changes from the (preserved) clientSeq
+       └─ validateClientSeqContinuity guards continuity (loud on mismatch)
+  └─ dedup/VV/min-VV keyed on StableActorID                         [Seam 2]
+```
+
+### Analytics invariants (Q4)
+
+The decoupled form keeps per-session rows, so `CountActivatedClients`
+(`memory/database.go:1699`, `mongo/client.go:1742`) and `GetProjectStats`
+(`projects.go:134`) are preserved. Two invariants must be recorded so a later
+refactor does not silently break them:
+
+- **`client_events` must keep emitting the per-session row id (`cli.ID`),
+  never the stable actor** (`yorkie_server.go:83`). The warehouse active-clients
+  metric counts distinct `client_id`; substituting the stable actor collapses
+  its cardinality to distinct actors.
+- `CountActivatedClients` / `GetProjectStatsCounts` now count **sessions, not
+  unique actors** — a semantic note, no code change.
+- `session_events.user_id` (`channel/manager.go:696`) will carry the stable
+  actor post-change but is **not** a count key (session metric counts
+  `session_id`); cosmetic — leave it or switch to the row id for consistency.
+
+### Migration
+
+Purely additive at the DB layer. The proto gains an `ActivateClientResponse`
+field (additive, safe). The VV re-key writes new `VersionVectorInfo` rows under
+the stable actor; because VV rows are deleted on detach, a rolling deploy needs
+**no data migration** (new writes use the new key). The one transition hazard: a
+long-lived attached doc spanning the deploy could briefly hold mixed-keyed VV
+rows — confirm min-VV cannot regress GC during that window, or drain/migrate
+docs attached across the upgrade.
+
+### Risks and Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| Seam 2 must move dedup **and** VV keying together; moving only one lets min-VV compare mismatched key spaces → GC past un-synced tombstones (data loss) | Treat "change actor == dedup/VV/GC key" as a hard invariant; switch all Seam-2 sites in one change; land behind an opt-in path so default behavior is byte-identical |
+| Housekeeping (`FindDeactivateCandidates`, `housekeeping.go`) reaps a client idle past `ClientDeactivateThreshold`; a later return must revive under the same stable actor | Deterministic derivation reproduces the actor regardless of row lifecycle; revive reconciles via pull-before-trust |
+| A resumed checkpoint is behind `serverSeq` after compaction/purge | Pull-before-trust re-anchors via the three-tier contract before accepting pushes; never trust the stored `serverSeq` |
+| Tier 3 (`DocInfo` purged) has no server signal — attach silently mints a new empty doc | Closed only on the client: persist `docID`/`epoch` and raise a data-loss event on mismatch. Future server hardening: expose a distinguishable "purged" signal |
+| Two live tabs share one stable actor → one checkpoint → `clientSeq` collisions and self-filtered pull dedup (real edit loss) | Bounded by the SDK single-active-session lease; background tabs observe, do not drive sync |
+| `Database.TryAttaching` signature change (resume flag) ripples to both backends and all test doubles | Contained interface change; covered by existing attach test suites plus new resume-path tests |
+| VV re-key mixed-keying window on rolling deploy | See [Migration](#migration); confirm min-VV cannot regress during the transition |
+
+### Design Decisions
+
+| Decision | Reason |
+|----------|--------|
+| Decouple a stable `StableActorID` from `ClientInfo.ID` rather than upsert-by-key or client-side reuse | Upsert's `{project_id, key}` unique index is unenforceable on the sharded `ColClients`; client-side reuse is silently accepted by the server but breaks dedup/VV/checkpoint and needs the same server work anyway |
+| Derive the actor deterministically via plain `SHA256(tag \|\| projectID \|\| clientKey)[:12]` | No unique index, no upsert, no cross-session write coordination; plain hash (not HMAC) needs no shared secret and is identical on every node/restart/offline; concurrent activations converge on the same actor |
+| Return the stable actor additively in `ActivateClientResponse`; keep `clientId` = session `_id` on the wire | All RPC row lookups stay unchanged (~21 `IDFromActorID` sites); old SDKs keep working by ignoring the field |
+| Keep per-session client rows | Preserves checkpoints, housekeeping, and activation metrics; isolates the change to the actor-identity layer |
+| Resume checkpoint conditionally in `AttachDocument`, guarded by `validateClientSeqContinuity`; drop the `TryAttaching` seq resets | Un-pushed local changes cannot push from a zeroed checkpoint; a single owner site plus the existing continuity guard turns a bad resume into a loud error, not corruption |
+| Reuse epoch + snapshot machinery for pull-before-trust; reuse `ErrEpochMismatch` | The stale-after-compaction recovery path already exists; a parallel path would duplicate and drift |
+
+## Alternatives Considered
+
+| Alternative | Why not |
+|-------------|---------|
+| `ActivateClient` upsert-by-`clientKey` (reuse `ClientInfo.ID`) | Unique index on `{project_id, key}` unenforceable on the sharded `ColClients`; racy inserts; index build fails against existing duplicate rows; two tabs sharing a key collapse to one checkpoint |
+| Pure client-side actor reuse (SDK persists its actor, no server change) | The server persists a change's actor from the wire (`change_info.go:72`) and never checks it against `clientInfo.ID`, so a divergent push is silently accepted — then breaks (1) self-echo dedup (`pushpull.go:568` goes false → own changes echo back and re-apply; non-idempotent ops like `IncreaseOperation` double-count), (2) VV accounting (VV rows keyed by session id, vector entries by the persisted actor → min-VV mixes key spaces → GC past un-synced tombstones), (3) checkpoint continuity (attach zeros seqs while the restored doc continues the persisted actor's `clientSeq`). Fixing any of these requires the same server changes as the decoupled field |
+| Client-side rebase on restore (SDK gets a new actor and rewrites pending tickets) | The pushed/pending boundary is per-embedded-ticket, not per-change; a normal edit references already-pushed elements under the old actor, forcing mixed-actor changes that miss the actor-keyed element map (`root.go`, `Ticket.Key()`) or corrupt the actorID tie-break ordering. The only discriminator (a lamport watermark) is unsound: one change shares one lamport and lamport is bumped non-monotonically on every pull. Failure mode is silent divergence. Detailed in the SDK companion doc |
+| Keep the checkpoint reset and re-push everything from `0` | `validateClientSeqContinuity` rejects changes whose `clientSeq` does not continue from the checkpoint; also re-uploads already-acked work |
+
+## Open Questions
+
+- **VV re-key transition window.** Whether a one-time migration or drain is
+  needed for docs attached across the rolling deploy (see [Migration](#migration)).
+- **`TryAttaching` signature.** Resume-intent flag vs `change.Checkpoint`; and
+  whether the mongo atomic `FindOneAndUpdate` can drop the seq `$set` lines
+  without losing the attaching-status transition guarantee.
+- **Tier 3 purge signal.** Whether the server should eventually expose a
+  distinguishable "document purged" signal on attach (future hardening).
+
+## Tasks
+
+Track execution plans in `docs/tasks/active/` as separate task documents. See
+the yorkie-js-sdk companion design `docs/design/offline-local-persistence.md`
+for the client-side storage, serialization, restore flow, and multi-tab lease
+that this protocol enables.

--- a/docs/design/offline-resumable-attach.md
+++ b/docs/design/offline-resumable-attach.md
@@ -422,6 +422,14 @@ docs attached across the upgrade.
   reuse the non-zero `pack.Checkpoint` presented at attach — no proto flag.)
 - **Tier 3 purge signal.** Whether the server should eventually expose a
   distinguishable "document purged" signal on attach (future hardening).
+- **Epoch-0 sentinel.** A presented epoch of `0` is treated as "no epoch
+  presented" (old SDK / never-synced) and falls back to the current doc epoch.
+  Consequence: a brand-new document (epoch `0`) force-compacted exactly once
+  (`0 → 1`) during a client's offline window presents `0` and is not detected as
+  stale. A doc compacted at least once before the client joins (epoch `≥ 1`) is
+  covered. Closing this narrow gap needs a 1-based initial epoch or a separate
+  "epoch present" flag; deferred to avoid changing the broader document-epoch
+  semantics.
 
 ## Tasks
 

--- a/docs/design/offline-resumable-attach.md
+++ b/docs/design/offline-resumable-attach.md
@@ -248,23 +248,43 @@ checkpoint starts at `0` while the restored local changes continue the actor's
 
 #### Conditional checkpoint reset (Q3)
 
-Make the reset-to-`0` conditional at exactly two owned sites; leave
-`validateClientSeqContinuity` (`pushpull.go:205`) as the loud safety net.
+There are **two distinct resume cases**, and only one of them can rely on
+server-side row memory. `AttachDocument` (`client_info.go:142`) today seeds
+`ClientDocInfo{ServerSeq: 0, ClientSeq: 0}` unconditionally; leave
+`validateClientSeqContinuity` (`pushpull.go`) as the loud safety net for both.
 
-1. `ClientInfo.AttachDocument` (`client_info.go:154-159`): **preserve** existing
-   `ServerSeq`/`ClientSeq` when the same stable-actor row already holds a
-   `ClientDocInfo` for `docID` in `Attached`/`Attaching` status (crash/reload
-   resume); otherwise zero as today. Thread an explicit **resume-intent flag**
-   (or `change.Checkpoint`) into the pure-struct method rather than reading
-   global state, to keep it testable.
-2. Both `TryAttaching` impls (`memory/database.go:1064-1068`,
-   `mongo/client.go:1112-1113`): stop clobbering `server_seq`/`client_seq` on the
-   `attached→attaching` transition, letting `AttachDocument` be the sole owner.
+**Case A — same-session re-attach** (detach then re-attach without deactivating;
+same client row). The row still holds a `ClientDocInfo` for `docID`, so
+`AttachDocument` can **preserve** its `ServerSeq`/`ClientSeq` when the existing
+entry is `Attached`/`Attaching`. Also stop the `TryAttaching` impls
+(`memory/database.go`, `mongo/client.go`) from clobbering `server_seq`/`client_seq`
+on the `attached→attaching` transition, so `AttachDocument` is the sole owner.
+
+**Case B — reload / new session** (the primary offline case). A reload runs a
+fresh `ActivateClient`, which mints a **new per-session `_id` and a new client
+row with no `ClientDocInfo` history** — the server has *no* memory of the prior
+session's checkpoint. So preserving row seqs cannot help here. Instead, the
+client presents its **locally-persisted checkpoint in the attach `ChangePack`**
+(`pack.Checkpoint`), and `AttachDocument` seeds `ClientDocInfo` from that
+presented checkpoint (instead of `0`) when it is non-zero. **No new proto field
+is needed** — `pack.Checkpoint` already rides the attach request; a non-zero
+presented checkpoint *is* the resume signal (resolving the earlier
+"resume-intent flag vs `change.Checkpoint`" open question in favor of the
+latter). Thread the presented checkpoint into the pure-struct `AttachDocument`
+so it stays testable.
+
+Guarding Case B (a client-presented checkpoint is untrusted input):
+- `validateClientSeqContinuity` rejects a `clientSeq` that does not continue the
+  presented one — a bad `clientSeq` fails loudly, not silently.
+- **pull-before-trust** (Q2) re-anchors the presented `serverSeq`: if the server
+  compacted/GC'd past it, or it exceeds the doc's real `serverSeq`, the client is
+  sent a snapshot to re-anchor before its pushes are accepted, so a client cannot
+  skip changes by over-claiming `serverSeq`.
 
 Do **not** touch `DetachDocument`/`RemoveDocument` resets — a genuine detach must
-restart `clientSeq` at `1`. The current `IsAlreadyDetached` guard
-(`clients.go:160-163`) blocks re-attach today, so the resume path is opened
-deliberately via the resume-intent flag, not by relaxing the guard.
+restart `clientSeq` at `1`. For Case A the `IsAlreadyDetached` guard
+(`clients.go:160-163`) blocks re-attach today, so that path is opened
+deliberately, not by relaxing the guard.
 
 #### Pull-before-trust reconciliation (Q2)
 
@@ -291,15 +311,15 @@ snapshot-threshold + `FindClosestSnapshotInfo` empty-fallback** machinery (see
 ### Data flow
 
 ```
-attach(docKey, sessionId, resumeIntent?, lastCheckpoint?)
-  └─ server resolves StableActorID = derive(project_id, clientKey)  [Seam 1]
-  └─ AttachDocument: resumeIntent && existing ClientDocInfo[docKey] Attached/Attaching
-       ? preserve ClientSeq/ServerSeq                               [Q3]
-       : checkpoint = 0 (fresh)
-  └─ pull-before-trust: epoch/serverSeq behind → snapshot re-anchor [Q2 tiers]
-  └─ client pushes pending changes from the (preserved) clientSeq
+attach(docKey, ChangePack{ Checkpoint: presentedCkpt, changes })
+  └─ ActivateClient already ran → new per-session _id + StableActorID  [Seam 1]
+  └─ AttachDocument seeds ClientDocInfo:
+       Case A (same-session re-attach, row still has ClientDocInfo) → preserve seqs
+       Case B (reload / new row) → seed from presentedCkpt if non-zero, else 0  [Q3]
+  └─ pull-before-trust: epoch / presented serverSeq behind → snapshot re-anchor [Q2]
+  └─ client pushes pending changes from the seeded clientSeq
        └─ validateClientSeqContinuity guards continuity (loud on mismatch)
-  └─ dedup/VV/min-VV recognize own actor via compare-both           [Seam 2]
+  └─ dedup/VV/min-VV recognize own actor via compare-both              [Seam 2]
 ```
 
 ### Analytics invariants (Q4)
@@ -338,7 +358,7 @@ docs attached across the upgrade.
 | A resumed checkpoint is behind `serverSeq` after compaction/purge | Pull-before-trust re-anchors via the three-tier contract before accepting pushes; never trust the stored `serverSeq` |
 | Tier 3 (`DocInfo` purged) has no server signal — attach silently mints a new empty doc | Closed only on the client: persist `docID`/`epoch` and raise a data-loss event on mismatch. Future server hardening: expose a distinguishable "purged" signal |
 | Two live tabs share one stable actor → one checkpoint → `clientSeq` collisions and self-filtered pull dedup (real edit loss) | Bounded by the SDK single-active-session lease; background tabs observe, do not drive sync |
-| `Database.TryAttaching` signature change (resume flag) ripples to both backends and all test doubles | Contained interface change; covered by existing attach test suites plus new resume-path tests |
+| Threading the presented checkpoint into `AttachDocument` / dropping the `TryAttaching` seq resets ripples to both backends and all test doubles | Contained interface change; no proto change (reuses `pack.Checkpoint`); covered by existing attach suites plus new resume-path tests |
 | VV re-key mixed-keying window on rolling deploy | See [Migration](#migration); confirm min-VV cannot regress during the transition |
 
 ### Design Decisions
@@ -365,9 +385,10 @@ docs attached across the upgrade.
 
 - **VV re-key transition window.** Whether a one-time migration or drain is
   needed for docs attached across the rolling deploy (see [Migration](#migration)).
-- **`TryAttaching` signature.** Resume-intent flag vs `change.Checkpoint`; and
-  whether the mongo atomic `FindOneAndUpdate` can drop the seq `$set` lines
-  without losing the attaching-status transition guarantee.
+- **`TryAttaching` seq reset.** Whether the mongo atomic `FindOneAndUpdate` can
+  drop the `server_seq`/`client_seq` `$set` lines without losing the
+  attaching-status transition guarantee. (The resume-signal question is settled:
+  reuse the non-zero `pack.Checkpoint` presented at attach — no proto flag.)
 - **Tier 3 purge signal.** Whether the server should eventually expose a
   distinguishable "document purged" signal on attach (future hardening).
 

--- a/docs/design/offline-resumable-attach.md
+++ b/docs/design/offline-resumable-attach.md
@@ -308,31 +308,46 @@ snapshot-threshold + `FindClosestSnapshotInfo` empty-fallback** machinery (see
   snapshot; raise a data-loss event on re-attach when the returned `docID`
   differs or `serverSeq` regressed to `0` against a non-empty local snapshot).
 
-**Interaction with Q3 checkpoint seeding (must fix together).** The epoch check
-that fires Tier 2 is `clientDocInfo.Epoch != docInfo.Epoch` (`pushpull.go:445`).
-The Q3 increment currently seeds a resumed `ClientDocInfo.Epoch` from the
-**current** `docInfo.Epoch`, which **masks** Tier 2: a client that went offline,
-had its doc compacted (epoch bumped), and then resumed would be seeded with the
-new epoch, so the mismatch never fires and the client never re-anchors from a
-snapshot — its local baseline sits in the old epoch while the server advanced.
-The Q3 serverSeq clamp only caps over-claims; it does **not** re-anchor this
-case. So Q2 must make the resume path **present the client's persisted epoch**
-(the offline `StoredDoc` already stores `epoch`) and seed `ClientDocInfo.Epoch`
-from *that*, not from the current doc epoch — then the existing epoch machinery
-fires Tier 2 and re-anchors. Until Q2 lands, the current-doc-epoch seeding is a
-known interim limitation (safe only while no compaction occurs during an offline
-window). Presenting the epoch needs a carrier at attach (extend the presented
-checkpoint or the attach request); pin the exact carrier when Q2 is implemented.
+**Interaction with Q3 checkpoint seeding (RESOLVED, server side).** The epoch
+check that fires Tier 2 is `clientDocInfo.Epoch != docInfo.Epoch`
+(`pushpull.go`). The Q3 increment originally seeded a resumed
+`ClientDocInfo.Epoch` from the **current** `docInfo.Epoch`, which **masked**
+Tier 2: a client that went offline, had its doc force-compacted (epoch bumped),
+and then resumed was seeded with the new epoch, so the mismatch never fired and
+the client never re-anchored from a snapshot — its local baseline sat in the old
+epoch while the server advanced. The Q3 serverSeq clamp only caps over-claims; it
+does **not** re-anchor this case.
+
+The server now **presents and seeds the client's persisted epoch**. A new
+`epoch` field on `ChangePack` (`resources.proto`) is the carrier and flows both
+ways: the response sets it to the doc's current epoch (`ServerPack.ApplyDocInfo`
+→ `ToPBChangePack`) so a client can learn and persist it; the attach request
+carries the client's last-known epoch (`Pack.Epoch`, decoded in
+`converter.FromChangePack`). On a Case B resume, `clientInfo.AttachDocument`
+seeds `ClientDocInfo.Epoch` from that presented epoch (when non-zero) instead of
+the current doc epoch. If the doc was compacted while the client was offline, the
+seeded old epoch differs from the current doc epoch, so the existing epoch check
+fires `ErrEpochMismatch` and the existing snapshot re-anchor machinery runs — no
+new path. A presented epoch of `0` (old SDKs, or a client that only ever synced
+at epoch 0) falls back to the current doc epoch, preserving today's behavior.
+
+**Remaining companion work (SDK side).** The yorkie-js-sdk must persist the
+`epoch` returned in the sync/attach response alongside the offline snapshot and
+present it in the attach `ChangePack.epoch` on resume. Until the SDK presents a
+non-zero epoch, the server falls back to the current-doc-epoch seeding (the prior
+interim behavior), so this is safe to ship server-first.
 
 ### Data flow
 
 ```
-attach(docKey, ChangePack{ Checkpoint: presentedCkpt, changes })
+attach(docKey, ChangePack{ Checkpoint: presentedCkpt, Epoch: presentedEpoch, changes })
   └─ ActivateClient already ran → new per-session _id + StableActorID  [Seam 1]
   └─ AttachDocument seeds ClientDocInfo:
        Case A (same-session re-attach, row still has ClientDocInfo) → preserve seqs
        Case B (reload / new row) → seed from presentedCkpt if non-zero, else 0  [Q3]
-  └─ pull-before-trust: epoch / presented serverSeq behind → snapshot re-anchor [Q2]
+                                → seed Epoch from presentedEpoch if non-zero    [Q2]
+  └─ pull-before-trust: stale epoch → ErrEpochMismatch → snapshot re-anchor     [Q2]
+     (response ChangePack.Epoch carries the doc's current epoch for the client)
   └─ client pushes pending changes from the seeded clientSeq
        └─ validateClientSeqContinuity guards continuity (loud on mismatch)
   └─ dedup/VV/min-VV recognize own actor via compare-both              [Seam 2]
@@ -374,7 +389,7 @@ docs attached across the upgrade.
 | A resumed checkpoint is behind `serverSeq` after compaction/purge | Pull-before-trust re-anchors via the three-tier contract before accepting pushes; never trust the stored `serverSeq` |
 | Tier 3 (`DocInfo` purged) has no server signal — attach silently mints a new empty doc | Closed only on the client: persist `docID`/`epoch` and raise a data-loss event on mismatch. Future server hardening: expose a distinguishable "purged" signal |
 | Two live tabs share one stable actor → one checkpoint → `clientSeq` collisions and self-filtered pull dedup (real edit loss) | Bounded by the SDK single-active-session lease; background tabs observe, do not drive sync |
-| Threading the presented checkpoint into `AttachDocument` / dropping the `TryAttaching` seq resets ripples to both backends and all test doubles | Contained interface change; no proto change (reuses `pack.Checkpoint`); covered by existing attach suites plus new resume-path tests |
+| Threading the presented checkpoint into `AttachDocument` / dropping the `TryAttaching` seq resets ripples to both backends and all test doubles | Contained interface change; the checkpoint reuses `pack.Checkpoint` (no proto change), and the epoch rides a single additive `ChangePack.epoch` field (Q2, safe both ways); covered by existing attach suites plus new resume-path tests |
 | VV re-key mixed-keying window on rolling deploy | See [Migration](#migration); confirm min-VV cannot regress during the transition |
 
 ### Design Decisions

--- a/docs/design/offline-resumable-attach.md
+++ b/docs/design/offline-resumable-attach.md
@@ -254,11 +254,21 @@ server-side row memory. `AttachDocument` (`client_info.go:142`) today seeds
 `validateClientSeqContinuity` (`pushpull.go`) as the loud safety net for both.
 
 **Case A — same-session re-attach** (detach then re-attach without deactivating;
-same client row). The row still holds a `ClientDocInfo` for `docID`, so
-`AttachDocument` can **preserve** its `ServerSeq`/`ClientSeq` when the existing
-entry is `Attached`/`Attaching`. Also stop the `TryAttaching` impls
-(`memory/database.go`, `mongo/client.go`) from clobbering `server_seq`/`client_seq`
-on the `attached→attaching` transition, so `AttachDocument` is the sole owner.
+same client row) is **not reachable** on any production path, so it is **not
+implemented**. In principle the row could still hold a `ClientDocInfo` for
+`docID` whose `ServerSeq`/`ClientSeq` `AttachDocument` preserves, but no flow
+ever presents such a row: an `Attached` entry is preempted by the
+`ErrDocumentAlreadyAttached` check in `AttachDocument`, and no path ever persists
+an `Attaching` row with non-zero seqs — `TryAttaching` zeros them on the
+`attached→attaching` transition, and a genuine `DetachDocument` zeros them before
+the `IsAlreadyDetached` guard (`clients.go`) blocks re-attach. Resume is therefore
+carried **entirely by Case B** (the client-presented checkpoint). Both
+`TryAttaching` impls (`memory/database.go`, `mongo/client.go`) **reset**
+`server_seq`/`client_seq` to `0` on the transition, aligned across backends;
+`AttachDocument` remains the sole owner of the real seed and overwrites the entry
+from the presented checkpoint. If a same-session preserve-seqs path is ever
+needed, reintroduce Case A as an explicit branch keyed on a non-zero-seq
+`Attaching` row and drop the resets together.
 
 **Case B — reload / new session** (the primary offline case). A reload runs a
 fresh `ActivateClient`, which mints a **new per-session `_id` and a new client
@@ -282,9 +292,9 @@ Guarding Case B (a client-presented checkpoint is untrusted input):
   skip changes by over-claiming `serverSeq`.
 
 Do **not** touch `DetachDocument`/`RemoveDocument` resets — a genuine detach must
-restart `clientSeq` at `1`. For Case A the `IsAlreadyDetached` guard
-(`clients.go:160-163`) blocks re-attach today, so that path is opened
-deliberately, not by relaxing the guard.
+restart `clientSeq` at `1`. The `IsAlreadyDetached` guard (`clients.go`) still
+blocks re-attach of a detached row; Case A is not implemented, so this guard is
+not relaxed.
 
 #### Pull-before-trust reconciliation (Q2)
 
@@ -323,13 +333,26 @@ The server now **presents and seeds the client's persisted epoch**. A new
 ways: the response sets it to the doc's current epoch (`ServerPack.ApplyDocInfo`
 → `ToPBChangePack`) so a client can learn and persist it; the attach request
 carries the client's last-known epoch (`Pack.Epoch`, decoded in
-`converter.FromChangePack`). On a Case B resume, `clientInfo.AttachDocument`
-seeds `ClientDocInfo.Epoch` from that presented epoch (when non-zero) instead of
-the current doc epoch. If the doc was compacted while the client was offline, the
-seeded old epoch differs from the current doc epoch, so the existing epoch check
-fires `ErrEpochMismatch` and the existing snapshot re-anchor machinery runs — no
-new path. A presented epoch of `0` (old SDKs, or a client that only ever synced
-at epoch 0) falls back to the current doc epoch, preserving today's behavior.
+`converter.FromChangePack`). `clientInfo.AttachDocument` seeds `ClientDocInfo.Epoch`
+from that presented epoch **whenever it is non-zero**, instead of the current doc
+epoch. If the doc was compacted while the client was offline, the seeded old epoch
+differs from the current doc epoch, so the existing epoch check fires
+`ErrEpochMismatch` and the existing snapshot re-anchor machinery runs — no new
+path. A presented epoch of `0` (old SDKs, or a client that only ever synced at
+epoch 0) falls back to the current doc epoch, preserving today's behavior.
+
+The presented epoch is seeded **independently of the presented `serverSeq`**. This
+matters for a doc force-compacted to an **empty** root (a presence-only doc): the
+compacted snapshot sits at `serverSeq 0`, so the Q3 over-claim clamp in
+`clients.AttachDocument` drives the presented `serverSeq` to `0`, and the
+checkpoint-seeding gate (`presented.ServerSeq != 0`) routes into the fresh branch.
+Were epoch seeding gated on the same `serverSeq`, a stale client resuming against a
+compacted-to-empty doc would be seeded the **current** epoch, `ErrEpochMismatch`
+would never fire, and recovery would instead come (correctly, no data loss) via
+`ErrInvalidClientSeq` from `validateClientSeqContinuity` — a different tier than
+the design's "stale epoch → `ErrEpochMismatch`". Seeding the epoch on its own
+`presentedEpoch != 0` signal keeps the compacted-to-empty case on the same
+epoch-mismatch recovery tier as the compacted-to-non-empty case.
 
 **Remaining companion work (SDK side).** The yorkie-js-sdk must persist the
 `epoch` returned in the sync/attach response alongside the offline snapshot and
@@ -342,10 +365,10 @@ interim behavior), so this is safe to ship server-first.
 ```
 attach(docKey, ChangePack{ Checkpoint: presentedCkpt, Epoch: presentedEpoch, changes })
   └─ ActivateClient already ran → new per-session _id + StableActorID  [Seam 1]
-  └─ AttachDocument seeds ClientDocInfo:
-       Case A (same-session re-attach, row still has ClientDocInfo) → preserve seqs
+  └─ AttachDocument seeds ClientDocInfo (Case A is unreachable, not implemented):
        Case B (reload / new row) → seed from presentedCkpt if non-zero, else 0  [Q3]
-                                → seed Epoch from presentedEpoch if non-zero    [Q2]
+                                → seed Epoch from presentedEpoch if non-zero,   [Q2]
+                                  independent of presentedCkpt.ServerSeq
   └─ pull-before-trust: stale epoch → ErrEpochMismatch → snapshot re-anchor     [Q2]
      (response ChangePack.Epoch carries the doc's current epoch for the client)
   └─ client pushes pending changes from the seeded clientSeq
@@ -389,7 +412,7 @@ docs attached across the upgrade.
 | A resumed checkpoint is behind `serverSeq` after compaction/purge | Pull-before-trust re-anchors via the three-tier contract before accepting pushes; never trust the stored `serverSeq` |
 | Tier 3 (`DocInfo` purged) has no server signal — attach silently mints a new empty doc | Closed only on the client: persist `docID`/`epoch` and raise a data-loss event on mismatch. Future server hardening: expose a distinguishable "purged" signal |
 | Two live tabs share one stable actor → one checkpoint → `clientSeq` collisions and self-filtered pull dedup (real edit loss) | Bounded by the SDK single-active-session lease; background tabs observe, do not drive sync |
-| Threading the presented checkpoint into `AttachDocument` / dropping the `TryAttaching` seq resets ripples to both backends and all test doubles | Contained interface change; the checkpoint reuses `pack.Checkpoint` (no proto change), and the epoch rides a single additive `ChangePack.epoch` field (Q2, safe both ways); covered by existing attach suites plus new resume-path tests |
+| Threading the presented checkpoint into `AttachDocument` ripples to both backends and all test doubles | Contained interface change; the checkpoint reuses `pack.Checkpoint` (no proto change), and the epoch rides a single additive `ChangePack.epoch` field (Q2, safe both ways); covered by existing attach suites plus new resume-path tests |
 | VV re-key mixed-keying window on rolling deploy | See [Migration](#migration); confirm min-VV cannot regress during the transition |
 
 ### Design Decisions
@@ -400,7 +423,7 @@ docs attached across the upgrade.
 | Derive the actor deterministically via plain `SHA256(tag \|\| projectID \|\| clientKey)[:12]` | No unique index, no upsert, no cross-session write coordination; plain hash (not HMAC) needs no shared secret and is identical on every node/restart/offline; concurrent activations converge on the same actor |
 | Return the stable actor additively in `ActivateClientResponse`; keep `clientId` = session `_id` on the wire | All RPC row lookups stay unchanged (~21 `IDFromActorID` sites); old SDKs keep working by ignoring the field |
 | Keep per-session client rows | Preserves checkpoints, housekeeping, and activation metrics; isolates the change to the actor-identity layer |
-| Resume checkpoint conditionally in `AttachDocument`, guarded by `validateClientSeqContinuity`; drop the `TryAttaching` seq resets | Un-pushed local changes cannot push from a zeroed checkpoint; a single owner site plus the existing continuity guard turns a bad resume into a loud error, not corruption |
+| Resume checkpoint conditionally in `AttachDocument`, guarded by `validateClientSeqContinuity`; keep the `TryAttaching` seq resets (aligned across backends) | Un-pushed local changes cannot push from a zeroed checkpoint; `AttachDocument` is the sole seed owner and overwrites the zeroed entry from the presented checkpoint (Case B), so the resets are harmless and keep both backends in step; a bad resume becomes a loud error, not corruption |
 | Reuse epoch + snapshot machinery for pull-before-trust; reuse `ErrEpochMismatch` | The stale-after-compaction recovery path already exists; a parallel path would duplicate and drift |
 
 ## Alternatives Considered
@@ -416,10 +439,13 @@ docs attached across the upgrade.
 
 - **VV re-key transition window.** Whether a one-time migration or drain is
   needed for docs attached across the rolling deploy (see [Migration](#migration)).
-- **`TryAttaching` seq reset.** Whether the mongo atomic `FindOneAndUpdate` can
-  drop the `server_seq`/`client_seq` `$set` lines without losing the
-  attaching-status transition guarantee. (The resume-signal question is settled:
-  reuse the non-zero `pack.Checkpoint` presented at attach — no proto flag.)
+- **`TryAttaching` seq reset (RESOLVED).** Both backends **keep** resetting
+  `server_seq`/`client_seq` to `0` on the attaching transition, aligned: memory
+  mutates the entry in place, mongo `$set`s both to `0`. Because Case A is
+  unreachable, preserving seqs bought nothing; `AttachDocument` is the sole seed
+  owner and overwrites the zeroed entry from the presented checkpoint (Case B).
+  (The resume-signal question is settled: reuse the non-zero `pack.Checkpoint`
+  presented at attach — no proto flag.)
 - **Tier 3 purge signal.** Whether the server should eventually expose a
   distinguishable "document purged" signal on attach (future hardening).
 - **Epoch-0 sentinel.** A presented epoch of `0` is treated as "no epoch

--- a/docs/design/offline-resumable-attach.md
+++ b/docs/design/offline-resumable-attach.md
@@ -308,6 +308,22 @@ snapshot-threshold + `FindClosestSnapshotInfo` empty-fallback** machinery (see
   snapshot; raise a data-loss event on re-attach when the returned `docID`
   differs or `serverSeq` regressed to `0` against a non-empty local snapshot).
 
+**Interaction with Q3 checkpoint seeding (must fix together).** The epoch check
+that fires Tier 2 is `clientDocInfo.Epoch != docInfo.Epoch` (`pushpull.go:445`).
+The Q3 increment currently seeds a resumed `ClientDocInfo.Epoch` from the
+**current** `docInfo.Epoch`, which **masks** Tier 2: a client that went offline,
+had its doc compacted (epoch bumped), and then resumed would be seeded with the
+new epoch, so the mismatch never fires and the client never re-anchors from a
+snapshot — its local baseline sits in the old epoch while the server advanced.
+The Q3 serverSeq clamp only caps over-claims; it does **not** re-anchor this
+case. So Q2 must make the resume path **present the client's persisted epoch**
+(the offline `StoredDoc` already stores `epoch`) and seed `ClientDocInfo.Epoch`
+from *that*, not from the current doc epoch — then the existing epoch machinery
+fires Tier 2 and re-anchors. Until Q2 lands, the current-doc-epoch seeding is a
+known interim limitation (safe only while no compaction occurs during an offline
+window). Presenting the epoch needs a carrier at attach (extend the presented
+checkpoint or the attach request); pin the exact carrier when Q2 is implemented.
+
 ### Data flow
 
 ```

--- a/pkg/document/change/pack.go
+++ b/pkg/document/change/pack.go
@@ -40,6 +40,14 @@ type Pack struct {
 	// 2. In response(Snapshot), it is the version vector of the snapshot of the document.
 	VersionVector time.VersionVector
 
+	// Epoch is the compaction epoch carried in both directions.
+	// 1. In request, it is the client's last-known epoch, presented on resume so
+	//    the server can detect a stale-epoch baseline (see the pull-before-trust
+	//    reconciliation in docs/design/offline-resumable-attach.md).
+	// 2. In response, it is the document's current epoch, so the client can learn
+	//    and persist it for the next resume.
+	Epoch int64
+
 	// IsRemoved is a flag that indicates whether the document is removed.
 	IsRemoved bool
 }

--- a/server/backend/database/client_info.go
+++ b/server/backend/database/client_info.go
@@ -160,12 +160,22 @@ func (i *ClientInfo) Deactivate() {
 //     so its pending changes push, hence the resume signal is the ServerSeq, not
 //     the ClientSeq.
 //
+// epoch is the document's current compaction epoch and is the default seed for
+// Case A and fresh attach. presentedEpoch is the client's persisted epoch (from
+// the attach ChangePack). On a Case B resume it is seeded verbatim when non-zero
+// (pull-before-trust, Q2): if the doc was force-compacted while the client was
+// offline, the seeded old epoch differs from the current doc epoch, so the epoch
+// check in pushpull fires ErrEpochMismatch and the client re-anchors from a
+// snapshot. Non-resume callers pass 0 for presentedEpoch, which keeps the
+// current-doc-epoch behavior unchanged.
+//
 // validateClientSeqContinuity (pushpull.go) remains the loud safety net that
 // rejects a clientSeq not continuing the seeded one.
 func (i *ClientInfo) AttachDocument(
 	docID types.ID,
 	alreadyAttached bool,
 	epoch int64,
+	presentedEpoch int64,
 	presented change.Checkpoint,
 ) error {
 	if i.Status != ClientActivated {
@@ -206,23 +216,28 @@ func (i *ClientInfo) AttachDocument(
 	// pending changes are not mistaken for already-pushed work.
 	serverSeq := int64(0)
 	clientSeq := uint32(0)
+	seededEpoch := epoch
 	if presented.ServerSeq != 0 {
 		serverSeq = presented.ServerSeq
 		clientSeq = presented.ClientSeq
+
+		// Q2 pull-before-trust: on a Case B resume, seed the client's persisted
+		// epoch (presentedEpoch) rather than the current doc epoch. If the doc
+		// was force-compacted while the client was offline, the two differ, so
+		// the epoch check in pushpull fires ErrEpochMismatch and the existing
+		// snapshot re-anchor machinery runs. When the client presents no epoch
+		// (0), fall back to the current doc epoch. See docs/design/
+		// offline-resumable-attach.md, "Interaction with Q3 checkpoint seeding".
+		if presentedEpoch != 0 {
+			seededEpoch = presentedEpoch
+		}
 	}
 
-	// TODO(hackerwins): Q2 pull-before-trust. Seeding Epoch from the current doc
-	// epoch masks the compaction-while-offline case: a resumed client whose doc
-	// was compacted (epoch bumped) is seeded with the new epoch, so the epoch
-	// check in pushpull never fires and the client never re-anchors from a
-	// snapshot. Q2 must instead seed from the client's persisted epoch so the
-	// existing epoch machinery re-anchors. See docs/design/offline-resumable-
-	// attach.md, "Interaction with Q3 checkpoint seeding".
 	i.Documents[docID] = &ClientDocInfo{
 		Status:    DocumentAttached,
 		ServerSeq: serverSeq,
 		ClientSeq: clientSeq,
-		Epoch:     epoch,
+		Epoch:     seededEpoch,
 	}
 	i.UpdatedAt = gotime.Now()
 

--- a/server/backend/database/client_info.go
+++ b/server/backend/database/client_info.go
@@ -364,6 +364,34 @@ func (i *ClientInfo) RefKey() types.ClientRefKey {
 	}
 }
 
+// IsOwnActor reports whether the given actorID belongs to this client, i.e.
+// whether a change or a version-vector entry stamped with actorID is this
+// client's own. It compares against both identities the client may stamp: the
+// per-session ID (old SDKs) and the StableActorID (new SDKs). Rows written
+// before StableActorID existed leave it empty, so an empty StableActorID never
+// matches.
+//
+// This compare-both check is the backward-compatible key correctness switch for
+// self-echo dedup, version-vector liveness, min-VV, and GC. The hard invariant:
+// the actor stamped into a change must be recognizable as this client's own by
+// the same predicate that keys dedup/VV/GC, or GC can advance past un-synced
+// tombstones.
+func (i *ClientInfo) IsOwnActor(actorID types.ID) bool {
+	return i.ID == actorID || (i.StableActorID != "" && i.StableActorID == actorID)
+}
+
+// OwnActorID returns the actor this client stamps into its own changes: the
+// StableActorID for new SDKs, or the per-session ID for old SDKs (and for rows
+// written before StableActorID existed). Use it when a value must be keyed by
+// the client's own actor, e.g. the size-1 version vector returned to a
+// GC-disabled client so its lamport clock advances under the right key.
+func (i *ClientInfo) OwnActorID() (time.ActorID, error) {
+	if i.StableActorID != "" {
+		return i.StableActorID.ToActorID()
+	}
+	return i.ID.ToActorID()
+}
+
 // IsServerClient returns true if this client represents a server‐side process.
 func (i *ClientInfo) IsServerClient() bool {
 	actorID, err := i.ID.ToActorID()

--- a/server/backend/database/client_info.go
+++ b/server/backend/database/client_info.go
@@ -139,7 +139,35 @@ func (i *ClientInfo) Deactivate() {
 }
 
 // AttachDocument attaches the given document to this client.
-func (i *ClientInfo) AttachDocument(docID types.ID, alreadyAttached bool, epoch int64) error {
+//
+// AttachDocument is the sole owner of the seeded checkpoint (server_seq /
+// client_seq) on attach; the TryAttaching transition no longer touches those
+// seqs (they default to 0 when it creates a fresh Attaching entry). The
+// presented checkpoint is the client-supplied pack.Checkpoint and carries the
+// resume signal for offline-persistent clients (see
+// docs/design/offline-resumable-attach.md, "Conditional checkpoint reset").
+// Seeding distinguishes:
+//
+//   - Case A (same-session re-attach): the client row already holds a
+//     ClientDocInfo for docID in Attached/Attaching status with non-zero seqs
+//     — server-side row memory is authoritative and is preserved.
+//   - Case B (reload / new session): a client presents its persisted checkpoint
+//     with a non-zero ServerSeq (the resume signal), so seeding takes it,
+//     letting restored un-pushed changes push from the right clientSeq.
+//   - Fresh attach: the presented ServerSeq is 0 (never synced with the server),
+//     so seed 0/0. A fresh attach that already carries local edits legitimately
+//     presents a non-zero ClientSeq with ServerSeq 0; that must still seed 0/0
+//     so its pending changes push, hence the resume signal is the ServerSeq, not
+//     the ClientSeq.
+//
+// validateClientSeqContinuity (pushpull.go) remains the loud safety net that
+// rejects a clientSeq not continuing the seeded one.
+func (i *ClientInfo) AttachDocument(
+	docID types.ID,
+	alreadyAttached bool,
+	epoch int64,
+	presented change.Checkpoint,
+) error {
 	if i.Status != ClientActivated {
 		return fmt.Errorf("client(%s) attaches %s: %w",
 			i.ID, docID, ErrClientNotActivated)
@@ -159,10 +187,34 @@ func (i *ClientInfo) AttachDocument(docID types.ID, alreadyAttached bool, epoch 
 			i.ID, docID, ErrDocumentAlreadyAttached)
 	}
 
+	// Case A: a same-session re-attach whose Attaching/Attached row still
+	// carries non-zero seqs is authoritative; preserve them.
+	if i.hasDocument(docID) &&
+		(i.Documents[docID].ServerSeq != 0 || i.Documents[docID].ClientSeq != 0) &&
+		(i.Documents[docID].Status == DocumentAttached ||
+			i.Documents[docID].Status == DocumentAttaching) {
+		i.Documents[docID].Status = DocumentAttached
+		i.Documents[docID].Epoch = epoch
+		i.UpdatedAt = gotime.Now()
+		return nil
+	}
+
+	// Case B vs fresh attach: seed from the presented checkpoint only when it
+	// carries the resume signal (a non-zero ServerSeq, i.e. the client has
+	// synced with the server before). A fresh attach — even one carrying local
+	// edits, whose ClientSeq is non-zero but ServerSeq is 0 — seeds 0/0 so its
+	// pending changes are not mistaken for already-pushed work.
+	serverSeq := int64(0)
+	clientSeq := uint32(0)
+	if presented.ServerSeq != 0 {
+		serverSeq = presented.ServerSeq
+		clientSeq = presented.ClientSeq
+	}
+
 	i.Documents[docID] = &ClientDocInfo{
 		Status:    DocumentAttached,
-		ServerSeq: 0,
-		ClientSeq: 0,
+		ServerSeq: serverSeq,
+		ClientSeq: clientSeq,
 		Epoch:     epoch,
 	}
 	i.UpdatedAt = gotime.Now()

--- a/server/backend/database/client_info.go
+++ b/server/backend/database/client_info.go
@@ -65,8 +65,16 @@ type ClientDocInfoMap map[types.ID]*ClientDocInfo
 
 // ClientInfo is a structure representing information of a client.
 type ClientInfo struct {
-	// ID is the unique ID of the client.
+	// ID is the unique ID of the client. It is a fresh per-session ObjectID
+	// minted on every activation and used as the session row id for RPC
+	// lookups and sharding.
 	ID types.ID `bson:"_id"`
+
+	// StableActorID is the stable actor identity derived deterministically from
+	// the project ID and client key. Unlike ID, it is the same across activate
+	// cycles for the same logical client, so locally-persisted un-pushed changes
+	// replay under a consistent actor. It carries no unique index.
+	StableActorID types.ID `bson:"stable_actor_id"`
 
 	// ProjectID is the ID of the project the client belongs to.
 	ProjectID types.ID `bson:"project_id"`
@@ -332,14 +340,15 @@ func (i *ClientInfo) DeepCopy() *ClientInfo {
 	}
 
 	return &ClientInfo{
-		ID:        i.ID,
-		ProjectID: i.ProjectID,
-		Key:       i.Key,
-		Status:    i.Status,
-		Documents: documents,
-		Metadata:  i.Metadata,
-		CreatedAt: i.CreatedAt,
-		UpdatedAt: i.UpdatedAt,
+		ID:            i.ID,
+		StableActorID: i.StableActorID,
+		ProjectID:     i.ProjectID,
+		Key:           i.Key,
+		Status:        i.Status,
+		Documents:     documents,
+		Metadata:      i.Metadata,
+		CreatedAt:     i.CreatedAt,
+		UpdatedAt:     i.UpdatedAt,
 	}
 }
 

--- a/server/backend/database/client_info.go
+++ b/server/backend/database/client_info.go
@@ -209,21 +209,27 @@ func (i *ClientInfo) AttachDocument(
 	// pending changes are not mistaken for already-pushed work.
 	serverSeq := int64(0)
 	clientSeq := uint32(0)
-	seededEpoch := epoch
 	if presented.ServerSeq != 0 {
 		serverSeq = presented.ServerSeq
 		clientSeq = presented.ClientSeq
+	}
 
-		// Q2 pull-before-trust: on a Case B resume, seed the client's persisted
-		// epoch (presentedEpoch) rather than the current doc epoch. If the doc
-		// was force-compacted while the client was offline, the two differ, so
-		// the epoch check in pushpull fires ErrEpochMismatch and the existing
-		// snapshot re-anchor machinery runs. When the client presents no epoch
-		// (0), fall back to the current doc epoch. See docs/design/
-		// offline-resumable-attach.md, "Interaction with Q3 checkpoint seeding".
-		if presentedEpoch != 0 {
-			seededEpoch = presentedEpoch
-		}
+	// Q2 pull-before-trust: seed the client's persisted epoch (presentedEpoch)
+	// rather than the current doc epoch whenever the client presents one. If the
+	// doc was force-compacted while the client was offline, the two differ, so
+	// the epoch check in pushpull fires ErrEpochMismatch and the existing
+	// snapshot re-anchor machinery runs. When the client presents no epoch (0),
+	// fall back to the current doc epoch. The presented epoch is an independent
+	// resume signal from the presented ServerSeq: a doc force-compacted to an
+	// EMPTY root sits at ServerSeq 0, so the serverSeq over-claim clamp in
+	// clients.AttachDocument drives presented.ServerSeq to 0 even for a genuine
+	// resume. Gating epoch seeding on presented.ServerSeq would then miss this
+	// case, seed the current epoch, and route recovery through ErrInvalidClientSeq
+	// instead of the design's "stale epoch -> ErrEpochMismatch". See docs/design/
+	// offline-resumable-attach.md, "Interaction with Q3 checkpoint seeding".
+	seededEpoch := epoch
+	if presentedEpoch != 0 {
+		seededEpoch = presentedEpoch
 	}
 
 	i.Documents[docID] = &ClientDocInfo{

--- a/server/backend/database/client_info.go
+++ b/server/backend/database/client_info.go
@@ -141,16 +141,13 @@ func (i *ClientInfo) Deactivate() {
 // AttachDocument attaches the given document to this client.
 //
 // AttachDocument is the sole owner of the seeded checkpoint (server_seq /
-// client_seq) on attach; the TryAttaching transition no longer touches those
-// seqs (they default to 0 when it creates a fresh Attaching entry). The
-// presented checkpoint is the client-supplied pack.Checkpoint and carries the
-// resume signal for offline-persistent clients (see
-// docs/design/offline-resumable-attach.md, "Conditional checkpoint reset").
+// client_seq) on attach; the TryAttaching transition resets those seqs to 0 on
+// the attached→attaching transition, so a fresh Attaching entry always arrives
+// here with zero seqs. The presented checkpoint is the client-supplied
+// pack.Checkpoint and carries the resume signal for offline-persistent clients
+// (see docs/design/offline-resumable-attach.md, "Conditional checkpoint reset").
 // Seeding distinguishes:
 //
-//   - Case A (same-session re-attach): the client row already holds a
-//     ClientDocInfo for docID in Attached/Attaching status with non-zero seqs
-//     — server-side row memory is authoritative and is preserved.
 //   - Case B (reload / new session): a client presents its persisted checkpoint
 //     with a non-zero ServerSeq (the resume signal), so seeding takes it,
 //     letting restored un-pushed changes push from the right clientSeq.
@@ -160,14 +157,22 @@ func (i *ClientInfo) Deactivate() {
 //     so its pending changes push, hence the resume signal is the ServerSeq, not
 //     the ClientSeq.
 //
-// epoch is the document's current compaction epoch and is the default seed for
-// Case A and fresh attach. presentedEpoch is the client's persisted epoch (from
-// the attach ChangePack). On a Case B resume it is seeded verbatim when non-zero
-// (pull-before-trust, Q2): if the doc was force-compacted while the client was
-// offline, the seeded old epoch differs from the current doc epoch, so the epoch
-// check in pushpull fires ErrEpochMismatch and the client re-anchors from a
-// snapshot. Non-resume callers pass 0 for presentedEpoch, which keeps the
-// current-doc-epoch behavior unchanged.
+// (The design doc also describes a "Case A" same-session re-attach that
+// preserves an existing non-zero-seq row. That path is not reachable on any
+// production flow: an Attached row is preempted by the ErrDocumentAlreadyAttached
+// check below, and no path ever persists an Attaching row with non-zero seqs —
+// TryAttaching resets them and a detach zeroes them before the IsAlreadyDetached
+// guard blocks re-attach. Resume is carried entirely by Case B, so Case A is not
+// implemented here.)
+//
+// epoch is the document's current compaction epoch and is the default seed for a
+// fresh attach. presentedEpoch is the client's persisted epoch (from the attach
+// ChangePack). It is seeded verbatim when non-zero (pull-before-trust, Q2): if
+// the doc was force-compacted while the client was offline, the seeded old epoch
+// differs from the current doc epoch, so the epoch check in pushpull fires
+// ErrEpochMismatch and the client re-anchors from a snapshot. Non-resume callers
+// pass 0 for presentedEpoch, which keeps the current-doc-epoch behavior
+// unchanged.
 //
 // validateClientSeqContinuity (pushpull.go) remains the loud safety net that
 // rejects a clientSeq not continuing the seeded one.
@@ -195,18 +200,6 @@ func (i *ClientInfo) AttachDocument(
 	if i.hasDocument(docID) && i.Documents[docID].Status == DocumentAttached {
 		return fmt.Errorf("client(%s) attaches %s: %w",
 			i.ID, docID, ErrDocumentAlreadyAttached)
-	}
-
-	// Case A: a same-session re-attach whose Attaching/Attached row still
-	// carries non-zero seqs is authoritative; preserve them.
-	if i.hasDocument(docID) &&
-		(i.Documents[docID].ServerSeq != 0 || i.Documents[docID].ClientSeq != 0) &&
-		(i.Documents[docID].Status == DocumentAttached ||
-			i.Documents[docID].Status == DocumentAttaching) {
-		i.Documents[docID].Status = DocumentAttached
-		i.Documents[docID].Epoch = epoch
-		i.UpdatedAt = gotime.Now()
-		return nil
 	}
 
 	// Case B vs fresh attach: seed from the presented checkpoint only when it

--- a/server/backend/database/client_info.go
+++ b/server/backend/database/client_info.go
@@ -211,6 +211,13 @@ func (i *ClientInfo) AttachDocument(
 		clientSeq = presented.ClientSeq
 	}
 
+	// TODO(hackerwins): Q2 pull-before-trust. Seeding Epoch from the current doc
+	// epoch masks the compaction-while-offline case: a resumed client whose doc
+	// was compacted (epoch bumped) is seeded with the new epoch, so the epoch
+	// check in pushpull never fires and the client never re-anchors from a
+	// snapshot. Q2 must instead seed from the client's persisted epoch so the
+	// existing epoch machinery re-anchors. See docs/design/offline-resumable-
+	// attach.md, "Interaction with Q3 checkpoint seeding".
 	i.Documents[docID] = &ClientDocInfo{
 		Status:    DocumentAttached,
 		ServerSeq: serverSeq,

--- a/server/backend/database/client_info_test.go
+++ b/server/backend/database/client_info_test.go
@@ -107,34 +107,6 @@ func TestClientInfo(t *testing.T) {
 		assert.Equal(t, int64(5), clientInfo.Documents[dummyDocID].Epoch)
 	})
 
-	t.Run("attach preserves existing row seqs test", func(t *testing.T) {
-		// Case A (same-session re-attach): an existing Attaching row still
-		// carries its seqs; AttachDocument preserves them (the element-wise max
-		// keeps them ahead of a lower presented checkpoint).
-		clientInfo := database.ClientInfo{
-			Status: database.ClientActivated,
-			Documents: map[types.ID]*database.ClientDocInfo{
-				dummyDocID: {
-					Status:    database.DocumentAttaching,
-					ServerSeq: 10,
-					ClientSeq: 8,
-					Epoch:     1,
-				},
-			},
-		}
-
-		// A lower (or zero) presented checkpoint must not roll the row back.
-		err := clientInfo.AttachDocument(dummyDocID, false, 1, 0, change.InitialCheckpoint)
-		assert.NoError(t, err)
-
-		cp := clientInfo.Checkpoint(dummyDocID)
-		assert.Equal(t, int64(10), cp.ServerSeq)
-		assert.Equal(t, uint32(8), cp.ClientSeq)
-		isAttached, err := clientInfo.IsAttached(dummyDocID)
-		assert.NoError(t, err)
-		assert.True(t, isAttached)
-	})
-
 	t.Run("attach seeds zero for fresh presented checkpoint test", func(t *testing.T) {
 		// Fresh attach (presented == InitialCheckpoint): today's behavior,
 		// seed 0/0.

--- a/server/backend/database/client_info_test.go
+++ b/server/backend/database/client_info_test.go
@@ -37,7 +37,7 @@ func TestClientInfo(t *testing.T) {
 			Status: database.ClientActivated,
 		}
 
-		err := clientInfo.AttachDocument(dummyDocID, false, 0, change.InitialCheckpoint)
+		err := clientInfo.AttachDocument(dummyDocID, false, 0, 0, change.InitialCheckpoint)
 		assert.NoError(t, err)
 		isAttached, err := clientInfo.IsAttached(dummyDocID)
 		assert.NoError(t, err)
@@ -55,7 +55,7 @@ func TestClientInfo(t *testing.T) {
 		assert.NoError(t, err)
 		assert.False(t, isAttached)
 
-		err = clientInfo.AttachDocument(dummyDocID, false, 0, change.InitialCheckpoint)
+		err = clientInfo.AttachDocument(dummyDocID, false, 0, 0, change.InitialCheckpoint)
 		assert.NoError(t, err)
 		isAttached, err = clientInfo.IsAttached(dummyDocID)
 		assert.NoError(t, err)
@@ -66,17 +66,45 @@ func TestClientInfo(t *testing.T) {
 	t.Run("attach seeds from presented checkpoint test", func(t *testing.T) {
 		// Case B (reload / new session): a non-zero presented checkpoint is the
 		// resume signal and seeds ClientDocInfo so restored un-pushed changes
-		// push from the right clientSeq.
+		// push from the right clientSeq. With no presented epoch (0), the epoch
+		// falls back to the current doc epoch.
 		clientInfo := database.ClientInfo{Status: database.ClientActivated}
 
 		presented := change.NewCheckpoint(7, 5)
-		err := clientInfo.AttachDocument(dummyDocID, false, 3, presented)
+		err := clientInfo.AttachDocument(dummyDocID, false, 3, 0, presented)
 		assert.NoError(t, err)
 
 		cp := clientInfo.Checkpoint(dummyDocID)
 		assert.Equal(t, int64(7), cp.ServerSeq)
 		assert.Equal(t, uint32(5), cp.ClientSeq)
 		assert.Equal(t, int64(3), clientInfo.Documents[dummyDocID].Epoch)
+	})
+
+	t.Run("attach seeds presented epoch on resume test", func(t *testing.T) {
+		// Case B resume with a stale presented epoch (Q2 pull-before-trust): the
+		// client's persisted epoch (2) is seeded verbatim, not the current doc
+		// epoch (5). The seeded old epoch differs from the doc epoch, so the
+		// epoch check in pushpull fires ErrEpochMismatch and re-anchors from a
+		// snapshot. This is the signal that survives a force-compaction that
+		// happened while the client was offline.
+		clientInfo := database.ClientInfo{Status: database.ClientActivated}
+
+		presented := change.NewCheckpoint(7, 5)
+		err := clientInfo.AttachDocument(dummyDocID, false, 5, 2, presented)
+		assert.NoError(t, err)
+
+		assert.Equal(t, int64(2), clientInfo.Documents[dummyDocID].Epoch)
+	})
+
+	t.Run("fresh attach ignores presented epoch test", func(t *testing.T) {
+		// A fresh attach (ServerSeq 0) is not a resume, so the presented epoch
+		// is ignored and the current doc epoch is seeded.
+		clientInfo := database.ClientInfo{Status: database.ClientActivated}
+
+		err := clientInfo.AttachDocument(dummyDocID, false, 5, 2, change.InitialCheckpoint)
+		assert.NoError(t, err)
+
+		assert.Equal(t, int64(5), clientInfo.Documents[dummyDocID].Epoch)
 	})
 
 	t.Run("attach preserves existing row seqs test", func(t *testing.T) {
@@ -96,7 +124,7 @@ func TestClientInfo(t *testing.T) {
 		}
 
 		// A lower (or zero) presented checkpoint must not roll the row back.
-		err := clientInfo.AttachDocument(dummyDocID, false, 1, change.InitialCheckpoint)
+		err := clientInfo.AttachDocument(dummyDocID, false, 1, 0, change.InitialCheckpoint)
 		assert.NoError(t, err)
 
 		cp := clientInfo.Checkpoint(dummyDocID)
@@ -112,7 +140,7 @@ func TestClientInfo(t *testing.T) {
 		// seed 0/0.
 		clientInfo := database.ClientInfo{Status: database.ClientActivated}
 
-		err := clientInfo.AttachDocument(dummyDocID, false, 0, change.InitialCheckpoint)
+		err := clientInfo.AttachDocument(dummyDocID, false, 0, 0, change.InitialCheckpoint)
 		assert.NoError(t, err)
 
 		cp := clientInfo.Checkpoint(dummyDocID)
@@ -127,7 +155,7 @@ func TestClientInfo(t *testing.T) {
 		// changes as already-pushed, so it must seed 0/0.
 		clientInfo := database.ClientInfo{Status: database.ClientActivated}
 
-		err := clientInfo.AttachDocument(dummyDocID, false, 0, change.NewCheckpoint(0, 2))
+		err := clientInfo.AttachDocument(dummyDocID, false, 0, 0, change.NewCheckpoint(0, 2))
 		assert.NoError(t, err)
 
 		cp := clientInfo.Checkpoint(dummyDocID)
@@ -158,7 +186,7 @@ func TestClientInfo(t *testing.T) {
 			Status: database.ClientActivated,
 		}
 
-		err := clientInfo.AttachDocument(dummyDocID, false, 0, change.InitialCheckpoint)
+		err := clientInfo.AttachDocument(dummyDocID, false, 0, 0, change.InitialCheckpoint)
 		assert.NoError(t, err)
 		isAttached, err := clientInfo.IsAttached(dummyDocID)
 		assert.NoError(t, err)
@@ -175,7 +203,7 @@ func TestClientInfo(t *testing.T) {
 			Status: database.ClientDeactivated,
 		}
 
-		err := clientInfo.AttachDocument(dummyDocID, false, 0, change.InitialCheckpoint)
+		err := clientInfo.AttachDocument(dummyDocID, false, 0, 0, change.InitialCheckpoint)
 		assert.ErrorIs(t, err, database.ErrClientNotActivated)
 
 		err = clientInfo.EnsureDocumentAttached(dummyDocID)
@@ -209,13 +237,13 @@ func TestClientInfo(t *testing.T) {
 			Status: database.ClientActivated,
 		}
 
-		err := clientInfo.AttachDocument(dummyDocID, false, 0, change.InitialCheckpoint)
+		err := clientInfo.AttachDocument(dummyDocID, false, 0, 0, change.InitialCheckpoint)
 		assert.NoError(t, err)
 		isAttached, err := clientInfo.IsAttached(dummyDocID)
 		assert.NoError(t, err)
 		assert.True(t, isAttached)
 
-		err = clientInfo.AttachDocument(dummyDocID, false, 0, change.InitialCheckpoint)
+		err = clientInfo.AttachDocument(dummyDocID, false, 0, 0, change.InitialCheckpoint)
 		assert.ErrorIs(t, err, database.ErrDocumentAlreadyAttached)
 	})
 
@@ -298,7 +326,7 @@ func TestClientInfo(t *testing.T) {
 			Status: database.ClientActivated,
 		}
 
-		err := clientInfo.AttachDocument(dummyDocID, false, 0, change.InitialCheckpoint)
+		err := clientInfo.AttachDocument(dummyDocID, false, 0, 0, change.InitialCheckpoint)
 		assert.NoError(t, err)
 		isAttached, err := clientInfo.IsAttached(dummyDocID)
 		assert.NoError(t, err)

--- a/server/backend/database/client_info_test.go
+++ b/server/backend/database/client_info_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/yorkie-team/yorkie/api/types"
 	"github.com/yorkie-team/yorkie/pkg/document/change"
+	"github.com/yorkie-team/yorkie/pkg/document/time"
 	"github.com/yorkie-team/yorkie/server/backend/database"
 )
 
@@ -144,6 +145,80 @@ func TestClientInfo(t *testing.T) {
 
 		err = clientInfo.AttachDocument(dummyDocID, false, 0)
 		assert.ErrorIs(t, err, database.ErrDocumentAlreadyAttached)
+	})
+
+	t.Run("is own actor compare-both test", func(t *testing.T) {
+		sessionID := types.ID("0000000000000000000000aa")
+		stableID := types.ID("0000000000000000000000bb")
+		thirdParty := types.ID("0000000000000000000000cc")
+
+		// New SDK: both session id and stable actor are recognized as own.
+		newClient := database.ClientInfo{ID: sessionID, StableActorID: stableID}
+		assert.True(t, newClient.IsOwnActor(sessionID))
+		assert.True(t, newClient.IsOwnActor(stableID))
+		assert.False(t, newClient.IsOwnActor(thirdParty))
+
+		// Old SDK / pre-Phase-1 row: empty StableActorID must never match, so
+		// only the session id is recognized as own.
+		oldClient := database.ClientInfo{ID: sessionID}
+		assert.True(t, oldClient.IsOwnActor(sessionID))
+		assert.False(t, oldClient.IsOwnActor(stableID))
+		assert.False(t, oldClient.IsOwnActor(thirdParty))
+		// An empty StableActorID must not match an empty query actor either.
+		assert.False(t, oldClient.IsOwnActor(types.ID("")))
+	})
+
+	t.Run("own actor id prefers stable actor test", func(t *testing.T) {
+		sessionID := types.IDFromActorID(time.MaxActorID)
+		stableID := types.DeriveActorID(dummyProjectID, "own-actor-key")
+
+		// New SDK: OwnActorID returns the stable actor.
+		newClient := database.ClientInfo{ID: sessionID, StableActorID: stableID}
+		actorID, err := newClient.OwnActorID()
+		assert.NoError(t, err)
+		stableActor, err := stableID.ToActorID()
+		assert.NoError(t, err)
+		assert.Equal(t, stableActor, actorID)
+
+		// Old SDK / pre-Phase-1 row: OwnActorID falls back to the session id.
+		oldClient := database.ClientInfo{ID: sessionID}
+		actorID, err = oldClient.OwnActorID()
+		assert.NoError(t, err)
+		sessionActor, err := sessionID.ToActorID()
+		assert.NoError(t, err)
+		assert.Equal(t, sessionActor, actorID)
+	})
+
+	t.Run("dedup path recognizes stable-actor own changes test", func(t *testing.T) {
+		sessionID := types.ID("0000000000000000000000aa")
+		stableID := types.DeriveActorID(dummyProjectID, "dedup-key")
+		thirdParty := types.DeriveActorID(dummyProjectID, "third-party-key")
+
+		// New SDK stamps the stable actor into its changes.
+		clientInfo := database.ClientInfo{ID: sessionID, StableActorID: stableID}
+
+		// A pulled change carrying the client's stable actor, already acked by
+		// the checkpoint, is this client's own and must be deduped.
+		ownChange := &database.ChangeInfo{ActorID: stableID, ClientSeq: 3}
+		// A change from another client is never this client's own.
+		otherChange := &database.ChangeInfo{ActorID: thirdParty, ClientSeq: 3}
+
+		// Mirror the filter condition in packs.pullChangeInfos: a change is
+		// dropped when it is the client's own AND the checkpoint already
+		// covers its clientSeq.
+		cpClientSeq := uint32(5)
+		dedup := func(ci *database.ChangeInfo) bool {
+			return clientInfo.IsOwnActor(ci.ActorID) && cpClientSeq >= ci.ClientSeq
+		}
+		assert.True(t, dedup(ownChange), "stable-actor own change must dedup")
+		assert.False(t, dedup(otherChange), "third-party change must not dedup")
+
+		// An old-SDK client whose changes carry the session id must still
+		// dedup its own changes and never dedup a stable-actor stranger.
+		oldClient := database.ClientInfo{ID: sessionID}
+		oldOwn := &database.ChangeInfo{ActorID: sessionID, ClientSeq: 3}
+		assert.True(t, oldClient.IsOwnActor(oldOwn.ActorID))
+		assert.False(t, oldClient.IsOwnActor(stableID))
 	})
 
 	t.Run("document detached when client deactivate test", func(t *testing.T) {

--- a/server/backend/database/client_info_test.go
+++ b/server/backend/database/client_info_test.go
@@ -96,15 +96,32 @@ func TestClientInfo(t *testing.T) {
 		assert.Equal(t, int64(2), clientInfo.Documents[dummyDocID].Epoch)
 	})
 
-	t.Run("fresh attach ignores presented epoch test", func(t *testing.T) {
-		// A fresh attach (ServerSeq 0) is not a resume, so the presented epoch
-		// is ignored and the current doc epoch is seeded.
+	t.Run("fresh attach without presented epoch seeds doc epoch test", func(t *testing.T) {
+		// A fresh attach that presents no epoch (0) seeds the current doc epoch.
+		clientInfo := database.ClientInfo{Status: database.ClientActivated}
+
+		err := clientInfo.AttachDocument(dummyDocID, false, 5, 0, change.InitialCheckpoint)
+		assert.NoError(t, err)
+
+		assert.Equal(t, int64(5), clientInfo.Documents[dummyDocID].Epoch)
+	})
+
+	t.Run("empty-root resume seeds presented epoch despite zero serverSeq test", func(t *testing.T) {
+		// A doc force-compacted to an EMPTY root sits at ServerSeq 0, so the
+		// over-claim clamp drives the presented ServerSeq to 0 even for a genuine
+		// resume. The presented epoch is an independent resume signal: it is
+		// seeded (2) rather than the current doc epoch (5) whenever non-zero, so
+		// the epoch check downstream fires ErrEpochMismatch. The checkpoint still
+		// seeds 0/0 because ServerSeq is 0.
 		clientInfo := database.ClientInfo{Status: database.ClientActivated}
 
 		err := clientInfo.AttachDocument(dummyDocID, false, 5, 2, change.InitialCheckpoint)
 		assert.NoError(t, err)
 
-		assert.Equal(t, int64(5), clientInfo.Documents[dummyDocID].Epoch)
+		assert.Equal(t, int64(2), clientInfo.Documents[dummyDocID].Epoch)
+		cp := clientInfo.Checkpoint(dummyDocID)
+		assert.Equal(t, int64(0), cp.ServerSeq)
+		assert.Equal(t, uint32(0), cp.ClientSeq)
 	})
 
 	t.Run("attach seeds zero for fresh presented checkpoint test", func(t *testing.T) {

--- a/server/backend/database/client_info_test.go
+++ b/server/backend/database/client_info_test.go
@@ -37,7 +37,7 @@ func TestClientInfo(t *testing.T) {
 			Status: database.ClientActivated,
 		}
 
-		err := clientInfo.AttachDocument(dummyDocID, false, 0)
+		err := clientInfo.AttachDocument(dummyDocID, false, 0, change.InitialCheckpoint)
 		assert.NoError(t, err)
 		isAttached, err := clientInfo.IsAttached(dummyDocID)
 		assert.NoError(t, err)
@@ -55,12 +55,84 @@ func TestClientInfo(t *testing.T) {
 		assert.NoError(t, err)
 		assert.False(t, isAttached)
 
-		err = clientInfo.AttachDocument(dummyDocID, false, 0)
+		err = clientInfo.AttachDocument(dummyDocID, false, 0, change.InitialCheckpoint)
 		assert.NoError(t, err)
 		isAttached, err = clientInfo.IsAttached(dummyDocID)
 		assert.NoError(t, err)
 		assert.True(t, isAttached)
 
+	})
+
+	t.Run("attach seeds from presented checkpoint test", func(t *testing.T) {
+		// Case B (reload / new session): a non-zero presented checkpoint is the
+		// resume signal and seeds ClientDocInfo so restored un-pushed changes
+		// push from the right clientSeq.
+		clientInfo := database.ClientInfo{Status: database.ClientActivated}
+
+		presented := change.NewCheckpoint(7, 5)
+		err := clientInfo.AttachDocument(dummyDocID, false, 3, presented)
+		assert.NoError(t, err)
+
+		cp := clientInfo.Checkpoint(dummyDocID)
+		assert.Equal(t, int64(7), cp.ServerSeq)
+		assert.Equal(t, uint32(5), cp.ClientSeq)
+		assert.Equal(t, int64(3), clientInfo.Documents[dummyDocID].Epoch)
+	})
+
+	t.Run("attach preserves existing row seqs test", func(t *testing.T) {
+		// Case A (same-session re-attach): an existing Attaching row still
+		// carries its seqs; AttachDocument preserves them (the element-wise max
+		// keeps them ahead of a lower presented checkpoint).
+		clientInfo := database.ClientInfo{
+			Status: database.ClientActivated,
+			Documents: map[types.ID]*database.ClientDocInfo{
+				dummyDocID: {
+					Status:    database.DocumentAttaching,
+					ServerSeq: 10,
+					ClientSeq: 8,
+					Epoch:     1,
+				},
+			},
+		}
+
+		// A lower (or zero) presented checkpoint must not roll the row back.
+		err := clientInfo.AttachDocument(dummyDocID, false, 1, change.InitialCheckpoint)
+		assert.NoError(t, err)
+
+		cp := clientInfo.Checkpoint(dummyDocID)
+		assert.Equal(t, int64(10), cp.ServerSeq)
+		assert.Equal(t, uint32(8), cp.ClientSeq)
+		isAttached, err := clientInfo.IsAttached(dummyDocID)
+		assert.NoError(t, err)
+		assert.True(t, isAttached)
+	})
+
+	t.Run("attach seeds zero for fresh presented checkpoint test", func(t *testing.T) {
+		// Fresh attach (presented == InitialCheckpoint): today's behavior,
+		// seed 0/0.
+		clientInfo := database.ClientInfo{Status: database.ClientActivated}
+
+		err := clientInfo.AttachDocument(dummyDocID, false, 0, change.InitialCheckpoint)
+		assert.NoError(t, err)
+
+		cp := clientInfo.Checkpoint(dummyDocID)
+		assert.Equal(t, int64(0), cp.ServerSeq)
+		assert.Equal(t, uint32(0), cp.ClientSeq)
+	})
+
+	t.Run("attach with local edits but zero serverSeq seeds zero test", func(t *testing.T) {
+		// A fresh attach carrying local edits presents a non-zero ClientSeq with
+		// ServerSeq 0. That is not a resume: the resume signal is the ServerSeq.
+		// Seeding a non-zero ClientSeq here would make pushpull drop the pending
+		// changes as already-pushed, so it must seed 0/0.
+		clientInfo := database.ClientInfo{Status: database.ClientActivated}
+
+		err := clientInfo.AttachDocument(dummyDocID, false, 0, change.NewCheckpoint(0, 2))
+		assert.NoError(t, err)
+
+		cp := clientInfo.Checkpoint(dummyDocID)
+		assert.Equal(t, int64(0), cp.ServerSeq)
+		assert.Equal(t, uint32(0), cp.ClientSeq)
 	})
 
 	t.Run("check if in project test", func(t *testing.T) {
@@ -86,7 +158,7 @@ func TestClientInfo(t *testing.T) {
 			Status: database.ClientActivated,
 		}
 
-		err := clientInfo.AttachDocument(dummyDocID, false, 0)
+		err := clientInfo.AttachDocument(dummyDocID, false, 0, change.InitialCheckpoint)
 		assert.NoError(t, err)
 		isAttached, err := clientInfo.IsAttached(dummyDocID)
 		assert.NoError(t, err)
@@ -103,7 +175,7 @@ func TestClientInfo(t *testing.T) {
 			Status: database.ClientDeactivated,
 		}
 
-		err := clientInfo.AttachDocument(dummyDocID, false, 0)
+		err := clientInfo.AttachDocument(dummyDocID, false, 0, change.InitialCheckpoint)
 		assert.ErrorIs(t, err, database.ErrClientNotActivated)
 
 		err = clientInfo.EnsureDocumentAttached(dummyDocID)
@@ -137,13 +209,13 @@ func TestClientInfo(t *testing.T) {
 			Status: database.ClientActivated,
 		}
 
-		err := clientInfo.AttachDocument(dummyDocID, false, 0)
+		err := clientInfo.AttachDocument(dummyDocID, false, 0, change.InitialCheckpoint)
 		assert.NoError(t, err)
 		isAttached, err := clientInfo.IsAttached(dummyDocID)
 		assert.NoError(t, err)
 		assert.True(t, isAttached)
 
-		err = clientInfo.AttachDocument(dummyDocID, false, 0)
+		err = clientInfo.AttachDocument(dummyDocID, false, 0, change.InitialCheckpoint)
 		assert.ErrorIs(t, err, database.ErrDocumentAlreadyAttached)
 	})
 
@@ -226,7 +298,7 @@ func TestClientInfo(t *testing.T) {
 			Status: database.ClientActivated,
 		}
 
-		err := clientInfo.AttachDocument(dummyDocID, false, 0)
+		err := clientInfo.AttachDocument(dummyDocID, false, 0, change.InitialCheckpoint)
 		assert.NoError(t, err)
 		isAttached, err := clientInfo.IsAttached(dummyDocID)
 		assert.NoError(t, err)

--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -1062,10 +1062,13 @@ func (d *DB) TryAttaching(_ context.Context, refKey types.ClientRefKey, docID ty
 		clientInfo.Documents = make(map[types.ID]*database.ClientDocInfo)
 	}
 
+	// NOTE(hackerwins): Do not reset server_seq/client_seq here. AttachDocument
+	// is the sole owner of the seeded checkpoint so it can preserve a
+	// same-session re-attach's seqs (Case A) or seed from the client-presented
+	// checkpoint (Case B). A fresh Attaching entry defaults both to 0, matching
+	// the previous behavior. See docs/design/offline-resumable-attach.md.
 	clientInfo.Documents[docID] = &database.ClientDocInfo{
-		Status:    database.DocumentAttaching,
-		ServerSeq: 0,
-		ClientSeq: 0,
+		Status: database.DocumentAttaching,
 	}
 	clientInfo.UpdatedAt = gotime.Now()
 

--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -1062,14 +1062,20 @@ func (d *DB) TryAttaching(_ context.Context, refKey types.ClientRefKey, docID ty
 		clientInfo.Documents = make(map[types.ID]*database.ClientDocInfo)
 	}
 
-	// NOTE(hackerwins): Do not reset server_seq/client_seq here. AttachDocument
-	// is the sole owner of the seeded checkpoint so it can preserve a
-	// same-session re-attach's seqs (Case A) or seed from the client-presented
-	// checkpoint (Case B). A fresh Attaching entry defaults both to 0, matching
-	// the previous behavior. See docs/design/offline-resumable-attach.md.
-	clientInfo.Documents[docID] = &database.ClientDocInfo{
-		Status: database.DocumentAttaching,
+	// NOTE(hackerwins): Reset server_seq/client_seq to 0 on the attaching
+	// transition. AttachDocument owns the seeded checkpoint: a Case B resume
+	// overwrites this entry from the client-presented checkpoint, and a fresh
+	// attach seeds 0/0, so zeroing here matches AttachDocument's fresh baseline.
+	// The mongo backend zeroes the same two fields; keep the two in step. See
+	// docs/design/offline-resumable-attach.md.
+	existing := clientInfo.Documents[docID]
+	if existing == nil {
+		existing = &database.ClientDocInfo{}
+		clientInfo.Documents[docID] = existing
 	}
+	existing.Status = database.DocumentAttaching
+	existing.ServerSeq = 0
+	existing.ClientSeq = 0
 	clientInfo.UpdatedAt = gotime.Now()
 
 	if err := txn.Insert(tblClients, clientInfo); err != nil {

--- a/server/backend/database/memory/database.go
+++ b/server/backend/database/memory/database.go
@@ -990,14 +990,15 @@ func (d *DB) ActivateClient(
 	now := gotime.Now()
 
 	clientInfo := &database.ClientInfo{
-		ID:        types.NewID(),
-		ProjectID: projectID,
-		Key:       key,
-		Metadata:  metadata,
-		Status:    database.ClientActivated,
-		Documents: make(database.ClientDocInfoMap),
-		CreatedAt: now,
-		UpdatedAt: now,
+		ID:            types.NewID(),
+		StableActorID: types.DeriveActorID(projectID, key),
+		ProjectID:     projectID,
+		Key:           key,
+		Metadata:      metadata,
+		Status:        database.ClientActivated,
+		Documents:     make(database.ClientDocInfoMap),
+		CreatedAt:     now,
+		UpdatedAt:     now,
 	}
 
 	if err := txn.Insert(tblClients, clientInfo); err != nil {

--- a/server/backend/database/memory/database_test.go
+++ b/server/backend/database/memory/database_test.go
@@ -126,6 +126,10 @@ func TestDB(t *testing.T) {
 		testcases.RunTryAttachingAndDeactivateClientTest(t, db, projectID)
 	})
 
+	t.Run("VersionVectorStableActor test", func(t *testing.T) {
+		testcases.RunVersionVectorStableActorTest(t, db, projectID)
+	})
+
 	t.Run("UpdateProjectInfo test", func(t *testing.T) {
 		testcases.RunUpdateProjectInfoTest(t, db)
 	})

--- a/server/backend/database/memory/database_test.go
+++ b/server/backend/database/memory/database_test.go
@@ -126,6 +126,10 @@ func TestDB(t *testing.T) {
 		testcases.RunTryAttachingAndDeactivateClientTest(t, db, projectID)
 	})
 
+	t.Run("AttachResumeCheckpoint test", func(t *testing.T) {
+		testcases.RunAttachResumeCheckpointTest(t, db, projectID)
+	})
+
 	t.Run("VersionVectorStableActor test", func(t *testing.T) {
 		testcases.RunVersionVectorStableActorTest(t, db, projectID)
 	})

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -1107,12 +1107,16 @@ func (c *Client) TryAttaching(
 			"status":                           database.ClientActivated,
 			clientDocInfoKey(docID, StatusKey): bson.M{"$ne": database.DocumentAttached},
 		},
+		// NOTE(hackerwins): Do not $set server_seq/client_seq here. AttachDocument
+		// is the sole owner of the seeded checkpoint so it can preserve a
+		// same-session re-attach's seqs (Case A) or seed from the
+		// client-presented checkpoint (Case B). A fresh Attaching entry created
+		// by this $set omits both, which decode as 0, matching prior behavior.
+		// See docs/design/offline-resumable-attach.md.
 		bson.M{
 			"$set": bson.M{
-				clientDocInfoKey(docID, StatusKey):    database.DocumentAttaching,
-				clientDocInfoKey(docID, "server_seq"): int64(0),
-				clientDocInfoKey(docID, "client_seq"): uint32(0),
-				"updated_at":                          gotime.Now(),
+				clientDocInfoKey(docID, StatusKey): database.DocumentAttaching,
+				"updated_at":                       gotime.Now(),
 			},
 			"$addToSet": bson.M{
 				"attaching_docs": docID,

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -1107,16 +1107,19 @@ func (c *Client) TryAttaching(
 			"status":                           database.ClientActivated,
 			clientDocInfoKey(docID, StatusKey): bson.M{"$ne": database.DocumentAttached},
 		},
-		// NOTE(hackerwins): Do not $set server_seq/client_seq here. AttachDocument
-		// is the sole owner of the seeded checkpoint so it can preserve a
-		// same-session re-attach's seqs (Case A) or seed from the
-		// client-presented checkpoint (Case B). A fresh Attaching entry created
-		// by this $set omits both, which decode as 0, matching prior behavior.
-		// See docs/design/offline-resumable-attach.md.
+		// NOTE(hackerwins): Reset server_seq/client_seq to 0 on the attaching
+		// transition. AttachDocument owns the seeded checkpoint: a Case B resume
+		// overwrites this entry from the client-presented checkpoint, and a fresh
+		// attach seeds 0/0, so zeroing here matches AttachDocument's fresh
+		// baseline. $set (not $setOnInsert) so an existing non-zero-seq entry is
+		// also zeroed, keeping this in step with the memory backend. See
+		// docs/design/offline-resumable-attach.md.
 		bson.M{
 			"$set": bson.M{
-				clientDocInfoKey(docID, StatusKey): database.DocumentAttaching,
-				"updated_at":                       gotime.Now(),
+				clientDocInfoKey(docID, StatusKey):    database.DocumentAttaching,
+				clientDocInfoKey(docID, "server_seq"): int64(0),
+				clientDocInfoKey(docID, "client_seq"): uint32(0),
+				"updated_at":                          gotime.Now(),
 			},
 			"$addToSet": bson.M{
 				"attaching_docs": docID,

--- a/server/backend/database/mongo/client.go
+++ b/server/backend/database/mongo/client.go
@@ -1070,14 +1070,15 @@ func (c *Client) ActivateClient(
 	now := gotime.Now()
 
 	info := &database.ClientInfo{
-		ID:        types.NewID(),
-		ProjectID: projectID,
-		Key:       key,
-		Status:    database.ClientActivated,
-		Documents: make(database.ClientDocInfoMap),
-		Metadata:  metadata,
-		CreatedAt: now,
-		UpdatedAt: now,
+		ID:            types.NewID(),
+		StableActorID: types.DeriveActorID(projectID, key),
+		ProjectID:     projectID,
+		Key:           key,
+		Status:        database.ClientActivated,
+		Documents:     make(database.ClientDocInfoMap),
+		Metadata:      metadata,
+		CreatedAt:     now,
+		UpdatedAt:     now,
 	}
 
 	if _, err := c.collection(ColClients).InsertOne(ctx, info); err != nil {

--- a/server/backend/database/mongo/client_test.go
+++ b/server/backend/database/mongo/client_test.go
@@ -146,6 +146,10 @@ func TestClient(t *testing.T) {
 		testcases.RunTryAttachingAndDeactivateClientTest(t, cli, dummyProjectID)
 	})
 
+	t.Run("AttachResumeCheckpoint test", func(t *testing.T) {
+		testcases.RunAttachResumeCheckpointTest(t, cli, dummyProjectID)
+	})
+
 	t.Run("VersionVectorStableActor test", func(t *testing.T) {
 		testcases.RunVersionVectorStableActorTest(t, cli, dummyProjectID)
 	})

--- a/server/backend/database/mongo/client_test.go
+++ b/server/backend/database/mongo/client_test.go
@@ -146,6 +146,10 @@ func TestClient(t *testing.T) {
 		testcases.RunTryAttachingAndDeactivateClientTest(t, cli, dummyProjectID)
 	})
 
+	t.Run("VersionVectorStableActor test", func(t *testing.T) {
+		testcases.RunVersionVectorStableActorTest(t, cli, dummyProjectID)
+	})
+
 	t.Run("UpdateProjectInfo test", func(t *testing.T) {
 		testcases.RunUpdateProjectInfoTest(t, cli)
 	})

--- a/server/backend/database/testcases/testcases.go
+++ b/server/backend/database/testcases/testcases.go
@@ -2582,3 +2582,65 @@ func RunFindCompactionCandidatesTest(t *testing.T, db database.Database, project
 		}
 	})
 }
+
+// RunVersionVectorStableActorTest verifies that a client whose changes carry
+// its StableActorID keeps a correct version-vector liveness key: its own VV
+// entry is tracked while attached, removed on detach, and min-VV never regresses
+// so GC cannot advance past its un-synced tombstones. It exercises the
+// compare-both invariant at the DB layer for both memory and MongoDB backends.
+func RunVersionVectorStableActorTest(t *testing.T, db database.Database, projectID types.ID) {
+	t.Run("stable-actor VV liveness and detach cleanup test", func(t *testing.T) {
+		ctx := context.Background()
+		docKey := helper.TestKey(t)
+
+		// 01. Activate a new-SDK client and attach a document. The stable actor
+		// is what the client stamps into its own changes and its VV entries.
+		clientInfo, err := db.ActivateClient(ctx, projectID, t.Name(), nil)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, clientInfo.StableActorID)
+
+		stableActor, err := clientInfo.StableActorID.ToActorID()
+		assert.NoError(t, err)
+
+		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
+		assert.NoError(t, err)
+		docRefKey := docInfo.RefKey()
+		assert.NoError(t, clientInfo.AttachDocument(docRefKey.DocID, false, docInfo.Epoch))
+		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+
+		// 02. The client pushes a VV keyed by its StableActorID (as a new SDK
+		// stamps its changes). min-VV must include the stable-actor entry so
+		// tombstones stay alive for this client.
+		clientVV := time.VersionVector{stableActor: 7}
+		minVV, err := db.UpdateMinVersionVector(ctx, clientInfo, docRefKey, clientVV)
+		assert.NoError(t, err)
+		v, ok := minVV.Get(stableActor)
+		assert.True(t, ok, "min-VV must track the stable-actor entry while attached")
+		assert.Equal(t, int64(7), v)
+
+		// GetMinVersionVector observes the same stored entry.
+		minVV, err = db.GetMinVersionVector(ctx, docRefKey, time.NewVersionVector())
+		assert.NoError(t, err)
+		v, ok = minVV.Get(stableActor)
+		assert.True(t, ok)
+		assert.Equal(t, int64(0), v, "min against an empty peer VV floors the entry at 0")
+
+		// 03. Detach the document. The VV row keyed by the session id is
+		// removed, dropping the stored stable-actor entry. On detach the
+		// pushpull pipeline still passes the client's own presented VV as the
+		// incoming vector, so that call still sees the entry — that is expected
+		// and self-consistent.
+		assert.NoError(t, clientInfo.DetachDocument(docRefKey.DocID))
+		_, err = db.UpdateMinVersionVector(ctx, clientInfo, docRefKey, clientVV)
+		assert.NoError(t, err)
+
+		// From any peer's perspective (an empty incoming vector, i.e. the
+		// detached client no longer presents its VV), the stable-actor entry is
+		// gone: the row was deleted, so min-VV does not hold un-synced
+		// tombstones alive and GC can advance. No regression.
+		minVV, err = db.GetMinVersionVector(ctx, docRefKey, time.NewVersionVector())
+		assert.NoError(t, err)
+		_, ok = minVV.Get(stableActor)
+		assert.False(t, ok, "detach must drop the stored stable-actor VV entry")
+	})
+}

--- a/server/backend/database/testcases/testcases.go
+++ b/server/backend/database/testcases/testcases.go
@@ -1335,6 +1335,49 @@ func RunAttachResumeCheckpointTest(t *testing.T, db database.Database, projectID
 		assert.Equal(t, uint32(0), cp.ClientSeq)
 		assert.Equal(t, int64(0), cp.ServerSeq)
 	})
+
+	t.Run("TryAttaching zeroes seqs on an existing doc row test", func(t *testing.T) {
+		ctx := context.Background()
+
+		clientInfo, err := db.ActivateClient(ctx, projectID, t.Name(), nil)
+		assert.NoError(t, err)
+		docInfo, err := db.FindOrCreateDocInfo(
+			ctx, clientInfo.RefKey(), key.Key(fmt.Sprintf("tests$%s", t.Name())), false,
+		)
+		assert.NoError(t, err)
+
+		// Advance the persisted row to a non-zero-seq Attached state (5/4) so the
+		// stored ClientDocInfo carries real seqs, then detach. This is the only
+		// way to leave a persisted, non-Attached doc row behind that a later
+		// TryAttaching will act on. (No public path persists a non-zero-seq
+		// non-Attached row: DetachDocument/UpdateClientInfoAfterPushPull zero the
+		// seqs for any non-Attached status.)
+		docInfo.ServerSeq = 5
+		_, err = db.TryAttaching(ctx, clientInfo.RefKey(), docInfo.ID)
+		assert.NoError(t, err)
+		assert.NoError(t, clientInfo.AttachDocument(
+			docInfo.ID, false, docInfo.Epoch, 0, change.NewCheckpoint(5, 4),
+		))
+		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+		assert.NoError(t, clientInfo.DetachDocument(docInfo.ID))
+		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+
+		// TryAttaching on the pre-existing (now detached) doc row drives it to
+		// Attaching and must land on zeroed seqs in BOTH backends: memory mutates
+		// the entry in place, mongo $sets server_seq/client_seq to 0 (previously it
+		// $set only status, diverging from memory). AttachDocument then owns the
+		// real seed (Case B overwrites from the presented checkpoint).
+		attaching, err := db.TryAttaching(ctx, clientInfo.RefKey(), docInfo.ID)
+		assert.NoError(t, err)
+		assert.Equal(t, database.DocumentAttaching, attaching.Documents[docInfo.ID].Status)
+		assert.Equal(t, int64(0), attaching.Documents[docInfo.ID].ServerSeq)
+		assert.Equal(t, uint32(0), attaching.Documents[docInfo.ID].ClientSeq)
+
+		reloaded, err := db.FindClientInfoByRefKey(ctx, clientInfo.RefKey())
+		assert.NoError(t, err)
+		assert.Equal(t, int64(0), reloaded.Checkpoint(docInfo.ID).ServerSeq)
+		assert.Equal(t, uint32(0), reloaded.Checkpoint(docInfo.ID).ClientSeq)
+	})
 }
 
 // RunUpdateProjectInfoTest runs the UpdateProjectInfo tests for the given db.

--- a/server/backend/database/testcases/testcases.go
+++ b/server/backend/database/testcases/testcases.go
@@ -1131,9 +1131,15 @@ func RunActivateClientDeactivateClientTest(t *testing.T, db database.Database, p
 		clientInfo, err := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
 		assert.NoError(t, err)
 
+		// The stable actor is derived deterministically and must be populated on
+		// activation, independent of the fresh per-session ID.
+		assert.Equal(t, types.DeriveActorID(projectID, t.Name()), clientInfo.StableActorID)
+		assert.NoError(t, clientInfo.StableActorID.Validate())
+
 		found, err := db.FindClientInfoByRefKey(ctx, clientInfo.RefKey())
 		assert.NoError(t, err)
 		assert.Equal(t, clientInfo.Key, found.Key)
+		assert.Equal(t, clientInfo.StableActorID, found.StableActorID)
 	})
 
 	t.Run("activate/deactivate client test", func(t *testing.T) {
@@ -1158,6 +1164,11 @@ func RunActivateClientDeactivateClientTest(t *testing.T, db database.Database, p
 		assert.Equal(t, t.Name(), info2.Key)
 		assert.Equal(t, database.ClientActivated, info2.Status)
 		assert.NotEqual(t, info1.ID, info2.ID) // Different client IDs
+
+		// The stable actor, unlike the session ID, is identical across two
+		// activations of the same key so persisted changes replay consistently.
+		assert.Equal(t, info1.StableActorID, info2.StableActorID)
+		assert.NotEmpty(t, info1.StableActorID)
 
 		info1, err = db.DeactivateClient(ctx, info1.RefKey())
 		assert.NoError(t, err)

--- a/server/backend/database/testcases/testcases.go
+++ b/server/backend/database/testcases/testcases.go
@@ -494,7 +494,7 @@ func RunFindChangesBetweenServerSeqsTest(
 		clientInfo, _ := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
 		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		refKey := docInfo.RefKey()
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		bytesID, _ := clientInfo.ID.Bytes()
@@ -793,7 +793,7 @@ func RunFindChangeInfosBetweenServerSeqsTest(
 
 		clientInfo, _ := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
 		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		updatedClientInfo, _ := db.FindClientInfoByRefKey(ctx, clientInfo.RefKey())
@@ -824,7 +824,7 @@ func RunFindChangeInfosBetweenServerSeqsTest(
 		clientInfo, _ := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
 		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		refKey := docInfo.RefKey()
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		// 01. Create a document and store changes
@@ -896,7 +896,7 @@ func RunFindChangeInfosBetweenServerSeqsTest(
 		clientInfo, _ := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
 		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		refKey := docInfo.RefKey()
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		// 01. Create a document and store changes
@@ -962,7 +962,7 @@ func RunFindLatestChangeInfoTest(t *testing.T,
 		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NoError(t, err)
 		refKey := docInfo.RefKey()
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		// 02. Create a document and store changes.
@@ -1203,7 +1203,7 @@ func RunTryAttachingAndDeactivateClientTest(t *testing.T, db database.Database, 
 		assert.NoError(t, err)
 
 		// 05. failure case: client is activated, but document is already attached
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, 0, change.InitialCheckpoint))
 		err = db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo)
 		assert.NoError(t, err)
 		_, err = db.TryAttaching(ctx, clientInfo.RefKey(), docInfo.ID)
@@ -1238,7 +1238,7 @@ func RunTryAttachingAndDeactivateClientTest(t *testing.T, db database.Database, 
 		assert.Error(t, err)
 
 		// 03. failure case: client has attached document
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, 0, change.InitialCheckpoint))
 		err = db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo)
 		assert.NoError(t, err)
 		_, err = db.DeactivateClient(ctx, clientInfo.RefKey())
@@ -1277,7 +1277,7 @@ func RunAttachResumeCheckpointTest(t *testing.T, db database.Database, projectID
 		presented := change.NewCheckpoint(5, 4)
 		_, err = db.TryAttaching(ctx, clientInfo.RefKey(), docInfo.ID)
 		assert.NoError(t, err)
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, presented))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, 0, presented))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		reloaded, err := db.FindClientInfoByRefKey(ctx, clientInfo.RefKey())
@@ -1299,7 +1299,7 @@ func RunAttachResumeCheckpointTest(t *testing.T, db database.Database, projectID
 
 		_, err = db.TryAttaching(ctx, clientInfo.RefKey(), docInfo.ID)
 		assert.NoError(t, err)
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		reloaded, err := db.FindClientInfoByRefKey(ctx, clientInfo.RefKey())
@@ -1325,7 +1325,7 @@ func RunAttachResumeCheckpointTest(t *testing.T, db database.Database, projectID
 		_, err = db.TryAttaching(ctx, clientInfo.RefKey(), docInfo.ID)
 		assert.NoError(t, err)
 		assert.NoError(t, clientInfo.AttachDocument(
-			docInfo.ID, false, docInfo.Epoch, change.NewCheckpoint(0, 2),
+			docInfo.ID, false, docInfo.Epoch, 0, change.NewCheckpoint(0, 2),
 		))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
@@ -1794,7 +1794,7 @@ func RunCreateChangeInfosTest(t *testing.T, db database.Database, projectID type
 		clientInfo, _ := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
 		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		docRefKey := docInfo.RefKey()
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		// 02. Remove the document and check the document is removed.
@@ -1813,7 +1813,7 @@ func RunCreateChangeInfosTest(t *testing.T, db database.Database, projectID type
 		clientInfo1, _ := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
 		docInfo1, _ := db.FindOrCreateDocInfo(ctx, clientInfo1.RefKey(), docKey, false)
 		docRefKey1 := docInfo1.RefKey()
-		assert.NoError(t, clientInfo1.AttachDocument(docRefKey1.DocID, false, docInfo1.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, clientInfo1.AttachDocument(docRefKey1.DocID, false, docInfo1.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo1, docInfo1))
 
 		// 02. Remove the document.
@@ -1824,7 +1824,7 @@ func RunCreateChangeInfosTest(t *testing.T, db database.Database, projectID type
 		// 03. Create a document with same key and check they have same key but different id.
 		docInfo2, _ := db.FindOrCreateDocInfo(ctx, clientInfo1.RefKey(), docKey, false)
 		docRefKey2 := docInfo2.RefKey()
-		assert.NoError(t, clientInfo1.AttachDocument(docRefKey2.DocID, false, docInfo2.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, clientInfo1.AttachDocument(docRefKey2.DocID, false, docInfo2.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo1, docInfo2))
 		assert.Equal(t, docInfo1.Key, docInfo2.Key)
 		assert.NotEqual(t, docInfo1.ID, docInfo2.ID)
@@ -1837,7 +1837,7 @@ func RunCreateChangeInfosTest(t *testing.T, db database.Database, projectID type
 		clientInfo, _ := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
 		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		docRefKey := docInfo.RefKey()
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		// Set removed_at in docInfo and store changes
@@ -1867,7 +1867,7 @@ func RunCreateChangeInfosTest(t *testing.T, db database.Database, projectID type
 		assert.NotEqual(t, gotime.Date(1, gotime.January, 1, 0, 0, 0, 0, gotime.UTC), docInfo1.UpdatedAt)
 		assert.Equal(t, docInfo1.CreatedAt, docInfo1.UpdatedAt)
 		refKey := docInfo1.RefKey()
-		assert.NoError(t, clientInfo.AttachDocument(refKey.DocID, false, docInfo1.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, clientInfo.AttachDocument(refKey.DocID, false, docInfo1.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo1))
 
 		bytesID, _ := clientInfo.ID.Bytes()
@@ -1929,7 +1929,7 @@ func RunUpdateClientInfoAfterPushPullTest(t *testing.T, db database.Database, pr
 
 		err = db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo)
 		assert.ErrorIs(t, err, database.ErrDocumentNeverAttached)
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 	})
 
@@ -1941,7 +1941,7 @@ func RunUpdateClientInfoAfterPushPullTest(t *testing.T, db database.Database, pr
 		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NoError(t, err)
 
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		result, err := db.FindClientInfoByRefKey(ctx, clientInfo.RefKey())
@@ -1959,7 +1959,7 @@ func RunUpdateClientInfoAfterPushPullTest(t *testing.T, db database.Database, pr
 		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NoError(t, err)
 
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, 0, change.InitialCheckpoint))
 		clientInfo.Documents[docInfo.ID].ServerSeq = 1
 		clientInfo.Documents[docInfo.ID].ClientSeq = 1
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
@@ -2001,7 +2001,7 @@ func RunUpdateClientInfoAfterPushPullTest(t *testing.T, db database.Database, pr
 		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NoError(t, err)
 
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, 0, change.InitialCheckpoint))
 		clientInfo.Documents[docInfo.ID].ServerSeq = 1
 		clientInfo.Documents[docInfo.ID].ClientSeq = 1
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
@@ -2030,7 +2030,7 @@ func RunUpdateClientInfoAfterPushPullTest(t *testing.T, db database.Database, pr
 		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NoError(t, err)
 
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, 0, change.InitialCheckpoint))
 		clientInfo.Documents[docInfo.ID].ServerSeq = 1
 		clientInfo.Documents[docInfo.ID].ClientSeq = 1
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
@@ -2089,7 +2089,7 @@ func RunUpdateClientInfoAfterPushPullTest(t *testing.T, db database.Database, pr
 		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NoError(t, err)
 
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		clientInfo.ID = "invalid clientInfo id"
@@ -2120,7 +2120,7 @@ func RunIsDocumentAttachedOrAttachingTest(t *testing.T, db database.Database, pr
 		assert.False(t, attached)
 
 		// 02. Check if document is attached after attaching
-		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID, false, d1.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID, false, d1.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c1, d1))
 		attached, err = db.IsDocumentAttachedOrAttaching(ctx, docRefKey1, "")
 		assert.NoError(t, err)
@@ -2134,9 +2134,9 @@ func RunIsDocumentAttachedOrAttachingTest(t *testing.T, db database.Database, pr
 		assert.False(t, attached)
 
 		// 04. Check if document is attached after two clients attaching
-		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID, false, d1.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID, false, d1.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c1, d1))
-		assert.NoError(t, c2.AttachDocument(docRefKey1.DocID, false, d1.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, c2.AttachDocument(docRefKey1.DocID, false, d1.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c2, d1))
 		attached, err = db.IsDocumentAttachedOrAttaching(ctx, docRefKey1, "")
 		assert.NoError(t, err)
@@ -2170,14 +2170,14 @@ func RunIsDocumentAttachedOrAttachingTest(t *testing.T, db database.Database, pr
 
 		// 01. Check if documents are attached after attaching
 		docRefKey1 := d1.RefKey()
-		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID, false, d1.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID, false, d1.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c1, d1))
 		attached, err := db.IsDocumentAttachedOrAttaching(ctx, docRefKey1, "")
 		assert.NoError(t, err)
 		assert.True(t, attached)
 
 		docRefKey2 := d2.RefKey()
-		assert.NoError(t, c1.AttachDocument(docRefKey2.DocID, false, d2.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, c1.AttachDocument(docRefKey2.DocID, false, d2.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c1, d2))
 		attached, err = db.IsDocumentAttachedOrAttaching(ctx, docRefKey2, "")
 		assert.NoError(t, err)
@@ -2263,7 +2263,7 @@ func RunIsDocumentAttachedOrAttachingTest(t *testing.T, db database.Database, pr
 		assert.False(t, attached)
 
 		// 02. Check if document is attached after attaching
-		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID, false, d1.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID, false, d1.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c1, d1))
 		attached, err = db.IsDocumentAttachedOrAttaching(ctx, docRefKey1, "")
 		assert.NoError(t, err)
@@ -2283,9 +2283,9 @@ func RunIsDocumentAttachedOrAttachingTest(t *testing.T, db database.Database, pr
 		assert.False(t, attached)
 
 		// 04. Check if document is attached after two clients attaching
-		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID, false, d1.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID, false, d1.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c1, d1))
-		assert.NoError(t, c2.AttachDocument(docRefKey1.DocID, false, d1.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, c2.AttachDocument(docRefKey1.DocID, false, d1.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c2, d1))
 		attached, err = db.IsDocumentAttachedOrAttaching(ctx, docRefKey1, "")
 		assert.NoError(t, err)
@@ -2335,7 +2335,7 @@ func RunFindClientInfosByAttachedDocRefKeyTest(t *testing.T, db database.Databas
 		clientInfo1, _ := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
 		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo1.RefKey(), docKey, false)
 		docRefKey := docInfo.RefKey()
-		assert.NoError(t, clientInfo1.AttachDocument(docRefKey.DocID, false, docInfo.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, clientInfo1.AttachDocument(docRefKey.DocID, false, docInfo.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo1, docInfo))
 
 		clientInfos, err := db.FindAttachedClientInfosByRefKey(ctx, docRefKey)
@@ -2344,7 +2344,7 @@ func RunFindClientInfosByAttachedDocRefKeyTest(t *testing.T, db database.Databas
 		assert.Equal(t, clientInfo1.ID, clientInfos[0].ID)
 
 		clientInfo2, _ := db.ActivateClient(ctx, projectID, t.Name()+"2", map[string]string{"userID": t.Name() + "2"})
-		assert.NoError(t, clientInfo2.AttachDocument(docRefKey.DocID, false, docInfo.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, clientInfo2.AttachDocument(docRefKey.DocID, false, docInfo.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo2, docInfo))
 		clientInfos, err = db.FindAttachedClientInfosByRefKey(ctx, docRefKey)
 		assert.NoError(t, err)
@@ -2376,11 +2376,11 @@ func RunFindAttachedClientCountsByDocIDsTest(t *testing.T, db database.Database,
 		docKey1, docKey2 := key.Key(fmt.Sprintf("tests$%s-1", t.Name())), key.Key(fmt.Sprintf("tests$%s-2", t.Name()))
 		docInfo1, _ := db.FindOrCreateDocInfo(ctx, clientInfo1.RefKey(), docKey1, false)
 		docInfo2, _ := db.FindOrCreateDocInfo(ctx, clientInfo2.RefKey(), docKey2, false)
-		assert.NoError(t, clientInfo1.AttachDocument(docInfo1.ID, false, docInfo1.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, clientInfo1.AttachDocument(docInfo1.ID, false, docInfo1.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo1, docInfo1))
-		assert.NoError(t, clientInfo1.AttachDocument(docInfo2.ID, false, docInfo2.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, clientInfo1.AttachDocument(docInfo2.ID, false, docInfo2.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo1, docInfo2))
-		assert.NoError(t, clientInfo2.AttachDocument(docInfo1.ID, false, docInfo1.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, clientInfo2.AttachDocument(docInfo1.ID, false, docInfo1.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo2, docInfo1))
 		{
 			attachedMap, err := db.FindAttachedClientCountsByDocIDs(ctx, projectID, []types.ID{docInfo1.ID, docInfo2.ID})
@@ -2431,7 +2431,7 @@ func RunPurgeDocument(t *testing.T, db database.Database, projectID types.ID) {
 		docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
 		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		docRefKey := docInfo.RefKey()
-		assert.NoError(t, clientInfo.AttachDocument(docRefKey.DocID, false, docInfo.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, clientInfo.AttachDocument(docRefKey.DocID, false, docInfo.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		// 02. Purge the document and check the document is purged.
@@ -2688,7 +2688,7 @@ func RunVersionVectorStableActorTest(t *testing.T, db database.Database, project
 		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NoError(t, err)
 		docRefKey := docInfo.RefKey()
-		assert.NoError(t, clientInfo.AttachDocument(docRefKey.DocID, false, docInfo.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, clientInfo.AttachDocument(docRefKey.DocID, false, docInfo.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		// 02. The client pushes a VV keyed by its StableActorID (as a new SDK

--- a/server/backend/database/testcases/testcases.go
+++ b/server/backend/database/testcases/testcases.go
@@ -1254,6 +1254,89 @@ func RunTryAttachingAndDeactivateClientTest(t *testing.T, db database.Database, 
 	})
 }
 
+// RunAttachResumeCheckpointTest runs the resumable-checkpoint-on-attach tests
+// for the given db. It covers the conditional checkpoint reset (Q3): a reload
+// resume seeds the presented checkpoint (Case B), a fresh attach still starts
+// at 0, and TryAttaching no longer clobbers an existing row's seqs.
+func RunAttachResumeCheckpointTest(t *testing.T, db database.Database, projectID types.ID) {
+	t.Run("attach seeds from presented checkpoint test", func(t *testing.T) {
+		ctx := context.Background()
+
+		clientInfo, err := db.ActivateClient(ctx, projectID, t.Name(), nil)
+		assert.NoError(t, err)
+		docInfo, err := db.FindOrCreateDocInfo(
+			ctx, clientInfo.RefKey(), key.Key(fmt.Sprintf("tests$%s", t.Name())), false,
+		)
+		assert.NoError(t, err)
+
+		// Case B (reload / new session): a presented checkpoint with a non-zero
+		// ServerSeq is the resume signal and seeds the ClientDocInfo instead of
+		// 0. The doc has advanced to serverSeq 5, so serverSeq 5 does not exceed
+		// the doc's actual and no clamp applies.
+		docInfo.ServerSeq = 5
+		presented := change.NewCheckpoint(5, 4)
+		_, err = db.TryAttaching(ctx, clientInfo.RefKey(), docInfo.ID)
+		assert.NoError(t, err)
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, presented))
+		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+
+		reloaded, err := db.FindClientInfoByRefKey(ctx, clientInfo.RefKey())
+		assert.NoError(t, err)
+		cp := reloaded.Checkpoint(docInfo.ID)
+		assert.Equal(t, uint32(4), cp.ClientSeq)
+		assert.Equal(t, int64(5), cp.ServerSeq)
+	})
+
+	t.Run("fresh attach seeds zero test", func(t *testing.T) {
+		ctx := context.Background()
+
+		clientInfo, err := db.ActivateClient(ctx, projectID, t.Name(), nil)
+		assert.NoError(t, err)
+		docInfo, err := db.FindOrCreateDocInfo(
+			ctx, clientInfo.RefKey(), key.Key(fmt.Sprintf("tests$%s", t.Name())), false,
+		)
+		assert.NoError(t, err)
+
+		_, err = db.TryAttaching(ctx, clientInfo.RefKey(), docInfo.ID)
+		assert.NoError(t, err)
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
+		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+
+		reloaded, err := db.FindClientInfoByRefKey(ctx, clientInfo.RefKey())
+		assert.NoError(t, err)
+		cp := reloaded.Checkpoint(docInfo.ID)
+		assert.Equal(t, uint32(0), cp.ClientSeq)
+		assert.Equal(t, int64(0), cp.ServerSeq)
+	})
+
+	t.Run("fresh attach with local edits seeds zero test", func(t *testing.T) {
+		ctx := context.Background()
+
+		clientInfo, err := db.ActivateClient(ctx, projectID, t.Name(), nil)
+		assert.NoError(t, err)
+		docInfo, err := db.FindOrCreateDocInfo(
+			ctx, clientInfo.RefKey(), key.Key(fmt.Sprintf("tests$%s", t.Name())), false,
+		)
+		assert.NoError(t, err)
+
+		// A fresh attach that already carries local edits presents a non-zero
+		// ClientSeq but a zero ServerSeq. This is NOT a resume; it must seed 0/0
+		// so the pending changes are not mistaken for already-pushed work.
+		_, err = db.TryAttaching(ctx, clientInfo.RefKey(), docInfo.ID)
+		assert.NoError(t, err)
+		assert.NoError(t, clientInfo.AttachDocument(
+			docInfo.ID, false, docInfo.Epoch, change.NewCheckpoint(0, 2),
+		))
+		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
+
+		reloaded, err := db.FindClientInfoByRefKey(ctx, clientInfo.RefKey())
+		assert.NoError(t, err)
+		cp := reloaded.Checkpoint(docInfo.ID)
+		assert.Equal(t, uint32(0), cp.ClientSeq)
+		assert.Equal(t, int64(0), cp.ServerSeq)
+	})
+}
+
 // RunUpdateProjectInfoTest runs the UpdateProjectInfo tests for the given db.
 func RunUpdateProjectInfoTest(t *testing.T, db database.Database) {
 	t.Run("UpdateProjectInfo test", func(t *testing.T) {

--- a/server/backend/database/testcases/testcases.go
+++ b/server/backend/database/testcases/testcases.go
@@ -494,7 +494,7 @@ func RunFindChangesBetweenServerSeqsTest(
 		clientInfo, _ := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
 		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		refKey := docInfo.RefKey()
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		bytesID, _ := clientInfo.ID.Bytes()
@@ -793,7 +793,7 @@ func RunFindChangeInfosBetweenServerSeqsTest(
 
 		clientInfo, _ := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
 		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		updatedClientInfo, _ := db.FindClientInfoByRefKey(ctx, clientInfo.RefKey())
@@ -824,7 +824,7 @@ func RunFindChangeInfosBetweenServerSeqsTest(
 		clientInfo, _ := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
 		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		refKey := docInfo.RefKey()
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		// 01. Create a document and store changes
@@ -896,7 +896,7 @@ func RunFindChangeInfosBetweenServerSeqsTest(
 		clientInfo, _ := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
 		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		refKey := docInfo.RefKey()
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		// 01. Create a document and store changes
@@ -962,7 +962,7 @@ func RunFindLatestChangeInfoTest(t *testing.T,
 		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NoError(t, err)
 		refKey := docInfo.RefKey()
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		// 02. Create a document and store changes.
@@ -1203,7 +1203,7 @@ func RunTryAttachingAndDeactivateClientTest(t *testing.T, db database.Database, 
 		assert.NoError(t, err)
 
 		// 05. failure case: client is activated, but document is already attached
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
 		err = db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo)
 		assert.NoError(t, err)
 		_, err = db.TryAttaching(ctx, clientInfo.RefKey(), docInfo.ID)
@@ -1238,7 +1238,7 @@ func RunTryAttachingAndDeactivateClientTest(t *testing.T, db database.Database, 
 		assert.Error(t, err)
 
 		// 03. failure case: client has attached document
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
 		err = db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo)
 		assert.NoError(t, err)
 		_, err = db.DeactivateClient(ctx, clientInfo.RefKey())
@@ -1711,7 +1711,7 @@ func RunCreateChangeInfosTest(t *testing.T, db database.Database, projectID type
 		clientInfo, _ := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
 		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		docRefKey := docInfo.RefKey()
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		// 02. Remove the document and check the document is removed.
@@ -1730,7 +1730,7 @@ func RunCreateChangeInfosTest(t *testing.T, db database.Database, projectID type
 		clientInfo1, _ := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
 		docInfo1, _ := db.FindOrCreateDocInfo(ctx, clientInfo1.RefKey(), docKey, false)
 		docRefKey1 := docInfo1.RefKey()
-		assert.NoError(t, clientInfo1.AttachDocument(docRefKey1.DocID, false, docInfo1.Epoch))
+		assert.NoError(t, clientInfo1.AttachDocument(docRefKey1.DocID, false, docInfo1.Epoch, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo1, docInfo1))
 
 		// 02. Remove the document.
@@ -1741,7 +1741,7 @@ func RunCreateChangeInfosTest(t *testing.T, db database.Database, projectID type
 		// 03. Create a document with same key and check they have same key but different id.
 		docInfo2, _ := db.FindOrCreateDocInfo(ctx, clientInfo1.RefKey(), docKey, false)
 		docRefKey2 := docInfo2.RefKey()
-		assert.NoError(t, clientInfo1.AttachDocument(docRefKey2.DocID, false, docInfo2.Epoch))
+		assert.NoError(t, clientInfo1.AttachDocument(docRefKey2.DocID, false, docInfo2.Epoch, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo1, docInfo2))
 		assert.Equal(t, docInfo1.Key, docInfo2.Key)
 		assert.NotEqual(t, docInfo1.ID, docInfo2.ID)
@@ -1754,7 +1754,7 @@ func RunCreateChangeInfosTest(t *testing.T, db database.Database, projectID type
 		clientInfo, _ := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
 		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		docRefKey := docInfo.RefKey()
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		// Set removed_at in docInfo and store changes
@@ -1784,7 +1784,7 @@ func RunCreateChangeInfosTest(t *testing.T, db database.Database, projectID type
 		assert.NotEqual(t, gotime.Date(1, gotime.January, 1, 0, 0, 0, 0, gotime.UTC), docInfo1.UpdatedAt)
 		assert.Equal(t, docInfo1.CreatedAt, docInfo1.UpdatedAt)
 		refKey := docInfo1.RefKey()
-		assert.NoError(t, clientInfo.AttachDocument(refKey.DocID, false, docInfo1.Epoch))
+		assert.NoError(t, clientInfo.AttachDocument(refKey.DocID, false, docInfo1.Epoch, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo1))
 
 		bytesID, _ := clientInfo.ID.Bytes()
@@ -1846,7 +1846,7 @@ func RunUpdateClientInfoAfterPushPullTest(t *testing.T, db database.Database, pr
 
 		err = db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo)
 		assert.ErrorIs(t, err, database.ErrDocumentNeverAttached)
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 	})
 
@@ -1858,7 +1858,7 @@ func RunUpdateClientInfoAfterPushPullTest(t *testing.T, db database.Database, pr
 		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NoError(t, err)
 
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		result, err := db.FindClientInfoByRefKey(ctx, clientInfo.RefKey())
@@ -1876,7 +1876,7 @@ func RunUpdateClientInfoAfterPushPullTest(t *testing.T, db database.Database, pr
 		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NoError(t, err)
 
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
 		clientInfo.Documents[docInfo.ID].ServerSeq = 1
 		clientInfo.Documents[docInfo.ID].ClientSeq = 1
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
@@ -1918,7 +1918,7 @@ func RunUpdateClientInfoAfterPushPullTest(t *testing.T, db database.Database, pr
 		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NoError(t, err)
 
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
 		clientInfo.Documents[docInfo.ID].ServerSeq = 1
 		clientInfo.Documents[docInfo.ID].ClientSeq = 1
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
@@ -1947,7 +1947,7 @@ func RunUpdateClientInfoAfterPushPullTest(t *testing.T, db database.Database, pr
 		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NoError(t, err)
 
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
 		clientInfo.Documents[docInfo.ID].ServerSeq = 1
 		clientInfo.Documents[docInfo.ID].ClientSeq = 1
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
@@ -2006,7 +2006,7 @@ func RunUpdateClientInfoAfterPushPullTest(t *testing.T, db database.Database, pr
 		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NoError(t, err)
 
-		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
+		assert.NoError(t, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		clientInfo.ID = "invalid clientInfo id"
@@ -2037,7 +2037,7 @@ func RunIsDocumentAttachedOrAttachingTest(t *testing.T, db database.Database, pr
 		assert.False(t, attached)
 
 		// 02. Check if document is attached after attaching
-		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID, false, d1.Epoch))
+		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID, false, d1.Epoch, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c1, d1))
 		attached, err = db.IsDocumentAttachedOrAttaching(ctx, docRefKey1, "")
 		assert.NoError(t, err)
@@ -2051,9 +2051,9 @@ func RunIsDocumentAttachedOrAttachingTest(t *testing.T, db database.Database, pr
 		assert.False(t, attached)
 
 		// 04. Check if document is attached after two clients attaching
-		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID, false, d1.Epoch))
+		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID, false, d1.Epoch, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c1, d1))
-		assert.NoError(t, c2.AttachDocument(docRefKey1.DocID, false, d1.Epoch))
+		assert.NoError(t, c2.AttachDocument(docRefKey1.DocID, false, d1.Epoch, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c2, d1))
 		attached, err = db.IsDocumentAttachedOrAttaching(ctx, docRefKey1, "")
 		assert.NoError(t, err)
@@ -2087,14 +2087,14 @@ func RunIsDocumentAttachedOrAttachingTest(t *testing.T, db database.Database, pr
 
 		// 01. Check if documents are attached after attaching
 		docRefKey1 := d1.RefKey()
-		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID, false, d1.Epoch))
+		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID, false, d1.Epoch, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c1, d1))
 		attached, err := db.IsDocumentAttachedOrAttaching(ctx, docRefKey1, "")
 		assert.NoError(t, err)
 		assert.True(t, attached)
 
 		docRefKey2 := d2.RefKey()
-		assert.NoError(t, c1.AttachDocument(docRefKey2.DocID, false, d2.Epoch))
+		assert.NoError(t, c1.AttachDocument(docRefKey2.DocID, false, d2.Epoch, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c1, d2))
 		attached, err = db.IsDocumentAttachedOrAttaching(ctx, docRefKey2, "")
 		assert.NoError(t, err)
@@ -2180,7 +2180,7 @@ func RunIsDocumentAttachedOrAttachingTest(t *testing.T, db database.Database, pr
 		assert.False(t, attached)
 
 		// 02. Check if document is attached after attaching
-		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID, false, d1.Epoch))
+		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID, false, d1.Epoch, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c1, d1))
 		attached, err = db.IsDocumentAttachedOrAttaching(ctx, docRefKey1, "")
 		assert.NoError(t, err)
@@ -2200,9 +2200,9 @@ func RunIsDocumentAttachedOrAttachingTest(t *testing.T, db database.Database, pr
 		assert.False(t, attached)
 
 		// 04. Check if document is attached after two clients attaching
-		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID, false, d1.Epoch))
+		assert.NoError(t, c1.AttachDocument(docRefKey1.DocID, false, d1.Epoch, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c1, d1))
-		assert.NoError(t, c2.AttachDocument(docRefKey1.DocID, false, d1.Epoch))
+		assert.NoError(t, c2.AttachDocument(docRefKey1.DocID, false, d1.Epoch, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, c2, d1))
 		attached, err = db.IsDocumentAttachedOrAttaching(ctx, docRefKey1, "")
 		assert.NoError(t, err)
@@ -2252,7 +2252,7 @@ func RunFindClientInfosByAttachedDocRefKeyTest(t *testing.T, db database.Databas
 		clientInfo1, _ := db.ActivateClient(ctx, projectID, t.Name(), map[string]string{"userID": t.Name()})
 		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo1.RefKey(), docKey, false)
 		docRefKey := docInfo.RefKey()
-		assert.NoError(t, clientInfo1.AttachDocument(docRefKey.DocID, false, docInfo.Epoch))
+		assert.NoError(t, clientInfo1.AttachDocument(docRefKey.DocID, false, docInfo.Epoch, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo1, docInfo))
 
 		clientInfos, err := db.FindAttachedClientInfosByRefKey(ctx, docRefKey)
@@ -2261,7 +2261,7 @@ func RunFindClientInfosByAttachedDocRefKeyTest(t *testing.T, db database.Databas
 		assert.Equal(t, clientInfo1.ID, clientInfos[0].ID)
 
 		clientInfo2, _ := db.ActivateClient(ctx, projectID, t.Name()+"2", map[string]string{"userID": t.Name() + "2"})
-		assert.NoError(t, clientInfo2.AttachDocument(docRefKey.DocID, false, docInfo.Epoch))
+		assert.NoError(t, clientInfo2.AttachDocument(docRefKey.DocID, false, docInfo.Epoch, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo2, docInfo))
 		clientInfos, err = db.FindAttachedClientInfosByRefKey(ctx, docRefKey)
 		assert.NoError(t, err)
@@ -2293,11 +2293,11 @@ func RunFindAttachedClientCountsByDocIDsTest(t *testing.T, db database.Database,
 		docKey1, docKey2 := key.Key(fmt.Sprintf("tests$%s-1", t.Name())), key.Key(fmt.Sprintf("tests$%s-2", t.Name()))
 		docInfo1, _ := db.FindOrCreateDocInfo(ctx, clientInfo1.RefKey(), docKey1, false)
 		docInfo2, _ := db.FindOrCreateDocInfo(ctx, clientInfo2.RefKey(), docKey2, false)
-		assert.NoError(t, clientInfo1.AttachDocument(docInfo1.ID, false, docInfo1.Epoch))
+		assert.NoError(t, clientInfo1.AttachDocument(docInfo1.ID, false, docInfo1.Epoch, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo1, docInfo1))
-		assert.NoError(t, clientInfo1.AttachDocument(docInfo2.ID, false, docInfo2.Epoch))
+		assert.NoError(t, clientInfo1.AttachDocument(docInfo2.ID, false, docInfo2.Epoch, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo1, docInfo2))
-		assert.NoError(t, clientInfo2.AttachDocument(docInfo1.ID, false, docInfo1.Epoch))
+		assert.NoError(t, clientInfo2.AttachDocument(docInfo1.ID, false, docInfo1.Epoch, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo2, docInfo1))
 		{
 			attachedMap, err := db.FindAttachedClientCountsByDocIDs(ctx, projectID, []types.ID{docInfo1.ID, docInfo2.ID})
@@ -2348,7 +2348,7 @@ func RunPurgeDocument(t *testing.T, db database.Database, projectID types.ID) {
 		docKey := key.Key(fmt.Sprintf("tests$%s", t.Name()))
 		docInfo, _ := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		docRefKey := docInfo.RefKey()
-		assert.NoError(t, clientInfo.AttachDocument(docRefKey.DocID, false, docInfo.Epoch))
+		assert.NoError(t, clientInfo.AttachDocument(docRefKey.DocID, false, docInfo.Epoch, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		// 02. Purge the document and check the document is purged.
@@ -2605,7 +2605,7 @@ func RunVersionVectorStableActorTest(t *testing.T, db database.Database, project
 		docInfo, err := db.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NoError(t, err)
 		docRefKey := docInfo.RefKey()
-		assert.NoError(t, clientInfo.AttachDocument(docRefKey.DocID, false, docInfo.Epoch))
+		assert.NoError(t, clientInfo.AttachDocument(docRefKey.DocID, false, docInfo.Epoch, change.InitialCheckpoint))
 		assert.NoError(t, db.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		// 02. The client pushes a VV keyed by its StableActorID (as a new SDK

--- a/server/clients/clients.go
+++ b/server/clients/clients.go
@@ -150,13 +150,17 @@ func DeactivateAsync(
 // The presented checkpoint is the client-supplied pack.Checkpoint. A non-zero
 // presented checkpoint is the resume signal for offline-persistent clients: it
 // seeds ClientDocInfo so restored un-pushed changes push cleanly (Case B in
-// docs/design/offline-resumable-attach.md).
+// docs/design/offline-resumable-attach.md). presentedEpoch is the client's
+// persisted compaction epoch (from the attach ChangePack); on a Case B resume
+// it is seeded so a stale epoch fires ErrEpochMismatch and re-anchors from a
+// snapshot (pull-before-trust, Q2).
 func AttachDocument(
 	ctx context.Context,
 	be *backend.Backend,
 	clientInfo *database.ClientInfo,
 	docInfo *database.DocInfo,
 	isAttached bool,
+	presentedEpoch int64,
 	presented change.Checkpoint,
 ) (*database.ClientInfo, error) {
 	// NOTE(kokodak): Reattaching a document that has been detached is not allowed.
@@ -169,18 +173,18 @@ func AttachDocument(
 			clientInfo.ID, docInfo.ID, database.ErrDocumentAlreadyDetached)
 	}
 
-	// Minimal serverSeq safety clamp (stand-in for full Q2 pull-before-trust): a
-	// client must not skip changes by over-claiming ServerSeq. Clamp a presented
+	// serverSeq safety clamp (Q2 pull-before-trust, same-epoch tier): a client
+	// must not skip changes by over-claiming ServerSeq. Clamp a presented
 	// ServerSeq above the doc's actual server_seq to the doc's actual, so the
 	// client re-pulls anything it has not really seen. Continuity of clientSeq is
 	// still guarded loudly by validateClientSeqContinuity in pushpull.
 	//
-	// TODO(hackerwins): This clamp does not cover the compaction/epoch re-anchor
-	// case, where the doc's server_seq was reset below what the client legitimately
-	// saw. Full Q2 pull-before-trust re-anchors via the epoch + snapshot machinery
-	// (ErrEpochMismatch, FindClosestSnapshotInfo empty-fallback) before trusting
-	// the presented serverSeq. See docs/design/offline-resumable-attach.md,
-	// "Pull-before-trust reconciliation (Q2)".
+	// The compaction/epoch tier is handled separately: AttachDocument seeds the
+	// client's presented epoch, so a doc force-compacted while the client was
+	// offline makes the seeded epoch differ from the current doc epoch, and the
+	// epoch check in pushpull fires ErrEpochMismatch, re-anchoring from a snapshot.
+	// See docs/design/offline-resumable-attach.md, "Pull-before-trust
+	// reconciliation (Q2)".
 	if presented.ServerSeq > docInfo.ServerSeq {
 		presented = change.NewCheckpoint(docInfo.ServerSeq, presented.ClientSeq)
 	}
@@ -193,7 +197,7 @@ func AttachDocument(
 		}
 	}
 
-	if err := clientInfo.AttachDocument(docInfo.ID, isAttached, docInfo.Epoch, presented); err != nil {
+	if err := clientInfo.AttachDocument(docInfo.ID, isAttached, docInfo.Epoch, presentedEpoch, presented); err != nil {
 		return nil, err
 	}
 

--- a/server/clients/clients.go
+++ b/server/clients/clients.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/yorkie-team/yorkie/api/types"
 	"github.com/yorkie-team/yorkie/api/types/events"
+	"github.com/yorkie-team/yorkie/pkg/document/change"
 	"github.com/yorkie-team/yorkie/pkg/errors"
 	"github.com/yorkie-team/yorkie/server/backend"
 	"github.com/yorkie-team/yorkie/server/backend/database"
@@ -145,12 +146,18 @@ func DeactivateAsync(
 }
 
 // AttachDocument attaches the given document to the client.
+//
+// The presented checkpoint is the client-supplied pack.Checkpoint. A non-zero
+// presented checkpoint is the resume signal for offline-persistent clients: it
+// seeds ClientDocInfo so restored un-pushed changes push cleanly (Case B in
+// docs/design/offline-resumable-attach.md).
 func AttachDocument(
 	ctx context.Context,
 	be *backend.Backend,
 	clientInfo *database.ClientInfo,
 	docInfo *database.DocInfo,
 	isAttached bool,
+	presented change.Checkpoint,
 ) (*database.ClientInfo, error) {
 	// NOTE(kokodak): Reattaching a document that has been detached is not allowed.
 	// This check is necessary because TryAttaching does not validate this case.
@@ -162,6 +169,22 @@ func AttachDocument(
 			clientInfo.ID, docInfo.ID, database.ErrDocumentAlreadyDetached)
 	}
 
+	// Minimal serverSeq safety clamp (stand-in for full Q2 pull-before-trust): a
+	// client must not skip changes by over-claiming ServerSeq. Clamp a presented
+	// ServerSeq above the doc's actual server_seq to the doc's actual, so the
+	// client re-pulls anything it has not really seen. Continuity of clientSeq is
+	// still guarded loudly by validateClientSeqContinuity in pushpull.
+	//
+	// TODO(hackerwins): This clamp does not cover the compaction/epoch re-anchor
+	// case, where the doc's server_seq was reset below what the client legitimately
+	// saw. Full Q2 pull-before-trust re-anchors via the epoch + snapshot machinery
+	// (ErrEpochMismatch, FindClosestSnapshotInfo empty-fallback) before trusting
+	// the presented serverSeq. See docs/design/offline-resumable-attach.md,
+	// "Pull-before-trust reconciliation (Q2)".
+	if presented.ServerSeq > docInfo.ServerSeq {
+		presented = change.NewCheckpoint(docInfo.ServerSeq, presented.ClientSeq)
+	}
+
 	if !clientInfo.IsAttaching(docInfo.ID) {
 		var err error
 		clientInfo, err = be.DB.TryAttaching(ctx, clientInfo.RefKey(), docInfo.ID)
@@ -170,7 +193,7 @@ func AttachDocument(
 		}
 	}
 
-	if err := clientInfo.AttachDocument(docInfo.ID, isAttached, docInfo.Epoch); err != nil {
+	if err := clientInfo.AttachDocument(docInfo.ID, isAttached, docInfo.Epoch, presented); err != nil {
 		return nil, err
 	}
 

--- a/server/clients/clients_test.go
+++ b/server/clients/clients_test.go
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package clients_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yorkie-team/yorkie/api/types"
+	"github.com/yorkie-team/yorkie/pkg/document/change"
+	"github.com/yorkie-team/yorkie/pkg/key"
+	"github.com/yorkie-team/yorkie/server/backend"
+	"github.com/yorkie-team/yorkie/server/backend/database"
+	"github.com/yorkie-team/yorkie/server/backend/database/memory"
+	yorkiesync "github.com/yorkie-team/yorkie/server/backend/sync"
+	"github.com/yorkie-team/yorkie/server/clients"
+)
+
+func newTestBackend(t *testing.T) *backend.Backend {
+	db, err := memory.New()
+	assert.NoError(t, err)
+
+	return &backend.Backend{
+		DB:      db,
+		Lockers: yorkiesync.New(),
+	}
+}
+
+// TestAttachDocumentResumeCheckpoint exercises the conditional checkpoint reset
+// (Q3) through clients.AttachDocument: Case B seeding from the presented
+// checkpoint, the serverSeq safety clamp, and a fresh attach starting at 0.
+func TestAttachDocumentResumeCheckpoint(t *testing.T) {
+	ctx := context.Background()
+	be := newTestBackend(t)
+
+	project, err := be.DB.CreateProjectInfo(ctx, t.Name(), types.ID("000000000000000000000000"))
+	assert.NoError(t, err)
+
+	activate := func(name string) (*database.ClientInfo, *database.DocInfo) {
+		clientInfo, err := be.DB.ActivateClient(ctx, project.ID, name, nil)
+		assert.NoError(t, err)
+		docInfo, err := be.DB.FindOrCreateDocInfo(
+			ctx, clientInfo.RefKey(), key.Key(fmt.Sprintf("tests$%s", name)), false,
+		)
+		assert.NoError(t, err)
+		return clientInfo, docInfo
+	}
+
+	t.Run("Case B seeds from presented checkpoint", func(t *testing.T) {
+		clientInfo, docInfo := activate(t.Name())
+		docInfo.ServerSeq = 5
+
+		// A reload presents its persisted checkpoint. A non-zero serverSeq is the
+		// resume signal; it stays within the doc's actual (5), so no clamp.
+		presented := change.NewCheckpoint(5, 4)
+		got, err := clients.AttachDocument(ctx, be, clientInfo, docInfo, false, presented)
+		assert.NoError(t, err)
+
+		cp := got.Checkpoint(docInfo.ID)
+		assert.Equal(t, uint32(4), cp.ClientSeq)
+		assert.Equal(t, int64(5), cp.ServerSeq)
+	})
+
+	t.Run("fresh attach with local edits seeds zero", func(t *testing.T) {
+		clientInfo, docInfo := activate(t.Name())
+
+		// A non-zero clientSeq with serverSeq 0 is a fresh attach carrying local
+		// edits, not a resume; it must seed 0/0 so the pending changes push.
+		got, err := clients.AttachDocument(ctx, be, clientInfo, docInfo, false, change.NewCheckpoint(0, 3))
+		assert.NoError(t, err)
+
+		cp := got.Checkpoint(docInfo.ID)
+		assert.Equal(t, int64(0), cp.ServerSeq)
+		assert.Equal(t, uint32(0), cp.ClientSeq)
+	})
+
+	t.Run("serverSeq clamp caps an over-claimed presented serverSeq", func(t *testing.T) {
+		clientInfo, docInfo := activate(t.Name())
+		docInfo.ServerSeq = 2
+
+		// The client over-claims serverSeq=99; the clamp caps it to the doc's
+		// actual (2) so it re-pulls what it has not really seen. clientSeq is
+		// untouched.
+		presented := change.NewCheckpoint(99, 7)
+		got, err := clients.AttachDocument(ctx, be, clientInfo, docInfo, false, presented)
+		assert.NoError(t, err)
+
+		cp := got.Checkpoint(docInfo.ID)
+		assert.Equal(t, int64(2), cp.ServerSeq)
+		assert.Equal(t, uint32(7), cp.ClientSeq)
+	})
+
+	t.Run("fresh attach seeds zero", func(t *testing.T) {
+		clientInfo, docInfo := activate(t.Name())
+
+		got, err := clients.AttachDocument(ctx, be, clientInfo, docInfo, false, change.InitialCheckpoint)
+		assert.NoError(t, err)
+
+		cp := got.Checkpoint(docInfo.ID)
+		assert.Equal(t, int64(0), cp.ServerSeq)
+		assert.Equal(t, uint32(0), cp.ClientSeq)
+	})
+}

--- a/server/clients/clients_test.go
+++ b/server/clients/clients_test.go
@@ -70,7 +70,7 @@ func TestAttachDocumentResumeCheckpoint(t *testing.T) {
 		// A reload presents its persisted checkpoint. A non-zero serverSeq is the
 		// resume signal; it stays within the doc's actual (5), so no clamp.
 		presented := change.NewCheckpoint(5, 4)
-		got, err := clients.AttachDocument(ctx, be, clientInfo, docInfo, false, presented)
+		got, err := clients.AttachDocument(ctx, be, clientInfo, docInfo, false, 0, presented)
 		assert.NoError(t, err)
 
 		cp := got.Checkpoint(docInfo.ID)
@@ -78,12 +78,28 @@ func TestAttachDocumentResumeCheckpoint(t *testing.T) {
 		assert.Equal(t, int64(5), cp.ServerSeq)
 	})
 
+	t.Run("Case B seeds the presented epoch on resume", func(t *testing.T) {
+		clientInfo, docInfo := activate(t.Name())
+		docInfo.ServerSeq = 5
+		docInfo.Epoch = 5
+
+		// The client resumes presenting a stale epoch (2): its doc was
+		// force-compacted while it was offline. The presented epoch is seeded
+		// verbatim, not the current doc epoch, so the epoch mismatch in pushpull
+		// fires and the client re-anchors from a snapshot (Q2 pull-before-trust).
+		presented := change.NewCheckpoint(5, 4)
+		got, err := clients.AttachDocument(ctx, be, clientInfo, docInfo, false, 2, presented)
+		assert.NoError(t, err)
+
+		assert.Equal(t, int64(2), got.Documents[docInfo.ID].Epoch)
+	})
+
 	t.Run("fresh attach with local edits seeds zero", func(t *testing.T) {
 		clientInfo, docInfo := activate(t.Name())
 
 		// A non-zero clientSeq with serverSeq 0 is a fresh attach carrying local
 		// edits, not a resume; it must seed 0/0 so the pending changes push.
-		got, err := clients.AttachDocument(ctx, be, clientInfo, docInfo, false, change.NewCheckpoint(0, 3))
+		got, err := clients.AttachDocument(ctx, be, clientInfo, docInfo, false, 0, change.NewCheckpoint(0, 3))
 		assert.NoError(t, err)
 
 		cp := got.Checkpoint(docInfo.ID)
@@ -99,7 +115,7 @@ func TestAttachDocumentResumeCheckpoint(t *testing.T) {
 		// actual (2) so it re-pulls what it has not really seen. clientSeq is
 		// untouched.
 		presented := change.NewCheckpoint(99, 7)
-		got, err := clients.AttachDocument(ctx, be, clientInfo, docInfo, false, presented)
+		got, err := clients.AttachDocument(ctx, be, clientInfo, docInfo, false, 0, presented)
 		assert.NoError(t, err)
 
 		cp := got.Checkpoint(docInfo.ID)
@@ -110,7 +126,7 @@ func TestAttachDocumentResumeCheckpoint(t *testing.T) {
 	t.Run("fresh attach seeds zero", func(t *testing.T) {
 		clientInfo, docInfo := activate(t.Name())
 
-		got, err := clients.AttachDocument(ctx, be, clientInfo, docInfo, false, change.InitialCheckpoint)
+		got, err := clients.AttachDocument(ctx, be, clientInfo, docInfo, false, 0, change.InitialCheckpoint)
 		assert.NoError(t, err)
 
 		cp := got.Checkpoint(docInfo.ID)

--- a/server/packs/pushpull.go
+++ b/server/packs/pushpull.go
@@ -160,6 +160,16 @@ func PushPull(
 	// 04. publish document event and store the snapshot if needed.
 	if len(pushedChanges) > 0 || reqPack.IsRemoved {
 		be.Go(func(ctx context.Context) {
+			// Publish the DocChanged event under the per-session ID, not the
+			// stable actor. Watch subscribes with the wire clientId (the
+			// session id; yorkie_server.go Watch), and the pubsub self-echo
+			// filter (doc_subscription.go) drops events whose Actor equals the
+			// subscriber. Keying the publisher on the session id keeps that
+			// self-filter correct. A stable actor here would leak the client's
+			// own event back to itself; even so, that self-echo would be
+			// re-caught by the compare-both dedup in pullChangeInfos when the
+			// client next pulls, so no change would double-apply — but avoiding
+			// the wasted round trip is why we key on the session id.
 			publisher, err := clientInfo.ID.ToActorID()
 			if err != nil {
 				logging.From(ctx).Error(err)
@@ -373,8 +383,12 @@ func pullPack(
 			// pullSnapshot populated down to a single entry keyed by the
 			// requesting client's own actor: this preserves lamport
 			// progression via SetClocks while keeping the size-1 invariant
-			// the opt-out client maintains.
-			actorID, err := clientInfo.ID.ToActorID()
+			// the opt-out client maintains. Key on OwnActorID
+			// (StableActorID for new SDKs) so the entry matches the actor
+			// the client stamps into its own changes; otherwise its
+			// SetClocks would write the lamport under the wrong actor and its
+			// local clock would not advance.
+			actorID, err := clientInfo.OwnActorID()
 			if err != nil {
 				return nil, err
 			}
@@ -565,7 +579,11 @@ func pullChangeInfos(
 	//   "sync option with mixed mode test" in integration/client_test.go
 	var filteredChanges []*database.ChangeInfo
 	for _, pulledChange := range pulledChanges {
-		if clientInfo.ID == pulledChange.ActorID && cpAfterPush.ClientSeq >= pulledChange.ClientSeq {
+		// Recognize the change as this client's own via compare-both: old SDKs
+		// stamp the per-session ID, new SDKs stamp the StableActorID. Both must
+		// dedup, or a stable-actor client's own changes echo back and re-apply
+		// (non-idempotent ops double-count).
+		if clientInfo.IsOwnActor(pulledChange.ActorID) && cpAfterPush.ClientSeq >= pulledChange.ClientSeq {
 			continue
 		}
 

--- a/server/packs/pushpull_test.go
+++ b/server/packs/pushpull_test.go
@@ -38,6 +38,8 @@ import (
 	"github.com/yorkie-team/yorkie/client"
 	"github.com/yorkie-team/yorkie/pkg/document"
 	"github.com/yorkie-team/yorkie/pkg/document/change"
+	"github.com/yorkie-team/yorkie/pkg/document/json"
+	"github.com/yorkie-team/yorkie/pkg/document/presence"
 	"github.com/yorkie-team/yorkie/pkg/document/time"
 	"github.com/yorkie-team/yorkie/server/backend"
 	"github.com/yorkie-team/yorkie/server/backend/database"
@@ -888,6 +890,177 @@ func TestPacks(t *testing.T) {
 			}
 		}
 		assert.True(t, sawResumedPresence, "observer must pull the resumed change's presence effect")
+	})
+
+	t.Run("resume with matching epoch succeeds", func(t *testing.T) {
+		ctx := context.Background()
+
+		projectInfo, err := testBackend.DB.FindProjectInfoByID(ctx, database.DefaultProjectID)
+		assert.NoError(t, err)
+		project := projectInfo.ToProject()
+
+		clientKey := helper.TestKey(t).String()
+		docKey := helper.TestKey(t).String()
+
+		// 01. Initial session: attach and push one change so server_seq advances
+		// to 1 and the response carries the doc's current epoch (0).
+		activateResp, err := testClient.ActivateClient(
+			ctx,
+			connect.NewRequest(&api.ActivateClientRequest{ClientKey: clientKey}),
+		)
+		assert.NoError(t, err)
+		stableActor, err := hex.DecodeString(activateResp.Msg.ActorId)
+		assert.NoError(t, err)
+
+		resPack, err := testClient.AttachDocument(
+			ctx,
+			connect.NewRequest(&api.AttachDocumentRequest{
+				ClientId: activateResp.Msg.ClientId,
+				ChangePack: &api.ChangePack{
+					DocumentKey: docKey,
+					Checkpoint:  &api.Checkpoint{ServerSeq: 0, ClientSeq: 1},
+					Changes: []*api.Change{{
+						Id: &api.ChangeID{ClientSeq: 1, Lamport: 1, ActorId: stableActor},
+					}},
+				},
+			}),
+		)
+		assert.NoError(t, err)
+		docID := types.ID(resPack.Msg.DocumentId)
+		// The response carries the doc's current epoch so the client can persist it.
+		presentedEpoch := resPack.Msg.ChangePack.Epoch
+
+		_, err = testClient.DetachDocument(
+			ctx,
+			connect.NewRequest(&api.DetachDocumentRequest{
+				ClientId:   activateResp.Msg.ClientId,
+				DocumentId: resPack.Msg.DocumentId,
+				ChangePack: &api.ChangePack{
+					DocumentKey: docKey,
+					Checkpoint:  &api.Checkpoint{ServerSeq: 1, ClientSeq: 1},
+				},
+			}),
+		)
+		assert.NoError(t, err)
+
+		// 02. Resume presenting the SAME (matching) epoch. The epoch check does
+		// not fire, so the resume attaches and syncs normally.
+		resumeResp, err := testClient.ActivateClient(
+			ctx,
+			connect.NewRequest(&api.ActivateClientRequest{ClientKey: clientKey}),
+		)
+		assert.NoError(t, err)
+
+		_, err = testClient.AttachDocument(
+			ctx,
+			connect.NewRequest(&api.AttachDocumentRequest{
+				ClientId: resumeResp.Msg.ClientId,
+				ChangePack: &api.ChangePack{
+					DocumentKey: docKey,
+					Checkpoint:  &api.Checkpoint{ServerSeq: 1, ClientSeq: 1},
+					Epoch:       presentedEpoch,
+				},
+			}),
+		)
+		assert.NoError(t, err)
+
+		resumeActorID, err := time.ActorIDFromHex(resumeResp.Msg.ClientId)
+		assert.NoError(t, err)
+		resumeClientInfo, err := clients.FindActiveClientInfo(ctx, testBackend, types.ClientRefKey{
+			ProjectID: project.ID,
+			ClientID:  types.IDFromActorID(resumeActorID),
+		})
+		assert.NoError(t, err)
+		// The resumed client is seeded at the presented (matching) epoch.
+		assert.Equal(t, presentedEpoch, resumeClientInfo.Documents[docID].Epoch)
+	})
+
+	t.Run("resume with stale epoch after force compaction re-anchors", func(t *testing.T) {
+		ctx := context.Background()
+
+		projectInfo, err := testBackend.DB.FindProjectInfoByID(ctx, database.DefaultProjectID)
+		assert.NoError(t, err)
+		project := projectInfo.ToProject()
+
+		docKey := helper.TestKey(t)
+
+		// 01. Create a doc with real root content via a full SDK client, so the
+		// compacted snapshot carries a change and server_seq stays at 1 (a
+		// presence-only change would compact to an empty root at server_seq 0).
+		// Force-compact once so the working epoch is a non-zero value (1): a fresh
+		// doc's epoch is 0, and the presented-epoch seeding treats 0 as "no epoch
+		// presented" (falls back to the current doc epoch), so a non-zero epoch is
+		// needed to exercise the real stale-epoch signal.
+		sdkClient, err := client.Dial(testRPCAddr)
+		assert.NoError(t, err)
+		assert.NoError(t, sdkClient.Activate(ctx))
+		defer func() {
+			assert.NoError(t, sdkClient.Deactivate(ctx))
+			assert.NoError(t, sdkClient.Close())
+		}()
+
+		doc := document.New(docKey)
+		assert.NoError(t, sdkClient.Attach(ctx, doc))
+		assert.NoError(t, doc.Update(func(r *json.Object, p *presence.Presence) error {
+			r.SetString("k", "v")
+			return nil
+		}))
+		assert.NoError(t, sdkClient.Sync(ctx))
+		assert.NoError(t, sdkClient.Detach(ctx, doc))
+
+		seedDocInfo, err := documents.FindDocInfoByKey(ctx, testBackend, project, docKey)
+		assert.NoError(t, err)
+		docRefKey := seedDocInfo.RefKey()
+		assert.NoError(t, packs.Compact(ctx, testBackend, project.ID, seedDocInfo, true))
+
+		afterFirstCompact, err := documents.FindDocInfoByRefKey(ctx, testBackend, docRefKey)
+		assert.NoError(t, err)
+		// The non-zero epoch the offline client persists as its baseline, and the
+		// server_seq the compacted snapshot sits at.
+		staleEpoch := afterFirstCompact.Epoch
+		assert.NotZero(t, staleEpoch)
+		baselineServerSeq := afterFirstCompact.ServerSeq
+		assert.NotZero(t, baselineServerSeq,
+			"a doc with root content compacts to a snapshot change at server_seq 1")
+
+		// 02. The doc is force-compacted AGAIN while the client is offline; this
+		// bumps the epoch past what the client persisted, but leaves server_seq at
+		// the compacted snapshot so the resume serverSeq is not clamped away.
+		assert.NoError(t, packs.Compact(ctx, testBackend, project.ID, afterFirstCompact, true))
+
+		compactedInfo, err := documents.FindDocInfoByRefKey(ctx, testBackend, docRefKey)
+		assert.NoError(t, err)
+		assert.NotEqual(t, staleEpoch, compactedInfo.Epoch,
+			"force compaction must bump the doc epoch past the client's persisted epoch")
+		assert.Equal(t, baselineServerSeq, compactedInfo.ServerSeq,
+			"compaction of a one-change doc keeps server_seq at the snapshot")
+
+		// 03. Resume presenting the STALE (pre-compaction) epoch with the baseline
+		// serverSeq as the resume signal. It equals the doc's current server_seq,
+		// so no clamp defeats the signal; AttachDocument seeds the stale epoch
+		// (Case B), and the epoch check in pushpull fires ErrEpochMismatch — the
+		// re-anchor signal. The client then re-attaches for a snapshot via the
+		// existing machinery (same recovery path as the compaction integration test).
+		resumeResp, err := testClient.ActivateClient(
+			ctx,
+			connect.NewRequest(&api.ActivateClientRequest{ClientKey: helper.TestKey(t).String() + "-resume"}),
+		)
+		assert.NoError(t, err)
+
+		_, err = testClient.AttachDocument(
+			ctx,
+			connect.NewRequest(&api.AttachDocumentRequest{
+				ClientId: resumeResp.Msg.ClientId,
+				ChangePack: &api.ChangePack{
+					DocumentKey: docKey.String(),
+					Checkpoint:  &api.Checkpoint{ServerSeq: baselineServerSeq, ClientSeq: 1},
+					Epoch:       staleEpoch,
+				},
+			}),
+		)
+		assert.Error(t, err)
+		assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+		assert.Equal(t, "ErrEpochMismatch", converter.ErrorCodeOf(err))
 	})
 }
 

--- a/server/packs/pushpull_test.go
+++ b/server/packs/pushpull_test.go
@@ -705,6 +705,190 @@ func TestPacks(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, uint32(3), clientInfoAfter.Checkpoint(docID).ClientSeq)
 	})
+
+	// Regression guard for the offline "resume" attach path: the acked-baseline
+	// seeding in AttachDocument (server/rpc/yorkie_server.go). On resume the SDK
+	// presents a PROJECTED checkpoint (createChangePack calls
+	// increaseClientSeq(len(changes))), so ClientSeq = acked baseline + number
+	// of pending changes. The RPC recovers the baseline via
+	// pack.Checkpoint.ClientSeq - len(pack.Changes) before seeding ClientDocInfo
+	// (Case B). If that recovery regresses to seeding the projected value, the
+	// resumed client's pending changes have clientSeq <= the seeded checkpoint
+	// and pushpull silently drops them as already-pushed — the un-pushed edits
+	// vanish. This drives the same RPC attach path a restored SDK client uses
+	// and asserts the pending change is accepted, not dropped.
+	t.Run("resumed attach seeds the acked baseline and keeps pending changes", func(t *testing.T) {
+		ctx := context.Background()
+
+		projectInfo, err := testBackend.DB.FindProjectInfoByID(ctx, database.DefaultProjectID)
+		assert.NoError(t, err)
+		project := projectInfo.ToProject()
+
+		clientKey := helper.TestKey(t).String()
+		docKey := helper.TestKey(t).String()
+
+		// 01. Initial session: activate, attach with one local change, so the
+		// doc's server_seq advances to 1 and the client's checkpoint is acked at
+		// (serverSeq=1, clientSeq=1). The change is stamped with the stable actor
+		// (ActivateClientResponse.ActorId), exactly as a real SDK client does via
+		// doc.setActor; this actor is deterministic per (project, clientKey), so
+		// the resumed session below reuses it.
+		activateResp, err := testClient.ActivateClient(
+			ctx,
+			connect.NewRequest(&api.ActivateClientRequest{ClientKey: clientKey}),
+		)
+		assert.NoError(t, err)
+		stableActorHex := activateResp.Msg.ActorId
+		stableActor, err := hex.DecodeString(stableActorHex)
+		assert.NoError(t, err)
+
+		resPack, err := testClient.AttachDocument(
+			ctx,
+			connect.NewRequest(&api.AttachDocumentRequest{
+				ClientId: activateResp.Msg.ClientId,
+				ChangePack: &api.ChangePack{
+					DocumentKey: docKey,
+					Checkpoint:  &api.Checkpoint{ServerSeq: 0, ClientSeq: 1},
+					Changes: []*api.Change{{
+						Id: &api.ChangeID{ClientSeq: 1, Lamport: 1, ActorId: stableActor},
+					}},
+				},
+			}),
+		)
+		assert.NoError(t, err)
+
+		docID := types.ID(resPack.Msg.DocumentId)
+		docRefKey := types.DocRefKey{ProjectID: project.ID, DocID: docID}
+
+		docInfo, err := documents.FindDocInfoByRefKey(ctx, testBackend, docRefKey)
+		assert.NoError(t, err)
+		// The acked baseline the client persists locally: serverSeq=1, clientSeq=1.
+		assert.Equal(t, int64(1), docInfo.ServerSeq)
+
+		// Detach models the tab closing; the reload runs a fresh ActivateClient
+		// with no server memory of the prior checkpoint (Case B).
+		_, err = testClient.DetachDocument(
+			ctx,
+			connect.NewRequest(&api.DetachDocumentRequest{
+				ClientId:   activateResp.Msg.ClientId,
+				DocumentId: resPack.Msg.DocumentId,
+				ChangePack: &api.ChangePack{
+					DocumentKey: docKey,
+					Checkpoint:  &api.Checkpoint{ServerSeq: 1, ClientSeq: 2},
+					Changes: []*api.Change{{
+						Id: &api.ChangeID{ClientSeq: 2, Lamport: 2, ActorId: stableActor},
+					}},
+				},
+			}),
+		)
+		assert.NoError(t, err)
+
+		docInfo, err = documents.FindDocInfoByRefKey(ctx, testBackend, docRefKey)
+		assert.NoError(t, err)
+		serverSeqAfterDetach := docInfo.ServerSeq
+
+		// 02. Resume: a fresh ActivateClient with the same clientKey yields a new
+		// per-session client row (Case B: no ClientDocInfo history) but the same
+		// stable actor. The restored SDK client presents its PROJECTED checkpoint:
+		// acked baseline clientSeq=1 + one pending change = clientSeq=2, carrying
+		// that pending change at clientSeq=2. ServerSeq=1 is the baseline it saw.
+		resumeResp, err := testClient.ActivateClient(
+			ctx,
+			connect.NewRequest(&api.ActivateClientRequest{ClientKey: clientKey}),
+		)
+		assert.NoError(t, err)
+		// The stable actor must survive reactivation; otherwise the pending
+		// change's lineage would not be recognized as this client's own.
+		assert.Equal(t, stableActorHex, resumeResp.Msg.ActorId)
+		// A genuine reload is a new session row, not the old one.
+		assert.NotEqual(t, activateResp.Msg.ClientId, resumeResp.Msg.ClientId)
+
+		// The pending change carries a presence PUT so its effect is durably
+		// stored and pulled by an observer. (A change with no operations and no
+		// presence advances server_seq but leaves no retrievable row in the
+		// Mongo backend, so presence gives the resume an observable footprint.)
+		_, err = testClient.AttachDocument(
+			ctx,
+			connect.NewRequest(&api.AttachDocumentRequest{
+				ClientId: resumeResp.Msg.ClientId,
+				ChangePack: &api.ChangePack{
+					DocumentKey: docKey,
+					// PROJECTED checkpoint: ClientSeq = baseline(1) + pending(1).
+					Checkpoint: &api.Checkpoint{ServerSeq: 1, ClientSeq: 2},
+					Changes: []*api.Change{{
+						Id: &api.ChangeID{ClientSeq: 2, Lamport: 3, ActorId: stableActor},
+						PresenceChange: &api.PresenceChange{
+							Type: api.PresenceChange_CHANGE_TYPE_PUT,
+							Presence: &api.Presence{
+								Data: map[string]string{"resumed": "true"},
+							},
+						},
+					}},
+				},
+			}),
+		)
+		assert.NoError(t, err)
+
+		// 03. Assert the pending change was ACCEPTED and applied, not dropped.
+		// If the baseline recovery regressed (seed the projected clientSeq=2),
+		// pushpull would drop the pending change at clientSeq=2 as already-pushed
+		// and server_seq would stay at serverSeqAfterDetach.
+		docInfo, err = documents.FindDocInfoByRefKey(ctx, testBackend, docRefKey)
+		assert.NoError(t, err)
+		assert.Equal(t, serverSeqAfterDetach+1, docInfo.ServerSeq,
+			"resumed pending change must advance server_seq, not be dropped as already-pushed")
+
+		// The resumed session's checkpoint must reflect the pushed pending change.
+		resumeActorID, err := time.ActorIDFromHex(resumeResp.Msg.ClientId)
+		assert.NoError(t, err)
+		resumeClientInfo, err := clients.FindActiveClientInfo(ctx, testBackend, types.ClientRefKey{
+			ProjectID: project.ID,
+			ClientID:  types.IDFromActorID(resumeActorID),
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, uint32(2), resumeClientInfo.Checkpoint(docID).ClientSeq)
+		assert.Equal(t, docInfo.ServerSeq, resumeClientInfo.Checkpoint(docID).ServerSeq)
+
+		// The resumed change is durably stored at the new server_seq (the
+		// empty-op changes at earlier seqs leave no retrievable row, but the
+		// presence-carrying resumed change does).
+		stored, err := packs.FindChanges(ctx, testBackend, docInfo, docInfo.ServerSeq, docInfo.ServerSeq)
+		assert.NoError(t, err)
+		assert.Len(t, stored, 1)
+		assert.Equal(t, uint32(2), stored[0].ID().ClientSeq())
+
+		// 04. A fresh observer client attaches and pulls; it must see the resumed
+		// change's effect. Its checkpoint advances to the current server_seq and
+		// the resumed presence change is among the pulled changes. If the resume
+		// had been dropped, server_seq would sit one short and the presence
+		// change would be absent.
+		observerResp, err := testClient.ActivateClient(
+			ctx,
+			connect.NewRequest(&api.ActivateClientRequest{ClientKey: helper.TestKey(t).String() + "-observer"}),
+		)
+		assert.NoError(t, err)
+
+		observerPack, err := testClient.AttachDocument(
+			ctx,
+			connect.NewRequest(&api.AttachDocumentRequest{
+				ClientId: observerResp.Msg.ClientId,
+				ChangePack: &api.ChangePack{
+					DocumentKey: docKey,
+					Checkpoint:  &api.Checkpoint{ServerSeq: 0, ClientSeq: 0},
+				},
+			}),
+		)
+		assert.NoError(t, err)
+		assert.Equal(t, docInfo.ServerSeq, observerPack.Msg.ChangePack.Checkpoint.ServerSeq)
+
+		var sawResumedPresence bool
+		for _, c := range observerPack.Msg.ChangePack.Changes {
+			if pc := c.GetPresenceChange(); pc != nil && pc.GetPresence().GetData()["resumed"] == "true" {
+				sawResumedPresence = true
+			}
+		}
+		assert.True(t, sawResumedPresence, "observer must pull the resumed change's presence effect")
+	})
 }
 
 // assertRejectedPushPullUnchanged reloads DocInfo/ClientInfo after a rejected

--- a/server/packs/pushpull_test.go
+++ b/server/packs/pushpull_test.go
@@ -1062,6 +1062,91 @@ func TestPacks(t *testing.T) {
 		assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
 		assert.Equal(t, "ErrEpochMismatch", converter.ErrorCodeOf(err))
 	})
+
+	t.Run("resume after compaction to empty root re-anchors via epoch", func(t *testing.T) {
+		ctx := context.Background()
+
+		projectInfo, err := testBackend.DB.FindProjectInfoByID(ctx, database.DefaultProjectID)
+		assert.NoError(t, err)
+		project := projectInfo.ToProject()
+
+		docKey := helper.TestKey(t)
+
+		// 01. Create a doc that carries ONLY a presence change (no root content).
+		// Such a doc compacts to an EMPTY root, so its server_seq falls back to 0
+		// (CompactChangeInfos: len(changes)==0 -> newServerSeq 0), unlike the
+		// root-content case which keeps server_seq at 1. Force-compact once so the
+		// epoch becomes non-zero (1): the presented-epoch seeding treats 0 as "no
+		// epoch presented", so a non-zero epoch is required to exercise the signal.
+		sdkClient, err := client.Dial(testRPCAddr)
+		assert.NoError(t, err)
+		assert.NoError(t, sdkClient.Activate(ctx))
+		defer func() {
+			assert.NoError(t, sdkClient.Deactivate(ctx))
+			assert.NoError(t, sdkClient.Close())
+		}()
+
+		doc := document.New(docKey)
+		assert.NoError(t, sdkClient.Attach(ctx, doc))
+		assert.NoError(t, doc.Update(func(r *json.Object, p *presence.Presence) error {
+			p.Set("cursor", "0")
+			return nil
+		}))
+		assert.NoError(t, sdkClient.Sync(ctx))
+		assert.NoError(t, sdkClient.Detach(ctx, doc))
+
+		seedDocInfo, err := documents.FindDocInfoByKey(ctx, testBackend, project, docKey)
+		assert.NoError(t, err)
+		docRefKey := seedDocInfo.RefKey()
+		assert.NoError(t, packs.Compact(ctx, testBackend, project.ID, seedDocInfo, true))
+
+		afterFirstCompact, err := documents.FindDocInfoByRefKey(ctx, testBackend, docRefKey)
+		assert.NoError(t, err)
+		staleEpoch := afterFirstCompact.Epoch
+		assert.NotZero(t, staleEpoch)
+		// The empty-root compaction drives server_seq to 0.
+		assert.Equal(t, int64(0), afterFirstCompact.ServerSeq,
+			"a presence-only doc compacts to an empty root at server_seq 0")
+
+		// 02. Force-compact AGAIN while the client is offline; the epoch advances
+		// past the client's persisted epoch, server_seq stays at 0.
+		assert.NoError(t, packs.Compact(ctx, testBackend, project.ID, afterFirstCompact, true))
+
+		compactedInfo, err := documents.FindDocInfoByRefKey(ctx, testBackend, docRefKey)
+		assert.NoError(t, err)
+		assert.NotEqual(t, staleEpoch, compactedInfo.Epoch,
+			"force compaction must bump the doc epoch past the client's persisted epoch")
+		assert.Equal(t, int64(0), compactedInfo.ServerSeq)
+
+		// 03. Resume presenting the STALE epoch. The client persisted server_seq 1
+		// (its pre-compaction baseline), but the doc now sits at server_seq 0, so
+		// the over-claim clamp in AttachDocument drives presented.ServerSeq to 0.
+		// Even so, the presented epoch is an INDEPENDENT resume signal: seeding the
+		// stale epoch makes the epoch check fire ErrEpochMismatch, matching the
+		// design's "stale epoch -> ErrEpochMismatch" recovery tier. Before the fix,
+		// the ServerSeq==0 gate routed into the fresh branch (current epoch) and
+		// recovery came via ErrInvalidClientSeq instead.
+		resumeResp, err := testClient.ActivateClient(
+			ctx,
+			connect.NewRequest(&api.ActivateClientRequest{ClientKey: helper.TestKey(t).String() + "-resume"}),
+		)
+		assert.NoError(t, err)
+
+		_, err = testClient.AttachDocument(
+			ctx,
+			connect.NewRequest(&api.AttachDocumentRequest{
+				ClientId: resumeResp.Msg.ClientId,
+				ChangePack: &api.ChangePack{
+					DocumentKey: docKey.String(),
+					Checkpoint:  &api.Checkpoint{ServerSeq: 1, ClientSeq: 1},
+					Epoch:       staleEpoch,
+				},
+			}),
+		)
+		assert.Error(t, err)
+		assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+		assert.Equal(t, "ErrEpochMismatch", converter.ErrorCodeOf(err))
+	})
 }
 
 // assertRejectedPushPullUnchanged reloads DocInfo/ClientInfo after a rejected

--- a/server/packs/pushpull_test.go
+++ b/server/packs/pushpull_test.go
@@ -1147,6 +1147,122 @@ func TestPacks(t *testing.T) {
 		assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
 		assert.Equal(t, "ErrEpochMismatch", converter.ErrorCodeOf(err))
 	})
+
+	t.Run("stale-epoch resume recovers via clean re-attach and re-push", func(t *testing.T) {
+		ctx := context.Background()
+
+		projectInfo, err := testBackend.DB.FindProjectInfoByID(ctx, database.DefaultProjectID)
+		assert.NoError(t, err)
+		project := projectInfo.ToProject()
+
+		docKey := helper.TestKey(t)
+
+		// 01. Seed a doc with root content and force-compact twice so the working
+		// epoch is non-zero (compaction of a one-change doc keeps server_seq at 1),
+		// mirroring the stale-epoch re-anchor setup.
+		sdkClient, err := client.Dial(testRPCAddr)
+		assert.NoError(t, err)
+		assert.NoError(t, sdkClient.Activate(ctx))
+		defer func() {
+			assert.NoError(t, sdkClient.Deactivate(ctx))
+			assert.NoError(t, sdkClient.Close())
+		}()
+
+		doc := document.New(docKey)
+		assert.NoError(t, sdkClient.Attach(ctx, doc))
+		assert.NoError(t, doc.Update(func(r *json.Object, p *presence.Presence) error {
+			r.SetString("k", "v")
+			return nil
+		}))
+		assert.NoError(t, sdkClient.Sync(ctx))
+		assert.NoError(t, sdkClient.Detach(ctx, doc))
+
+		seedDocInfo, err := documents.FindDocInfoByKey(ctx, testBackend, project, docKey)
+		assert.NoError(t, err)
+		docRefKey := seedDocInfo.RefKey()
+		assert.NoError(t, packs.Compact(ctx, testBackend, project.ID, seedDocInfo, true))
+
+		afterFirstCompact, err := documents.FindDocInfoByRefKey(ctx, testBackend, docRefKey)
+		assert.NoError(t, err)
+		staleEpoch := afterFirstCompact.Epoch
+		assert.NotZero(t, staleEpoch)
+		baselineServerSeq := afterFirstCompact.ServerSeq
+		assert.NoError(t, packs.Compact(ctx, testBackend, project.ID, afterFirstCompact, true))
+
+		compactedInfo, err := documents.FindDocInfoByRefKey(ctx, testBackend, docRefKey)
+		assert.NoError(t, err)
+		currentEpoch := compactedInfo.Epoch
+		assert.NotEqual(t, staleEpoch, currentEpoch)
+
+		// 02. A stale resume is rejected with ErrEpochMismatch (the re-anchor
+		// signal). clients.AttachDocument commits the attach row before PushPull
+		// runs the epoch check, so the rejected session is left attached at the
+		// stale baseline — exactly the "attached but sync fails" state a live
+		// client sees after an offline compaction.
+		rejectResp, err := testClient.ActivateClient(
+			ctx,
+			connect.NewRequest(&api.ActivateClientRequest{ClientKey: helper.TestKey(t).String() + "-reject"}),
+		)
+		assert.NoError(t, err)
+		_, err = testClient.AttachDocument(
+			ctx,
+			connect.NewRequest(&api.AttachDocumentRequest{
+				ClientId: rejectResp.Msg.ClientId,
+				ChangePack: &api.ChangePack{
+					DocumentKey: docKey.String(),
+					Checkpoint:  &api.Checkpoint{ServerSeq: baselineServerSeq, ClientSeq: 1},
+					Epoch:       staleEpoch,
+				},
+			}),
+		)
+		assert.Equal(t, "ErrEpochMismatch", converter.ErrorCodeOf(err))
+
+		// 03. Recovery: the client re-anchors by attaching CLEAN — a fresh session
+		// (a reload re-activates), checkpoint reset to 0, and no stale epoch. The
+		// resume then seeds the current doc epoch, so the epoch check no longer
+		// fires; the re-anchor delivers the compacted state and a pending change
+		// stamped as a fresh local edit pushes on the new epoch. This closes the
+		// arc the stale-epoch tests stop short of: rejection -> re-anchor -> push.
+		recoverResp, err := testClient.ActivateClient(
+			ctx,
+			connect.NewRequest(&api.ActivateClientRequest{ClientKey: helper.TestKey(t).String() + "-recover"}),
+		)
+		assert.NoError(t, err)
+		stableActor, err := hex.DecodeString(recoverResp.Msg.ActorId)
+		assert.NoError(t, err)
+
+		recoverPack, err := testClient.AttachDocument(
+			ctx,
+			connect.NewRequest(&api.AttachDocumentRequest{
+				ClientId: recoverResp.Msg.ClientId,
+				ChangePack: &api.ChangePack{
+					DocumentKey: docKey.String(),
+					Checkpoint:  &api.Checkpoint{ServerSeq: 0, ClientSeq: 1},
+					Changes: []*api.Change{{
+						Id: &api.ChangeID{ClientSeq: 1, Lamport: 1, ActorId: stableActor},
+						PresenceChange: &api.PresenceChange{
+							Type: api.PresenceChange_CHANGE_TYPE_PUT,
+							Presence: &api.Presence{
+								Data: map[string]string{"recovered": "true"},
+							},
+						},
+					}},
+				},
+			}),
+		)
+		assert.NoError(t, err, "clean re-attach after a stale-epoch rejection must re-anchor, not fail")
+		// The recovered client is anchored on the doc's CURRENT epoch, not the
+		// stale one it was rejected for.
+		assert.Equal(t, currentEpoch, recoverPack.Msg.ChangePack.Epoch)
+
+		// 04. The re-pushed change advanced server_seq past the compacted baseline,
+		// proving the client makes progress again after re-anchoring rather than
+		// staying permanently rejected.
+		recoveredInfo, err := documents.FindDocInfoByRefKey(ctx, testBackend, docRefKey)
+		assert.NoError(t, err)
+		assert.Greater(t, recoveredInfo.ServerSeq, baselineServerSeq,
+			"the recovered client's change must advance server_seq on the new epoch")
+	})
 }
 
 // assertRejectedPushPullUnchanged reloads DocInfo/ClientInfo after a rejected

--- a/server/packs/serverpack.go
+++ b/server/packs/serverpack.go
@@ -47,6 +47,11 @@ type ServerPack struct {
 	// 2. In response(Snapshot), it is the version vector of the snapshot of the document.
 	VersionVector time.VersionVector
 
+	// Epoch is the document's current compaction epoch. It is carried in the
+	// response so the client can persist it and present it on the next resume,
+	// letting the server detect a stale-epoch baseline (pull-before-trust).
+	Epoch int64
+
 	// IsRemoved is a flag that indicates whether the document is removed.
 	IsRemoved bool
 }
@@ -123,6 +128,7 @@ func (p *ServerPack) ToPBChangePack() (*api.ChangePack, error) {
 		Checkpoint:  converter.ToCheckpoint(p.Checkpoint),
 		Changes:     pbChanges,
 		Snapshot:    p.Snapshot,
+		Epoch:       p.Epoch,
 		IsRemoved:   p.IsRemoved,
 	}
 
@@ -141,4 +147,8 @@ func (p *ServerPack) ApplyDocInfo(info *database.DocInfo) {
 	if info.IsRemoved() {
 		p.IsRemoved = true
 	}
+
+	// Carry the doc's current epoch so the client can persist it and present it
+	// on the next resume (pull-before-trust, docs/design/offline-resumable-attach.md).
+	p.Epoch = info.Epoch
 }

--- a/server/rpc/yorkie_server.go
+++ b/server/rpc/yorkie_server.go
@@ -220,7 +220,7 @@ func (s *yorkieServer) AttachDocument(
 		)
 	}
 
-	clientInfo, err = clients.AttachDocument(ctx, s.backend, clientInfo, docInfo, pack.IsAttached())
+	clientInfo, err = clients.AttachDocument(ctx, s.backend, clientInfo, docInfo, pack.IsAttached(), pack.Checkpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/server/rpc/yorkie_server.go
+++ b/server/rpc/yorkie_server.go
@@ -229,7 +229,7 @@ func (s *yorkieServer) AttachDocument(
 	if n := uint32(pack.ChangesLen()); baseline.ClientSeq >= n {
 		baseline = change.NewCheckpoint(pack.Checkpoint.ServerSeq, pack.Checkpoint.ClientSeq-n)
 	}
-	clientInfo, err = clients.AttachDocument(ctx, s.backend, clientInfo, docInfo, pack.IsAttached(), baseline)
+	clientInfo, err = clients.AttachDocument(ctx, s.backend, clientInfo, docInfo, pack.IsAttached(), pack.Epoch, baseline)
 	if err != nil {
 		return nil, err
 	}

--- a/server/rpc/yorkie_server.go
+++ b/server/rpc/yorkie_server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/yorkie-team/yorkie/api/types/events"
 	api "github.com/yorkie-team/yorkie/api/yorkie/v1"
 	"github.com/yorkie-team/yorkie/pkg/document"
+	"github.com/yorkie-team/yorkie/pkg/document/change"
 	"github.com/yorkie-team/yorkie/pkg/document/time"
 	"github.com/yorkie-team/yorkie/pkg/key"
 	"github.com/yorkie-team/yorkie/server/backend"
@@ -220,7 +221,15 @@ func (s *yorkieServer) AttachDocument(
 		)
 	}
 
-	clientInfo, err = clients.AttachDocument(ctx, s.backend, clientInfo, docInfo, pack.IsAttached(), pack.Checkpoint)
+	// pack.Checkpoint.ClientSeq is the client's projected checkpoint
+	// (acked baseline + len(changes), from createChangePack.increaseClientSeq).
+	// Recover the acked baseline so a resumed client's ClientDocInfo is seeded at
+	// the baseline; its pending changes then validate and advance from there.
+	baseline := pack.Checkpoint
+	if n := uint32(pack.ChangesLen()); baseline.ClientSeq >= n {
+		baseline = change.NewCheckpoint(pack.Checkpoint.ServerSeq, pack.Checkpoint.ClientSeq-n)
+	}
+	clientInfo, err = clients.AttachDocument(ctx, s.backend, clientInfo, docInfo, pack.IsAttached(), baseline)
 	if err != nil {
 		return nil, err
 	}

--- a/server/rpc/yorkie_server.go
+++ b/server/rpc/yorkie_server.go
@@ -105,6 +105,7 @@ func (s *yorkieServer) ActivateClient(
 
 	return connect.NewResponse(&api.ActivateClientResponse{
 		ClientId: cli.ID.String(),
+		ActorId:  cli.StableActorID.String(),
 	}), nil
 }
 

--- a/test/bench/push_pull_bench_test.go
+++ b/test/bench/push_pull_bench_test.go
@@ -93,7 +93,7 @@ func setUpClientsAndDocs(
 		assert.NoError(b, err)
 		docInfo, err := be.DB.FindOrCreateDocInfo(ctx, clientInfo.RefKey(), docKey, false)
 		assert.NoError(b, err)
-		assert.NoError(b, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch))
+		assert.NoError(b, clientInfo.AttachDocument(docInfo.ID, false, docInfo.Epoch, 0, change.InitialCheckpoint))
 		assert.NoError(b, be.DB.UpdateClientInfoAfterPushPull(ctx, clientInfo, docInfo))
 
 		bytesID, _ := clientInfo.ID.Bytes()


### PR DESCRIPTION
## Summary

Server-side protocol for **offline local persistence**: a client can persist its document (with un-pushed local changes) locally and, on the next session, resume it cleanly. Design: `docs/design/offline-resumable-attach.md`. Companion SDK PR: yorkie-team/yorkie-js-sdk#1338 (the SDK presents/consumes the protocol added here).

### Stable actor (Seam 1 + Seam 2)

- `DeriveActorID(projectID, clientKey)` in `api/types` — deterministic `SHA256("yorkie/stable-actor/v1" || projectID || clientKey)[:12]` with reserved-value (`InitialActorID` / `MaxActorID`) avoidance. Plain hash (no shared secret, identical across nodes/restarts/offline).
- `ClientInfo.StableActorID` additive field, populated in `ActivateClient` (memory + mongo); the per-session `_id` is unchanged. Returned additively as `ActivateClientResponse.actor_id`.
- **Seam 2**: pull dedup and version-vector liveness recognize the client's own actor via **compare-both** (`IsOwnActor`: session `_id` OR stable actor), so old/new SDKs and old/new servers all interoperate and GC stays correct. Activation analytics stay keyed on the per-session row id.

### Resumable checkpoint (Q3)

- `AttachDocument` seeds `ClientDocInfo` from the client-presented `pack.Checkpoint`: Case A (same-session re-attach preserves seqs); Case B (reload seeds the **acked baseline**, recovered as `clientSeq − len(changes)` because the wire checkpoint is projected — a bug found by the cross-repo e2e). serverSeq over-claim is clamped; `validateClientSeqContinuity` remains the loud guard.

### Pull-before-trust (Q2)

- Added `int64 epoch = 8` to `ChangePack` (a bidirectional carrier). Responses carry the doc's current epoch; a resume attach seeds the client's presented epoch. A doc force-compacted while the client was offline makes the seeded (old) epoch differ from the current, so the **existing** epoch-mismatch → snapshot re-anchor machinery runs (no parallel path).

### Generated code

`resources.pb.go` and the openapi `ChangePack.epoch` / `ActivateClientResponse.actor_id` were regenerated surgically; unrelated pre-existing `make proto` drift (connect-go toolchain downgrade, `resources.proto` restore schema) is deliberately not committed.

### Documented follow-ups

epoch-0 sentinel (a brand-new doc compacted exactly once during an offline window — needs a 1-based epoch), VV re-key rolling-deploy window, Tier-3 purge signal. See the design doc's Open Questions.

## Test plan

- `make fmt` / `make lint` — 0 issues; `go build ./...`
- `go test ./...` (unit): `DeriveActorID` (determinism, per-project namespacing, pinned vectors, reserved guard), `IsOwnActor` truth table, `ChangePack.Epoch` converter round-trip, `AttachDocument` seeding (Case A/B/fresh, presented epoch).
- MongoDB integration (`-tags integration`): `ActivateClient` StableActorID; compare-both VV liveness + detach cleanup; resumed-attach acked-baseline keeps pending changes; resume with matching epoch; **resume with stale epoch after force-compaction → ErrEpochMismatch re-anchor**; `TestSDKRPCServerBackend` attach/detach/reattach regression; `TestDocumentCompaction` no regression.
- Cross-repo e2e (SDK PR #1338, opt-in, against a server built from this branch): reload-with-pending resume **and** offline-compaction epoch re-anchor both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added offline-resumable document attachments that preserve pending local changes across reloads.
  - Added stable actor identifiers for consistent client recognition across sessions.
  - Added compaction epoch metadata to change exchanges for safer synchronization.
  - Added stale-epoch detection and snapshot-based re-anchoring during resume.
  - Exposed actor identifiers and epoch metadata through the API.

- **Documentation**
  - Added design documentation covering offline-resumable attachments and recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->