### PR TITLE
Release v0.7.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and Yorkie adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## [v0.7.21] - 2026-09-13
+
+### Added
+
+- Add the element-restore wire fields and a capability handshake, and stop generated code from drifting by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1981
+
+### Fixed
+
+- Stop garbage collection from deleting a restored object member by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1978
+- Stop collection from moving the RGA forward skip's stopping point by @hackerwins in https://github.com/yorkie-team/yorkie/pull/1980
+
 ## [v0.7.20] - 2026-09-09
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-YORKIE_VERSION := 0.7.20
+YORKIE_VERSION := 0.7.21
 
 GO_PROJECT = github.com/yorkie-team/yorkie
 

--- a/api/docs/yorkie.base.yaml
+++ b/api/docs/yorkie.base.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Yorkie
   description: "Yorkie is an open source document store for building collaborative editing applications."
-  version: v0.7.20
+  version: v0.7.21
 servers:
   - url: https://api.yorkie.dev
     description: Production server

--- a/api/docs/yorkie/v1/admin.openapi.yaml
+++ b/api/docs/yorkie/v1/admin.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.20
+  version: v0.7.21
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/api/docs/yorkie/v1/cluster.openapi.yaml
+++ b/api/docs/yorkie/v1/cluster.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.20
+  version: v0.7.21
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/api/docs/yorkie/v1/resources.openapi.yaml
+++ b/api/docs/yorkie/v1/resources.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.20
+  version: v0.7.21
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/api/docs/yorkie/v1/yorkie.openapi.yaml
+++ b/api/docs/yorkie/v1/yorkie.openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: Yorkie is an open source document store for building collaborative
     editing applications.
   title: Yorkie
-  version: v0.7.20
+  version: v0.7.21
 servers:
 - description: Production server
   url: https://api.yorkie.dev

--- a/build/charts/yorkie-cluster/Chart.yaml
+++ b/build/charts/yorkie-cluster/Chart.yaml
@@ -9,8 +9,8 @@ maintainers:
 
 sources:
   - https://github.com/yorkie-team/yorkie
-version: 0.7.20
-appVersion: "0.7.20"
+version: 0.7.21
+appVersion: "0.7.21"
 kubeVersion: ">=1.28.0-0"
 
 dependencies:


### PR DESCRIPTION
## What this does

Cuts `v0.7.21` over `v0.7.20..main` — three commits, all by @hackerwins.

| file | change |
| --- | --- |
| `Makefile` | `YORKIE_VERSION := 0.7.21` |
| `build/charts/yorkie-cluster/Chart.yaml` | `version`, `appVersion` |
| `api/docs/yorkie.base.yaml` | `v0.7.21` |
| `api/docs/yorkie/v1/{admin,yorkie,resources}.openapi.yaml` | `v0.7.21` |
| `CHANGELOG.md` | the v0.7.21 section |

## Why these charts and not the others

No commit in `v0.7.20..main` touched `build/charts/`, so the separate-track
charts do not move: `yorkie-analytics` stays at `0.7.20` and
`yorkie-monitoring` at `0.7.7`. They carry the version of the release that last
changed them, so bumping them here would skip a version for no reason.

`api/docs/yorkie/v1/cluster.openapi.yaml` is a separate track as well and keeps
`v0.7.20`, even though #1981 regenerated its contents.

## CHANGELOG classification

#1981 is listed under **Added**, not Changed. Its title names the generated-code
drift, but the diff adds real wire fields — `capabilities`, `restore_mode` and
`revived_at` in `resources.proto` — and that is what a consumer of this release
needs to know about. Classified from the diff, not the title.

## The window

- **#1978** — garbage collection deleted a restored object member. Undoing a
  removal restored the member and the next collection pass deleted it again, on
  every replica except the one that undid, and on the server, which replays the
  change log with `OpSourceReplay` to build snapshots. The key then disappeared
  from every snapshot built afterwards and from every client that later loaded
  one.
- **#1980** — collection moved the RGA forward skip's stopping point. RGA picks
  where an insert lands by walking forward from its anchor over the nodes
  currently linked in, tombstones included, and collection unlinks exactly
  those. Two replicas differing only in whether collection had run ordered the
  same later insert differently, with nothing to reconverge them. All three
  RGA-shaped structures were affected: Array, Text and Tree.
- **#1981** — the element-restore wire fields and a capability handshake, plus
  the generated-code drift that would otherwise have buried them.

Both fixes are convergence bugs rather than crashes, which is why they are worth
taking promptly: nothing fails loudly, the replicas simply stop agreeing.

## Test plan

CI. The release commit changes version strings and prose only; the code it
releases was tested on its own PRs.

## After merge

1. `make build-binaries` → 6 archives
2. Publish the GitHub Release with the archives attached
3. `docker-publish` runs off the Release (~15 min for the image)
4. `yorkie-cluster` chart is published automatically by Release Charts on merge,
   ahead of the binaries

Then `yorkie-js-sdk` v0.7.21, dashboard/homepage, and the devops bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for restoring elements with improved compatibility negotiation.
  * Added safeguards to prevent generated-code inconsistencies.

* **Bug Fixes**
  * Fixed an issue where restored object members could be incorrectly removed during cleanup.
  * Fixed collection movement behavior when advancing through list content.

* **Release**
  * Updated the release and API documentation version to 0.7.21.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->