### PR TITLE
Stop garbage collection from deleting a restored object member

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -1,5 +1,5 @@
 ---
-updated: 2026-08-22
+updated: 2026-09-12
 ---
 
 # Tasks Index
@@ -20,6 +20,8 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| Applying one change twice corrupts an object's createdAt index (2026-09-11) | [20260911-duplicate-change-application-not-idempotent-todo.md](./active/20260911-duplicate-change-application-not-idempotent-todo.md) | - |
+| Project Stats Long-Retention Windows Implementation Plan (2026-08-31) | [20260831-project-stats-long-retention-todo.md](./active/20260831-project-stats-long-retention-todo.md) | [20260831-project-stats-long-retention-lessons.md](./active/20260831-project-stats-long-retention-lessons.md) |
 | Tree: recover style ranges collapsed by a merge at the from anchor (2026-08-22) | [20260822-tree-style-from-side-anchor-todo.md](./active/20260822-tree-style-from-side-anchor-todo.md) | [20260822-tree-style-from-side-anchor-lessons.md](./active/20260822-tree-style-from-side-anchor-lessons.md) |
 | DocSize: a snapshot rebuild over-credits one ticket per tombstone (2026-08-17) | [20260817-docsize-snapshot-rebuild-drift-todo.md](./active/20260817-docsize-snapshot-rebuild-drift-todo.md) | [20260817-docsize-snapshot-rebuild-drift-lessons.md](./active/20260817-docsize-snapshot-rebuild-drift-lessons.md) |
 | DocSize: port the container-removal accounting fix to the JS SDK (2026-08-17) | [20260817-docsize-js-sdk-parity-todo.md](./active/20260817-docsize-js-sdk-parity-todo.md) | [20260817-docsize-js-sdk-parity-lessons.md](./active/20260817-docsize-js-sdk-parity-lessons.md) |

--- a/docs/tasks/active/20260816-remote-redo-replica-divergence-todo.md
+++ b/docs/tasks/active/20260816-remote-redo-replica-divergence-todo.md
@@ -122,6 +122,45 @@ unsafe to sync to a peer running the other. Do not fix Go alone.
 Either direction needs the identical decision applied in
 `yorkie-js-sdk`.
 
