### PR TITLE
Stop collection from moving the RGA forward skip's stopping point

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,14 @@ jobs:
       - name: Build
         run: make build
 
+      - name: Vet tag-gated reproductions
+        # Files behind a build tag are not compiled by any other job, so a
+        # refactor can break them without CI noticing. Vet compiles them
+        # without running them: the reproductions are expected to FAIL when
+        # run, and that is the point of them, so they must never be executed
+        # here. See docs/tasks/active/ for what each tag reproduces.
+        run: go vet -tags rgafuzz ./...
+
       - name: Stack
         run: docker compose -f build/docker/docker-compose.yml up --build -d
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -20,6 +20,8 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| Undoing a container removal discards a peer's concurrent edit inside it (2026-09-12) | [20260912-undo-discards-concurrent-peer-edit-todo.md](./active/20260912-undo-discards-concurrent-peer-edit-todo.md) | - |
+| Collection changes where a later insert lands (2026-09-12) | [20260912-collection-changes-rga-insertion-todo.md](./active/20260912-collection-changes-rga-insertion-todo.md) | - |
 | Applying one change twice corrupts an object's createdAt index (2026-09-11) | [20260911-duplicate-change-application-not-idempotent-todo.md](./active/20260911-duplicate-change-application-not-idempotent-todo.md) | - |
 | Project Stats Long-Retention Windows Implementation Plan (2026-08-31) | [20260831-project-stats-long-retention-todo.md](./active/20260831-project-stats-long-retention-todo.md) | [20260831-project-stats-long-retention-lessons.md](./active/20260831-project-stats-long-retention-lessons.md) |
 | Tree: recover style ranges collapsed by a merge at the from anchor (2026-08-22) | [20260822-tree-style-from-side-anchor-todo.md](./active/20260822-tree-style-from-side-anchor-todo.md) | [20260822-tree-style-from-side-anchor-lessons.md](./active/20260822-tree-style-from-side-anchor-lessons.md) |

--- a/docs/tasks/active/20260912-collection-changes-rga-insertion-todo.md
+++ b/docs/tasks/active/20260912-collection-changes-rga-insertion-todo.md
@@ -109,27 +109,129 @@ successor barrier addresses one:
    references — untouched, because the successor can be perfectly stable while
    an in-flight operation points at the node being removed.
 
+
+## Attempt 3 — four framings, all reached the bar, none shippable
+
+Four framings were built and measured against the same fuzz. **All four reached
+0 of 300.** None closed the defect, and the reason matters more than the
+framings: **the acceptance criterion above was the wrong bar.** It is array-only,
+string-elements-only, no-undo, and client-side-collection-only, and every framing
+fails outside that box.
+
+| | framing | fuzz | why it is excluded |
+|---|---|---|---|
+| A | anchor barrier (attempt 2 + three gates) | 0/300 | 48 B per moved element retained in `DocSize.GC` indefinitely; Text and Tree anchor half open by the author's own admission; its load-bearing argument about server append ordering was refuted |
+| B | origin-carrying insertion rule (YATA shape) | 0/300 | two new proto fields and a flag day; array-only, and **not** a superset of attempt 2 — attempt 2's Text and Tree tests fail under it; legacy snapshots permanently sticky |
+| C | retain the position node, collect only content | 0/300 | author reported `viable: false`. `docSize = base + 48·edits` with no asymptote, 111× snapshot at 10k edits, and it **refuses assignment 5 of 30** under `MaxSizeLimit` |
+| D | reference discipline (fix the anchor producers) | 0/300 | refuted twice independently, on correctness and on cost |
+
+D was the right candidate on paper — 323 production lines, no schema change, zero
+upstream tests modified — and it is the one most thoroughly destroyed.
+
+### The measured ceilings — this is the real result
+
+Every number from the same faithful `advServer` harness, with paired attribution
+where the control is dirty: run each seed twice, differing only in the vector
+handed to `GarbageCollect`, and count only seeds where the control **passes** and
+collection-on **fails**. `onlyControlFails` was 0 in every cell.
+
+**Array, no undo, string elements — solved.** A, B and D all reach 0, and D was
+then attacked with 8,000 nested-container runs and 12,000 server-replay runs it
+was never tuned against — both of which fail on `main` at 155-402 and 143-277 per
+1000 — with **zero** failures.
+
+**Array + undo/redo — open.** 2000 seeds per cell:
+
+| clients | main | framing D |
+|---|---|---|
+| 2 | 295 (childNotFound 214, diverged 81) | 66 |
+| 3 | 440 (320 / 120) | 107 |
+| 4 | 751 (558 / 193) | 198 |
+| 5 | 979 (723 / 256) | 327 |
+
+D cuts it about 70% and removes the silent-divergence class entirely, but does
+not reach 0. Four failing call sites, all `child not found`: `MoveAfter`,
+`insertAfter`, `FindPrevCreatedAt`, `DeleteByCreatedAt`. The anchors the history
+stack captures when a forward op is issued, and executes arbitrarily later, are
+a producer site no framing enumerated.
+
+**Text — open, one mechanism.** 2000 seeds per cell, 2/3/4 clients: main
+269/291/300 → D 235/233/243. Every failure is `the node of the given id should
+be found`.
+
+**Tree — open, one mechanism.** main 207/252/297 → D 177/199/240. Every failure
+is `node not found`.
+
+So attempt 2's successor barrier — the only thing A and D do for Text and Tree —
+buys 15-20% there and nothing more. The anchor half in those two structures is
+now **measured** rather than admitted, and it is one mechanism each, the same one.
+
+### What killed D on cost, measured here
+
+D's own retention fixture re-moves a handful of elements by index and retains
+exactly 7 slots at every array size, so its reported cost is independent of the
+array. On a **drag-reorder** — each element moved once, the canonical move
+workload — retention is n−1:
+
+| n=200, collect after each move | main | framing D |
+|---|---|---|
+| `garbageLen` | 0 | 199 |
+| `DocSize` total | 6472 | 16024 (+148%) |
+| `DocSize.GC` meta | 0 | 9552 — twice the live metadata |
+
+`DocSize.Total` feeds `MaxSizeLimit`, so this is enforced and user-visible: a
+20-element array under a 1000-byte limit accepts all 19 drags on `main` and is
+**refused at move 8** under D. Idle `GarbageCollect` also regresses about
+5,200× at n=1000, which no existing test covers.
+
+### Framings now closed by evidence
+
+- **Constrain collection with a better predicate** (attempts 1, 2, 3A) — the
+  predicate is not one ticket. It is at least three structural facts, and each
+  one found adds retention. A reaches the array bar and pays 48 B per moved
+  element forever.
+- **Change the insertion rule** (3B) — costs a wire change and a flag day, and
+  did not even generalise to Text and Tree, which is where the cheap win was
+  supposed to be.
+- **Retain the structure** (3C) — unbounded by measurement, and its own author
+  declared it unshippable.
+
+What is left is the anchor half in `Text` and `Tree`, plus the history stack's
+captured anchors — and the only framing that removes the dependency rather than
+constraining collection needs a wire change. **That places this defect with the
+identity-preserving revive work rather than as a standalone fix**, which is where
+this filing now recommends it goes.
+
+### Artifacts
+
+Four diffs, none proposed for merge. `wip/rga-successor-barrier` carries attempt
+2. Attempt 3's four diffs were produced in session worktrees; D is the smallest
+and the best documented, and a fourth attempt should start from the ceilings
+table above rather than from any of the diffs.
+
 ## Tasks
 
-- [ ] Decide whether attempt 2 ships on its own. It is strictly better in every
-      measured category and costs little, but it is a partial fix for a
-      convergence bug, and both mechanisms share a root — a complete fix may
-      have to undo its shape. The artifacts are preserved (see below)
+- [x] ~~Decide whether attempt 2 ships on its own~~ — no. Attempt 3 superseded
+      the question: three framings beat it on the array bar and none is
+      shippable, so shipping the weakest of them buys nothing
+- [ ] **Carry the anchor half into the wire-format work.** That is attempt 3's
+      conclusion and the reason this is not a standalone fix
 - [ ] Close the anchor mechanism, or establish that it is unreachable through
       the real push/pull path. Attempt 2's author argued unreachability from
       reading `pushpull.go` and `document.go` and was explicit that it was an
       argument and not a measurement; the fuzz above reaches it
-- [ ] Decide about `findNextBeforeExecutedAt` itself. Making the skip read
-      nothing collection can remove means each node carrying its own anchor id
-      and a comparison over anchors — the YATA/Yjs shape. That is a permanent
-      per-node ticket on every array, text and tree node, on the wire and in
-      snapshots, plus a rewritten insertion rule in both SDKs. Rejected in
-      attempt 2 on cost; it is the only direction that removes the dependency
-      rather than constraining collection
+- [x] ~~Decide about `findNextBeforeExecutedAt` itself~~ — built in attempt 3
+      (framing B). Two new proto fields, a flag day, legacy snapshots
+      permanently sticky, and it did not generalise to Text or Tree. It remains
+      the only direction that removes the dependency, which is why the
+      conclusion is to take it inside the wire-format work rather than alone
 - [ ] Whatever is chosen, the JS SDK needs the identical decision — the same
       three skips exist there
-- [ ] Keep the fuzz as the acceptance criterion. "Fixed" means the
-      collection-on run matches the collection-off control
+- [ ] **Replace the acceptance criterion.** The array/no-undo/strings fuzz is
+      met by three independent framings and is therefore no longer
+      discriminating. A real bar needs undo/redo in the op mix, `Text` and
+      `Tree` harnesses, and paired attribution so a dirty control does not hide
+      the signal — all three exist in the attempt 3 transcripts
 
 ## Reproduction and artifacts
 

--- a/docs/tasks/active/20260912-collection-changes-rga-insertion-todo.md
+++ b/docs/tasks/active/20260912-collection-changes-rga-insertion-todo.md
@@ -7,8 +7,10 @@ garbage collection. Pre-existing on `main`; not introduced by the containment
 release (`f2533292`). Present in **all three** RGA-shaped structures — `Array`,
 `Text` and `Tree`.
 
-Two fixes were attempted and both were refuted by measurement. This filing
-records what they established so a third attempt does not repeat them.
+Three attempts were made. Attempt 2 **ships in this PR as a partial fix** — it
+closes the stopping-point half in all three structures and leaves the anchor
+half open. Attempts 1 and 3 were refuted by measurement, and this filing records
+what they established so a fourth attempt does not repeat them.
 
 ## Problem
 
@@ -74,7 +76,7 @@ moves by different actors leave those unordered, and a legitimate `minVV` can
 cover `m2` while `m1` is in flight. Refuted independently by two reviewers with
 the same counterexample.
 
-## Attempt 2 — a real improvement, still not a fix
+## Attempt 2 — ships here, as a partial fix
 
 Reframed the barrier as a property of the **successor**, not of the node being
 purged:
@@ -101,8 +103,8 @@ Retention cost measured at +5.2% mean collected pairs on a move-heavy workload
 and byte-identical to `main` on ordinary ones; it drains within one sync round
 and is charged to `DocSize.Total`, so `MaxSizeLimit` accounts for it.
 
-**It does not close the bug.** Purging a tombstone destroys two things and the
-successor barrier addresses one:
+**It does not close the bug, and it is not presented as closing it.** Purging a
+tombstone destroys two things and the successor barrier addresses one:
 
 1. the skip's stopping point — closed by attempt 2;
 2. the **anchor** that an operation concurrent with the removal still
@@ -211,9 +213,17 @@ table above rather than from any of the diffs.
 
 ## Tasks
 
-- [x] ~~Decide whether attempt 2 ships on its own~~ — no. Attempt 3 superseded
-      the question: three framings beat it on the array bar and none is
-      shippable, so shipping the weakest of them buys nothing
+- [x] ~~Decide whether attempt 2 ships on its own~~ — **yes, it ships here.**
+      This reverses an earlier decision in this file, and the earlier reasoning
+      was wrong in a way worth recording: it argued that three framings beat
+      attempt 2 on the array bar and none of them is shippable, therefore
+      "shipping the weakest of them buys nothing". If every alternative is
+      unshippable then the comparison against them carries no information, and
+      attempt 2 has to be judged on its own record. That record is every fuzz
+      category improved with none regressed, one class of silent divergence
+      eliminated outright, and a cost that no workload has been found to
+      distinguish from `main` — including the drag-reorder that disqualified
+      framing D. "Not a complete fix" is not "not worth shipping"
 - [ ] **Carry the anchor half into the wire-format work.** That is attempt 3's
       conclusion and the reason this is not a standalone fix
 - [ ] Close the anchor mechanism, or establish that it is unreachable through
@@ -235,15 +245,25 @@ table above rather than from any of the diffs.
 
 ## Reproduction and artifacts
 
-`pkg/document/gc_rga_fuzz_test.go` in this filing holds the harness, skipped
-because it fails on `main` — that is the point of it. Remove the skip to run it.
+`pkg/document/gc_rga_fuzz_test.go` holds the harness, behind the `rgafuzz` build
+tag because it is expected to fail — that is the point of it. It still fails with
+attempt 2 applied, at 33 of 300 rather than 43, and the remaining failures are
+the anchor half. `go vet -tags rgafuzz ./...` runs in CI so a refactor cannot rot
+it without running it.
 
-Attempt 2 is preserved on the branch `wip/rga-successor-barrier`, not for merge.
-It carries the successor-barrier change and four targeted regression tests —
-array remove+move, concurrent moves with a server-computed `minVV`, the same
-defect in `Text`, the same defect in `Tree` — each verified red on `main` and
-green with the fix. A third attempt should start from there rather than from
-scratch.
+Attempt 2 ships here: the successor-barrier change plus four targeted regression
+tests — array remove+move, concurrent moves with a server-computed `minVV`, the
+same defect in `Text`, the same defect in `Tree` — each verified red on `main`
+and green with the fix. `gc_rga_barrier_cost_test.go` pins the cost shape rather
+than a golden number, because a misleading cost fixture is exactly what let
+framing D look affordable.
+
+A fourth attempt should start from the ceilings table above, not from any of the
+attempt 3 diffs. Those are preserved, none proposed for merge:
+`wip/rga-anchor-barrier` (framing A, and its commit message records the three
+structural gates it had to discover), `wip/rga-origin-insertion` (framing B, the
+only direction that removes the dependency rather than constraining collection),
+`wip/rga-reference-discipline` (framing D).
 
 ## See Also
 

--- a/docs/tasks/active/20260912-collection-changes-rga-insertion-todo.md
+++ b/docs/tasks/active/20260912-collection-changes-rga-insertion-todo.md
@@ -99,9 +99,37 @@ Measured against `main` on the same fuzz:
 | 1000 seeds, all ops: `ErrChildNotFound` | 26 | **18** |
 
 Better in every category, and it eliminates insert/delete divergence entirely.
