### PR TITLE
Release v0.7.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and Yorkie adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## [v0.7.20] - 2026-09-09
+
+### Added
+
+- Add server-side offline-resumable attach (stable actor, resume, epoch) by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1969
+
+### Changed
+
+- Key watch subscriptions by the client's stable actor by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1970
+
+### Fixed
+
+- Keep the project-stats dual read on the HLL rollups and split at real coverage by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1976
+
 ## [v0.7.19] - 2026-09-03
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-YORKIE_VERSION := 0.7.19
+YORKIE_VERSION := 0.7.20
 
 GO_PROJECT = github.com/yorkie-team/yorkie
 

--- a/api/docs/yorkie.base.yaml
+++ b/api/docs/yorkie.base.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Yorkie
   description: "Yorkie is an open source document store for building collaborative editing applications."
-  version: v0.7.19
+  version: v0.7.20
 servers:
   - url: https://api.yorkie.dev
     description: Production server

--- a/api/docs/yorkie/v1/admin.openapi.yaml
+++ b/api/docs/yorkie/v1/admin.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.19
+  version: v0.7.20
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/api/docs/yorkie/v1/resources.openapi.yaml
+++ b/api/docs/yorkie/v1/resources.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.19
+  version: v0.7.20
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/api/docs/yorkie/v1/yorkie.openapi.yaml
+++ b/api/docs/yorkie/v1/yorkie.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.19
+  version: v0.7.20
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/build/charts/yorkie-analytics/Chart.yaml
+++ b/build/charts/yorkie-analytics/Chart.yaml
@@ -11,8 +11,8 @@ maintainers:
 
 sources:
   - https://github.com/yorkie-team/yorkie
-version: 0.7.19
-appVersion: "0.7.19"
+version: 0.7.20
+appVersion: "0.7.20"
 kubeVersion: ">=1.24.0-0"
 
 keywords:

--- a/build/charts/yorkie-cluster/Chart.yaml
+++ b/build/charts/yorkie-cluster/Chart.yaml
@@ -9,8 +9,8 @@ maintainers:
 
 sources:
   - https://github.com/yorkie-team/yorkie
-version: 0.7.19
-appVersion: "0.7.19"
+version: 0.7.20
+appVersion: "0.7.20"
 kubeVersion: ">=1.28.0-0"
 
 dependencies:


### PR DESCRIPTION
## What this does

Bumps the version for the v0.7.20 release.

- `Makefile`: `YORKIE_VERSION := 0.7.20`
- `build/charts/yorkie-cluster/Chart.yaml`: version, appVersion → 0.7.20
- `build/charts/yorkie-analytics/Chart.yaml`: version, appVersion → 0.7.20
- `api/docs/yorkie.base.yaml`, `api/docs/yorkie/v1/{admin,yorkie,resources}.openapi.yaml`: v0.7.20
- `CHANGELOG.md`: v0.7.20 entry

## Why yorkie-analytics moves too

#1976 changed `build/charts/yorkie-analytics/templates/starrocks/configmap.yaml`
(the `rl_session_daily` `ADD ROLLUP` and its readiness poll). Chart versions
carry the release version they last changed in, so the analytics chart goes to
0.7.20 with this release.

`yorkie-monitoring` (0.7.7) and `api/docs/yorkie/v1/cluster.openapi.yaml`
(v0.7.8) are untouched and stay where they are.

## Changelog

### Added
- Add server-side offline-resumable attach (stable actor, resume, epoch) (#1969)

### Changed
- Key watch subscriptions by the client's stable actor (#1970)

### Fixed
- Keep the project-stats dual read on the HLL rollups and split at real coverage (#1976)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Released version 0.7.20.
  * Updated application and deployment package versions across supported services.

* **Documentation**
  * Updated API documentation to reflect version 0.7.20.
  * Added release notes covering offline-resumable attach behavior, stable client actor handling for watch subscriptions, and project statistics coverage processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->