+### Update (2026-09-12): direction 1 taken, both open questions answered
+
+Fixed by **direction 1** in PR #1978, with the JS half in
+`yorkie-js-sdk#1341`. The two SDKs ship together, as this document required.
+
+The severity was also worse than described above. The mechanism here is
+redo of a `Set`; the same gate is reached by **undo of an object member
+removal**, which needs no redo at all, and the loss is not confined to
+peers — the server replays the change log with `OpSourceReplay` to build
+snapshots (`server/packs/snapshot.go:121`, `:238`), so the restored key
+disappears from every snapshot built afterwards and from every client that
+later loads one. Pinned by `TestUndoneObjectRemoveSurvivesCollection`
+(`pkg/document/gc_restore_test.go`), RED on `main`.
+
+Direction 1's two open questions, answered:
+
+- *Is dropping the gate safe for an ordinary `Set` that collides with a
+  tombstoned `createdAt`?* Yes. An ordinary `Set` carries a freshly issued
+  `createdAt`, so the lookup misses and costs one map read. It hits only
+  under duplicate application — and there the unconditional deregister is
+  the **better** of the two, since the gated version left the earlier
+  copy's descendants registered forever. Duplicate application is its own
+  defect, filed as
+  `20260911-duplicate-change-application-not-idempotent-todo.md`.
+- *Do `Remove`'s array reverse (`Add`) and `Move`'s reverse have the same
+  gating?* No. The only `OpSourceUndoRedo`-gated deregister was the one in
+  `set.go`. The array path is immune for a different reason —
+  `executeUndoRedo` re-tickets the restored element — and
+  `TestUndoneArrayRemoveSurvivesCollection` pins that, so the asymmetry
+  cannot be closed in the direction that would reintroduce this bug.
+
+Direction 2 (re-ticketing `Remove`'s reverse `Set`) was prototyped
+separately in the JS SDK and **rejected on measurement**: giving a restored
+element a fresh identity makes it a *new* element, so every operation
+stacked against the old one stops applying. Reconciling the descendants
+makes the two ends of one operation name different objects and it throws;
+not reconciling them makes the undo a silent no-op. No arrangement
+satisfies both. See `docs/design/element-identity.md` in `yorkie-js-sdk`.
+
 ### Reproduction sketch
 
 Two clients, plain `Object.Set`, no presence involved (confirms the bug
@@ -161,24 +200,27 @@ end-state key loss.
 
 ## Tasks
 
-- [ ] Reproduce with an explicit integration test in `yorkie` (both the
-      end-state divergence and, ideally, the intermediate
-      `gcElementPairMap` state) before attempting a fix
-- [ ] Decide between the two fix directions above (or find a better one)
-      for both SDKs — this needs its own design discussion, since
-      direction 1 has an open safety question and direction 2 needs the
-      equivalent JS change designed alongside it
-- [ ] Check whether `Remove`'s `*crdt.Array` reverse (`Add`) and `Move`'s
-      reverse have the same `OpSourceUndoRedo`-gated special-casing that
-      would need the identical treatment (`remove.go`, `move.go`)
+- [x] Reproduce before attempting a fix — `pkg/document/gc_restore_test.go`,
+      RED on `main`. It pins the end state on both replicas; the
+      intermediate `gcElementPairMap` state is pinned separately by
+      `TestUndoneObjectRemoveLeavesNoGarbage`, which rejects a fix that
+      merely *skips* the stale entry and leaves `GarbageLen` above zero
+- [x] Decide between the two fix directions — **direction 1**, with both of
+      its open safety questions answered. See the 2026-09-12 update above
+- [x] Check whether `Remove`'s `*crdt.Array` reverse (`Add`) and `Move`'s
+      reverse have the same gating — they do not; see the same update
 - [ ] Fix in `yorkie` and `yorkie-js-sdk` together; land both before
-      either ships, or add a version gate
-- [ ] Add the regression test from the reproduction sketch to both SDKs'
-      undo/redo integration suites
+      either ships, or add a version gate — **in review**: #1978 and
+      `yorkie-js-sdk#1341`, each naming the other as a merge prerequisite
+- [x] Add the regression test from the reproduction sketch to both SDKs —
+      `gc_restore_test.go` here, `test/unit/document/gc_containment_test.ts`
+      and `test/integration/gc_containment_test.ts` there
 - [ ] Re-tighten `test/integration/doc_presence_test.go`'s mixed
       op+presence redo assertion back to asserting on the peer (`d2`)
-      instead of locally (`d1`) once fixed — see the comment referencing
-      this document at that call site
+      instead of locally (`d1`) now that the gate is gone — see the comment
+      referencing this document at that call site. Deliberately left for a
+      follow-up: it is a presence-path assertion change, and bundling it
+      would mix an unrelated test rewrite into a containment release
 
 ## Related: `Presence.Initialize` leaves `clonePresences` stale
 

--- a/docs/tasks/active/20260911-duplicate-change-application-not-idempotent-todo.md
+++ b/docs/tasks/active/20260911-duplicate-change-application-not-idempotent-todo.md
@@ -40,19 +40,41 @@ AFTER GC     d1={"keep":0}               d2={"keep":0,"obj":{"k":1}}
 `nodeMapByKey` — the index `Marshal`, `Get` and `Has` read — still holds the
 live winner. The replicas diverge permanently.
 
-## Why it is not reachable today
+## How it is reached
 
 Duplicate application is defended at the server boundary, in two places, both
 because operations are not idempotent:
 
-- `server/packs/pushpull.go` drops a pushed change whose `clientSeq` is at or
-  below the client's stored checkpoint.
-- The pull filter drops a client's own changes on the way back out, with a
-  comment naming the hazard: "non-idempotent ops double-count".
+- `pushPack` drops a pushed change whose `clientSeq` is at or below the
+  client's stored checkpoint (`server/packs/pushpull.go:258-268`).
+- `pullChangeInfos` drops a client's own changes on the way back out, with a
+  comment naming the hazard: "non-idempotent ops double-count"
+  (`pushpull.go:597`).
 
 So the guards are what hold the line, not the CRDT. A test helper that pushes
 without consuming the server's checkpoint reproduces it immediately, which is
 how it was found.
+
+**`pullSnapshot` is not behind either guard.** `pushPack` filters the list it
+*stores* — `pushables` — and leaves `reqPack.Changes` untouched, and
+`pullSnapshot` applies that raw list:
+
+```go
+doc, err := BuildInternalDocForServerSeq(ctx, be, docInfo, initialServerSeq)
+...
+if reqPack.HasChanges() {
+    doc.ApplyChangePack(change.NewPack(..., reqPack.Changes, ...))
+```
+
+`initialSeq` is `docInfo.ServerSeq - len(pushables)` (`pushpull.go:327`), so on
+a retry where every change was skipped as already pushed, it is the current
+`serverSeq` and the document already holds them. `applyChanges` has no
+version-vector deduplication, so they are applied a second time. The snapshot
+built from that document is what the client receives and adopts.
+
+Reaching it needs a client to retry a pack after a lost response *and* to be at
+least `snapshotThreshold` changes behind, so the pull takes the snapshot branch
+(`pushpull.go:472`). Rare, not impossible — and silent when it happens.
 
 ## Why there is no cheap containment fix
 
@@ -78,4 +100,8 @@ ambiguous and there is no local repair. The fix has to prevent the collision.
 - [ ] Audit the other operations for the same shape: `Add` and `ArraySet`
       overwrite `RGATreeList.nodeMapByCreatedAt` and `elementMapByCreatedAt`
       in `insertAfter` with no collision check either.
+- [ ] Close the `pullSnapshot` hole regardless of that decision: it should
+      apply the changes `pushPack` accepted, not the ones the client sent.
+      Cheapest shape is to hand the filtered list down rather than re-deriving
+      it, so the two paths cannot drift apart again.
 - [ ] Whatever the decision, pin it with a test that applies one change twice.

--- a/docs/tasks/active/20260911-duplicate-change-application-not-idempotent-todo.md
+++ b/docs/tasks/active/20260911-duplicate-change-application-not-idempotent-todo.md
@@ -1,0 +1,81 @@
+# Applying one change twice corrupts an object's createdAt index
+
+**Created**: 2026-09-11
+
+Found while fixing the undone-object-remove data loss
+(`pkg/document/operations/set.go`) and confirmed **pre-existing on `main`**:
+`git show v0.6.0:pkg/document/crdt/element_rht.go` has the same unconditional
+write. Filed separately because it needs no undo/redo to reach, and because
+containing it properly means deciding what idempotent operation application
+should mean — a larger question than the release that surfaced it.
+
+## Problem
+
+`ElementRHT.SetWithExecutedAt` writes `nodeMapByCreatedAt` before it decides
+the LWW race:
+
+```go
+node, ok := rht.nodeMapByKey[k]
+newNode := newElementRHTNode(k, v)
+rht.nodeMapByCreatedAt[v.CreatedAt().Key()] = newNode   // unconditional
+```
+
+When `v` loses, the key keeps its old occupant but the createdAt index now
+points at the loser. Every other index in `Root` — `elementMap`,
+`gcElementPairMap`, `sizeInGC` — is keyed by createdAt too, so from that
+point on two distinct live elements answer to one identity and each index
+can disagree with the next about which one it means.
+
+The only way to give one createdAt two occupants is to apply the same `Set`
+twice. Measured, with no undo anywhere: deliver the creating change to a peer
+twice, then remove the member on the origin.
+
+```
+AFTER DUP    d1={"keep":0,"obj":{"k":1}} d2={"keep":0,"obj":{"k":1}}
+AFTER REMOVE d1={"keep":0}               d2={"keep":0,"obj":{"k":1}}
+AFTER GC     d1={"keep":0}               d2={"keep":0,"obj":{"k":1}}
+```
+
+`Remove` tombstones the loser that `nodeMapByCreatedAt` resolves to, while
+`nodeMapByKey` — the index `Marshal`, `Get` and `Has` read — still holds the
+live winner. The replicas diverge permanently.
+
+## Why it is not reachable today
+
+Duplicate application is defended at the server boundary, in two places, both
+because operations are not idempotent:
+
+- `server/packs/pushpull.go` drops a pushed change whose `clientSeq` is at or
+  below the client's stored checkpoint.
+- The pull filter drops a client's own changes on the way back out, with a
+  comment naming the hazard: "non-idempotent ops double-count".
+
+So the guards are what hold the line, not the CRDT. A test helper that pushes
+without consuming the server's checkpoint reproduces it immediately, which is
+how it was found.
+
+## Why there is no cheap containment fix
+
+Every candidate guard sits downstream of the collision and cannot undo it:
+
+- Skipping the byCA write for a loser breaks the ordinary concurrent-`Set`
+  case, where the loser is tombstoned, registered as a GC pair, and must stay
+  reachable by createdAt for `purge` to find it.
+- Dropping the stale `gcElementPairMap` entry at collection time leaves
+  `sizeInGC` — also keyed by createdAt — charging `docSize.GC` for an element
+  that no longer owns the identity, so `DocSize()` diverges instead.
+
+Once two elements share a createdAt, every createdAt-keyed structure is
+ambiguous and there is no local repair. The fix has to prevent the collision.
+
+## Tasks
+
+- [ ] Decide whether operation application should be idempotent at the CRDT
+      layer, or whether the server-boundary guards are the contract. If the
+      latter, say so where `SetWithExecutedAt` can be read to promise
+      otherwise, and consider rejecting a `Set` whose createdAt is already
+      occupied rather than silently corrupting the index.
+- [ ] Audit the other operations for the same shape: `Add` and `ArraySet`
+      overwrite `RGATreeList.nodeMapByCreatedAt` and `elementMapByCreatedAt`
+      in `insertAfter` with no collision check either.
+- [ ] Whatever the decision, pin it with a test that applies one change twice.

--- a/docs/tasks/archive/README.md
+++ b/docs/tasks/archive/README.md
@@ -1,5 +1,5 @@
 ---
-updated: 2026-08-22
+updated: 2026-09-12
 ---
 
 # Tasks Archive

--- a/pkg/document/crdt/array.go
+++ b/pkg/document/crdt/array.go
@@ -91,6 +91,11 @@ func (a *Array) Delete(idx int, deletedAt *time.Ticket) (Element, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Same nil as DeleteByCreatedAt reports when the removal lost to one
+	// already recorded; Element() would dereference the missing node.
+	if node == nil {
+		return nil, nil
+	}
 	return node.Element(), nil
 }
 

--- a/pkg/document/crdt/array.go
+++ b/pkg/document/crdt/array.go
@@ -249,6 +249,11 @@ func (a *Array) DeleteByCreatedAt(createdAt *time.Ticket, deletedAt *time.Ticket
 	if err != nil {
 		return nil, err
 	}
+	// nil when the removal lost to one already recorded on the element, which
+	// mirrors what ElementRHT.DeleteByCreatedAt reports for an Object.
+	if node == nil {
+		return nil, nil
+	}
 	return node.Element(), nil
 }
 

--- a/pkg/document/crdt/element_rht.go
+++ b/pkg/document/crdt/element_rht.go
@@ -275,6 +275,16 @@ func (rht *ElementRHT) purge(elem Element) error {
 	if !ok {
 		return fmt.Errorf("purge %s: %w", elem.CreatedAt().Key(), ErrChildNotFound)
 	}
+
+	// The slot names a creation time, not an element. Undo of a Remove
+	// re-inserts a copy under the original createdAt and SetWithExecutedAt
+	// re-points this map at it, so unlinking whatever the key answers with
+	// would delete a live member on a tombstone's behalf. The tombstone is
+	// already off both maps by then, so there is nothing left to unlink.
+	if node.elem != elem {
+		return nil
+	}
+
 	delete(rht.nodeMapByCreatedAt, node.elem.CreatedAt().Key())
 
 	nodeByKey, ok := rht.nodeMapByKey[node.key]

--- a/pkg/document/crdt/rga_tree_list.go
+++ b/pkg/document/crdt/rga_tree_list.go
@@ -505,6 +505,13 @@ func (a *RGATreeList) purge(elem Element) error {
 		return fmt.Errorf("purge %s: %w", elem.CreatedAt().Key(), ErrChildNotFound)
 	}
 
+	// Same guard as ElementRHT.purge: releasing the position node of an entry
+	// that now holds a different element would unlink a live one on a
+	// tombstone's behalf.
+	if entry.elem != elem {
+		return nil
+	}
+
 	node := entry.positionNode
 	delete(a.elementMapByCreatedAt, elem.CreatedAt().Key())
 	a.release(node)

--- a/pkg/document/crdt/rga_tree_list.go
+++ b/pkg/document/crdt/rga_tree_list.go
@@ -346,8 +346,16 @@ func (a *RGATreeList) DeleteByCreatedAt(createdAt *time.Ticket, deletedAt *time.
 
 	node := entry.positionNode
 
+	// A removal that loses to one already recorded on the element changes
+	// nothing, and reporting the node anyway invites the caller to register a
+	// GC pair for an element this removal did not tombstone. Report only the
+	// removal that took: `Remove` returns false when an earlier removal
+	// already won, and the caller decides what to do with the nil.
 	alreadyRemoved := node.IsRemoved()
-	if entry.elem.Remove(deletedAt) && !alreadyRemoved {
+	if !entry.elem.Remove(deletedAt) {
+		return nil, nil
+	}
+	if !alreadyRemoved {
 		a.nodeMapByIndex.UpdateWeight(node.indexNode)
 	}
 	return node, nil

--- a/pkg/document/crdt/root.go
+++ b/pkg/document/crdt/root.go
@@ -50,14 +50,34 @@ type Root struct {
 
 	// sizeInGC maps the creation time of every registered element whose size
 	// counts toward docSize.GC rather than docSize.Live, to the exact amount
-	// charged. Each element's size belongs to exactly one of the two, and an
-	// element reaches GC by more routes than it has removals: it can be
-	// removed itself, or be a descendant of a removed container. Recording
-	// the amount rather than a flag keeps the two sides symmetric even though
-	// DataSize is not stable over an element's lifetime -- it grows by a
-	// ticket the moment removedAt is set, which can happen after the size has
-	// already moved.
-	sizeInGC map[string]resource.DataSize
+	// charged and to the element it is charged for. Each element's size
+	// belongs to exactly one of the two, and an element reaches GC by more
+	// routes than it has removals: it can be removed itself, or be a
+	// descendant of a removed container. Recording the amount rather than a
+	// flag keeps the two sides symmetric even though DataSize is not stable
+	// over an element's lifetime -- it grows by a ticket the moment removedAt
+	// is set, which can happen after the size has already moved.
+	sizeInGC map[string]gcCharge
+}
+
+// gcCharge is what docSize.GC is holding on behalf of one element, and which
+// element that is.
+//
+// The identity is load-bearing. A createdAt is meant to name one element, but
+// it does not for the whole of a document's life: undo restores
+// `value.DeepCopy()` of a removed element, and the copy keeps the original's
+// createdAt while the original is still a tombstone. Charging or releasing by
+// key alone then bills whichever of the two happens to occupy the slot, and a
+// size can be taken out of docSize.Live that Live was never holding -- which
+// is how docSize goes negative.
+//
+// A zero size is not the same as no record. It says this element has been
+// released: charged to neither side, because its subtree was orphaned by a
+// restore and nothing will ever collect it. Anything that later charges it
+// again has to know Live is not the side to take it from.
+type gcCharge struct {
+	elem Element
+	size resource.DataSize
 }
 
 // NewRoot creates a new instance of Root.
@@ -66,7 +86,7 @@ func NewRoot(root *Object) *Root {
 		elementMap:       make(map[string]Element),
 		gcElementPairMap: make(map[string]ElementPair),
 		gcNodePairMap:    make(map[string]GCPair),
-		sizeInGC:         make(map[string]resource.DataSize),
+		sizeInGC:         make(map[string]gcCharge),
 		docSize: resource.DocSize{
 			Live: resource.DataSize{
 				Data: 0,
@@ -131,15 +151,6 @@ func (r *Root) RegisterElement(element Element) {
 	}
 }
 
-// DeregisterElement deregisters the given element and its descendants from
-// the hash tables. It is exported for operations that must replace an
-// element under a pre-existing createdAt during undo/redo (set_operation.ts:
-// 98-104 in the JS SDK), where a previously tombstoned element is restored
-// under the same identity and its stale entry must be dropped first.
-func (r *Root) DeregisterElement(element Element) int {
-	return r.deregisterElement(element)
-}
-
 // deregisterElement deregister the given element from hash tables.
 func (r *Root) deregisterElement(element Element) int {
 	count := 0
@@ -150,16 +161,38 @@ func (r *Root) deregisterElement(element Element) int {
 		// amount actually charged. A descendant created inside an
 		// already-removed container never passed through a removal, so it
 		// still sits in Live; subtracting it from GC would push GC below zero
-		// and leave its cost in Live forever.
-		if charged, ok := r.sizeInGC[createdAt]; ok {
-			r.docSize.GC.Sub(charged)
+		// and leave its cost in Live forever. A charge recorded against some
+		// other element that shares this createdAt says nothing about this
+		// one, which is still in Live.
+		if charged, ok := r.sizeInGC[createdAt]; ok && charged.elem == elem {
+			r.docSize.GC.Sub(charged.size)
 			delete(r.sizeInGC, createdAt)
 		} else {
 			r.docSize.Live.Sub(elem.DataSize())
 		}
 
-		delete(r.elementMap, createdAt)
-		delete(r.gcElementPairMap, createdAt)
+		// NOTE(hackerwins): Drop the index entries by identity, not by key.
+		// A createdAt is meant to name one element, but undo breaks that: it
+		// restores `value.DeepCopy()` of a removed container, and the copy
+		// keeps every descendant's createdAt while the original is still a
+		// tombstone. Only the top level of an undone ArraySet gets a fresh
+		// ticket (document.go's executeUndoRedo), so the descendants below it
+		// are answered by the live copy while the tombstone is still the one
+		// being collected here. `delete(map, createdAt)` would evict the live
+		// element's entry, and every later operation addressed at it fails
+		// with ErrNotApplicableDataType -- on the server's replay too, which
+		// makes the stored change log unreplayable.
+		//
+		// Comparing the slot against the element being deregistered leaves
+		// the entry alone when it has been taken over. The tombstone loses
+		// nothing by it: it is already unlinked from the tree, and whatever
+		// now owns the slot will clear it when its own turn comes.
+		if r.elementMap[createdAt] == elem {
+			delete(r.elementMap, createdAt)
+		}
+		if pair, ok := r.gcElementPairMap[createdAt]; ok && pair.elem == elem {
+			delete(r.gcElementPairMap, createdAt)
+		}
 		count++
 	}
 
@@ -213,27 +246,115 @@ func (r *Root) RegisterRemovedElementPair(parent Container, elem Element) {
 	}
 }
 
+// UnregisterRemovedElementPair drops the collection entry registered under the
+// given createdAt, if there is one, and releases the GC charge it holds. It
+// reports whether an entry was dropped.
+//
+// It is the narrow counterpart of RegisterRemovedElementPair, for the one
+// caller that has to retire a tombstone without collecting it: a Set that
+// restores an element under a createdAt a tombstone already answers to
+// (set_operation.ts:98-104 in the JS SDK). ElementRHT.SetWithExecutedAt has by
+// then re-pointed nodeMapByCreatedAt at the restored copy, so the entry the
+// removal left behind now resolves, through that index, to live data -- and
+// collection would purge it. Dropping the entry is what stops that.
+//
+// Deliberately narrow. The obvious alternative, deregistering the tombstone
+// and its descendants outright, reaches past the entry that is stale: the
+// tombstone's descendant set can be a strict superset of the restored copy's
+// -- a peer may have added a child into the container after the undoing
+// replica took its copy -- and deregistering evicts those descendants from
+// elementMap with nothing to put them back. A later change addressed at one of
+// them then fails on every replica, and permanently on the server, which
+// replays the same change log to rebuild the document and its snapshots.
+//
+// What it still does reach is the accounting, and it has to. SetWithExecutedAt
+// has displaced this tombstone from its container's nodeMapByCreatedAt, so the
+// subtree is orphaned: dropping the entry is dropping the only thing that would
+// ever have collected it. Its cost is therefore released from wherever it sits
+// -- docSize.GC for anything a removal moved there, docSize.Live for a member a
+// peer added into the container after it was already removed -- which is
+// exactly the split deregisterElement makes on the collection path, and leaves
+// the restored copy that RegisterElement is about to charge to Live as the only
+// thing accounted for.
+//
+// Collection entries belonging to the subtree's own tombstones go with it, for
+// the same reason: nothing can reach them to collect them, so leaving them
+// would hold GarbageLen above zero forever and let a later pass subtract a cost
+// this call has already released.
+func (r *Root) UnregisterRemovedElementPair(createdAt *time.Ticket) bool {
+	pair, ok := r.gcElementPairMap[createdAt.Key()]
+	if !ok {
+		return false
+	}
+
+	r.release(pair.elem)
+	if container, ok := pair.elem.(Container); ok {
+		container.Descendants(func(e Element, _ Container) bool {
+			r.release(e)
+			return false
+		})
+	}
+
+	delete(r.gcElementPairMap, createdAt.Key())
+	return true
+}
+
+// release forgets the cost of an element that has become unreachable without
+// being collected, and any collection entry naming it. It leaves elementMap
+// alone: the slot may since have been taken over by a live element restored
+// under this same createdAt, and that element's registration has to stand.
+func (r *Root) release(elem Element) {
+	createdAt := elem.CreatedAt().Key()
+
+	// Subtract from whichever side is actually holding it, by the amount
+	// actually charged -- the same split deregisterElement makes. A member
+	// added into an already-removed container never passed through a removal,
+	// so it still sits in Live.
+	if charged, ok := r.sizeInGC[createdAt]; ok && charged.elem == elem {
+		r.docSize.GC.Sub(charged.size)
+	} else {
+		r.docSize.Live.Sub(elem.DataSize())
+	}
+
+	// Record the release rather than forgetting it. This element stays
+	// addressable -- that is the whole point of not deregistering it -- so a
+	// peer that has not seen the restore can still remove something inside
+	// this subtree, and moveSizeToGC would then take its size out of Live for
+	// a second time and drive docSize negative. A zero charge says Live is
+	// not holding it, and the identity says which element that is about, so a
+	// copy restored under the same createdAt is still charged normally.
+	r.sizeInGC[createdAt] = gcCharge{elem: elem}
+
+	if pair, ok := r.gcElementPairMap[createdAt]; ok && pair.elem == elem {
+		delete(r.gcElementPairMap, createdAt)
+	}
+}
+
 // moveSizeToGC moves the size of the given element from Live to GC, and
-// reports whether it moved a size Live was holding. A size already in GC --
-// because the element was removed before, or because a container above it was
-// -- only has its charge topped up: DataSize grows by a ticket when removedAt
-// is set, which can happen after the move.
+// reports whether it moved a size Live was holding. A size already charged to
+// GC for this same element -- because it was removed before, because a
+// container above it was, or because a restore released it -- only has its
+// charge topped up: DataSize grows by a ticket when removedAt is set, which
+// can happen after the move.
+//
+// A charge recorded against a different element that shares this createdAt is
+// not this element's: this one is still in Live and moves in full. The record
+// it displaces is a released one (zero), so nothing charged is lost.
 func (r *Root) moveSizeToGC(elem Element) bool {
 	createdAt := elem.CreatedAt().Key()
 	size := elem.DataSize()
 
-	charged, ok := r.sizeInGC[createdAt]
-	if ok {
+	if charged, ok := r.sizeInGC[createdAt]; ok && charged.elem == elem {
 		diff := size
-		diff.Sub(charged)
+		diff.Sub(charged.size)
 		r.docSize.GC.Add(diff)
-		r.sizeInGC[createdAt] = size
+		r.sizeInGC[createdAt] = gcCharge{elem, size}
 		return false
 	}
 
 	r.docSize.GC.Add(size)
 	r.docSize.Live.Sub(size)
-	r.sizeInGC[createdAt] = size
+	r.sizeInGC[createdAt] = gcCharge{elem, size}
 	return true
 }
 

--- a/pkg/document/crdt/root.go
+++ b/pkg/document/crdt/root.go
@@ -256,6 +256,31 @@ func (r *Root) GarbageCollect(vector time.VersionVector) (int, error) {
 	count := 0
 
 	for _, pair := range r.gcElementPairMap {
+		// A registered pair is a claim that its element is a tombstone, and
+		// both steps below trust it: EqualToOrAfter dereferences the ticket
+		// without checking it, and Purge deletes whatever the element's
+		// createdAt currently resolves to. An element that is registered but
+		// not removed would panic on the first and delete a live member on
+		// the second, which is the shape of every bug in this area.
+		//
+		// Nothing produces that state today -- removedAt is only ever cleared
+		// on Text and Tree nodes, which live in gcNodePairMap and have their
+		// own UnregisterGCPair path, never on an Element. Two known routes
+		// would reach it: identity-preserving revive for Elements, deferred
+		// out of this release, and RGATreeList.DeleteByCreatedAt, which hands
+		// Remove.Execute a node to register even when entry.elem.Remove
+		// declined (only when the delete ticket does not follow the element's
+		// createdAt, which a causal change log cannot produce).
+		//
+		// Skipping leaves the entry on the worklist rather than dropping it,
+		// so a revived element's size stays charged to GC until revive brings
+		// the GC->Live accounting that gcNodePairMap already has. A leak is
+		// the safe failure here; losing the element, or panicking inside a
+		// server-side snapshot build, is not.
+		if pair.elem.RemovedAt() == nil {
+			continue
+		}
+
 		if vector.EqualToOrAfter(pair.elem.RemovedAt()) {
 			if err := pair.parent.Purge(pair.elem); err != nil {
 				return 0, err

--- a/pkg/document/crdt/root_liveness_test.go
+++ b/pkg/document/crdt/root_liveness_test.go
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package crdt_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yorkie-team/yorkie/pkg/document/crdt"
+	"github.com/yorkie-team/yorkie/test/helper"
+)
+
+// TestGarbageCollectSkipsLiveRegisteredElement pins that collection tolerates
+// a registered pair whose element is not removed, instead of dereferencing a
+// nil removedAt and deleting a live member.
+//
+// The two ways to reach that state are both out of this release:
+// identity-preserving revive for Elements, which clears removedAt in place
+// the way Text and Tree nodes already do, and the unconditional node return
+// in RGATreeList.DeleteByCreatedAt, which registers a pair for a removal
+// entry.elem.Remove declined. This test drives the state directly instead,
+// because neither route is reachable from a causal change log today. It is
+// the guard that makes either one land as a skipped entry rather than a panic
+// inside a snapshot build.
+func TestGarbageCollectSkipsLiveRegisteredElement(t *testing.T) {
+	root := helper.TestRoot()
+	ctx := helper.TextChangeContext(root)
+
+	obj := crdt.NewObject(crdt.NewElementRHT(), ctx.IssueTimeTicket())
+	root.Object().Set("obj", obj)
+	root.RegisterElement(obj)
+
+	removedAt := ctx.IssueTimeTicket()
+	_, err := root.Object().DeleteByCreatedAt(obj.CreatedAt(), removedAt)
+	require.NoError(t, err)
+	root.RegisterRemovedElementPair(root.Object(), obj)
+	assert.Equal(t, 1, root.GarbageLen())
+
+	// Revive in place: the element keeps its identity and its registration,
+	// and stops being a tombstone. Nothing in the Element path does this yet.
+	obj.SetRemovedAt(nil)
+
+	n, err := root.GarbageCollect(helper.MaxVersionVector())
+	require.NoError(t, err)
+	assert.Equal(t, 0, n, "collection purged an element that is not removed")
+	assert.Equal(t, obj, root.FindByCreatedAt(obj.CreatedAt()),
+		"the revived element lost its registration")
+	assert.True(t, root.Object().Has("obj"),
+		"the revived element was unlinked from its key")
+}

--- a/pkg/document/gc_array_set_test.go
+++ b/pkg/document/gc_array_set_test.go
@@ -70,6 +70,35 @@ func TestArraySetCollectsTheReplacedElement(t *testing.T) {
 			steady, doc.DocSize()))
 }
 
+// TestArraySetDoesNotExhaustTheSizeLimit pins that repeated assignment does
+// not walk a document into its size limit.
+//
+// `Update` checks MaxSizeLimit against the clone root it builds
+// (document.go:257-258), not against the root the operation is replayed on,
+// so fixing only `ArraySet.Execute` left the limit gated on an accounting
+// that still grew without bound: at a limit of 300 over a baseline of 100,
+// the eighth `arr[0] = v` was refused while `DocSize()` still reported 100.
+func TestArraySetDoesNotExhaustTheSizeLimit(t *testing.T) {
+	doc := document.New("array-set-size-limit")
+	doc.MaxSizeLimit = 300
+	require.NoError(t, doc.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.SetNewArray("arr").AddInteger(0)
+		return nil
+	}))
+
+	for i := 1; i <= 30; i++ {
+		require.NoError(t, doc.Update(func(r *json.Object, _ *presence.Presence) error {
+			r.GetArray("arr").SetInteger(0, i)
+			return nil
+		}), "assignment %d was refused", i)
+		doc.GarbageCollect(helper.MaxVersionVector(doc.ActorID()))
+	}
+
+	assert.Equal(t, `{"arr":[30]}`, doc.Marshal())
+	size := doc.DocSize()
+	assert.Equal(t, 100, size.Total())
+}
+
 // TestArraySetKeepsTheReplacedElementAddressable pins the other half: the
 // element the assignment displaced is a tombstone, not a hole. Collecting it
 // must not disturb the value that replaced it.

--- a/pkg/document/gc_array_set_test.go
+++ b/pkg/document/gc_array_set_test.go
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package document_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yorkie-team/yorkie/pkg/document"
+	"github.com/yorkie-team/yorkie/pkg/document/json"
+	"github.com/yorkie-team/yorkie/pkg/document/presence"
+	"github.com/yorkie-team/yorkie/test/helper"
+)
+
+// TestArraySetCollectsTheReplacedElement pins that assigning into an array
+// releases the element it displaced.
+//
+// `ArraySet.Execute` inserts the new value, deletes the old one and then
+// discards what the delete handed back, so the displaced element was never
+// registered for collection: it stayed charged to `docSize.Live` and no
+// collection could reach it. No undo is involved -- an ordinary `arr[i] = x`
+// in a loop grew the document without bound, and `docSize` is what the server
+// enforces against its size limit.
+func TestArraySetCollectsTheReplacedElement(t *testing.T) {
+	doc := document.New("array-set-gc")
+	require.NoError(t, doc.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.SetNewArray("arr").AddInteger(0)
+		return nil
+	}))
+
+	set := func(v int) {
+		require.NoError(t, doc.Update(func(r *json.Object, _ *presence.Presence) error {
+			r.GetArray("arr").SetInteger(0, v)
+			return nil
+		}))
+		doc.GarbageCollect(helper.MaxVersionVector(doc.ActorID()))
+	}
+
+	// One cycle establishes the steady state: an array holding one integer,
+	// with the element it displaced collected.
+	set(1)
+	steady := doc.DocSize()
+	require.Equal(t, 0, doc.GarbageLen())
+
+	for i := 2; i <= 10; i++ {
+		set(i)
+	}
+
+	assert.Equal(t, `{"arr":[10]}`, doc.Marshal())
+	assert.Equal(t, 0, doc.GarbageLen())
+	assert.Equal(t, steady, doc.DocSize(),
+		fmt.Sprintf("nine more assignments grew the document: %v -> %v",
+			steady, doc.DocSize()))
+}
+
+// TestArraySetKeepsTheReplacedElementAddressable pins the other half: the
+// element the assignment displaced is a tombstone, not a hole. Collecting it
+// must not disturb the value that replaced it.
+func TestArraySetKeepsTheReplacedElementAddressable(t *testing.T) {
+	doc := document.New("array-set-addressable")
+	require.NoError(t, doc.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.SetNewArray("arr").AddInteger(1).AddInteger(2).AddInteger(3)
+		return nil
+	}))
+	require.NoError(t, doc.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.GetArray("arr").SetInteger(1, 99)
+		return nil
+	}))
+	doc.GarbageCollect(helper.MaxVersionVector(doc.ActorID()))
+
+	assert.Equal(t, `{"arr":[1,99,3]}`, doc.Marshal())
+
+	// The replacement is still a normal member: it can be read, replaced
+	// again and removed.
+	require.NoError(t, doc.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.GetArray("arr").SetInteger(1, 100)
+		return nil
+	}))
+	assert.Equal(t, `{"arr":[1,100,3]}`, doc.Marshal())
+
+	require.NoError(t, doc.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.GetArray("arr").Delete(1)
+		return nil
+	}))
+	doc.GarbageCollect(helper.MaxVersionVector(doc.ActorID()))
+	assert.Equal(t, `{"arr":[1,3]}`, doc.Marshal())
+	assert.Equal(t, 0, doc.GarbageLen())
+}