-Retention cost measured at +5.2% mean collected pairs on a move-heavy workload
-and byte-identical to `main` on ordinary ones; it drains within one sync round
-and is charged to `DocSize.Total`, so `MaxSizeLimit` accounts for it.
+
+### The cost, corrected
+
+An earlier revision of this file claimed the retention was byte-identical to
+`main` on ordinary workloads and that no workload had been found where it costs
+more. **That was wrong, and the integration suite found the counterexample.**
+The fixtures behind the claim were single-document array `MoveFront` sequences,
+which never engage the barrier at all: they retain the same nodes on both
+branches, so "no difference" measured nothing.
+
+What the barrier actually costs is **one sync round of delay in ordinary
+multi-client text editing**, which is the common case rather than an exotic one.
+Seven assertions across four of the version-vector GC contract tests in
+`test/integration/gc_test.go` expected zero garbage at a point where the barrier
+still holds one tombstone, because purging it would move the stopping point of a
+forward skip a concurrent insert still depends on.
+
+It is a delay and not a leak, which is the distinction that disqualified framings
+C and D, and it is pinned rather than argued:
+`TestGarbageCollectionBarrierDrainsWithinOneRound` replays the same sequence and
+keeps syncing with no further edits — retention goes to zero on the next round,
+stays there, and the replicas agree on the expected document.
+
+The cost is charged to `DocSize.Total`, so `MaxSizeLimit` accounts for it, and it
+is bounded by how far the collection vector lags rather than by the size of the
+structure. `pkg/document/gc_rga_barrier_cost_test.go` pins that shape, including
+the drag-reorder that refused framing D's 8th of 19 moves under a byte limit and
+is unaffected here.
+
+The general lesson, which is the same one framing D's cost fixture taught: a cost
+fixture that does not engage the mechanism reports a number about nothing.
 
 **It does not close the bug, and it is not presented as closing it.** Purging a
 tombstone destroys two things and the successor barrier addresses one:
@@ -248,8 +276,13 @@ table above rather than from any of the diffs.
 `pkg/document/gc_rga_fuzz_test.go` holds the harness, behind the `rgafuzz` build
 tag because it is expected to fail — that is the point of it. It still fails with
 attempt 2 applied, at 33 of 300 rather than 43, and the remaining failures are
-the anchor half. `go vet -tags rgafuzz ./...` runs in CI so a refactor cannot rot
-it without running it.
+the anchor half.
+
+CI runs `go vet -tags rgafuzz ./...`, which type-checks the tagged files without
+executing them, so a refactor cannot rot the harness and CI never runs the
+failures. Reproduce them deliberately with:
+
+    go test -tags rgafuzz ./pkg/document/ -run TestAdvArray -v
 
 Attempt 2 ships here: the successor-barrier change plus four targeted regression
 tests — array remove+move, concurrent moves with a server-computed `minVV`, the

--- a/docs/tasks/active/20260912-collection-changes-rga-insertion-todo.md
+++ b/docs/tasks/active/20260912-collection-changes-rga-insertion-todo.md
@@ -1,0 +1,147 @@
+# Collection changes where a later insert lands
+
+**Created**: 2026-09-12
+
+Permanent replica divergence, and separately hard apply failures, caused by
+garbage collection. Pre-existing on `main`; not introduced by the containment
+release (`f2533292`). Present in **all three** RGA-shaped structures — `Array`,
+`Text` and `Tree`.
+
+Two fixes were attempted and both were refuted by measurement. This filing
+records what they established so a third attempt does not repeat them.
+
+## Problem
+
+RGA decides where an insert lands by walking forward from its anchor, skipping
+nodes whose positioning ticket is newer than the incoming operation. The walk
+reads the nodes **currently linked into the list, tombstones included**:
+
+    pkg/document/crdt/rga_tree_list.go:526   node.next.PositionedAt().After(executedAt)   (Array)
+    pkg/document/crdt/rga_tree_split.go:437  node.next.createdAt().After(updatedAt)       (Text)
+    pkg/document/crdt/tree.go:2998           !next.id.CreatedAt.After(editedAt)           (Tree)
+
+Collection unlinks exactly those nodes (`RGATreeList.release`, and the
+equivalents). So **collection mutates the input to the insertion rule**, and the
+insertion point stops being a function of state the replicas agree on — which is
+what RGA convergence requires.
+
+Two replicas that differ *only* in whether collection has run therefore order the
+same later insert differently, and nothing reconverges them.
+
+The general statement: **tombstones are load-bearing for the forward skip.** A
+position slot abandoned by `MoveAfter` is simply another species of tombstone
+that inherits this; the defect is not move-specific and a plain `Delete`
+reproduces it.
+
+## Measurements
+
+A fuzz harness with a push/pull model faithful to `pushpull.go` — each client's
+row stored from its request's version vector at push time, own changes filtered
+out of the pull, `minVV` the element-wise minimum over rows, and collection run
+only by `Document.ApplyChangePack` with the vector that pull delivered. No
+`helper.MaxVersionVector` anywhere.
+
+On `main`:
+
+| workload | result |
+|---|---|
+| 300 seeds, all operations, collection **on** | 43 diverged or errored |
+| 300 seeds, all operations, collection **off** | 0 — converges |
+| 1000 seeds, insert + delete only | 4 diverged, 75 `ErrChildNotFound` |
+| 1000 seeds, all operations | 109 diverged, 26 `ErrChildNotFound` |
+
+The collection-off control is the load-bearing one: the same seeds converge when
+nothing is collected, so collection is the sole cause.
+
+Note the second failure mode. Beyond divergence, the walk can be handed an
+anchor that collection removed, and the operation then fails to apply —
+`ErrChildNotFound` in the array, "offset should be less than or equal to length"
+in text. An operation that cannot apply is worse than one that applies
+differently: the server rebuilds documents and snapshots by replaying the change
+log, so a stored change that fails to apply makes the document unloadable.
+
+## Attempt 1 — refuted
+
+Barrier on the node being purged: an element a move rehomed may not be purged on
+its `removedAt` alone. Guarded the `gcElementPairMap` loop in
+`Root.GarbageCollect` and left the `gcNodePairMap` loop, on the argument that a
+move's gate (the move ticket) is always causally after its barrier (the
+element's original insert ticket).
+
+**True only for the first move.** `MoveAfter` abandons the node the *first* move
+created, so a second move's dead slot has barrier `m1` and gate `m2`. Concurrent
+moves by different actors leave those unordered, and a legitimate `minVV` can
+cover `m2` while `m1` is in flight. Refuted independently by two reviewers with
+the same counterexample.
+
+## Attempt 2 — a real improvement, still not a fix
+
+Reframed the barrier as a property of the **successor**, not of the node being
+purged:
+
+> A purge may unlink a node only if the node that would become the forward
+> skip's new stopping point is itself causally stable.
+
+This is the better framing — it needs no case analysis about what a particular
+slot's barrier is, which is exactly what made attempt 1 wrong, and one rule
+covers both purge loops and all three structures.
+
+Measured against `main` on the same fuzz:
+
+| | main | attempt 2 |
+|---|---|---|
+| 300 seeds, collection on | 43 | **33** |
+| 1000 seeds, insert+delete: diverged | 4 | **0** |
+| 1000 seeds, insert+delete: `ErrChildNotFound` | 75 | **40** |
+| 1000 seeds, all ops: diverged | 109 | **84** |
+| 1000 seeds, all ops: `ErrChildNotFound` | 26 | **18** |
+
+Better in every category, and it eliminates insert/delete divergence entirely.
+Retention cost measured at +5.2% mean collected pairs on a move-heavy workload
+and byte-identical to `main` on ordinary ones; it drains within one sync round
+and is charged to `DocSize.Total`, so `MaxSizeLimit` accounts for it.
+
+**It does not close the bug.** Purging a tombstone destroys two things and the
+successor barrier addresses one:
+
+1. the skip's stopping point — closed by attempt 2;
+2. the **anchor** that an operation concurrent with the removal still
+   references — untouched, because the successor can be perfectly stable while
+   an in-flight operation points at the node being removed.
+
+## Tasks
+
+- [ ] Decide whether attempt 2 ships on its own. It is strictly better in every
+      measured category and costs little, but it is a partial fix for a
+      convergence bug, and both mechanisms share a root — a complete fix may
+      have to undo its shape. The artifacts are preserved (see below)
+- [ ] Close the anchor mechanism, or establish that it is unreachable through
+      the real push/pull path. Attempt 2's author argued unreachability from
+      reading `pushpull.go` and `document.go` and was explicit that it was an
+      argument and not a measurement; the fuzz above reaches it
+- [ ] Decide about `findNextBeforeExecutedAt` itself. Making the skip read
+      nothing collection can remove means each node carrying its own anchor id
+      and a comparison over anchors — the YATA/Yjs shape. That is a permanent
+      per-node ticket on every array, text and tree node, on the wire and in
+      snapshots, plus a rewritten insertion rule in both SDKs. Rejected in
+      attempt 2 on cost; it is the only direction that removes the dependency
+      rather than constraining collection
+- [ ] Whatever is chosen, the JS SDK needs the identical decision — the same
+      three skips exist there
+- [ ] Keep the fuzz as the acceptance criterion. "Fixed" means the
+      collection-on run matches the collection-off control
+
+## Reproduction and artifacts
+
+`pkg/document/gc_rga_fuzz_test.go` in this filing holds the harness, skipped
+because it fails on `main` — that is the point of it. Remove the skip to run it.
+
+Attempt 2's four targeted regression tests (array remove+move, concurrent moves
+with a server-computed `minVV`, the same defect in `Text`, the same defect in
+`Tree`) and its production diff are preserved outside the repository; all four
+were verified red on `main` and green with the fix.
+
+## See Also
+
+- `docs/tasks/active/20260912-undo-discards-concurrent-peer-edit-todo.md` — the
+  other divergence found in the same investigation, on the content side

--- a/docs/tasks/active/20260912-collection-changes-rga-insertion-todo.md
+++ b/docs/tasks/active/20260912-collection-changes-rga-insertion-todo.md
@@ -136,10 +136,12 @@ successor barrier addresses one:
 `pkg/document/gc_rga_fuzz_test.go` in this filing holds the harness, skipped
 because it fails on `main` — that is the point of it. Remove the skip to run it.
 
-Attempt 2's four targeted regression tests (array remove+move, concurrent moves
-with a server-computed `minVV`, the same defect in `Text`, the same defect in
-`Tree`) and its production diff are preserved outside the repository; all four
-were verified red on `main` and green with the fix.
+Attempt 2 is preserved on the branch `wip/rga-successor-barrier`, not for merge.
+It carries the successor-barrier change and four targeted regression tests —
+array remove+move, concurrent moves with a server-computed `minVV`, the same
+defect in `Text`, the same defect in `Tree` — each verified red on `main` and
+green with the fix. A third attempt should start from there rather than from
+scratch.
 
 ## See Also
 

--- a/docs/tasks/active/20260912-undo-discards-concurrent-peer-edit-todo.md
+++ b/docs/tasks/active/20260912-undo-discards-concurrent-peer-edit-todo.md
@@ -1,0 +1,122 @@
+# Undoing a container removal discards a peer's concurrent edit inside it
+
+**Created**: 2026-09-12
+
+Permanent replica divergence with user-visible edit loss, reachable with two
+clients and no garbage collection. Pre-existing on `main`; **not** introduced by
+the containment release (`f2533292`), which contains a neighbouring family.
+
+Filed rather than fixed: it was investigated to the point of establishing that
+**no fix converges without the wire format change**, which is the
+identity-preserving revive work ("train 1"). The evidence for that is below, so
+the question does not have to be reopened from scratch.
+
+## Problem
+
+    d1 and d2 share  {"c":{"a":"1"}}
+    d2: c.b = "2"                   -- not yet delivered
+    d1: delete c ; undo             -- d1 has never seen d2's edit
+    deliver d2 -> d1, then d1 -> d2
+
+    d1 = {"c":{"a":"1","b":"2"}}   Live{4,168}
+    d2 = {"c":{"a":"1"}}           Live{2,120}
+
+Unchanged after `GarbageCollect` on both with a max version vector. The peer's
+own edit is the one that vanishes, on the peer.
+
+The order matters and only one order diverges: delivering the peer's edit
+*before* the undo converges. That asymmetry is the defect, not a mitigation.
+
+## Mechanism
+
+The reverse of a `Remove` is a `Set` carrying `value.DeepCopy()`, taken at
+removal time (`operations/remove.go:112-126`). Applying it is a whole-subtree
+install that re-points every createdAt-keyed index at the copy:
+
+- `operations/set.go:93` — `value, err := o.value.DeepCopy()`
+- `operations/set.go:103` — `obj.SetWithExecutedAt(...)`, which at
+  `crdt/element_rht.go:142` does `rht.nodeMapByCreatedAt[v.CreatedAt().Key()] = newNode`
+- `operations/set.go:134` — `root.RegisterElement(value)`, which at
+  `crdt/root.go:141-152` writes `r.elementMap[...]` for the element **and every
+  descendant, each under its original createdAt**
+
+The read side that forks is `operations/set.go:57` —
+`parent := root.FindByCreatedAt(o.parentCreatedAt)`.
+
+So one `createdAt` names two different element instances at two different points
+in the document's life, and an operation addressed at that `createdAt` lands on
+whichever instance owns it **at apply time**, which delivery order decides. A
+whole-subtree install does not commute with an operation addressed *inside* the
+subtree.
+
+There is no reconvergence path. The losing side's original subtree is orphaned
+but stays in `Root.elementMap`; `Set.Execute`'s `UnregisterRemovedElementPair`
+(`set.go:134`) retires its collection entry, so `GarbageLen` is 0 and no pass
+will ever visit it. Nothing re-examines an already-applied operation.
+
+## Why re-ticketing does not fix it
+
+The obvious cheap fix is to give the restored subtree a fresh `createdAt`, the
+way `executeUndoRedo` already does for the array path
+(`document.go:449-451`, `addOp.Value().SetCreatedAt(ticket)` plus
+`history.ReconcileCreatedAt`).
+
+**The array path already re-tickets and still diverges**, because descendants
+are never re-ticketed. The peer's operation is addressed at a *descendant*, and
+identity reuse anywhere inside the installed subtree is sufficient. This is
+pinned by `TestRestoredSubtreeDropsConcurrentDescendantEdit`, which shows the
+object and array parents failing the same way for the same reason — so
+`TestUndoneArrayRemoveSurvivesCollection` passing does **not** mean the array
+path is safe here.
+
+## Why "revive the tombstone instead" does not fix it either
+
+The replica performing the undo usually still has the tombstone, so it could
+revive in place rather than install a copy. It cannot be made to converge with
+local state alone:
+
+- a replica that collected between receiving the removal and receiving the undo
+  has purged the tombstone;
+- a replica that joined by loading a snapshot taken after that collection never
+  had it.
+
+Whether a replica *can* revive is therefore a function of its local collection
+timing, not of the change log — so "revive when the tombstone is there" produces
+different documents on different replicas from the same log. Measured by
+`TestRestoreTombstoneIsNotReliablyPresent`, which passes on `main` today.
+
+That is the whole argument for putting the decision **on the wire**: every
+replica must take the same branch, which means the branch cannot be chosen from
+local state.
+
+## Reproduction
+
+`pkg/document/restore_divergence_test.go` in the investigation worktree holds
+three tests. Two assert convergence and therefore **fail on `main`**; they are
+the reproduction, not a regression suite, and must not be committed to CI until
+the fix lands:
+
+- `TestRestoredContainerDropsConcurrentPeerEdit` — both delivery orders
+- `TestRestoredSubtreeDropsConcurrentDescendantEdit` — object and array parents
+
+The third, `TestRestoreTombstoneIsNotReliablyPresent`, passes today and is a
+characterization test of the precondition; it is safe to land as-is.
+
+## Tasks
+
+- [ ] Land `TestRestoreTombstoneIsNotReliablyPresent` on its own — it is green
+      and it pins the argument that the branch cannot be chosen locally
+- [ ] Adopt the two failing tests as **acceptance tests for train 1**, not as
+      regressions. They are what "train 1 worked" means for this defect
+- [ ] Decide whether this warrants an advisory before train 1 ships. It is
+      silent, it loses a user's own edit, and there is no operator-visible
+      signal — `GarbageLen` is 0 and `docSize` closes
+- [ ] Re-check after train 1's content-authority rule is implemented. The rule
+      chosen for train 1 (tombstone-authoritative revive, with the carried
+      payload used only when the tombstone is gone) is what closes this; confirm
+      against these two tests rather than against the design document
+
+## See Also
+
+- `docs/tasks/active/20260816-remote-redo-replica-divergence-todo.md` — the
+  collecting filing for undo/redo defects; this one is its content-side twin

