### PR TITLE
Key watch subscriptions by the client's stable actor

### DIFF
--- a/api/yorkie/v1/yorkie.pb.go
+++ b/api/yorkie/v1/yorkie.pb.go
@@ -509,9 +509,14 @@ func (x *DetachDocumentResponse) GetChangePack() *ChangePack {
 }
 
 type WatchRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	ClientId      string                 `protobuf:"bytes,1,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
-	Resources     []*ResourceDescriptor  `protobuf:"bytes,2,rep,name=resources,proto3" json:"resources,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	ClientId  string                 `protobuf:"bytes,1,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
+	Resources []*ResourceDescriptor  `protobuf:"bytes,2,rep,name=resources,proto3" json:"resources,omitempty"`
+	// actor_id is the stable actor the client stamps into its changes. When set,
+	// the server subscribes the client under it so watch peer ids and
+	// watched/unwatched events match the presence CRDT keying. Old SDKs omit it
+	// and the server falls back to client_id (the session id).
+	ActorId       string `protobuf:"bytes,3,opt,name=actor_id,json=actorId,proto3" json:"actor_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -558,6 +563,13 @@ func (x *WatchRequest) GetResources() []*ResourceDescriptor {
 		return x.Resources
 	}
 	return nil
+}
+
+func (x *WatchRequest) GetActorId() string {
+	if x != nil {
+		return x.ActorId
+	}
+	return ""
 }
 
 type ResourceDescriptor struct {
@@ -2858,10 +2870,11 @@ const file_yorkie_v1_yorkie_proto_rawDesc = "" +
 	"\x16remove_if_not_attached\x18\x04 \x01(\bR\x13removeIfNotAttached\"P\n" +
 	"\x16DetachDocumentResponse\x126\n" +
 	"\vchange_pack\x18\x02 \x01(\v2\x15.yorkie.v1.ChangePackR\n" +
-	"changePack\"h\n" +
+	"changePack\"\x83\x01\n" +
 	"\fWatchRequest\x12\x1b\n" +
 	"\tclient_id\x18\x01 \x01(\tR\bclientId\x12;\n" +
-	"\tresources\x18\x02 \x03(\v2\x1d.yorkie.v1.ResourceDescriptorR\tresources\"\x97\x01\n" +
+	"\tresources\x18\x02 \x03(\v2\x1d.yorkie.v1.ResourceDescriptorR\tresources\x12\x19\n" +
+	"\bactor_id\x18\x03 \x01(\tR\aactorId\"\x97\x01\n" +
 	"\x12ResourceDescriptor\x12;\n" +
 	"\bdocument\x18\x01 \x01(\v2\x1d.yorkie.v1.DocumentDescriptorH\x00R\bdocument\x128\n" +
 	"\achannel\x18\x02 \x01(\v2\x1c.yorkie.v1.ChannelDescriptorH\x00R\achannelB\n" +

--- a/api/yorkie/v1/yorkie.proto
+++ b/api/yorkie/v1/yorkie.proto
@@ -115,6 +115,11 @@ message DetachDocumentResponse {
 message WatchRequest {
   string client_id = 1;
   repeated ResourceDescriptor resources = 2;
+  // actor_id is the stable actor the client stamps into its changes. When set,
+  // the server subscribes the client under it so watch peer ids and
+  // watched/unwatched events match the presence CRDT keying. Old SDKs omit it
+  // and the server falls back to client_id (the session id).
+  string actor_id = 3;
 }
 
 message ResourceDescriptor {

--- a/server/clients/clients.go
+++ b/server/clients/clients.go
@@ -41,7 +41,9 @@ var (
 
 	// ErrActorMismatch is returned when a request declares an actor that is not
 	// the authenticated client's own stable actor.
-	ErrActorMismatch = errors.PermissionDenied("actor id does not match the authenticated client").WithCode("ErrActorMismatch")
+	ErrActorMismatch = errors.PermissionDenied(
+		"actor id does not match the authenticated client",
+	).WithCode("ErrActorMismatch")
 )
 
 // Activate activates the given client.

--- a/server/clients/clients.go
+++ b/server/clients/clients.go
@@ -38,6 +38,10 @@ var (
 
 	// ErrInvalidClientID is returned when the given Key is not valid ClientID.
 	ErrInvalidClientID = errors.InvalidArgument("invalid client id").WithCode("ErrInvalidClientID")
+
+	// ErrActorMismatch is returned when a request declares an actor that is not
+	// the authenticated client's own stable actor.
+	ErrActorMismatch = errors.PermissionDenied("actor id does not match the authenticated client").WithCode("ErrActorMismatch")
 )
 
 // Activate activates the given client.

--- a/server/packs/pushpull.go
+++ b/server/packs/pushpull.go
@@ -160,20 +160,26 @@ func PushPull(
 	// 04. publish document event and store the snapshot if needed.
 	if len(pushedChanges) > 0 || reqPack.IsRemoved {
 		be.Go(func(ctx context.Context) {
-			// Publish the DocChanged event under the per-session ID, not the
-			// stable actor. Watch subscribes with the wire clientId (the
-			// session id; yorkie_server.go Watch), and the pubsub self-echo
-			// filter (doc_subscription.go) drops events whose Actor equals the
-			// subscriber. Keying the publisher on the session id keeps that
-			// self-filter correct. A stable actor here would leak the client's
-			// own event back to itself; even so, that self-echo would be
-			// re-caught by the compare-both dedup in pullChangeInfos when the
-			// client next pulls, so no change would double-apply — but avoiding
-			// the wasted round trip is why we key on the session id.
+			// Publish under the actor the client stamps into its changes so the
+			// pubsub self-echo filter (doc_subscription.go drops events whose
+			// Actor equals the subscriber) recognizes the author's own event.
+			// Watch now subscribes under that same actor (WatchRequest.actor_id,
+			// yorkie_server.go Watch): new SDKs stamp and subscribe under the
+			// stable actor, old SDKs under the session id. The pushed change's
+			// actor is exactly that identity for both. A remove-only pack carries
+			// no pushed change to read the actor from, so fall back to the session
+			// id; the client is detaching (its Watch is torn down), so a missed
+			// self-echo there is moot. OwnActorID() is not used for the fallback:
+			// ActivateClient sets StableActorID for every client, so it would
+			// return the stable actor even for old SDKs that subscribe under the
+			// session id.
 			publisher, err := clientInfo.ID.ToActorID()
 			if err != nil {
 				logging.From(ctx).Error(err)
 				return
+			}
+			if len(reqPack.Changes) > 0 {
+				publisher = reqPack.Changes[0].ID().ActorID()
 			}
 
 			// TODO(hackerwins): For now, we are publishing the event to pubsub and

--- a/server/packs/pushpull.go
+++ b/server/packs/pushpull.go
@@ -160,16 +160,17 @@ func PushPull(
 	// 04. publish document event and store the snapshot if needed.
 	if len(pushedChanges) > 0 || reqPack.IsRemoved {
 		be.Go(func(ctx context.Context) {
-			// Publish under the actor the client stamps into its changes so the
-			// pubsub self-echo filter (doc_subscription.go drops events whose
-			// Actor equals the subscriber) recognizes the author's own event.
-			// Watch now subscribes under that same actor (WatchRequest.actor_id,
-			// yorkie_server.go Watch): new SDKs stamp and subscribe under the
-			// stable actor, old SDKs under the session id. The pushed change's
-			// actor is exactly that identity for both. A remove-only pack carries
-			// no pushed change to read the actor from, so fall back to the session
-			// id; the client is detaching (its Watch is torn down), so a missed
-			// self-echo there is moot. OwnActorID() is not used for the fallback:
+			// Publish under the actor of an accepted change so the pubsub
+			// self-echo filter (doc_subscription.go drops events whose Actor
+			// equals the subscriber) recognizes the author's own event. Watch
+			// subscribes under that same actor (WatchRequest.actor_id,
+			// yorkie_server.go Watch): new SDKs under the stable actor, old SDKs
+			// under the session id. Read it from an accepted change
+			// (pushedChanges), not reqPack.Changes[0], which may be an
+			// already-acknowledged change with a different actor in a malformed
+			// pack. A remove-only pack has no accepted change, so fall back to the
+			// session id; the client is detaching (its Watch is torn down), so a
+			// missed self-echo is moot. OwnActorID() is not used for the fallback:
 			// ActivateClient sets StableActorID for every client, so it would
 			// return the stable actor even for old SDKs that subscribe under the
 			// session id.
@@ -178,8 +179,12 @@ func PushPull(
 				logging.From(ctx).Error(err)
 				return
 			}
-			if len(reqPack.Changes) > 0 {
-				publisher = reqPack.Changes[0].ID().ActorID()
+			if len(pushedChanges) > 0 {
+				publisher, err = pushedChanges[0].ActorID.ToActorID()
+				if err != nil {
+					logging.From(ctx).Error(err)
+					return
+				}
 			}
 
 			// TODO(hackerwins): For now, we are publishing the event to pubsub and

--- a/server/rpc/server_test.go
+++ b/server/rpc/server_test.go
@@ -176,6 +176,10 @@ func TestSDKRPCServerBackend(t *testing.T) {
 		testcases.RunWatchDocumentTest(t, testClient)
 	})
 
+	t.Run("watch document actor mismatch test", func(t *testing.T) {
+		testcases.RunWatchDocumentActorMismatchTest(t, testClient)
+	})
+
 	t.Run("max subscribers per document test", func(t *testing.T) {
 		testcases.RunMaxSubscribersPerDocumentConcurrencyTest(t, testClient, testAdminClient, testAdminAuthInterceptor)
 	})

--- a/server/rpc/testcases/testcases.go
+++ b/server/rpc/testcases/testcases.go
@@ -656,6 +656,61 @@ func RunWatchDocumentTest(
 	//assert.Contains(t, err.Error(), "EOF")
 }
 
+// RunWatchDocumentActorMismatchTest verifies that Watch rejects a declared
+// actor_id that is not the authenticated client's own stable actor, while
+// accepting the client's own actor.
+func RunWatchDocumentActorMismatchTest(
+	t *testing.T,
+	testClient v1connect.YorkieServiceClient,
+) {
+	ctx := context.Background()
+
+	// Two distinct clients: A watches; B's actor is the spoof target.
+	respA, err := testClient.ActivateClient(
+		ctx, connect.NewRequest(&api.ActivateClientRequest{ClientKey: t.Name() + "-a"}))
+	assert.NoError(t, err)
+	respB, err := testClient.ActivateClient(
+		ctx, connect.NewRequest(&api.ActivateClientRequest{ClientKey: t.Name() + "-b"}))
+	assert.NoError(t, err)
+	assert.NotEqual(t, respA.Msg.ActorId, respB.Msg.ActorId)
+
+	resPack, err := testClient.AttachDocument(
+		ctx, connect.NewRequest(&api.AttachDocumentRequest{
+			ClientId: respA.Msg.ClientId,
+			ChangePack: &api.ChangePack{
+				DocumentKey: helper.TestKey(t).String(),
+				Checkpoint:  &api.Checkpoint{ServerSeq: 0, ClientSeq: 0},
+			},
+		}))
+	assert.NoError(t, err)
+
+	docResources := []*api.ResourceDescriptor{{
+		Resource: &api.ResourceDescriptor_Document{
+			Document: &api.DocumentDescriptor{DocumentId: resPack.Msg.DocumentId},
+		},
+	}}
+
+	// 01. A declares B's actor -> rejected with ErrActorMismatch.
+	spoof, err := testClient.Watch(ctx, connect.NewRequest(&api.WatchRequest{
+		ClientId:  respA.Msg.ClientId,
+		ActorId:   respB.Msg.ActorId,
+		Resources: docResources,
+	}))
+	assert.NoError(t, err)
+	assert.False(t, spoof.Receive())
+	assert.Equal(t, "ErrActorMismatch", converter.ErrorCodeOf(spoof.Err()))
+
+	// 02. A declares its own actor -> accepted.
+	own, err := testClient.Watch(ctx, connect.NewRequest(&api.WatchRequest{
+		ClientId:  respA.Msg.ClientId,
+		ActorId:   respA.Msg.ActorId,
+		Resources: docResources,
+	}))
+	assert.NoError(t, err)
+	assert.True(t, own.Receive())
+	assert.NotNil(t, own.Msg())
+}
+
 // RunMaxSubscribersPerDocumentConcurrencyTest runs the MaxSubscribersPerDocument test.
 func RunMaxSubscribersPerDocumentConcurrencyTest(
 	t *testing.T,

--- a/server/rpc/yorkie_server.go
+++ b/server/rpc/yorkie_server.go
@@ -581,6 +581,18 @@ func (s *yorkieServer) Watch(
 		return err
 	}
 
+	// Presence peers are keyed by the stable actor stamped into presence
+	// changes. Subscribe under the client-declared actor when present so the
+	// watch peer list and watched/unwatched events align with the presence
+	// CRDT keying; old SDKs omit it and fall back to the session id.
+	presenceID := clientID
+	if req.Msg.ActorId != "" {
+		presenceID, err = time.ActorIDFromHex(req.Msg.ActorId)
+		if err != nil {
+			return err
+		}
+	}
+
 	project := projects.From(ctx)
 	if _, err = clients.FindActiveClientInfo(ctx, s.backend, types.ClientRefKey{
 		ProjectID: project.ID,
@@ -595,7 +607,7 @@ func (s *yorkieServer) Watch(
 		return err
 	}
 
-	docSubs, channelSubs, resourceInits, err := s.subscribeResources(ctx, req.Msg, clientID, project)
+	docSubs, channelSubs, resourceInits, err := s.subscribeResources(ctx, req.Msg, presenceID, project)
 	if err != nil {
 		return err
 	}

--- a/server/rpc/yorkie_server.go
+++ b/server/rpc/yorkie_server.go
@@ -581,24 +581,30 @@ func (s *yorkieServer) Watch(
 		return err
 	}
 
+	project := projects.From(ctx)
+	clientInfo, err := clients.FindActiveClientInfo(ctx, s.backend, types.ClientRefKey{
+		ProjectID: project.ID,
+		ClientID:  types.IDFromActorID(clientID),
+	})
+	if err != nil {
+		return err
+	}
+
 	// Presence peers are keyed by the stable actor stamped into presence
 	// changes. Subscribe under the client-declared actor when present so the
 	// watch peer list and watched/unwatched events align with the presence
-	// CRDT keying; old SDKs omit it and fall back to the session id.
+	// CRDT keying; old SDKs omit it and fall back to the session id. The
+	// declared actor must be this authenticated client's own stable actor, so
+	// a client cannot subscribe under another client's presence identity.
 	presenceID := clientID
 	if req.Msg.ActorId != "" {
+		if types.ID(req.Msg.ActorId) != clientInfo.StableActorID {
+			return clients.ErrActorMismatch
+		}
 		presenceID, err = time.ActorIDFromHex(req.Msg.ActorId)
 		if err != nil {
 			return err
 		}
-	}
-
-	project := projects.From(ctx)
-	if _, err = clients.FindActiveClientInfo(ctx, s.backend, types.ClientRefKey{
-		ProjectID: project.ID,
-		ClientID:  types.IDFromActorID(clientID),
-	}); err != nil {
-		return err
 	}
 
 	if err := auth.VerifyAccess(ctx, s.backend, &types.AccessInfo{


### PR DESCRIPTION
## Summary

Follow-up to #1969. That change gave each client a stable actor (derived from
project + clientKey) that opted-in SDKs stamp into changes, but the `Watch`
stream still identified presence peers by the per-session `client_id`. Presence
is keyed by the change actor, so the two identity spaces diverged for new-SDK
clients: realtime presence peers became invisible and watched/unwatched events
no longer matched the presence CRDT keys.

This adds `WatchRequest.actor_id` so the client declares the actor it stamps.
`Watch` subscribes under it (falling back to the session `client_id` when
absent, as the Go client and old SDKs do), aligning peer ids and
watched/unwatched events with presence. `DocChanged` is published under the
pushed change's actor for the same reason, keeping the pubsub self-echo filter
(drops events whose `Actor` equals the subscriber) correct for both old
(session id) and new (stable actor) clients.

## Backward compatibility

- Additive proto field; clients that omit `actor_id` fall back to the session
  id, so behavior is unchanged for old SDKs and the Go client.
- Mixed old/new clients on one document still correlate presence: each
  subscribes under the same actor it stamps into its changes.
- **Release ordering (required):** the companion SDK
  (yorkie-team/yorkie-js-sdk#1338) must not release before this ships. A new SDK
  talking to a server that has #1969 but not this fix subscribes under the
  stable actor while the server keys peers by the session id, breaking realtime
  presence.

## Test plan

- `make test` (integration): existing doc-presence / watch / document suites
  pass unchanged — the Go client takes the session-id fallback.
- Verified end-to-end against yorkie-js-sdk#1338 built from this branch: the
  full presence, object, and gc suites are stable across four consecutive runs.

> Note: the generated openapi/connect docs are omitted from this branch because
> the local buf version produced unrelated drift. Run `make proto` with the
> pinned toolchain before merge to regenerate them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Watch subscriptions can use a stable actor identity for presence tracking.
  * Clients that omit an actor identity continue using their existing client identity.

* **Bug Fixes**
  * Presence subscriptions and document-change events remain consistent when client sessions change.
  * Watch requests using an actor identity that does not belong to the authenticated client are rejected with a permission error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->