--- a/pkg/document/gc_restore_test.go
+++ b/pkg/document/gc_restore_test.go
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package document_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yorkie-team/yorkie/pkg/document"
+	"github.com/yorkie-team/yorkie/pkg/document/change"
+	"github.com/yorkie-team/yorkie/pkg/document/json"
+	"github.com/yorkie-team/yorkie/pkg/document/presence"
+	"github.com/yorkie-team/yorkie/pkg/document/time"
+	"github.com/yorkie-team/yorkie/test/helper"
+)
+
+// deliverChanges pushes the sender's pending changes into the receiver,
+// mimicking a server round-trip. The receiver applies them with
+// OpSourceRemote, which is also how the server itself replays a change log to
+// build a snapshot -- the path that decides what every later joiner sees.
+//
+// The ack half matters as much as the push. CreateChangePack does not clear
+// localChanges; the server's response does, by returning a checkpoint that
+// ApplyChangePack walks the queue against. Without it the sender re-pushes
+// every change it has ever made on the next call, and the receiver applies
+// change 1 twice -- which no real peer does: pushPull drops a change whose
+// clientSeq is at or below the stored checkpoint on the way in, and drops a
+// client's own changes on the way back out, precisely because operations are
+// not idempotent. Replaying one twice diverges the replicas on its own --
+// with no undo involved at all, see
+// docs/tasks/active/20260911-duplicate-change-application-not-idempotent-todo.md
+// -- and would mask the defect these tests are about.
+func deliverChanges(t *testing.T, from, to *document.Document) {
+	t.Helper()
+	pack := from.CreateChangePack()
+	require.NoError(t, to.ApplyChangePack(change.NewPack(
+		pack.DocumentKey,
+		change.NewCheckpoint(0, 0),
+		pack.Changes,
+		time.InitialVersionVector,
+		nil,
+	)))
+	require.NoError(t, from.ApplyChangePack(change.NewPack(
+		pack.DocumentKey,
+		pack.Checkpoint,
+		nil,
+		time.InitialVersionVector,
+		nil,
+	)))
+}
+
+// TestUndoneObjectRemoveSurvivesCollection pins that a member restored by
+// undoing its removal is still there after collection, on every replica.
+//
+// Undoing the removal of an object member restores it under its original
+// createdAt. `ElementRHT.SetWithExecutedAt` re-keys `nodeMapByCreatedAt` onto
+// the restored node, so the entry left in `gcElementPairMap` by the removal
+// now resolves, through that index, to the live member -- and `purge` deletes
+// it. The replica that performed the undo is spared because `Set.Execute`
+// deregisters the stale entry, but it only does so for `OpSourceUndoRedo`, so
+// every peer and the server keep it.
+func TestUndoneObjectRemoveSurvivesCollection(t *testing.T) {
+	d1 := document.New("restore-gc")
+	d2 := document.New("restore-gc")
+
+	require.NoError(t, d1.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.SetNewObject("obj").SetInteger("k", 1)
+		r.SetInteger("keep", 0)
+		return nil
+	}))
+	deliverChanges(t, d1, d2)
+
+	require.NoError(t, d1.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.Delete("obj")
+		return nil
+	}, "remove obj"))
+	require.NoError(t, d1.Undo())
+	deliverChanges(t, d1, d2)
+
+	assert.Equal(t, `{"keep":0,"obj":{"k":1}}`, d1.Marshal())
+	assert.Equal(t, `{"keep":0,"obj":{"k":1}}`, d2.Marshal())
+
+	vector := helper.MaxVersionVector(d1.ActorID(), d2.ActorID())
+	d1.GarbageCollect(vector)
+	d2.GarbageCollect(vector)
+
+	assert.Equal(t, `{"keep":0,"obj":{"k":1}}`, d1.Marshal())
+	assert.Equal(t, `{"keep":0,"obj":{"k":1}}`, d2.Marshal(),
+		"collection deleted the restored member on the replica that did not undo")
+}
+
+// TestUndoneObjectRemoveLeavesNoGarbage pins that the tombstone the removal
+// registered is actually collected, on every replica.
+//
+// The stale entry a peer keeps resolves to the restored member, whose
+// removedAt is nil, so collection can never take it: the worklist entry and
+// the size charged against it stay for the life of the document.
+func TestUndoneObjectRemoveLeavesNoGarbage(t *testing.T) {
+	d1 := document.New("restore-gc-len")
+	d2 := document.New("restore-gc-len")
+
+	require.NoError(t, d1.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.SetNewObject("obj").SetInteger("k", 1)
+		return nil
+	}))
+	deliverChanges(t, d1, d2)
+
+	require.NoError(t, d1.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.Delete("obj")
+		return nil
+	}, "remove obj"))
+	require.NoError(t, d1.Undo())
+	deliverChanges(t, d1, d2)
+
+	vector := helper.MaxVersionVector(d1.ActorID(), d2.ActorID())
+	d1.GarbageCollect(vector)
+	d2.GarbageCollect(vector)
+
+	assert.Equal(t, 0, d1.GarbageLen())
+	assert.Equal(t, 0, d2.GarbageLen(),
+		"the peer holds a worklist entry that can never be collected")
+	assert.Equal(t, d1.DocSize().GC, d2.DocSize().GC,
+		"the peer charges garbage the undoing replica does not")
+}
+
+// TestUndoneObjectRemoveStaysAddressableAfterCollection pins that the
+// restored member is still reachable by its identity after collection, not
+// merely still present in the marshalled output.
+//
+// Marshal reads ElementRHT.nodeMapByKey; every later operation reaches the
+// member through Root.elementMap and nodeMapByCreatedAt instead. A fix that
+// only stopped purge from unlinking the key -- by checking that the node it
+// found holds the element it was asked to purge -- would leave collection to
+// deregister the stale pair's element anyway, and deregisterElement deletes
+// Root.elementMap under that createdAt: the identity the restored member now
+// owns. The member would survive the assertions above and the next change
+// touching it would fail to apply, which on the server aborts a snapshot
+// rebuild. That is a worse outcome than the data loss it replaces, so pin
+// the difference rather than the symptom.
+func TestUndoneObjectRemoveStaysAddressableAfterCollection(t *testing.T) {
+	d1 := document.New("restore-gc-addressable")
+	d2 := document.New("restore-gc-addressable")
+
+	require.NoError(t, d1.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.SetNewObject("obj").SetInteger("k", 1)
+		return nil
+	}))
+	deliverChanges(t, d1, d2)
+
+	require.NoError(t, d1.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.Delete("obj")
+		return nil
+	}, "remove obj"))
+	require.NoError(t, d1.Undo())
+	deliverChanges(t, d1, d2)
+
+	vector := helper.MaxVersionVector(d1.ActorID(), d2.ActorID())
+	d1.GarbageCollect(vector)
+	d2.GarbageCollect(vector)
+
+	// Written on the replica that undid, applied on the one that did not:
+	// the write resolves the member through d1's indexes and the apply
+	// through d2's, so both halves of the identity have to have survived.
+	require.NoError(t, d1.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.GetObject("obj").SetInteger("x", 5)
+		return nil
+	}))
+	require.NoError(t, d1.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.GetObject("obj").Delete("k")
+		return nil
+	}))
+	deliverChanges(t, d1, d2)
+
+	assert.Equal(t, `{"obj":{"x":5}}`, d1.Marshal())
+	assert.Equal(t, `{"obj":{"x":5}}`, d2.Marshal(),
+		"the restored member is no longer reachable by its createdAt")
+}
+
+// TestUndoneArrayRemoveSurvivesCollection is the array counterpart of
+// TestUndoneObjectRemoveSurvivesCollection. It passes on main, and is here to
+// hold that line: the array path is immune only because executeUndoRedo
+// reissues the restored element's createdAt (document.go:449-451) instead of
+// restoring it under its original one, so the tombstone and the restored
+// element never share a key in RGATreeList.elementMapByCreatedAt and
+// `purge` cannot reach the live element through the dead one's identity. The
+// comment there names this exact hazard. Any change that makes the array
+// restore identity-preserving -- the revive work this release defers --
+// reintroduces the object bug here, and this test is what catches it.
+func TestUndoneArrayRemoveSurvivesCollection(t *testing.T) {
+	d1 := document.New("restore-gc-array")
+	d2 := document.New("restore-gc-array")
+
+	require.NoError(t, d1.Update(func(r *json.Object, _ *presence.Presence) error {
+		a := r.SetNewArray("arr")
+		a.AddNewObject().SetInteger("k", 1)
+		a.AddInteger(9)
+		return nil
+	}))
+	deliverChanges(t, d1, d2)
+
+	require.NoError(t, d1.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.GetArray("arr").Delete(0)
+		return nil
+	}, "remove arr[0]"))
+	require.NoError(t, d1.Undo())
+	deliverChanges(t, d1, d2)
+
+	assert.Equal(t, `{"arr":[{"k":1},9]}`, d1.Marshal())
+	assert.Equal(t, `{"arr":[{"k":1},9]}`, d2.Marshal())
+
+	vector := helper.MaxVersionVector(d1.ActorID(), d2.ActorID())
+	d1.GarbageCollect(vector)
+	d2.GarbageCollect(vector)
+
+	assert.Equal(t, `{"arr":[{"k":1},9]}`, d1.Marshal())
+	assert.Equal(t, `{"arr":[{"k":1},9]}`, d2.Marshal(),
+		"collection deleted the restored element on the replica that did not undo")
+	assert.Equal(t, 0, d1.GarbageLen())
+	assert.Equal(t, 0, d2.GarbageLen())
+}