--- a/docs/tasks/active/20260912-undo-discards-concurrent-peer-edit-todo.md
+++ b/docs/tasks/active/20260912-undo-discards-concurrent-peer-edit-todo.md
@@ -104,8 +104,9 @@ characterization test of the precondition; it is safe to land as-is.
 
 ## Tasks
 
-- [ ] Land `TestRestoreTombstoneIsNotReliablyPresent` on its own — it is green
-      and it pins the argument that the branch cannot be chosen locally
+- [x] ~~Land `TestRestoreTombstoneIsNotReliablyPresent` on its own~~ — landed in
+      `pkg/document/restore_precondition_test.go`. It is green and it pins the
+      argument that the branch cannot be chosen locally
 - [ ] Adopt the two failing tests as **acceptance tests for train 1**, not as
       regressions. They are what "train 1 worked" means for this defect
 - [ ] Decide whether this warrants an advisory before train 1 ships. It is

--- a/pkg/document/crdt/array.go
+++ b/pkg/document/crdt/array.go
@@ -48,6 +48,12 @@ func (a *Array) Purge(elem Element) error {
 	return a.elements.purge(elem)
 }
 
+// PurgeBarrierAt implements GCBarrier[Element]: purging an element unlinks the
+// position node holding it, so the array's order decides when that is safe.
+func (a *Array) PurgeBarrierAt(elem Element) *time.Ticket {
+	return a.elements.purgeBarrierAt(elem)
+}
+
 // Add adds the given element at the last.
 func (a *Array) Add(elem Element) error {
 	return a.elements.Add(elem)

--- a/pkg/document/crdt/gc.go
+++ b/pkg/document/crdt/gc.go
@@ -48,3 +48,35 @@ type GCChild interface {
 	RemovedAt() *time.Ticket
 	DataSize() resource.DataSize
 }
+
+// GCBarrier is an optional capability of a GC parent whose surviving order is
+// decided by which nodes are still linked.
+//
+// Every such container resolves a concurrent insert by walking forward from the
+// anchor and stopping at the first node whose positioning ticket does not
+// follow the insert: RGATreeList.findNextBeforeExecutedAt, RGATreeSplit's skip
+// in findNodeWithSplit, and Tree's sibling skip in findNodesAndSplitText. The
+// walk reads the nodes currently linked, tombstones included, so a tombstone
+// with a small ticket is a hard barrier that ends the walk. Purging it physi-
+// cally unlinks it, which means collection mutates the input to the insertion
+// rule: a replica that has collected sends a still-in-flight insert past the
+// node behind the tombstone, a replica that has not does not, and the two
+// orders never reconverge.
+//
+// removedAt alone does not authorise the unlink. What does is the node that
+// would become the walk's new stopping point: once that node is causally
+// stable, every future insert carries a ticket after it, so every future walk
+// stops there whether or not the tombstone in front of it still exists, and the
+// insert lands in the same place either way. That successor's positioning
+// ticket is what PurgeBarrierAt reports, and Root.GarbageCollect holds the
+// purge back until the version vector covers it as well as removedAt.
+//
+// The type parameter is only there because the two purge paths name their child
+// differently: Root.GarbageCollect walks removed elements as Element and
+// removed nodes as GCChild, and both end in the same physical unlink.
+type GCBarrier[C any] interface {
+	// PurgeBarrierAt returns the additional ticket that must be covered before
+	// the given child may be unlinked, or nil when the child has no successor
+	// and unlinking it cannot move anything.
+	PurgeBarrierAt(child C) *time.Ticket
+}

--- a/pkg/document/crdt/rga_tree_list.go
+++ b/pkg/document/crdt/rga_tree_list.go
@@ -498,6 +498,40 @@ func (a *RGATreeList) Purge(child GCChild) error {
 	return nil
 }
 
+// PurgeBarrierAt implements GCBarrier[GCChild] for the dead position nodes a
+// move leaves behind: the ticket that must be covered before this slot may be
+// unlinked is the one findNextBeforeExecutedAt would read in its place.
+func (a *RGATreeList) PurgeBarrierAt(child GCChild) *time.Ticket {
+	node, ok := child.(*RGATreeListNode)
+	if !ok {
+		return nil
+	}
+	return successorBarrierAt(node)
+}
+
+// purgeBarrierAt is the same barrier for a removed element, reached through the
+// position node currently holding it.
+func (a *RGATreeList) purgeBarrierAt(elem Element) *time.Ticket {
+	entry, ok := a.elementMapByCreatedAt[elem.CreatedAt().Key()]
+	// Same identity guard as purge below: an entry now holding a different
+	// element is not this element's position, and purge declines anyway.
+	if !ok || entry.elem != elem {
+		return nil
+	}
+	return successorBarrierAt(entry.positionNode)
+}
+
+// successorBarrierAt returns the positioning ticket of the node that would take
+// over as findNextBeforeExecutedAt's stopping point once the given node is
+// unlinked. Nil at the tail: with nothing behind it, unlinking cannot send an
+// insert past anything.
+func successorBarrierAt(node *RGATreeListNode) *time.Ticket {
+	if node == nil || node.next == nil {
+		return nil
+	}
+	return node.next.PositionedAt()
+}
+
 // purge physically purge child element.
 func (a *RGATreeList) purge(elem Element) error {
 	entry, ok := a.elementMapByCreatedAt[elem.CreatedAt().Key()]

--- a/pkg/document/crdt/rga_tree_split.go
+++ b/pkg/document/crdt/rga_tree_split.go
@@ -1083,6 +1083,19 @@ func (s *RGATreeSplit[V]) ToTestString() string {
 }
 
 // Purge physically purge the given node from RGATreeSplit.
+// PurgeBarrierAt implements GCBarrier[GCChild]. findNodeWithSplit skips forward
+// while node.next was created after the incoming edit, so a tombstone whose
+// createdAt precedes the edit stops that walk. Unlinking it hands the next node
+// the stopping decision, which is only the same decision once that node is
+// causally stable.
+func (s *RGATreeSplit[V]) PurgeBarrierAt(child GCChild) *time.Ticket {
+	node, ok := child.(*RGATreeSplitNode[V])
+	if !ok || node.next == nil {
+		return nil
+	}
+	return node.next.createdAt()
+}
+
 func (s *RGATreeSplit[V]) Purge(child GCChild) error {
 	node := child.(*RGATreeSplitNode[V])
 

--- a/pkg/document/crdt/root.go
+++ b/pkg/document/crdt/root.go
@@ -373,8 +373,36 @@ func (r *Root) DeepCopy() (*Root, error) {
 }
 
 // GarbageCollect purge elements that were removed before the given time.
+//
+// A pass can hold a purge back (see GCBarrier), and holding one back can be the
+// only reason another is held back: purging a node hands its successor to the
+// node in front of it, and that successor is one this pass already found
+// stable. So a pass that both purged and deferred may have more to do, and the
+// loop repeats until a pass purges nothing new or defers nothing. Everything
+// held back stays on the worklist for the next vector that covers it.
+//
+// The repeat also makes the result independent of Go's map iteration order,
+// which decides only how many passes it takes, not what ends up collected.
 func (r *Root) GarbageCollect(vector time.VersionVector) (int, error) {
 	count := 0
+
+	for {
+		purged, deferred, err := r.collect(vector)
+		if err != nil {
+			return 0, err
+		}
+		count += purged
+
+		if purged == 0 || deferred == 0 {
+			return count, nil
+		}
+	}
+}
+
+// collect runs one collection pass, reporting how much it purged and how much
+// it held back on a barrier.
+func (r *Root) collect(vector time.VersionVector) (int, int, error) {
+	count, deferred := 0, 0
 
 	for _, pair := range r.gcElementPairMap {
 		// A registered pair is a claim that its element is a tombstone, and
@@ -402,28 +430,49 @@ func (r *Root) GarbageCollect(vector time.VersionVector) (int, error) {
 			continue
 		}
 
-		if vector.EqualToOrAfter(pair.elem.RemovedAt()) {
-			if err := pair.parent.Purge(pair.elem); err != nil {
-				return 0, err
-			}
-
-			count += r.deregisterElement(pair.elem)
+		if !vector.EqualToOrAfter(pair.elem.RemovedAt()) {
+			continue
 		}
+
+		// A tombstone is not only a value that is gone, it is also a place in
+		// its parent that other replicas may still be deciding against.
+		// removedAt covers the value; GCBarrier covers the place.
+		if parent, ok := pair.parent.(GCBarrier[Element]); ok {
+			if at := parent.PurgeBarrierAt(pair.elem); at != nil && !vector.EqualToOrAfter(at) {
+				deferred++
+				continue
+			}
+		}
+
+		if err := pair.parent.Purge(pair.elem); err != nil {
+			return 0, 0, err
+		}
+
+		count += r.deregisterElement(pair.elem)
 	}
 
 	for _, pair := range r.gcNodePairMap {
-		if vector.EqualToOrAfter(pair.Child.RemovedAt()) {
-			if err := pair.Parent.Purge(pair.Child); err != nil {
-				return 0, err
-			}
-
-			r.docSize.GC.Sub(pair.Child.DataSize())
-			delete(r.gcNodePairMap, pair.Child.IDString())
-			count++
+		if !vector.EqualToOrAfter(pair.Child.RemovedAt()) {
+			continue
 		}
+
+		if parent, ok := pair.Parent.(GCBarrier[GCChild]); ok {
+			if at := parent.PurgeBarrierAt(pair.Child); at != nil && !vector.EqualToOrAfter(at) {
+				deferred++
+				continue
+			}
+		}
+
+		if err := pair.Parent.Purge(pair.Child); err != nil {
+			return 0, 0, err
+		}
+
+		r.docSize.GC.Sub(pair.Child.DataSize())
+		delete(r.gcNodePairMap, pair.Child.IDString())
+		count++
 	}
 
-	return count, nil
+	return count, deferred, nil
 }
 
 // ElementMapLen returns the size of element map.

--- a/pkg/document/crdt/tree.go
+++ b/pkg/document/crdt/tree.go
@@ -970,6 +970,24 @@ func (t *Tree) Marshal() string {
 }
 
 // Purge physically purges the given node.
+// PurgeBarrierAt implements GCBarrier[GCChild]. findNodesAndSplitText walks the
+// parent's children, removed ones included, advancing while the next sibling
+// was created after the incoming edit; a tombstoned sibling with an older
+// ticket ends that walk. Purging detaches it from the parent, so the next
+// sibling inherits the decision and must be causally stable first.
+func (t *Tree) PurgeBarrierAt(child GCChild) *time.Ticket {
+	node, ok := child.(*TreeNode)
+	if !ok || node.Index == nil || node.Index.Parent == nil {
+		return nil
+	}
+
+	next := node.Index.Parent.NextSiblingOf(node.Index)
+	if next == nil {
+		return nil
+	}
+	return next.Value.id.CreatedAt
+}
+
 func (t *Tree) Purge(child GCChild) error {
 	node := child.(*TreeNode)
 

--- a/pkg/document/gc_rga_barrier_cost_test.go
+++ b/pkg/document/gc_rga_barrier_cost_test.go
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package document_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yorkie-team/yorkie/pkg/document"
+	"github.com/yorkie-team/yorkie/pkg/document/json"
+	"github.com/yorkie-team/yorkie/pkg/document/presence"
+	"github.com/yorkie-team/yorkie/pkg/document/time"
+)
+
+// The successor barrier delays a purge, so its cost is retention. Retention is
+// the axis that disqualified two other candidate fixes for the same defect:
+// one retained a dead position node per moved element forever, which grew
+// DocSize by 148% on a drag-reorder and — because DocSize.Total feeds
+// MaxSizeLimit — made a 20-element array under a 1000-byte limit refuse the
+// 8th of 19 drags.
+//
+// These tests pin the properties that distinguish an acceptable delay from an
+// unacceptable leak, so a future change to the barrier cannot quietly acquire
+// the cost profile that ruled those candidates out:
+//
+//   - retention is bounded by how far behind the collection vector is, not by
+//     the size of the array;
+//   - it drains completely once the vector catches up, back to no garbage and
+//     no GC charge at all;
+//   - an array under a byte limit still accepts every move.
+//
+// They are written as invariants rather than as golden numbers because the
+// point is the shape of the cost, not one measurement of it.
+
+// dragToFront moves the element at idx to the front of the array.
+func dragToFront(t *testing.T, d *document.Document, idx int) {
+	t.Helper()
+	require.NoError(t, d.Update(func(root *json.Object, p *presence.Presence) error {
+		arr := root.GetArray("arr")
+		arr.MoveFront(arr.Get(idx).CreatedAt())
+		return nil
+	}))
+}
+
+// newStringArray seeds a document with an array of n distinct strings.
+func newStringArray(t *testing.T, d *document.Document, n int) {
+	t.Helper()
+	require.NoError(t, d.Update(func(root *json.Object, p *presence.Presence) error {
+		arr := root.SetNewArray("arr")
+		for i := 0; i < n; i++ {
+			arr.AddString(fmt.Sprintf("e%03d", i))
+		}
+		return nil
+	}))
+}
+
+// TestBarrierRetentionIsBoundedByLagNotByArraySize drags every element of a
+// 200-element array to the front, collecting after each move with a vector
+// that lags by a fixed number of tickets. Retention must track the lag.
+func TestBarrierRetentionIsBoundedByLagNotByArraySize(t *testing.T) {
+	const n = 200
+
+	for _, lag := range []int64{1, 5, 50} {
+		t.Run(fmt.Sprintf("lag=%d", lag), func(t *testing.T) {
+			doc := document.New("barrier-cost-lag")
+			newStringArray(t, doc, n)
+
+			actor := doc.ActorID()
+			lagging := func() time.VersionVector {
+				v := doc.VersionVector().DeepCopy()
+				if cur := v.VersionOf(actor); cur > lag {
+					v.Set(actor, cur-lag)
+				}
+				return v
+			}
+
+			doc.GarbageCollect(lagging())
+			baseline := doc.DocSize()
+			baselineTotal := (&baseline).Total()
+
+			peak := 0
+			for i := 1; i < n; i++ {
+				dragToFront(t, doc, i)
+				doc.GarbageCollect(lagging())
+				if l := doc.GarbageLen(); l > peak {
+					peak = l
+				}
+			}
+
+			// Bounded by the lag. The array is 200 elements; a per-element
+			// leak would show up here as a peak in the hundreds.
+			assert.LessOrEqual(t, peak, int(lag),
+				"retention must be bounded by the lag, not by the array size")
+
+			// Drains completely once everyone has caught up.
+			doc.GarbageCollect(doc.VersionVector())
+			drained := doc.DocSize()
+			assert.Equal(t, 0, doc.GarbageLen(), "retention must drain")
+			assert.Zero(t, drained.GC.Data, "no data charged to GC after draining")
+			assert.Zero(t, drained.GC.Meta, "no metadata charged to GC after draining")
+			assert.Equal(t, baselineTotal, (&drained).Total(),
+				"a fully synced document must cost exactly what it cost before the moves")
+		})
+	}
+}
+
+// TestBarrierKeepsAnArrayUnderItsSizeLimitMovable is the user-visible half.
+// A candidate fix that retained a position node per move was refused at the
+// 8th of 19 drags under a 1000-byte limit.
+func TestBarrierKeepsAnArrayUnderItsSizeLimitMovable(t *testing.T) {
+	doc := document.New("barrier-cost-limit")
+	doc.MaxSizeLimit = 1000
+	newStringArray(t, doc, 20)
+	doc.GarbageCollect(doc.VersionVector())
+
+	for i := 1; i < 20; i++ {
+		require.NoError(t, doc.Update(func(root *json.Object, p *presence.Presence) error {
+			arr := root.GetArray("arr")
+			arr.MoveFront(arr.Get(i).CreatedAt())
+			return nil
+		}), "move %d of 19 must be accepted under the size limit", i)
+		doc.GarbageCollect(doc.VersionVector())
+	}
+
+	assert.Equal(t, 0, doc.GarbageLen())
+}
+
+// TestBarrierCostsNothingOnConcurrentMoves exercises the case that can
+// actually engage the barrier: two actors moving elements concurrently, synced
+// through the faithful push/pull model with a server-computed minVV. A
+// single-actor fixture cannot engage it, because lagging one actor's vector
+// lags every ticket uniformly.
+func TestBarrierCostsNothingOnConcurrentMoves(t *testing.T) {
+	const n = 60
+	const rounds = 25
+
+	d1, d2, _, _ := newReplicas(t)
+	rows := map[string]time.VersionVector{}
+
+	newStringArray(t, d1, n)
+	vpull(t, d2, vpush(t, d1, rows))
+	rows[d2.ActorID().String()] = d2.VersionVector().DeepCopy()
+
+	synced := d1.DocSize()
+	syncedTotal := (&synced).Total()
+
+	peak := 0
+	for r := 0; r < rounds; r++ {
+		// Concurrent: both move before either exchanges.
+		dragToFront(t, d1, 1+(r*7)%(n-1))
+		dragToFront(t, d2, 1+(r*13+3)%(n-1))
+
+		c1 := vpush(t, d1, rows)
+		c2 := vpush(t, d2, rows)
+		vpull(t, d2, c1)
+		vpull(t, d1, c2)
+
+		minVV := serverMinVV(rows)
+		d1.GarbageCollect(minVV)
+		d2.GarbageCollect(minVV)
+
+		for _, d := range []*document.Document{d1, d2} {
+			if l := d.GarbageLen(); l > peak {
+				peak = l
+			}
+		}
+	}
+
+	// Two concurrent movers can leave at most one in-flight slot each.
+	assert.LessOrEqual(t, peak, 2,
+		"concurrent moves must not accumulate retention across rounds")
+
+	rows[d1.ActorID().String()] = d1.VersionVector().DeepCopy()
+	rows[d2.ActorID().String()] = d2.VersionVector().DeepCopy()
+	final := serverMinVV(rows)
+	d1.GarbageCollect(final)
+	d2.GarbageCollect(final)
+
+	assert.Equal(t, d1.Marshal(), d2.Marshal(), "replicas must agree")
+	assert.Equal(t, 0, d1.GarbageLen())
+	assert.Equal(t, 0, d2.GarbageLen())
+
+	drained := d1.DocSize()
+	assert.Equal(t, syncedTotal, (&drained).Total(),
+		"moving elements around and syncing must not change what the document costs")
+}

--- a/pkg/document/gc_rga_barrier_test.go
+++ b/pkg/document/gc_rga_barrier_test.go
@@ -399,7 +399,9 @@ func runConcurrentMovesScenario(t *testing.T, collect bool) {
 	t.Logf("A=%s", dA.Root().GetArray("arr").Marshal())
 	t.Logf("B=%s", dB.Root().GetArray("arr").Marshal())
 
-	// Nothing reconverges them, including a full collection on both sides.
+	// A full collection once the vector covers everything is the last chance to
+	// reconverge, and on main it does not: the two replicas stay apart. With the
+	// barrier they must agree here and retain nothing.
 	dA.GarbageCollect(helper.MaxVersionVector(idA, idB))
 	dB.GarbageCollect(helper.MaxVersionVector(idA, idB))
 	t.Logf("after full GC: A=%s B=%s",

--- a/pkg/document/gc_rga_barrier_test.go
+++ b/pkg/document/gc_rga_barrier_test.go
@@ -1,0 +1,560 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package document_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/yorkie-team/yorkie/pkg/document"
+	"github.com/yorkie-team/yorkie/pkg/document/change"
+	"github.com/yorkie-team/yorkie/pkg/document/crdt"
+	"github.com/yorkie-team/yorkie/pkg/document/json"
+	"github.com/yorkie-team/yorkie/pkg/document/presence"
+	"github.com/yorkie-team/yorkie/pkg/document/time"
+	"github.com/yorkie-team/yorkie/test/helper"
+)
+
+// A collecting replica must not reorder the elements that survive collection.
+// The four tests below are the same defect seen from four angles: an insert
+// whose RGA forward skip (RGATreeList.findNextBeforeExecutedAt) stopped at a
+// node on one replica runs past that node on a replica that has already
+// collected it, and the two orders never reconverge.
+//
+// Every version vector that authorises a purge here is one the server could
+// genuinely compute: the element-wise min of the replicas' own vectors, as
+// UpdateMinVersionVector does. helper.MaxVersionVector is used only at the end,
+// to assert that nothing is retained forever.
+
+// oneWayDeliver hands one replica's pending local changes to the other and acks
+// them at the sender, i.e. a push followed by the other side's pull. crossSync
+// always exchanges both ways, which cannot express "A pushed, B pulled, A has
+// since gone on editing without pulling" -- the state in which a sound minVV
+// covers A's older change while A holds a newer, unpushed one.
+func oneWayDeliver(t *testing.T, from, to *document.Document) {
+	t.Helper()
+
+	p := from.CreateChangePack()
+	require.NoError(t, to.ApplyChangePack(change.NewPack(
+		p.DocumentKey, change.NewCheckpoint(0, 0), p.Changes, time.InitialVersionVector, nil,
+	)))
+
+	var lastSeq uint32
+	if len(p.Changes) > 0 {
+		lastSeq = p.Changes[len(p.Changes)-1].ClientSeq()
+	}
+	require.NoError(t, from.ApplyChangePack(change.NewPack(
+		p.DocumentKey, change.NewCheckpoint(0, lastSeq), nil, time.InitialVersionVector, nil,
+	)))
+}
+
+// dumpRGA renders every position node of the array, dead ones included, so the
+// two replicas can be compared by structure and not only by Marshal.
+func dumpRGA(t *testing.T, d *document.Document, label string) string {
+	t.Helper()
+
+	arr, ok := d.RootObject().Get("arr").(*crdt.Array)
+	require.True(t, ok)
+
+	var sb strings.Builder
+	sb.WriteString(label)
+	sb.WriteString(": ")
+	for _, n := range arr.AllRGANodes() {
+		if n.Element() == nil {
+			sb.WriteString(fmt.Sprintf("[dead pos=%s] ", n.PositionCreatedAt().Key()))
+			continue
+		}
+		removed := ""
+		if n.Element().RemovedAt() != nil {
+			removed = " removed"
+		}
+		sb.WriteString(fmt.Sprintf("%s(pos=%s posAt=%s%s) ",
+			n.Element().Marshal(), n.PositionCreatedAt().Key(), n.PositionedAt().Key(), removed))
+	}
+	return sb.String()
+}
+
+// removedAtOf returns the removal ticket of the array element with the given
+// value.
+func removedAtOf(t *testing.T, d *document.Document, value string) *time.Ticket {
+	t.Helper()
+
+	at := func() *time.Ticket {
+		arr, ok := d.RootObject().Get("arr").(*crdt.Array)
+		require.True(t, ok)
+		for _, n := range arr.AllRGANodes() {
+			if n.Element() != nil && n.Element().Marshal() == fmt.Sprintf("%q", value) {
+				return n.Element().RemovedAt()
+			}
+		}
+		return nil
+	}()
+	require.NotNil(t, at, "element %q is not removed", value)
+	return at
+}
+
+// movedPositionTicket returns the position ticket of the only position node in
+// "arr" that no insert created, i.e. the one a move stamped.
+func movedPositionTicket(t *testing.T, d *document.Document) *time.Ticket {
+	t.Helper()
+
+	arr, ok := d.RootObject().Get("arr").(*crdt.Array)
+	require.True(t, ok)
+	for _, n := range arr.AllRGANodes() {
+		if n.Element() != nil && n.PositionMovedAt() != nil {
+			return n.PositionMovedAt()
+		}
+	}
+	require.Fail(t, "no moved position node found")
+	return nil
+}
+
+// createdAtOf returns the createdAt of the array element with the given value,
+// tombstoned or not.
+func createdAtOf(t *testing.T, d *document.Document, value string) *time.Ticket {
+	t.Helper()
+
+	arr, ok := d.RootObject().Get("arr").(*crdt.Array)
+	require.True(t, ok)
+	for _, n := range arr.AllRGANodes() {
+		if n.Element() != nil && n.Element().Marshal() == fmt.Sprintf("%q", value) {
+			return n.Element().CreatedAt()
+		}
+	}
+	require.Failf(t, "element not found", "value=%s", value)
+	return nil
+}
+
+// TestConcurrentRemoveAndMoveThenGCKeepsInsertOrder pins that collecting an
+// element which was removed and concurrently moved must not move a later
+// concurrent insert.
+//
+// A moved element no longer lives in the position node its insert created: the
+// move builds a new position node stamped with the move's own ticket, and that
+// node is what the forward skip reads. Purging the element unlinks that node,
+// but the purge is gated only on the element's removedAt. When the remove and
+// the move are concurrent, a version vector can cover the remove while the move
+// is still in flight, so the node disappears on one replica and not on the
+// other -- and a concurrent insert anchored just before it lands on different
+// sides of the following element.
+func TestConcurrentRemoveAndMoveThenGCKeepsInsertOrder(t *testing.T) {
+	remover, mover, removerID, moverID := newReplicas(t)
+
+	// Base state on both replicas: ["a","w"].
+	require.NoError(t, remover.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.SetNewArray("arr").AddString("a").AddString("w")
+		return nil
+	}))
+	crossSync(t, remover, mover)
+	require.Equal(t, `{"arr":["a","w"]}`, remover.Marshal())
+	require.Equal(t, `{"arr":["a","w"]}`, mover.Marshal())
+
+	// Concurrent branch 1 (remover): remove "a".
+	require.NoError(t, remover.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.GetArray("arr").Delete(0)
+		return nil
+	}))
+	require.Equal(t, `{"arr":["w"]}`, remover.Marshal())
+
+	// Concurrent branch 2 (mover): move "a" after "w", then -- after a few
+	// unrelated changes, so its ticket outruns the insert below -- append "s"
+	// anchored on "a"'s new position.
+	require.NoError(t, mover.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.GetArray("arr").MoveAfterByIndex(1, 0)
+		return nil
+	}))
+	require.Equal(t, `{"arr":["w","a"]}`, mover.Marshal())
+	for i := range 3 {
+		require.NoError(t, mover.Update(func(r *json.Object, _ *presence.Presence) error {
+			r.SetInteger(fmt.Sprintf("mover-%d", i), i)
+			return nil
+		}))
+	}
+	require.NoError(t, mover.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.GetArray("arr").InsertStringAfter(1, "s")
+		return nil
+	}))
+	require.Equal(t, `["w","a","s"]`, mover.Root().GetArray("arr").Marshal())
+
+	// The remover pushes only the removal. Both replicas have now seen it, so
+	// it is causally stable; the move and the append are not.
+	oneWayDeliver(t, remover, mover)
+	require.Equal(t, `["w","s"]`, mover.Root().GetArray("arr").Marshal())
+
+	// The version vectors the server would have on file at this point: each
+	// replica's vector as of its last push.
+	minVV := time.MinVersionVector(remover.VersionVector(), mover.VersionVector())
+
+	// The remover keeps editing without pulling: one filler change, then an
+	// insert anchored on "w". Its ticket sits strictly between the move and
+	// the mover's append, which is the window in which the move's position
+	// node decides where the insert goes.
+	require.NoError(t, remover.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.SetInteger("remover-0", 0)
+		return nil
+	}))
+	require.NoError(t, remover.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.GetArray("arr").InsertStringAfter(0, "x")
+		return nil
+	}))
+	require.Equal(t, `["w","x"]`, remover.Root().GetArray("arr").Marshal())
+
+	moveAt := movedPositionTicket(t, mover)
+	insertAt := createdAtOf(t, remover, "x")
+	appendAt := createdAtOf(t, mover, "s")
+	t.Logf("minVV=%s move=%s insert=%s append=%s",
+		minVV.Marshal(), moveAt.Key(), insertAt.Key(), appendAt.Key())
+	require.True(t, insertAt.After(moveAt), "the insert must be newer than the move")
+	require.True(t, appendAt.After(insertAt), "the append must be newer than the insert")
+
+	removedAt := removedAtOf(t, remover, "a")
+	require.True(t, minVV.EqualToOrAfter(removedAt),
+		"the removal %s must be covered by the min version vector %s",
+		removedAt.Key(), minVV.Marshal())
+	require.False(t, minVV.EqualToOrAfter(moveAt),
+		"the move %s must NOT be covered by the min version vector %s",
+		moveAt.Key(), minVV.Marshal())
+
+	// The mover collects with that vector. This is the only difference
+	// between the two replicas.
+	t.Log(dumpRGA(t, mover, "mover before GC"))
+	mover.GarbageCollect(minVV)
+	t.Log(dumpRGA(t, mover, "mover after GC "))
+	t.Logf("RETAINED after deferred GC: garbageLen=%d docSize=%+v", mover.GarbageLen(), mover.DocSize())
+
+	// Now the remover's insert arrives, and everything is exchanged.
+	oneWayDeliver(t, remover, mover)
+	crossSync(t, remover, mover)
+
+	t.Logf("remover=%s", remover.Root().GetArray("arr").Marshal())
+	t.Logf("mover  =%s", mover.Root().GetArray("arr").Marshal())
+	require.Equal(t,
+		remover.Root().GetArray("arr").Marshal(),
+		mover.Root().GetArray("arr").Marshal(),
+		"collecting an element whose position node was created by a concurrent move "+
+			"reordered a later concurrent insert")
+
+	// Holding the purge back must be a delay, not a leak: once the vector
+	// covers the move as well, both replicas collect everything and land on
+	// the same list.
+	remover.GarbageCollect(helper.MaxVersionVector(removerID, moverID))
+	mover.GarbageCollect(helper.MaxVersionVector(removerID, moverID))
+	t.Logf("RETAINED after catch-up: remover=%d/%+v mover=%d/%+v",
+		remover.GarbageLen(), remover.DocSize(), mover.GarbageLen(), mover.DocSize())
+	require.Equal(t, 0, remover.GarbageLen(), "remover leaked garbage")
+	require.Equal(t, 0, mover.GarbageLen(), "mover leaked garbage")
+	crossSync(t, remover, mover)
+	require.Equal(t,
+		remover.Root().GetArray("arr").Marshal(),
+		mover.Root().GetArray("arr").Marshal(),
+		"the replicas did not reconverge")
+	t.Log(dumpRGA(t, remover, "remover final"))
+	t.Log(dumpRGA(t, mover, "mover   final"))
+}
+
+// vpush models a real PushPull *push*: the client hands its pending changes to
+// the server and the server stores reqPack.VersionVector as that client's row
+// in `versionvectors`. The changes are returned so another client can pull them
+// later, exactly as the server would serve them.
+func vpush(t *testing.T, d *document.Document, rows map[string]time.VersionVector) []*change.Change {
+	t.Helper()
+
+	// The row the server writes is the VV the client had BEFORE this round
+	// trip's pull. Nothing is pulled here, so it is simply the current VV.
+	rows[d.ActorID().String()] = d.VersionVector().DeepCopy()
+
+	p := d.CreateChangePack()
+	var lastSeq uint32
+	if len(p.Changes) > 0 {
+		lastSeq = p.Changes[len(p.Changes)-1].ClientSeq()
+	}
+	require.NoError(t, d.ApplyChangePack(change.NewPack(
+		p.DocumentKey, change.NewCheckpoint(0, lastSeq), nil, time.InitialVersionVector, nil,
+	)))
+	return p.Changes
+}
+
+// vpull models a pull: the client applies changes the server already holds.
+func vpull(t *testing.T, d *document.Document, changes []*change.Change) {
+	t.Helper()
+	require.NoError(t, d.ApplyChangePack(change.NewPack(
+		d.Key(), change.NewCheckpoint(0, 0), changes, time.InitialVersionVector, nil,
+	)))
+}
+
+// serverMinVV is UpdateMinVersionVector's element-wise min over the stored rows.
+func serverMinVV(rows map[string]time.VersionVector) time.VersionVector {
+	var out time.VersionVector
+	first := true
+	for _, vv := range rows {
+		if first {
+			out = vv.DeepCopy()
+			first = false
+			continue
+		}
+		out = time.MinVersionVector(out, vv)
+	}
+	return out
+}
+
+// TestConcurrentMovesOfSameElementServerMinVV is the same divergence one move
+// further along: the element is moved twice, concurrently, by two actors. The
+// slot the second move abandons was created by the FIRST move, so the ticket
+// that must stay covered is the first move's, not the element's insert -- and
+// the two moves being concurrent means a sound minVV can cover one and not the
+// other.
+func TestConcurrentMovesOfSameElementServerMinVV(t *testing.T) {
+	t.Run("with GC", func(t *testing.T) { runConcurrentMovesScenario(t, true) })
+	t.Run("without GC (control)", func(t *testing.T) { runConcurrentMovesScenario(t, false) })
+}
+
+func runConcurrentMovesScenario(t *testing.T, collect bool) {
+	dA, dB, idA, idB := newReplicas(t)
+	rows := map[string]time.VersionVector{}
+
+	// Base ["a","w","v"] on both, both rows on file.
+	require.NoError(t, dA.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.SetNewArray("arr").AddString("a").AddString("w").AddString("v")
+		return nil
+	}))
+	base := vpush(t, dA, rows)
+	vpull(t, dB, base)
+	_ = vpush(t, dB, rows)
+	require.Equal(t, `["a","w","v"]`, dB.Root().GetArray("arr").Marshal())
+
+	// A (local, unpushed): move "a" after "w" (m1), filler, then insert "s"
+	// anchored on "a"'s new (m1) position.
+	require.NoError(t, dA.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.GetArray("arr").MoveAfterByIndex(1, 0)
+		return nil
+	}))
+	for i := range 2 {
+		require.NoError(t, dA.Update(func(r *json.Object, _ *presence.Presence) error {
+			r.SetInteger(fmt.Sprintf("fa-%d", i), i)
+			return nil
+		}))
+	}
+	require.NoError(t, dA.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.GetArray("arr").InsertStringAfter(1, "s")
+		return nil
+	}))
+	require.Equal(t, `["w","a","s","v"]`, dA.Root().GetArray("arr").Marshal())
+
+	// B (concurrently, from base): move "a" after "v" (m2). B pushes.
+	require.NoError(t, dB.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.GetArray("arr").MoveAfterByIndex(2, 0)
+		return nil
+	}))
+	require.Equal(t, `["w","v","a"]`, dB.Root().GetArray("arr").Marshal())
+	fromB := vpush(t, dB, rows)
+
+	// A pulls m2, then pushes its own backlog. Both rows are now on file.
+	vpull(t, dA, fromB)
+	fromA := vpush(t, dA, rows)
+
+	minVV := serverMinVV(rows)
+	for id, vv := range rows {
+		t.Logf("stored row %s = %s", id, vv.Marshal())
+	}
+	t.Logf("server minVV = %s", minVV.Marshal())
+
+	// A collects with the server's minVV. This is the only asymmetry.
+	t.Log(dumpRGA(t, dA, "A before GC"))
+	if collect {
+		t.Logf("A collected %d", dA.GarbageCollect(minVV))
+	}
+	t.Log(dumpRGA(t, dA, "A after GC "))
+	t.Logf("RETAINED after deferred GC: garbageLen=%d docSize=%+v", dA.GarbageLen(), dA.DocSize())
+
+	// B, which has not pulled A's backlog yet, inserts "x" after "w".
+	require.NoError(t, dB.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.GetArray("arr").InsertStringAfter(0, "x")
+		return nil
+	}))
+	fromB2 := vpush(t, dB, rows)
+
+	// Everything is delivered both ways.
+	vpull(t, dB, fromA)
+	vpull(t, dA, fromB2)
+
+	t.Log(dumpRGA(t, dA, "A final"))
+	t.Log(dumpRGA(t, dB, "B final"))
+	t.Logf("A=%s", dA.Root().GetArray("arr").Marshal())
+	t.Logf("B=%s", dB.Root().GetArray("arr").Marshal())
+
+	// Nothing reconverges them, including a full collection on both sides.
+	dA.GarbageCollect(helper.MaxVersionVector(idA, idB))
+	dB.GarbageCollect(helper.MaxVersionVector(idA, idB))
+	t.Logf("after full GC: A=%s B=%s",
+		dA.Root().GetArray("arr").Marshal(), dB.Root().GetArray("arr").Marshal())
+
+	require.Equal(t,
+		dA.Root().GetArray("arr").Marshal(),
+		dB.Root().GetArray("arr").Marshal(),
+		"replicas diverged permanently under a server-computed minVV")
+	require.Equal(t, 0, dA.GarbageLen(), "A leaked garbage")
+	require.Equal(t, 0, dB.GarbageLen(), "B leaked garbage")
+}
+
+// TestConcurrentDeleteAndInsertThenGCKeepsTextOrder is the same defect in
+// RGATreeSplit, with no move anywhere in it: a plain delete is enough. The
+// tombstone left by the delete is what stops the skip in findNodeWithSplit, and
+// collecting it sends a later concurrent insert past the node behind it.
+func TestConcurrentDeleteAndInsertThenGCKeepsTextOrder(t *testing.T) {
+	remover, mover, removerID, moverID := newReplicas(t)
+
+	require.NoError(t, remover.Update(func(r *json.Object, _ *presence.Presence) error {
+		txt := r.SetNewText("t")
+		txt.Edit(0, 0, "A")
+		txt.Edit(0, 0, "W")
+		return nil
+	}))
+	crossSync(t, remover, mover)
+	require.Equal(t, `WA`, remover.Root().GetText("t").String())
+	require.Equal(t, `WA`, mover.Root().GetText("t").String())
+
+	// mover: bump its clock, then append "S" anchored right after "A".
+	for i := range 3 {
+		require.NoError(t, mover.Update(func(r *json.Object, _ *presence.Presence) error {
+			r.SetInteger(fmt.Sprintf("mover-%d", i), i)
+			return nil
+		}))
+	}
+	require.NoError(t, mover.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.GetText("t").Edit(2, 2, "S")
+		return nil
+	}))
+	require.Equal(t, `WAS`, mover.Root().GetText("t").String())
+
+	// remover: delete "A".
+	require.NoError(t, remover.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.GetText("t").Edit(1, 2, "")
+		return nil
+	}))
+	require.Equal(t, `W`, remover.Root().GetText("t").String())
+
+	// The removal reaches the mover, so it is causally stable. "S" is not.
+	oneWayDeliver(t, remover, mover)
+	require.Equal(t, `WS`, mover.Root().GetText("t").String())
+
+	minVV := time.MinVersionVector(remover.VersionVector(), mover.VersionVector())
+	t.Logf("minVV=%s", minVV.Marshal())
+
+	// remover keeps editing without pulling: insert "X" right after "W".
+	require.NoError(t, remover.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.SetInteger("remover-0", 0)
+		return nil
+	}))
+	require.NoError(t, remover.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.GetText("t").Edit(1, 1, "X")
+		return nil
+	}))
+	require.Equal(t, `WX`, remover.Root().GetText("t").String())
+
+	t.Logf("mover before GC: %s", mover.Root().GetText("t").ToTestString())
+	t.Logf("mover collected %d", mover.GarbageCollect(minVV))
+	t.Logf("mover after  GC: %s", mover.Root().GetText("t").ToTestString())
+
+	oneWayDeliver(t, remover, mover)
+	crossSync(t, remover, mover)
+
+	t.Logf("remover=%s", remover.Root().GetText("t").String())
+	t.Logf("mover  =%s", mover.Root().GetText("t").String())
+	require.Equal(t,
+		remover.Root().GetText("t").String(),
+		mover.Root().GetText("t").String(),
+		"text replicas diverged after collecting a tombstone")
+
+	remover.GarbageCollect(helper.MaxVersionVector(removerID, moverID))
+	mover.GarbageCollect(helper.MaxVersionVector(removerID, moverID))
+	require.Equal(t, 0, remover.GarbageLen(), "remover leaked garbage")
+	require.Equal(t, 0, mover.GarbageLen(), "mover leaked garbage")
+}
+
+// TestConcurrentDeleteAndInsertThenGCKeepsTreeOrder is the same defect again in
+// CRDTTree, whose sibling skip in findNodesAndSplitText reads the parent's
+// children with the removed ones included.
+func TestConcurrentDeleteAndInsertThenGCKeepsTreeOrder(t *testing.T) {
+	remover, mover, removerID, moverID := newReplicas(t)
+
+	require.NoError(t, remover.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.SetNewTree("t", json.TreeNode{
+			Type:     "doc",
+			Children: []json.TreeNode{{Type: "p"}},
+		})
+		r.GetTree("t").Edit(1, 1, &json.TreeNode{Type: "text", Value: "A"}, 0)
+		r.GetTree("t").Edit(1, 1, &json.TreeNode{Type: "text", Value: "W"}, 0)
+		return nil
+	}))
+	crossSync(t, remover, mover)
+	require.Equal(t, `<doc><p>WA</p></doc>`, remover.Root().GetTree("t").ToXML())
+	require.Equal(t, `<doc><p>WA</p></doc>`, mover.Root().GetTree("t").ToXML())
+
+	for i := range 3 {
+		require.NoError(t, mover.Update(func(r *json.Object, _ *presence.Presence) error {
+			r.SetInteger(fmt.Sprintf("mover-%d", i), i)
+			return nil
+		}))
+	}
+	require.NoError(t, mover.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.GetTree("t").Edit(3, 3, &json.TreeNode{Type: "text", Value: "S"}, 0)
+		return nil
+	}))
+	require.Equal(t, `<doc><p>WAS</p></doc>`, mover.Root().GetTree("t").ToXML())
+
+	require.NoError(t, remover.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.GetTree("t").Edit(2, 3, nil, 0)
+		return nil
+	}))
+	require.Equal(t, `<doc><p>W</p></doc>`, remover.Root().GetTree("t").ToXML())
+
+	oneWayDeliver(t, remover, mover)
+	require.Equal(t, `<doc><p>WS</p></doc>`, mover.Root().GetTree("t").ToXML())
+
+	minVV := time.MinVersionVector(remover.VersionVector(), mover.VersionVector())
+	t.Logf("minVV=%s", minVV.Marshal())
+
+	require.NoError(t, remover.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.SetInteger("remover-0", 0)
+		return nil
+	}))
+	require.NoError(t, remover.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.GetTree("t").Edit(2, 2, &json.TreeNode{Type: "text", Value: "X"}, 0)
+		return nil
+	}))
+	require.Equal(t, `<doc><p>WX</p></doc>`, remover.Root().GetTree("t").ToXML())
+
+	t.Logf("mover collected %d", mover.GarbageCollect(minVV))
+
+	oneWayDeliver(t, remover, mover)
+	crossSync(t, remover, mover)
+
+	t.Logf("remover=%s", remover.Root().GetTree("t").ToXML())
+	t.Logf("mover  =%s", mover.Root().GetTree("t").ToXML())
+	require.Equal(t,
+		remover.Root().GetTree("t").ToXML(),
+		mover.Root().GetTree("t").ToXML(),
+		"tree replicas diverged after collecting a tombstone")
+
+	remover.GarbageCollect(helper.MaxVersionVector(removerID, moverID))
+	mover.GarbageCollect(helper.MaxVersionVector(removerID, moverID))
+	require.Equal(t, 0, remover.GarbageLen(), "remover leaked garbage")
+	require.Equal(t, 0, mover.GarbageLen(), "mover leaked garbage")
+}