--- a/pkg/document/gc_restore_test.go
+++ b/pkg/document/gc_restore_test.go
@@ -234,3 +234,150 @@ func TestUndoneArrayRemoveSurvivesCollection(t *testing.T) {
 	assert.Equal(t, 0, d1.GarbageLen())
 	assert.Equal(t, 0, d2.GarbageLen())
 }
+
+// broadcastChanges is deliverChanges for more than one receiver. The ack has
+// to happen once, after every receiver has the pack: it clears the sender's
+// localChanges, so acking per receiver would leave the second one with
+// nothing to apply.
+func broadcastChanges(t *testing.T, from *document.Document, tos ...*document.Document) {
+	t.Helper()
+	pack := from.CreateChangePack()
+	for _, to := range tos {
+		require.NoError(t, to.ApplyChangePack(change.NewPack(
+			pack.DocumentKey,
+			change.NewCheckpoint(0, 0),
+			pack.Changes,
+			time.InitialVersionVector,
+			nil,
+		)))
+	}
+	require.NoError(t, from.ApplyChangePack(change.NewPack(
+		pack.DocumentKey,
+		pack.Checkpoint,
+		nil,
+		time.InitialVersionVector,
+		nil,
+	)))
+}
+
+// TestRestoredContainerKeepsForeignDescendantsAddressable pins that restoring
+// a container does not cost the identities of members it does not carry.
+//
+// The reverse of a Remove is a Set of `value.DeepCopy()`, taken when the
+// removal was recorded. A peer that added a member into the container after
+// that copy was taken has a tombstone whose descendant set is a strict
+// superset of the copy's. Retiring the tombstone by deregistering it and its
+// descendants evicts those extra members from `elementMap`, and nothing puts
+// them back -- so the next change addressed at one of them fails with
+// ErrNotApplicableDataType.
+//
+// That failure is not confined to the replica it happens on. The server
+// rebuilds documents and snapshots by replaying the stored change log
+// (`server/packs/snapshot.go`, with OpSourceReplay), so a change that cannot
+// apply makes the document unloadable from then on, for everyone.
+//
+// The restored container still diverges -- d2's member is not in the copy, so
+// its edit lands on an orphaned subtree and is invisible. That is the
+// identity-preserving revive work this release defers. What must hold here is
+// narrower and is the whole point of the release: the change log stays
+// replayable.
+func TestRestoredContainerKeepsForeignDescendantsAddressable(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		collect bool
+	}{
+		{"undo arriving as a remote change", false},
+		// The server collects between syncs, so the tombstone is gone by the
+		// time the late change arrives. Nothing may depend on it still being
+		// registered.
+		{"with a collection pass before the late change", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d1 := document.New("restore-foreign")
+			d2 := document.New("restore-foreign")
+			d3 := document.New("restore-foreign")
+
+			require.NoError(t, d1.Update(func(r *json.Object, _ *presence.Presence) error {
+				r.SetNewObject("obj").SetInteger("k", 1)
+				return nil
+			}))
+			broadcastChanges(t, d1, d2, d3)
+
+			// d2 adds a member inside obj. d1 never sees it, so the copy its
+			// undo carries will not contain it.
+			require.NoError(t, d2.Update(func(r *json.Object, _ *presence.Presence) error {
+				r.GetObject("obj").SetNewObject("n").SetInteger("y", 1)
+				return nil
+			}))
+			broadcastChanges(t, d2, d3)
+
+			require.NoError(t, d1.Update(func(r *json.Object, _ *presence.Presence) error {
+				r.Delete("obj")
+				return nil
+			}, "remove obj"))
+			require.NoError(t, d1.Undo())
+			deliverChanges(t, d1, d3)
+
+			if tc.collect {
+				d3.GarbageCollect(helper.MaxVersionVector(
+					d1.ActorID(), d2.ActorID(), d3.ActorID()))
+			}
+
+			// d2, which has not seen the removal, edits the member it added.
+			require.NoError(t, d2.Update(func(r *json.Object, _ *presence.Presence) error {
+				r.GetObject("obj").GetObject("n").SetInteger("x", 5)
+				return nil
+			}))
+
+			pack := d2.CreateChangePack()
+			assert.NoError(t, d3.ApplyChangePack(change.NewPack(
+				pack.DocumentKey,
+				change.NewCheckpoint(0, 0),
+				pack.Changes,
+				time.InitialVersionVector,
+				nil,
+			)), "the peer's change no longer applies, so the stored change log is unreplayable")
+		})
+	}
+}
+
+// TestRepeatedRestoreAndRemoveCollects pins that a createdAt can be restored
+// and removed again without collection tripping over the tombstones that
+// accumulate under it.
+//
+// Each cycle leaves another tombstone answering to the same createdAt. A
+// collection worklist or a purge that resolves an entry through a
+// createdAt-keyed index rather than through the element it was registered for
+// will, on the second pass, either unlink a live member on a dead one's
+// behalf or fail to find the node at all -- and `Document.GarbageCollect`
+// turns that error into a panic.
+//
+// Map iteration order decides which entry a pass reaches first, so a single
+// run proves little; this repeats.
+func TestRepeatedRestoreAndRemoveCollects(t *testing.T) {
+	for range 200 {
+		d := document.New("restore-repeat")
+
+		require.NoError(t, d.Update(func(r *json.Object, _ *presence.Presence) error {
+			r.SetNewObject("o").SetInteger("k", 1)
+			return nil
+		}))
+
+		for range 3 {
+			require.NoError(t, d.Update(func(r *json.Object, _ *presence.Presence) error {
+				r.Delete("o")
+				return nil
+			}, "remove o"))
+			require.NoError(t, d.Undo())
+		}
+
+		require.NoError(t, d.Update(func(r *json.Object, _ *presence.Presence) error {
+			r.Delete("o")
+			return nil
+		}, "remove o"))
+
+		d.GarbageCollect(helper.MaxVersionVector(d.ActorID()))
+		assert.Equal(t, `{}`, d.Marshal())
+		assert.Equal(t, 0, d.GarbageLen())
+	}
+}