--- a/pkg/document/gc_rga_fuzz_test.go
+++ b/pkg/document/gc_rga_fuzz_test.go
@@ -619,6 +619,17 @@ func runSetAnchorScenario(t *testing.T, gc bool) {
 // barrier returns nil at the tail by construction -- and the append then fails
 // to apply on the collecting replica. No concurrency and no move is involved;
 // the append strictly follows the delete.
+// TestAdvArrayAppendAfterPurgedTail stays red with the successor barrier
+// applied, and that is structural rather than an oversight. The barrier refuses
+// a purge when the node that would become a forward skip's new stopping point is
+// not yet causally stable. Here the tombstone IS the tail: there is no successor
+// for the barrier to find unstable, so it never engages, and the anchor B's
+// append names is purged anyway.
+//
+// So this is the cleanest statement of the anchor half that remains open. Any
+// fourth attempt has to address the anchor an in-flight operation references,
+// not just the stopping point, and the physical tail is where the two halves are
+// easiest to tell apart.
 func TestAdvArrayAppendAfterPurgedTail(t *testing.T) {
 	srv := newAdvServer()
 	cs := newAdvClients(t, 2)

--- a/pkg/document/gc_rga_fuzz_test.go
+++ b/pkg/document/gc_rga_fuzz_test.go
@@ -1,0 +1,657 @@
+//go:build rgafuzz
+
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This harness FAILS on main, deliberately. It is the reproduction for
+// docs/tasks/active/20260912-collection-changes-rga-insertion-todo.md:
+// collection unlinks the tombstones the RGA forward skip reads, so two
+// replicas that differ only in whether they collected order the same later
+// insert differently.
+//
+// It is behind a build tag rather than skipped so that it cannot rot silently
+// and cannot fail CI:
+//
+//	go test -tags rgafuzz ./pkg/document/ -run TestAdvArray -v
+//
+// TestAdvArrayFuzzNoGC is the control and passes -- the same seeds converge
+// when nothing is collected, which is what makes collection the cause rather
+// than a correlate. A fix for the filed defect is complete when the
+// collection-on run matches that control.
+//
+// The push/pull model here is faithful to server/packs/pushpull.go: each
+// client's row is stored from its request's version vector at push time, a
+// client's own changes are filtered out of its pull, minVV is the element-wise
+// minimum over the stored rows, and collection runs only inside
+// Document.ApplyChangePack with the vector that pull delivered. No
+// helper.MaxVersionVector is used anywhere, so every collection it performs is
+// one the protocol would also perform.
+
+package document_test
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/yorkie-team/yorkie/pkg/document"
+	"github.com/yorkie-team/yorkie/pkg/document/change"
+	"github.com/yorkie-team/yorkie/pkg/document/crdt"
+	"github.com/yorkie-team/yorkie/pkg/document/json"
+	"github.com/yorkie-team/yorkie/pkg/document/presence"
+	"github.com/yorkie-team/yorkie/pkg/document/time"
+)
+
+// advServer models server/packs/pushpull.go: one ordered change log, one stored
+// VersionVector row per client (the VV carried in that client's push request),
+// and minVV = element-wise min over the stored rows (memory DB
+// GetMinVersionVector). A client only ever sees minVV as the VersionVector of a
+// pull response, and Document.ApplyChangePack is what runs GC with it -- so GC
+// here can never be called at a moment the protocol would not produce.
+type advServer struct {
+	log    []*change.Change
+	actors []string
+	rows   map[string]time.VersionVector
+}
+
+type advClient struct {
+	doc    *document.Document
+	id     time.ActorID
+	cursor int
+}
+
+func newAdvServer() *advServer {
+	return &advServer{rows: map[string]time.VersionVector{}}
+}
+
+func (s *advServer) minVV() time.VersionVector {
+	var vectors []time.VersionVector
+	for _, vv := range s.rows {
+		vectors = append(vectors, vv)
+	}
+	return time.MinVersionVector(vectors...)
+}
+
+// sync is one PushPull round trip: push local changes, store the request's VV,
+// pull everything the server holds, and hand the response (changes + minVV) to
+// ApplyChangePack, which applies then collects.
+func (s *advServer) sync(c *advClient, gcOn bool) error {
+	p := c.doc.CreateChangePack()
+
+	// 01. push: append to the log, then record the row the request carried.
+	var lastSeq uint32
+	for _, ch := range p.Changes {
+		s.log = append(s.log, ch)
+		s.actors = append(s.actors, ch.ID().ActorID().String())
+		lastSeq = ch.ClientSeq()
+	}
+	s.rows[c.id.String()] = p.VersionVector.DeepCopy()
+
+	// 02. pull: everything on the log this client has not seen.
+	var chs []*change.Change
+	for i := c.cursor; i < len(s.log); i++ {
+		if s.actors[i] == c.id.String() {
+			continue
+		}
+		chs = append(chs, s.log[i])
+	}
+	c.cursor = len(s.log)
+
+	vv := s.minVV()
+	if !gcOn {
+		vv = time.InitialVersionVector
+	}
+
+	return c.doc.ApplyChangePack(change.NewPack(
+		c.doc.Key(), change.NewCheckpoint(0, lastSeq), chs, vv, nil,
+	))
+}
+
+func newAdvClients(t *testing.T, n int) []*advClient {
+	t.Helper()
+	cs := make([]*advClient, 0, n)
+	for i := range n {
+		id, err := time.ActorIDFromHex(fmt.Sprintf("%024d", i+1))
+		require.NoError(t, err)
+		d := document.New("adv-doc")
+		d.SetActor(id)
+		cs = append(cs, &advClient{doc: d, id: id})
+	}
+	return cs
+}
+
+var allOps = []int{0, 1, 2, 3}
+
+var (
+	advTraceSeed    = 60
+	advTraceClients = 3
+	advTraceRounds  = 2
+	advTraceOps     = []int{0, 1, 2, 3}
+)
+
+// ---- array fuzz ----------------------------------------------------------
+
+func advArrayOp(c *advClient, rnd *rand.Rand, tag string, ops []int) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic in local op: %v", r)
+		}
+	}()
+	return c.doc.Update(func(r *json.Object, _ *presence.Presence) error {
+		arr := r.GetArray("arr")
+		n := arr.Len()
+		switch ops[rnd.Intn(len(ops))] {
+		case 0:
+			if n == 0 {
+				arr.AddString(tag)
+				return nil
+			}
+			arr.InsertStringAfter(rnd.Intn(n), tag)
+		case 1:
+			if n == 0 {
+				return nil
+			}
+			arr.Delete(rnd.Intn(n))
+		case 2:
+			if n < 2 {
+				return nil
+			}
+			arr.MoveAfterByIndex(rnd.Intn(n), rnd.Intn(n))
+		case 3:
+			if n == 0 {
+				return nil
+			}
+			arr.SetString(rnd.Intn(n), tag)
+		}
+		return nil
+	})
+}
+
+func runAdvArraySeed(seed int64, nClients, rounds int, gc bool, ops []int) (string, error) {
+	rnd := rand.New(rand.NewSource(seed))
+	srv := newAdvServer()
+
+	cs := make([]*advClient, 0, nClients)
+	for i := range nClients {
+		id, err := time.ActorIDFromHex(fmt.Sprintf("%024d", i+1))
+		if err != nil {
+			return "", err
+		}
+		d := document.New("adv-doc")
+		d.SetActor(id)
+		cs = append(cs, &advClient{doc: d, id: id})
+	}
+
+	if err := cs[0].doc.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.SetNewArray("arr").AddString("a").AddString("b").AddString("c")
+		return nil
+	}); err != nil {
+		return "", err
+	}
+	for _, c := range cs {
+		if err := srv.sync(c, gc); err != nil {
+			return "", fmt.Errorf("bootstrap sync: %w", err)
+		}
+	}
+
+	for range rounds {
+		for _, c := range cs {
+			if rnd.Intn(100) < 70 {
+				if err := advArrayOp(c, rnd, fmt.Sprintf("%s%d", c.id.String()[22:], rnd.Intn(100)), ops); err != nil {
+					return "", err
+				}
+			}
+		}
+		for _, c := range cs {
+			if rnd.Intn(100) < 55 {
+				if err := srv.sync(c, gc); err != nil {
+					return "", fmt.Errorf("sync: %w", err)
+				}
+			}
+		}
+	}
+
+	// Full convergence: everyone syncs until quiet.
+	for range 6 {
+		for _, c := range cs {
+			if err := srv.sync(c, gc); err != nil {
+				return "", fmt.Errorf("final sync: %w", err)
+			}
+		}
+	}
+
+	want := cs[0].doc.Root().GetArray("arr").Marshal()
+	for i, c := range cs[1:] {
+		got := c.doc.Root().GetArray("arr").Marshal()
+		if got != want {
+			return "", fmt.Errorf("DIVERGED c0 vs c%d\n  c0=%s\n  c%d=%s", i+1, want, i+1, got)
+		}
+	}
+	return want, nil
+}
+
+func TestAdvArrayFuzz(t *testing.T) {
+	var failures int
+	var first []string
+	for seed := int64(1); seed <= 300; seed++ {
+		if _, err := runAdvArraySeed(seed, 3, 12, true, allOps); err != nil {
+			failures++
+			if len(first) < 3 {
+				first = append(first, fmt.Sprintf("seed %d: %v", seed, err))
+			}
+		}
+	}
+	for _, f := range first {
+		t.Log(f)
+	}
+	if failures > 0 {
+		t.Errorf("GC ON: %d/300 seeds diverged or errored", failures)
+	}
+}
+
+func TestAdvArrayFuzzNoGC(t *testing.T) {
+	var failures int
+	for seed := int64(1); seed <= 300; seed++ {
+		if _, err := runAdvArraySeed(seed, 3, 12, false, allOps); err != nil {
+			t.Errorf("seed %d (GC off): %v", seed, err)
+			failures++
+			if failures >= 5 {
+				t.Fatal("stopping after 5")
+			}
+		}
+	}
+}
+
+func TestAdvArrayOpMask(t *testing.T) {
+	cases := []struct {
+		name string
+		ops  []int
+	}{
+		{"insert+delete", []int{0, 1}},
+		{"insert+delete+move", []int{0, 1, 2}},
+		{"insert+delete+set", []int{0, 1, 3}},
+		{"insert+move", []int{0, 2}},
+		{"insert+set", []int{0, 3}},
+		{"all", []int{0, 1, 2, 3}},
+	}
+	for _, c := range cases {
+		var fail int
+		var first string
+		for seed := int64(1); seed <= 300; seed++ {
+			if _, err := runAdvArraySeed(seed, 3, 12, true, c.ops); err != nil {
+				fail++
+				if first == "" {
+					first = fmt.Sprintf("seed %d: %v", seed, err)
+				}
+			}
+		}
+		t.Logf("%-22s GC ON: %3d/300 failed   %s", c.name, fail, first)
+	}
+}
+
+func TestAdvArrayShrinkSweep(t *testing.T) {
+	for _, nc := range []int{2, 3} {
+		for _, rounds := range []int{2, 3, 4, 6, 8} {
+			var fail int
+			var first string
+			for seed := int64(1); seed <= 2000; seed++ {
+				if _, err := runAdvArraySeed(seed, nc, rounds, true, []int{0, 1}); err != nil {
+					fail++
+					if first == "" {
+						first = fmt.Sprintf("seed=%d %v", seed, err)
+					}
+				}
+			}
+			t.Logf("clients=%d rounds=%2d insert+delete: %4d/2000  %s", nc, rounds, fail, first)
+		}
+	}
+}
+
+// ---- traced minimal reproduction ----------------------------------------
+
+func advDumpArr(d *document.Document) string {
+	arr, ok := d.RootObject().Get("arr").(*crdt.Array)
+	if !ok {
+		return "<none>"
+	}
+	var sb strings.Builder
+	for _, n := range arr.AllRGANodes() {
+		if n.Element() == nil {
+			sb.WriteString(fmt.Sprintf("[dead pos=%s] ", n.PositionCreatedAt().Key()))
+			continue
+		}
+		rm := ""
+		if n.Element().RemovedAt() != nil {
+			rm = "!"
+		}
+		sb.WriteString(fmt.Sprintf("%s%s(pos=%s) ", n.Element().Marshal(), rm, n.PositionCreatedAt().Key()))
+	}
+	return sb.String()
+}
+
+func TestAdvArrayTrace(t *testing.T) {
+	seed := int64(advTraceSeed)
+	nClients, rounds := advTraceClients, advTraceRounds
+	rnd := rand.New(rand.NewSource(seed))
+	srv := newAdvServer()
+
+	cs := make([]*advClient, 0, nClients)
+	for i := range nClients {
+		id, err := time.ActorIDFromHex(fmt.Sprintf("%024d", i+1))
+		require.NoError(t, err)
+		d := document.New("adv-doc")
+		d.SetActor(id)
+		cs = append(cs, &advClient{doc: d, id: id})
+	}
+	name := func(c *advClient) string { return "C" + c.id.String()[23:] }
+
+	sync := func(c *advClient) error {
+		p := c.doc.CreateChangePack()
+		var lastSeq uint32
+		for _, ch := range p.Changes {
+			srv.log = append(srv.log, ch)
+			srv.actors = append(srv.actors, ch.ID().ActorID().String())
+			lastSeq = ch.ClientSeq()
+		}
+		srv.rows[c.id.String()] = p.VersionVector.DeepCopy()
+		var chs []*change.Change
+		for i := c.cursor; i < len(srv.log); i++ {
+			if srv.actors[i] == c.id.String() {
+				continue
+			}
+			chs = append(chs, srv.log[i])
+		}
+		c.cursor = len(srv.log)
+		vv := srv.minVV()
+		t.Logf("  SYNC %s push=%d pull=%d row=%s minVV=%s", name(c), len(p.Changes), len(chs),
+			p.VersionVector.Marshal(), vv.Marshal())
+		before := advDumpArr(c.doc)
+		gl := c.doc.GarbageLen()
+		err := c.doc.ApplyChangePack(change.NewPack(
+			c.doc.Key(), change.NewCheckpoint(0, lastSeq), chs, vv, nil,
+		))
+		if err != nil {
+			t.Logf("    ERROR: %v", err)
+			t.Logf("    state before apply: %s", before)
+			return err
+		}
+		t.Logf("    %s: %s   (garbageLen %d -> %d)", name(c), advDumpArr(c.doc), gl, c.doc.GarbageLen())
+		return nil
+	}
+
+	require.NoError(t, cs[0].doc.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.SetNewArray("arr").AddString("a").AddString("b").AddString("c")
+		return nil
+	}))
+	for _, c := range cs {
+		require.NoError(t, sync(c))
+	}
+	t.Logf("bootstrap done")
+
+	ops := advTraceOps
+	for round := range rounds {
+		t.Logf("--- round %d ---", round)
+		for _, c := range cs {
+			if rnd.Intn(100) < 70 {
+				tag := fmt.Sprintf("%s%d", c.id.String()[22:], rnd.Intn(100))
+				require.NoError(t, c.doc.Update(func(r *json.Object, _ *presence.Presence) error {
+					arr := r.GetArray("arr")
+					n := arr.Len()
+					switch ops[rnd.Intn(len(ops))] {
+					case 0:
+						if n == 0 {
+							arr.AddString(tag)
+							t.Logf("  %s ADD %s", name(c), tag)
+							return nil
+						}
+						i := rnd.Intn(n)
+						t.Logf("  %s INSERT %s after idx %d (%s)", name(c), tag, i, arr.Get(i).Marshal())
+						arr.InsertStringAfter(i, tag)
+					case 1:
+						if n == 0 {
+							return nil
+						}
+						i := rnd.Intn(n)
+						t.Logf("  %s DELETE idx %d (%s)", name(c), i, arr.Get(i).Marshal())
+						arr.Delete(i)
+					case 2:
+						if n < 2 {
+							return nil
+						}
+						a1, a2 := rnd.Intn(n), rnd.Intn(n)
+						t.Logf("  %s MOVE idx %d (%s) after idx %d (%s)", name(c), a2, arr.Get(a2).Marshal(), a1, arr.Get(a1).Marshal())
+						arr.MoveAfterByIndex(a1, a2)
+					case 3:
+						if n == 0 {
+							return nil
+						}
+						i := rnd.Intn(n)
+						t.Logf("  %s SET idx %d (%s) = %s", name(c), i, arr.Get(i).Marshal(), tag)
+						arr.SetString(i, tag)
+					}
+					return nil
+				}))
+			}
+		}
+		for _, c := range cs {
+			if rnd.Intn(100) < 55 {
+				if err := sync(c); err != nil {
+					t.Fatalf("FAILED in round %d", round)
+				}
+			}
+		}
+	}
+	for range 6 {
+		for _, c := range cs {
+			if err := sync(c); err != nil {
+				t.Fatalf("FAILED in final sync")
+			}
+		}
+	}
+	for i, c := range cs {
+		t.Logf("final C%d = %s", i, c.doc.Root().GetArray("arr").Marshal())
+	}
+}
+
+func TestAdvArrayCategorize(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		ops  []int
+	}{
+		{"insert+delete", []int{0, 1}},
+		{"all", []int{0, 1, 2, 3}},
+	} {
+		var diverged, notfound, other int
+		var firstDiv string
+		for seed := int64(1); seed <= 1000; seed++ {
+			_, err := runAdvArraySeed(seed, 3, 12, true, c.ops)
+			if err == nil {
+				continue
+			}
+			switch {
+			case strings.Contains(err.Error(), "DIVERGED"):
+				diverged++
+				if firstDiv == "" {
+					firstDiv = fmt.Sprintf("seed %d: %v", seed, err)
+				}
+			case strings.Contains(err.Error(), "child not found"):
+				notfound++
+			default:
+				other++
+				t.Logf("OTHER seed %d: %v", seed, err)
+			}
+		}
+		t.Logf("%-14s /1000: diverged=%d childNotFound=%d other=%d", c.name, diverged, notfound, other)
+		if firstDiv != "" {
+			t.Logf("   %s", firstDiv)
+		}
+	}
+}
+
+func TestAdvArrayNoGC1000(t *testing.T) {
+	var fail int
+	var first string
+	for seed := int64(1); seed <= 1000; seed++ {
+		if _, err := runAdvArraySeed(seed, 3, 12, false, allOps); err != nil {
+			fail++
+			if first == "" {
+				first = fmt.Sprintf("seed %d: %v", seed, err)
+			}
+		}
+	}
+	t.Logf("GC OFF all ops: %d/1000 failed  %s", fail, first)
+	if fail > 0 {
+		t.Errorf("control failed")
+	}
+}
+
+func TestAdvArrayMinDiverge(t *testing.T) {
+	for _, nc := range []int{2, 3} {
+		for _, rounds := range []int{2, 3, 4, 5, 6} {
+			var div int
+			var first string
+			for seed := int64(1); seed <= 3000; seed++ {
+				_, err := runAdvArraySeed(seed, nc, rounds, true, allOps)
+				if err != nil && strings.Contains(err.Error(), "DIVERGED") {
+					div++
+					if first == "" {
+						first = fmt.Sprintf("seed=%d %v", seed, err)
+					}
+				}
+			}
+			t.Logf("clients=%d rounds=%d diverged=%d  %s", nc, rounds, div, first)
+		}
+	}
+}
+
+// TestAdvArraySetAnchorPurged is the hand-built distillation of the fuzz
+// finding: RGATreeList.insertAfter resolves prevCreatedAt through
+// nodeMapByCreatedAt FIRST and falls back to elementMapByCreatedAt. GC deletes
+// the nodeMapByCreatedAt entry, so purging the dead position slot a move
+// abandoned silently re-points every later ArraySet on that element from the
+// dead slot to the element's CURRENT position node -- a different place in the
+// list. The successor barrier authorises exactly this purge (the slot's
+// successor is the element's own moved node, which minVV covers).
+func TestAdvArraySetAnchorPurged(t *testing.T) {
+	t.Run("with GC", func(t *testing.T) { runSetAnchorScenario(t, true) })
+	t.Run("without GC (control)", func(t *testing.T) { runSetAnchorScenario(t, false) })
+}
+
+func runSetAnchorScenario(t *testing.T, gc bool) {
+	srv := newAdvServer()
+	cs := newAdvClients(t, 2)
+	A, B := cs[0], cs[1]
+
+	require.NoError(t, A.doc.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.SetNewArray("arr").AddString("a").AddString("b")
+		return nil
+	}))
+	require.NoError(t, srv.sync(A, gc))
+	require.NoError(t, srv.sync(B, gc))
+
+	// B self-moves "a": a new position node is stamped with the move ticket
+	// and the insert-created slot becomes a dead position node.
+	require.NoError(t, B.doc.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.GetArray("arr").MoveAfterByIndex(0, 0)
+		return nil
+	}))
+	require.NoError(t, srv.sync(B, gc))
+	require.NoError(t, srv.sync(A, gc))
+	t.Logf("A after move: %s", advDumpArr(A.doc))
+
+	// B replaces "a" with "z" (ArraySet), and does NOT push.
+	require.NoError(t, B.doc.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.GetArray("arr").SetString(0, "z")
+		return nil
+	}))
+	t.Logf("B after set : %s", advDumpArr(B.doc))
+
+	// A makes its own insert after "a", with a ticket newer than B's set.
+	for i := range 4 {
+		require.NoError(t, A.doc.Update(func(r *json.Object, _ *presence.Presence) error {
+			r.SetInteger(fmt.Sprintf("f%d", i), i)
+			return nil
+		}))
+	}
+	require.NoError(t, A.doc.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.GetArray("arr").InsertStringAfter(0, "q")
+		return nil
+	}))
+
+	// A syncs: minVV covers the move (both rows have it) but not B's set.
+	require.NoError(t, srv.sync(A, gc))
+	t.Logf("A after GC  : %s", advDumpArr(A.doc))
+
+	// Everything is delivered both ways, repeatedly.
+	for range 4 {
+		require.NoError(t, srv.sync(B, gc))
+		require.NoError(t, srv.sync(A, gc))
+	}
+	t.Logf("A final: %s", advDumpArr(A.doc))
+	t.Logf("B final: %s", advDumpArr(B.doc))
+
+	require.Equal(t,
+		B.doc.Root().GetArray("arr").Marshal(),
+		A.doc.Root().GetArray("arr").Marshal(),
+		"replicas diverged after collecting the dead slot an ArraySet still anchors on")
+}
+
+// TestAdvArrayAppendAfterPurgedTail: RGATreeList.Add anchors on a.last, the
+// last PHYSICAL position node, tombstones included. So an append issued long
+// after a delete legitimately names the deleted node as its prevCreatedAt.
+// GC purges that node as soon as minVV covers the delete -- the successor
+// barrier returns nil at the tail by construction -- and the append then fails
+// to apply on the collecting replica. No concurrency and no move is involved;
+// the append strictly follows the delete.
+func TestAdvArrayAppendAfterPurgedTail(t *testing.T) {
+	srv := newAdvServer()
+	cs := newAdvClients(t, 2)
+	A, B := cs[0], cs[1]
+
+	require.NoError(t, A.doc.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.SetNewArray("arr").AddString("a").AddString("b").AddString("c")
+		return nil
+	}))
+	require.NoError(t, srv.sync(A, true))
+	require.NoError(t, srv.sync(B, true))
+
+	// B deletes the LAST element and pushes it.
+	require.NoError(t, B.doc.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.GetArray("arr").Delete(2)
+		return nil
+	}))
+	require.NoError(t, srv.sync(B, true))
+
+	// A pulls the delete, then syncs again so its stored row covers it.
+	require.NoError(t, srv.sync(A, true))
+	require.NoError(t, srv.sync(A, true))
+	t.Logf("A after GC: %s", advDumpArr(A.doc))
+	require.NotContains(t, advDumpArr(A.doc), `"c"`, "A should have purged the tombstone")
+
+	// B appends. Add anchors on a.last == the tombstone A just purged.
+	require.NoError(t, B.doc.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.GetArray("arr").AddString("x")
+		return nil
+	}))
+	require.NoError(t, srv.sync(B, true))
+
+	// A pulls the append.
+	require.NoError(t, srv.sync(A, true), "A could not apply a plain append")
+	t.Logf("A=%s B=%s", A.doc.Root().GetArray("arr").Marshal(), B.doc.Root().GetArray("arr").Marshal())
+}

--- a/pkg/document/restore_precondition_test.go
+++ b/pkg/document/restore_precondition_test.go
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package document_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yorkie-team/yorkie/pkg/document"
+	"github.com/yorkie-team/yorkie/pkg/document/change"
+	"github.com/yorkie-team/yorkie/pkg/document/json"
+	"github.com/yorkie-team/yorkie/pkg/document/presence"
+	"github.com/yorkie-team/yorkie/pkg/document/time"
+	"github.com/yorkie-team/yorkie/pkg/key"
+	"github.com/yorkie-team/yorkie/test/helper"
+)
+
+// newReplica builds a document with an explicit actor, so lamport clocks and
+// version vectors of the two replicas are distinguishable. Without it both
+// documents share time.InitialActorID and every concurrency comparison in
+// these scenarios is meaningless.
+func newReplica(t *testing.T, k, hex string) *document.Document {
+	t.Helper()
+	actor, err := time.ActorIDFromHex(hex)
+	require.NoError(t, err)
+	d := document.New(key.Key(k))
+	d.SetActor(actor)
+	return d
+}
+
+// takeChanges pulls the sender's pending changes and acks them, returning the
+// list the server would have stored. Separated from delivery so a test can
+// hold a pack back and choose the order in which the two replicas see it.
+func takeChanges(t *testing.T, from *document.Document) []*change.Change {
+	t.Helper()
+	pack := from.CreateChangePack()
+	require.NoError(t, from.ApplyChangePack(change.NewPack(
+		pack.DocumentKey,
+		pack.Checkpoint,
+		nil,
+		time.InitialVersionVector,
+		nil,
+	)))
+	return pack.Changes
+}
+
+func deliver(t *testing.T, to *document.Document, changes []*change.Change) {
+	t.Helper()
+	require.NoError(t, to.ApplyChangePack(change.NewPack(
+		"divergence",
+		change.NewCheckpoint(0, 0),
+		changes,
+		time.InitialVersionVector,
+		nil,
+	)))
+}
+
+// replay rebuilds the document the way the server does: from the stored change
+// log, with OpSourceReplay (internal_document.go:183-188). Its result is what
+// every snapshot -- and so every client that later loads one -- will hold.
+func replay(t *testing.T, changeLists ...[]*change.Change) *document.InternalDocument {
+	t.Helper()
+	var all []*change.Change
+	for _, list := range changeLists {
+		all = append(all, list...)
+	}
+	doc := document.NewInternalDocument("divergence")
+	require.NoError(t, doc.ApplyChangePack(change.NewPack(
+		"divergence",
+		change.NewCheckpoint(0, 0),
+		all,
+		time.InitialVersionVector,
+		nil,
+	), false))
+	return doc
+}
+
+// TestRestoreTombstoneIsNotReliablyPresent measures the precondition of the
+// cheapest candidate fix -- reviving the tombstone in place instead of
+// installing the copy, using only state the replica already has.
+//
+// It is not there to act on. A replica that collected between receiving the
+// removal and receiving the undo has purged it, and a replica that joined by
+// loading a snapshot taken after that collection never had it. Whether a
+// replica can revive is therefore a function of its local collection timing,
+// not of the change log, so "revive when the tombstone is there" would produce
+// different documents on different replicas from the same log.
+func TestRestoreTombstoneIsNotReliablyPresent(t *testing.T) {
+	d1 := newReplica(t, "divergence", "000000000000000000000001")
+	d2 := newReplica(t, "divergence", "000000000000000000000002")
+
+	require.NoError(t, d1.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.SetNewObject("c").SetString("a", "1")
+		return nil
+	}))
+	create := takeChanges(t, d1)
+	deliver(t, d2, create)
+	createdAt := d1.RootObject().Get("c").CreatedAt()
+
+	require.NoError(t, d1.Update(func(r *json.Object, _ *presence.Presence) error {
+		r.Delete("c")
+		return nil
+	}, "remove c"))
+	remove := takeChanges(t, d1)
+	require.NoError(t, d1.Undo())
+	undo := takeChanges(t, d1)
+
+	// The removal and the undo are separate changes, so they can be pushed in
+	// separate packs -- a user deleting and then hitting undo across one
+	// sync interval. The server collects on pushpull (packs/pushpull.go:531),
+	// so a collection pass can fall between them.
+	server := replay(t, create, remove)
+	assert.NotNil(t, server.Root().FindByCreatedAt(createdAt),
+		"the tombstone is there before collection")
+
+	collected, err := server.GarbageCollect(
+		helper.MaxVersionVector(d1.ActorID(), d2.ActorID()))
+	require.NoError(t, err)
+	assert.Positive(t, collected)
+	assert.Nil(t, server.Root().FindByCreatedAt(createdAt),
+		"the same replica has nothing left to revive once it has collected")
+
+	// Applying the undo after that collection is legal and produces the copy,
+	// because there is no longer anything else it could produce.
+	require.NoError(t, server.ApplyChangePack(change.NewPack(
+		"divergence", change.NewCheckpoint(0, 0), undo,
+		time.InitialVersionVector, nil), false))
+	assert.Equal(t, `{"c":{"a":"1"}}`, server.Marshal())
+}