--- a/pkg/document/history_test.go
+++ b/pkg/document/history_test.go
@@ -175,8 +175,13 @@ func TestHistoryStack(t *testing.T) {
 		// ArraySet's reverse restores the replaced value under a freshly
 		// reissued createdAt (executeUndoRedo's ArraySet branch). This pins
 		// that a full undo/redo cycle leaves the document intact and that
-		// GC's view of the document -- whatever it tracks for ArraySet --
-		// does not change out from under us.
+		// every element the cycle displaces is collected.
+		//
+		// The counts used to be zero throughout, because ArraySet discarded
+		// the element it displaced instead of registering it: there was no
+		// garbage to report because nothing was tracking it. Each assignment
+		// now leaves one tombstone -- the value it replaced -- and collection
+		// takes it.
 		doc := document.New("d1")
 		assert.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
 			root.SetNewArray("list").AddInteger(1, 2, 3)
@@ -188,18 +193,24 @@ func TestHistoryStack(t *testing.T) {
 		}))
 		assert.Equal(t, `{"list":[9,2,3]}`, doc.Marshal())
 
+		// The assignment displaced `1`; that is the one tombstone so far.
+		assert.Equal(t, 1, doc.GarbageLen())
+
 		assert.NoError(t, doc.Undo())
 		assert.Equal(t, `{"list":[1,2,3]}`, doc.Marshal())