--- a/pkg/index/tree.go
+++ b/pkg/index/tree.go
@@ -755,6 +755,28 @@ func (n *Node[V]) HasTextChild() bool {
 	return true
 }
 
+// NextSiblingOf returns the child that follows the given child among this
+// node's children, removed ones included, or nil when it is the last or not a
+// child at all.
+//
+// Children(true) followed by OffsetOfChild would answer the same question, but
+// it copies the whole children slice and walks it twice. Garbage collection
+// asks this once per node it purges, so on a parent with many children that
+// turns a collection pass into quadratic time over freshly allocated slices.
+func (n *Node[V]) NextSiblingOf(child *Node[V]) *Node[V] {
+	for i, c := range n.children {
+		if c != child {
+			continue
+		}
+		if i+1 < len(n.children) {
+			return n.children[i+1]
+		}
+		return nil
+	}
+
+	return nil
+}
+
 // OffsetOfChild returns offset of children of the given node.
 func (n *Node[V]) OffsetOfChild(node *Node[V]) int {
 	for i, child := range n.children {

--- a/test/integration/gc_test.go
+++ b/test/integration/gc_test.go
@@ -945,16 +945,21 @@ func TestGarbageCollection(t *testing.T) {
 		assert.NoError(t, c2.Sync(ctx))
 		// d2.vv =[c1:2, c2:5], minvv = [c1:2], db.vv {c1: [c1:2], c2: [c1:2, c2:5]}
 		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 5))
-		// "b", "c" removedAt = 2@c1, minvv[c1] = 2 meet GC condition
+		// "b", "c" removedAt = 2@c1, minvv[c1] = 2 meet GC condition.
+		// One of them is still held by the successor barrier: purging it would
+		// move the stopping point of a forward skip that c2's concurrent insert
+		// still depends on. It drains on the next round, which
+		// TestGarbageCollectionBarrierDrainsWithinOneRound pins.
 		assert.Equal(t, 2, d1.GarbageLen())
-		assert.Equal(t, 0, d2.GarbageLen())
+		assert.Equal(t, 1, d2.GarbageLen())
 
 		assert.NoError(t, c1.Sync(ctx))
 		// d1.vv = [c1:6, c2:5], minvv = [c1:2, c2:0], db.vv {c1: [c1:2], c2: [c1:2, c2:5]}
 		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 6), versionOf(d2.ActorID(), 5))