-		assert.Equal(t, 0, doc.GarbageLen())
-		assert.Equal(t, 0, doc.GarbageCollect(helper.MaxVersionVector(doc.ActorID())))
+		// The undo restored `1` and displaced `9` in turn.
+		assert.Equal(t, 2, doc.GarbageLen())
+		assert.Equal(t, 2, doc.GarbageCollect(helper.MaxVersionVector(doc.ActorID())))
 		assert.Equal(t, `{"list":[1,2,3]}`, doc.Marshal())
+		assert.Equal(t, 0, doc.GarbageLen())
 
 		assert.True(t, doc.CanRedo())
 		assert.NoError(t, doc.Redo())
 		assert.Equal(t, `{"list":[9,2,3]}`, doc.Marshal())
-		assert.Equal(t, 0, doc.GarbageLen())
-		assert.Equal(t, 0, doc.GarbageCollect(helper.MaxVersionVector(doc.ActorID())))
+		assert.Equal(t, 1, doc.GarbageLen())
+		assert.Equal(t, 1, doc.GarbageCollect(helper.MaxVersionVector(doc.ActorID())))
 		assert.Equal(t, `{"list":[9,2,3]}`, doc.Marshal())
+		assert.Equal(t, 0, doc.GarbageLen())
 	})
 
 	t.Run("array add undo redo survives gc test", func(t *testing.T) {

--- a/pkg/document/json/array.go
+++ b/pkg/document/json/array.go
@@ -599,12 +599,25 @@ func (p *Array) setByIndexInternal(
 		ticket,
 	))
 
-	_, err = p.Set(createdAt, value, ticket)
+	removed, err := p.Set(createdAt, value, ticket)
 	if err != nil {
 		panic(err)
 	}
-	// TODO(junseo): GC logic is not implemented here
-	// because there is no way to distinguish between old and new element with same `createdAt`.
 	p.context.RegisterElement(value)
+
+	// NOTE(hackerwins): The displaced element has to be registered here too,
+	// not only in ArraySet.Execute. This path runs against the clone root that
+	// Update builds, and MaxSizeLimit is checked against that clone
+	// (document.go:257-258) -- not against the root the operation is later
+	// replayed on. Left out, an assignment loop trips the size limit on a
+	// document whose real size never moved: with a limit of 140 over a
+	// baseline of 100, the second `arr[0] = v` was refused while DocSize()
+	// still reported 100.
+	//
+	// json/object.go's setInternal already registers the value it replaces the
+	// same way.
+	if removed != nil {
+		p.context.RegisterRemovedElementPair(p, removed)
+	}
 	return elem
 }

--- a/pkg/document/operations/array_set.go
+++ b/pkg/document/operations/array_set.go
@@ -98,14 +98,27 @@ func (o *ArraySet) Execute(root *crdt.Root, source OpSource, _ time.VersionVecto
 		return ExecutionResult{}, err
 	}
 