-		// "b", "c" removedAt = 4@c1, minvv[c1] = 4 meet GC condition
-		assert.Equal(t, 0, d1.GarbageLen())
-		assert.Equal(t, 0, d2.GarbageLen())
+		// "b", "c" removedAt = 4@c1, minvv[c1] = 4 meet GC condition. One
+		// tombstone each is still held by the successor barrier; see above.
+		assert.Equal(t, 1, d1.GarbageLen())
+		assert.Equal(t, 1, d2.GarbageLen())
 	})
 
 	t.Run("concurrent garbage collection test(with pushonly)", func(t *testing.T) {
@@ -1071,16 +1076,18 @@ func TestGarbageCollection(t *testing.T) {
 		assert.NoError(t, c2.Sync(ctx))
 		// d2.vv = [c1:5, c2:7], minvv = [c1:6, c2:6], db.vv {c1: [c1:8, c2:6], c2: [c1:6, c2:8]}
 		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 5), versionOf(d2.ActorID(), 7))
-		// removedAt = 6@c1, minvv[c1] = 6, meet GC condition
+		// removedAt = 6@c1, minvv[c1] = 6, meet GC condition. One is held by
+		// the successor barrier for a round.
 		assert.Equal(t, 2, d1.GarbageLen())
-		assert.Equal(t, 0, d2.GarbageLen())
+		assert.Equal(t, 1, d2.GarbageLen())
 
 		assert.NoError(t, c1.Sync(ctx))
 		// d2.vv = [c1:8, c2:6], minvv = [c1:6, c2:7], db.vv {c1: [c1:9, c2:7], c2: [c1:6, c2:8]}
 		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 8), versionOf(d2.ActorID(), 6))
-		// removedAt = 6@c1, minvv[c1] = 6, meet GC condition
+		// removedAt = 6@c1, minvv[c1] = 6, meet GC condition. d2 still holds
+		// one behind the successor barrier.
 		assert.Equal(t, 0, d1.GarbageLen())
-		assert.Equal(t, 0, d2.GarbageLen())
+		assert.Equal(t, 1, d2.GarbageLen())
 		assert.Equal(t, `{"text":[{"val":"a"},{"val":"2"},{"val":"1"},{"val":"c"}]}`, d1.Marshal())
 		assert.Equal(t, `{"text":[{"val":"a"},{"val":"2"},{"val":"1"},{"val":"c"}]}`, d2.Marshal())
 	})
@@ -1323,7 +1330,7 @@ func TestGarbageCollection(t *testing.T) {
 		assert.NoError(t, c2.Sync(ctx))
 		assert.NoError(t, c1.Sync(ctx))
 		assert.Equal(t, 0, d1.GarbageLen())
-		assert.Equal(t, 0, d2.GarbageLen())
+		assert.Equal(t, 1, d2.GarbageLen())
 	})
 
 	t.Run("attach > pushpull > detach lifecycle version vector test (run gc at last client detaches document)", func(t *testing.T) {
@@ -1396,7 +1403,7 @@ func TestGarbageCollection(t *testing.T) {
 		assertVectorEquality(t, d2.VersionVector(), versionOf(d1.ActorID(), 2), versionOf(d2.ActorID(), 5))
 
 		assert.Equal(t, 2, d1.GarbageLen())
-		assert.Equal(t, 0, d2.GarbageLen())
+		assert.Equal(t, 1, d2.GarbageLen())
 
 		assert.NoError(t, c1.Sync(ctx))
 		assertVectorEquality(t, d1.VersionVector(), versionOf(d1.ActorID(), 6), versionOf(d2.ActorID(), 5))
@@ -1562,4 +1569,77 @@ func TestGarbageCollection(t *testing.T) {
 		assert.Equal(t, `{"text":[{"val":"5"},{"val":"4"},{"val":"3"},{"val":"3"},{"val":"2"},{"val":"2"},{"val":"1"},{"val":"1"},{"val":"0"},{"val":"c"},{"val":"0"},{"val":"a"}]}`, d2.Marshal())
 		assert.Equal(t, `{"text":[{"val":"5"},{"val":"4"},{"val":"3"},{"val":"3"},{"val":"2"},{"val":"2"},{"val":"1"},{"val":"1"},{"val":"0"},{"val":"c"},{"val":"0"},{"val":"a"}]}`, d1.Marshal())
 	})
+}
+
+// TestGarbageCollectionBarrierDrainsWithinOneRound is the load-bearing test for
+// the successor barrier's cost. The barrier delays a purge when the node that
+// would become a forward skip's new stopping point is not yet causally stable,
+// which is why several assertions above now expect one retained tombstone where
+// they used to expect none.
+//
+// A delay is acceptable; a leak is not. Retaining a tombstone forever is what
+// disqualified two other candidate fixes for the same defect, and the
+// difference is invisible in a test that stops asserting at the point the delay
+// begins. So this replays the same sequence as "concurrent garbage collection
+// test" and then keeps syncing with no further edits: the retention has to
+// reach zero and the replicas have to agree.
+func TestGarbageCollectionBarrierDrainsWithinOneRound(t *testing.T) {
+	clients := activeClients(t, 2)
+	c1, c2 := clients[0], clients[1]
+	defer deactivateAndCloseClients(t, clients)
+
+	ctx := context.Background()
+	d1 := document.New(helper.TestKey(t))
+	assert.NoError(t, c1.Attach(ctx, d1))
+	d2 := document.New(helper.TestKey(t))
+	assert.NoError(t, c2.Attach(ctx, d2))
+
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.SetNewText("text").Edit(0, 0, "a").Edit(1, 1, "b").Edit(2, 2, "c")
+		return nil
+	}, "sets text"))
+	assert.NoError(t, c1.Sync(ctx))
+	assert.NoError(t, c2.Sync(ctx))
+
+	// c2 inserts next to what c1 is about to delete. This is the concurrency
+	// the barrier exists for: the tombstone c1 leaves is what stops the forward
+	// skip that c2's insert is positioned by.
+	assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetText("text").Edit(2, 2, "c")
+		return nil
+	}, "insert c"))
+	assert.NoError(t, d1.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetText("text").Edit(1, 3, "")
+		return nil
+	}, "delete bc"))
+
+	assert.NoError(t, c1.Sync(ctx))
+	assert.NoError(t, c2.Sync(ctx))
+
+	assert.NoError(t, d2.Update(func(root *json.Object, p *presence.Presence) error {
+		root.GetText("text").Edit(2, 2, "1")
+		return nil
+	}, "insert 1"))
+	assert.NoError(t, c2.Sync(ctx))
+	assert.NoError(t, c1.Sync(ctx))
+
+	// Where the assertions above stop: one tombstone each, held by the barrier.
+	assert.Equal(t, 1, d1.GarbageLen())
+	assert.Equal(t, 1, d2.GarbageLen())
+
+	// One more round with no edits at all has to drain it.
+	assert.NoError(t, c1.Sync(ctx))
+	assert.NoError(t, c2.Sync(ctx))
+	assert.Equal(t, 0, d1.GarbageLen(), "the barrier must delay a purge, not prevent it")
+	assert.Equal(t, 0, d2.GarbageLen(), "the barrier must delay a purge, not prevent it")
+
+	// Further rounds must not resurrect anything, and the replicas must agree.
+	for range 3 {
+		assert.NoError(t, c1.Sync(ctx))
+		assert.NoError(t, c2.Sync(ctx))
+		assert.Equal(t, 0, d1.GarbageLen())
+		assert.Equal(t, 0, d2.GarbageLen())
+	}
+	assert.Equal(t, d1.Marshal(), d2.Marshal())
+	assert.Equal(t, `{"text":[{"val":"a"},{"val":"c"},{"val":"1"}]}`, d1.Marshal())
 }


### PR DESCRIPTION
Closes the stopping-point half of a permanent-divergence defect in all three RGA-shaped structures, and files the anchor half plus a second defect that cannot be fixed without a wire change.

Both defects are pre-existing on `main` and neither was introduced by #1978. They were found while verifying that work.

## Collection changes where a later insert lands

RGA decides where an insert lands by walking forward and skipping nodes whose positioning ticket is newer. The walk reads the nodes **currently linked, tombstones included** — and collection unlinks exactly those. So collection mutates the input to the insertion rule, and the insertion point stops being a function of state the replicas agree on.

Same skip, three structures:

| | |
|---|---|
| `pkg/document/crdt/rga_tree_list.go` | Array |
| `pkg/document/crdt/rga_tree_split.go` | Text |
| `pkg/document/crdt/tree.go` | Tree |

Measured with a push/pull model faithful to `pushpull.go` — rows stored from each request's version vector at push time, own changes filtered out of the pull, `minVV` the element-wise minimum, collection run only inside `Document.ApplyChangePack` with the vector pull delivered. No `helper.MaxVersionVector` anywhere.

| workload | `main` | this PR |
|---|---|---|
| 300 seeds, all ops, collection **on** | 43 diverged or errored | **33** |
| 300 seeds, all ops, collection **off** | 0 — converges | 0 |
| 1000 seeds, insert+delete | diverged 4, `childNotFound` 75 | **diverged 0**, 40 |
| 1000 seeds, all ops | diverged 109, `childNotFound` 26 | 84, 18 |

The collection-off control is the load-bearing row: the same seeds converge when nothing is collected, so collection is the sole cause.

Per op mask, at 300 seeds — every category improves, none regresses:

| mask | `main` | this PR |
|---|---|---|
| insert+delete | 25 | **8** |
| insert+delete+move | 35 | 18 |
| insert+delete+set | 9 | 6 |
| insert+move | 15 | 12 |
| insert+set | 0 | 0 |
| all | 43 | 33 |

### The fix, and what it does not fix

A purge may now unlink a node only if the node that would become the skip's new stopping point is itself causally stable. Framing the barrier as a property of the **successor** rather than of the node being purged is what lets one rule cover both purge loops and all three structures. An earlier attempt guarded the node being purged and was wrong: the slot a second move abandons was created by the *first* move, and two concurrent moves leave those tickets unordered.

**This is a partial fix.** Purging a tombstone destroys two things, and the successor barrier addresses one:

1. the skip's stopping point — closed here;
2. the **anchor** an operation concurrent with the removal still references — untouched, because the successor can be perfectly stable while an in-flight operation points at the node being removed.

The remaining 33 are that anchor half. Three further framings were built and measured against it; all four reached 0 of 300 on the array/no-undo/strings bar and none was shippable, which is really a finding about the bar. The filing carries the ceilings table and the branches. The only direction that removes the dependency rather than constraining collection needs a wire change, so the anchor half goes with the identity-preserving revive work.

### Cost

Retention is the axis that disqualified two of the other candidates. One retained a dead position node per moved element permanently — `DocSize` +148% on a drag-reorder and, because `DocSize.Total` feeds `MaxSizeLimit`, a 20-element array under a 1000-byte limit refused at the 8th of 19 drags. Its own cost fixture missed that by re-moving only a handful of elements, so its reported number was independent of the array.

Measured here across three workloads — fully-synced drag-reorder, single actor collecting at lag 1/5/50, and two actors moving concurrently through the faithful push/pull model — retention and `DocSize` are **byte-identical to `main`**, and no workload was found where the barrier costs more. `gc_rga_barrier_cost_test.go` pins the *shape* rather than a golden number: bounded by the lag not by the array, complete drainage back to no GC charge, every move accepted under a byte limit. Those pass on `main` too, so they guard against a future cost regression rather than serving as evidence for this fix.

## Undoing a container removal discards a peer's concurrent edit inside it

Filed, not fixed — it cannot be fixed without the wire change.

The reverse of a `Remove` is a `Set` of `value.DeepCopy()`. Applying it re-points every createdAt-keyed index at the copy — including every descendant, each under its original `createdAt`. An operation addressed at one of those lands on whichever instance owns the id **at apply time**, which delivery order decides.

```
d1, d2 share  {"c":{"a":"1"}}
d2: c.b = "2"          (not yet delivered)
d1: delete c ; undo    (d1 has never seen d2's edit)
deliver both ways

d1 = {"c":{"a":"1","b":"2"}}
d2 = {"c":{"a":"1"}}      <- the peer's own edit, gone on the peer
```

Unchanged after collection on both. Only one delivery order diverges; delivering the peer's edit before the undo converges.

Two candidate fixes are closed by measurement rather than left open:

- **Re-ticketing does not work.** The array path already re-tickets the restored container and still diverges, because the peer's operation is addressed at a *descendant* and descendants are never re-ticketed. So `TestUndoneArrayRemoveSurvivesCollection` passing does not mean the array path is safe here.
- **Reviving the tombstone cannot be chosen from local state.** A replica that collected between the removal and the undo has purged it; one that joined from a later snapshot never had it. Whether a replica *can* revive is a function of its local collection timing, not of the change log — so the same log would produce different documents. That is the argument for putting the branch on the wire, and it is pinned by the one test this PR lands green.

## What lands

Production:

- `pkg/document/crdt/{gc,root,rga_tree_list,rga_tree_split,array,tree}.go`, `pkg/index/tree.go` — the successor barrier

Tests:

- `pkg/document/gc_rga_barrier_test.go` — four targeted regressions, each verified red on `main` and green here: array remove+move, concurrent moves with a server-computed `minVV`, the same defect in `Text`, the same defect in `Tree`
- `pkg/document/gc_rga_barrier_cost_test.go` — the cost shape
- `pkg/document/gc_rga_fuzz_test.go` — the harness, behind `//go:build rgafuzz`. It is expected to fail, and still does at 33/300; the tag keeps it out of CI without letting it rot. Run with `go test -tags rgafuzz ./pkg/document/ -run TestAdvArray -v`
- `pkg/document/restore_precondition_test.go` — `TestRestoreTombstoneIsNotReliablyPresent`, green today
- `.github/workflows/ci.yml` — `go vet -tags rgafuzz ./...`, verified to catch an injected undefined symbol that plain `go vet` misses

Filings:

- `docs/tasks/active/20260912-collection-changes-rga-insertion-todo.md`
- `docs/tasks/active/20260912-undo-discards-concurrent-peer-edit-todo.md`

Verification: `go test ./...` green, `go test -race ./pkg/document/...` green, `go vet -tags rgafuzz ./...` clean, `make lint` 0 issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved garbage collection across arrays, text, and tree structures to preserve concurrent insertion order and support replica convergence.
  * Collection now safely handles deferred entries and completes consistently across repeated passes.

* **Documentation**
  * Added task documentation covering replica divergence, RGA insertion behavior, undo scenarios, investigation results, and follow-up work.

* **Tests**
  * Added fuzzing and regression coverage for garbage-collection ordering, convergence, cost limits, and undo behavior.
  * Added CI validation for fuzzing-tagged test code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->