-	_, err = obj.DeleteByCreatedAt(o.createdAt, o.executedAt)
+	removed, err := obj.DeleteByCreatedAt(o.createdAt, o.executedAt)
 	if err != nil {
 		return ExecutionResult{}, err
 	}
 
-	// TODO(junseo): GC logic is not implemented here
-	// because there is no way to distinguish between old and new element with same `createdAt`.
 	root.RegisterElement(value)
+
+	// NOTE(hackerwins): The element this assignment displaced has to be
+	// registered for collection. Discarding it left it charged to
+	// docSize.Live with nothing able to reach it: ten ordinary `arr[i] = x`
+	// assignments grew a one-integer document from {8,120} to {44,336} and
+	// collection reported nothing to do. docSize is what the server enforces
+	// against its size limit, so the growth is not merely cosmetic.
+	//
+	// The old TODO here said the two could not be told apart because they
+	// share a createdAt. They do not: o.createdAt names the element being
+	// displaced and value carries its own identity. A removal that lost to
+	// one already recorded comes back nil and registers nothing.
+	if removed != nil {
+		root.RegisterRemovedElementPair(obj, removed)
+	}
 
 	if previousCopy == nil {
 		return ExecutionResult{Observable: true}, nil

--- a/pkg/document/operations/set.go
+++ b/pkg/document/operations/set.go
@@ -129,9 +129,15 @@ func (o *Set) Execute(root *crdt.Root, source OpSource, _ time.VersionVector) (E
 	// An ordinary Set carries a freshly issued createdAt, so the lookup
 	// normally misses and costs one map read. It can hit: applying one Set
 	// twice leaves two live elements under one identity, and the lookup then
-	// answers with whichever the index holds. That is the defect filed in
-	// docs/tasks/active/20260911-duplicate-change-application-not-idempotent-todo.md,
-	// which the server's clientSeq checkpoint is what actually prevents.
+	// answers with whichever the index holds. The clientSeq checkpoint does
+	// not rule that out -- it stops a change being stored twice, not applied
+	// twice. pushPack filters the list it stores and leaves reqPack.Changes
+	// intact, so pullSnapshot replays a retried pack's own changes onto a
+	// document built for a serverSeq that already includes them. That is the
+	// defect filed in
+	// docs/tasks/active/20260911-duplicate-change-application-not-idempotent-todo.md.
+	// Deregistering is the better behaviour there too: gated, the earlier
+	// copy's descendants stayed registered forever.
 	if registered := root.FindByCreatedAt(value.CreatedAt()); registered != nil {
 		root.DeregisterElement(registered)
 	}

--- a/pkg/document/operations/set.go
+++ b/pkg/document/operations/set.go
@@ -124,9 +124,14 @@ func (o *Set) Execute(root *crdt.Root, source OpSource, _ time.VersionVector) (E
 	// build a snapshot, reach byte-identical state. Gating it on
 	// OpSourceUndoRedo spared only the replica that performed the undo and
 	// lost the member everywhere else, including in every snapshot built
-	// afterwards. The lookup costs one map read on an ordinary Set, whose
-	// value carries a freshly issued createdAt that nothing can be
-	// registered under.
+	// afterwards.
+	//
+	// An ordinary Set carries a freshly issued createdAt, so the lookup
+	// normally misses and costs one map read. It can hit: applying one Set
+	// twice leaves two live elements under one identity, and the lookup then
+	// answers with whichever the index holds. That is the defect filed in
+	// docs/tasks/active/20260911-duplicate-change-application-not-idempotent-todo.md,
+	// which the server's clientSeq checkpoint is what actually prevents.
 	if registered := root.FindByCreatedAt(value.CreatedAt()); registered != nil {
 		root.DeregisterElement(registered)
 	}

--- a/pkg/document/operations/set.go
+++ b/pkg/document/operations/set.go
@@ -102,19 +102,33 @@ func (o *Set) Execute(root *crdt.Root, source OpSource, _ time.VersionVector) (E
 	// win the LWW comparison at all.
 	removed := obj.SetWithExecutedAt(o.key, value, o.executedAt)
 
-	// NOTE(hackerwins): During undo/redo, this Set may restore an element
-	// under a createdAt that is already registered (set_operation.ts:98-104)
-	// -- for example, undoing a Remove re-inserts the removed element under
-	// its original identity. The stale entry must be deregistered before the
-	// restored element is registered again. It has to be the registered
-	// element that is deregistered, not the incoming copy: the copy's size and
-	// descendants are the ones about to be registered, so passing it would
-	// charge the wrong size against GC and leave the stale element's own
-	// descendants registered forever.
-	if source == OpSourceUndoRedo {
-		if registered := root.FindByCreatedAt(value.CreatedAt()); registered != nil {
-			root.DeregisterElement(registered)
-		}
+	// NOTE(hackerwins): A Set can restore an element under a createdAt that is
+	// already registered (set_operation.ts:98-104) -- undoing a Remove
+	// re-inserts the removed element under its original identity, and
+	// SetWithExecutedAt above has just handed that identity to the restored
+	// copy in the object's nodeMapByCreatedAt. Everything Root keys by
+	// createdAt must follow, or the tombstone keeps an entry naming an
+	// identity that no longer resolves to it.
+	//
+	// gcElementPairMap is the entry that matters: collection resolves
+	// pair.elem through the index that was just re-pointed, so a stale entry
+	// makes the next collection purge the restored element instead of the
+	// tombstone -- deleting live data. Deregistering is what drops it, and it
+	// has to be the registered element that is deregistered, not the incoming
+	// copy: the copy's size and descendants are the ones about to be
+	// registered, so passing it would charge the wrong size against GC and
+	// leave the stale element's own descendants registered forever.
+	//
+	// This is a condition on the state of the tree, not on who is applying:
+	// a peer receiving the undo, and the server replaying the change log to
+	// build a snapshot, reach byte-identical state. Gating it on
+	// OpSourceUndoRedo spared only the replica that performed the undo and
+	// lost the member everywhere else, including in every snapshot built
+	// afterwards. The lookup costs one map read on an ordinary Set, whose
+	// value carries a freshly issued createdAt that nothing can be
+	// registered under.
+	if registered := root.FindByCreatedAt(value.CreatedAt()); registered != nil {
+		root.DeregisterElement(registered)
 	}
 	root.RegisterElement(value)
 	if removed != nil {

--- a/pkg/document/operations/set.go
+++ b/pkg/document/operations/set.go
@@ -102,45 +102,35 @@ func (o *Set) Execute(root *crdt.Root, source OpSource, _ time.VersionVector) (E
 	// win the LWW comparison at all.
 	removed := obj.SetWithExecutedAt(o.key, value, o.executedAt)
 
-	// NOTE(hackerwins): A Set can restore an element under a createdAt that is
-	// already registered (set_operation.ts:98-104) -- undoing a Remove
-	// re-inserts the removed element under its original identity, and
+	// NOTE(hackerwins): A Set can restore an element under a createdAt that a
+	// tombstone already answers to (set_operation.ts:98-104) -- undoing a
+	// Remove re-inserts the removed element under its original identity, and
 	// SetWithExecutedAt above has just handed that identity to the restored
-	// copy in the object's nodeMapByCreatedAt. Everything Root keys by
-	// createdAt must follow, or the tombstone keeps an entry naming an
-	// identity that no longer resolves to it.
+	// copy in the object's nodeMapByCreatedAt.
 	//
-	// gcElementPairMap is the entry that matters: collection resolves
-	// pair.elem through the index that was just re-pointed, so a stale entry
-	// makes the next collection purge the restored element instead of the
-	// tombstone -- deleting live data. Deregistering is what drops it, and it
-	// has to be the registered element that is deregistered, not the incoming
-	// copy: the copy's size and descendants are the ones about to be
-	// registered, so passing it would charge the wrong size against GC and
-	// leave the stale element's own descendants registered forever.
+	// The entry that has to follow is the one in gcElementPairMap. Collection
+	// resolves it through the index that was just re-pointed, so leaving it
+	// makes the next pass purge the restored element instead of the tombstone
+	// -- deleting live data, on every replica and in every snapshot the server
+	// builds afterwards.
+	//
+	// Retiring that entry is the whole job, so retire only that entry. The
+	// tombstone's other registrations are deliberately left alone: its
+	// descendant set can be a strict superset of the restored copy's, since a
+	// peer may have added a child into the container after the undoing replica
+	// took its copy, and tearing the subtree out of elementMap would take those
+	// extra descendants with it, with nothing to put them back. See
+	// Root.UnregisterRemovedElementPair.
 	//
 	// This is a condition on the state of the tree, not on who is applying:
 	// a peer receiving the undo, and the server replaying the change log to
 	// build a snapshot, reach byte-identical state. Gating it on
 	// OpSourceUndoRedo spared only the replica that performed the undo and
-	// lost the member everywhere else, including in every snapshot built
-	// afterwards.
+	// lost the member everywhere else.
 	//
 	// An ordinary Set carries a freshly issued createdAt, so the lookup
-	// normally misses and costs one map read. It can hit: applying one Set
-	// twice leaves two live elements under one identity, and the lookup then
-	// answers with whichever the index holds. The clientSeq checkpoint does
-	// not rule that out -- it stops a change being stored twice, not applied
-	// twice. pushPack filters the list it stores and leaves reqPack.Changes
-	// intact, so pullSnapshot replays a retried pack's own changes onto a
-	// document built for a serverSeq that already includes them. That is the
-	// defect filed in
-	// docs/tasks/active/20260911-duplicate-change-application-not-idempotent-todo.md.
-	// Deregistering is the better behaviour there too: gated, the earlier
-	// copy's descendants stayed registered forever.
-	if registered := root.FindByCreatedAt(value.CreatedAt()); registered != nil {
-		root.DeregisterElement(registered)
-	}
+	// normally misses and costs one map read.
+	root.UnregisterRemovedElementPair(value.CreatedAt())
 	root.RegisterElement(value)
 	if removed != nil {
 		root.RegisterRemovedElementPair(obj, removed)


### PR DESCRIPTION
## What this fixes

Undoing the removal of an **object member** restores it correctly, and then the next
garbage collection **deletes it again** — on every replica except the one that performed the
undo, and on the server.

```go
d1.Update(func(r *json.Object, _ *presence.Presence) error {
    r.SetNewObject("obj").SetInteger("k", 1)
    r.SetInteger("keep", 0)
    return nil
})
// deliver to d2
d1.Update(func(r *json.Object, _ *presence.Presence) error { r.Delete("obj"); return nil })
d1.Undo()
// deliver to d2, then collect on both
```

```
d1  {"keep":0,"obj":{"k":1}}
d2  {"keep":0}                 <- the restored key is gone
```

The server takes the same path: it replays the change log with `OpSourceReplay` to build
snapshots (`server/packs/snapshot.go:121`, `:238`) and to compact, so the key disappears
from every snapshot built afterwards and from every client that later loads one.

### Mechanism

`Set.Execute` retired the stale entry only when `source == OpSourceUndoRedo`. That is a
condition on the *state of the tree* written as a condition on *who is applying*: the undo is
generated on one replica and executed on all of them, and every one of them has the same
stale entry to clear.

Left in place, the removal's `gcElementPairMap` entry keeps pointing at the tombstone while
`ElementRHT.SetWithExecutedAt` has re-keyed `nodeMapByCreatedAt` onto the restored member.
`purge` resolves through that index and deletes the live member.

### What it retires — corrected after review

An earlier revision of this PR ungated `DeregisterElement`. A pre-merge review found, and I
reproduced, that this is too much: it walks the tombstone's descendants, and the tombstone's
descendant set can be a **strict superset** of the restored copy's, because a peer may have
added a member into the container after the undoing replica took the copy its reverse
carries. Those members lost their `elementMap` entries with nothing to put them back, and
the next change addressed at one of them failed with `ErrNotApplicableDataType` — permanently,
since the server rebuilds documents and snapshots by replaying the same change log.

`Root.UnregisterRemovedElementPair` retires the one entry that is stale, releases the charge
the orphaned subtree holds, and leaves `elementMap` alone.

The same review found the general shape: every index deletion was by key, so
`delete(elementMap, createdAt)` removed whatever occupied the slot even when a live element
had taken over the identity. That is now an identity check, `sizeInGC` records which element
a charge is held for, and `ElementRHT.purge` / `RGATreeList.purge` get the matching guard.

## The other defects fixed here

Each is its own commit.

| | |
|---|---|
| **Assigning into an array never released what it displaced.** `ArraySet.Execute` deleted the old element and discarded what the delete returned, so it was never registered for collection. Ten ordinary `arr[i] = x` assignments grew a one-integer document from `Live{8,120}` to `Live{44,336}` with nothing to collect. No undo involved. | `array_set.go` |
| **The same leak on the local path, which is what gates the size limit.** `Update` runs the updater against a clone root and checks `MaxSizeLimit` against *that* clone (`document.go:257-258`). At a limit of 300 over a baseline of 100, the eighth `arr[0] = v` was refused while `DocSize()` still reported 100. With the registration in place the same loop runs 30 times and the size never leaves 100. | `json/array.go` |
| **`RGATreeList.DeleteByCreatedAt` reported a removal that did not take.** It returned its node even when `Remove` declined — `ElementRHT` already returns nil for the same case. Harmless until something registers on the strength of the return value, which the array-set fix does. | `rga_tree_list.go`, `array.go` |
| **`GarbageCollect` had no liveness check.** Defence in depth: it cannot fire today, because nothing clears `removedAt`. It becomes load-bearing the moment anything does, and a purge that can delete a live element is the shape of this whole bug. | `root.go` |

## Verification

`pkg/document/gc_restore_test.go` and `pkg/document/gc_array_set_test.go` are new. Checked
against pristine `main`:

- `TestUndoneObjectRemoveSurvivesCollection` — RED on `main`: `expected {"keep":0,"obj":{"k":1}}`, `actual {"keep":0}`.
- `TestArraySetCollectsTheReplacedElement` — RED on `main`: `{{8 120} {0 0}}` vs `{{44 336} {0 0}}`.
- `TestArraySetDoesNotExhaustTheSizeLimit` — RED on `main`: the eighth assignment is refused.
- `TestRestoredContainerKeepsForeignDescendantsAddressable` — RED on the earlier revision of
  this branch in both subtests, and **RED on pristine `main`** in the one that collects
  before the late change arrives, which is what the server does between syncs. It asserts
  that the stored change log stays replayable. It deliberately does not assert convergence:
  the restored container still diverges, because the copy the reverse carries never held the
  peer's member. That is the revive work this release precedes.
- `TestRepeatedRestoreAndRemoveCollects` — insurance rather than a pin. It passes on `main`
  and catches collection resolving an entry through a createdAt-keyed index instead of the
  element it was registered for, which panics out of `Document.GarbageCollect`. Map
  iteration order decides which entry a pass reaches first, so it repeats 200 times.
- `TestUndoneObjectRemoveLeavesNoGarbage` passes on `main` by design. It is the guard, not
  the pin: it rejects a fix that merely *skips* the stale entry and leaves `GarbageLen`
  above zero forever.

`go build ./...`, `go vet ./...`, `gofmt -l ./pkg` (empty), `make lint` (0 issues), and
`go test -tags integration -race ./...` against a local MongoDB: all green, no data races,
including `server/packs`, which is the snapshot and compaction path this fix is about.

The JS companion was exercised against a server built from this branch: the full
`yorkie-js-sdk` integration suite, 35 files / 2587 tests, passed.

One existing test changed. `array set undo redo survives gc test` asserted zero garbage
throughout; that was the leak rather than a property — nothing was tracking the displaced
elements, so there was nothing to report. It now asserts the tombstone each assignment
leaves and that collection takes it. The document content it checks is unchanged at every
step. No other existing expectation moved.

## Cross-SDK

`docs/tasks/active/20260816-remote-redo-replica-divergence-todo.md` filed the `Set`
deregister gate and says a fix must land in both SDKs, because Go's behaviour is faithful
parity with JS rather than a regression. The companion PR is **yorkie-js-sdk#1341**; this
one should not ship without it.

That document is updated in this PR rather than only here, so the answers survive the
merge: direction 1 is recorded as taken, direction 2 as rejected on measurement, and the
items below are checked off in the file. It also gains what the fix turned out to cover —
undo of an object member removal reaches the same gate with no redo involved, and the
server's snapshot replay carries the loss forward, which is worse than the peer-only
divergence it was originally filed as.

Two of its open checklist items are answered:

- *Whether making the retirement unconditional is safe for ordinary Sets.* It is: an
  ordinary `Set` carries a freshly issued `createdAt`, so the worklist lookup misses and
  costs one map read. It hits only under duplicate application, and retiring one entry is
  the safe direction there — unlike the subtree deregister this replaced. Duplicate
  application is filed separately.
- *Whether `Remove`'s array reverse (`Add`) and `Move`'s reverse have the same gating.*
  They do not — the only `OpSourceUndoRedo`-gated deregister is the one in `set.go`. The
  array path is immune for a different reason, `executeUndoRedo` re-ticketing the restored
  element, and `TestUndoneArrayRemoveSurvivesCollection` pins that.

## Not addressed

- **Applying one change twice corrupts the `createdAt` index.** Found while fixing this and
  confirmed pre-existing back to v0.6.0. The CRDT layer is not what holds the line — the
  server boundary is, and it has a hole. `pushPack` drops a duplicate push by `clientSeq`
  and `pullChangeInfos` filters a client's own changes out of its pull, but `pushPack`
  filters the list it *stores* and leaves `reqPack.Changes` intact, and `pullSnapshot`
  applies that raw list on a document built for `initialSeq`, which is
  `docInfo.ServerSeq - len(pushables)`. On a retry where every change was skipped as
  already pushed that is the current `serverSeq`, so the document already holds them and
  `applyChanges` has no version-vector deduplication. The client then adopts the resulting
  snapshot. Needs a retry after a lost response *and* a pull gap past the snapshot
  threshold — rare, not impossible, and silent. Filed as
  `docs/tasks/active/20260911-duplicate-change-application-not-idempotent-todo.md`, which
  now carries closing `pullSnapshot` as its own task; containing the general case means
  deciding what idempotent operation application should mean.

  *(Corrected after review: this bullet previously said the server made it unreachable.
  The checkpoint prevents a change being stored twice, not applied twice.)*
- **A stored change that cannot be replayed makes the document unloadable**, since the
  server rebuilds by replaying the change log. Real operational exposure, unchanged here.
- **Undo of a removal is still expressed as re-insertion of a copy**, which is the root
  cause behind yorkie-js-sdk#1340. Fixing that needs identity-preserving revive: a
  replicated liveness register and a restore mode on the wire, i.e. protobuf plus a
  coordinated release. This PR is the containment release that precedes it.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ty1RHZcasxfCMaDmuxLvyn
